### PR TITLE
perf-review: analysis and verification of intra-front parallelism

### DIFF
--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-05-30T17:53:15Z
+Generated: 2026-05-31T11:29:42Z
 
 ## Latest Session
 File: dev/sessions/2026-05-30-01.md
@@ -59,34 +59,34 @@ precision; 1e-12 gate, tolerance untouched).
 
 ## Git Status
 ```
-92b8150 bench: add dense-Hessian multi-RHS probe (#58 repro)
-2369fce fix(solve): batched iterative refinement for wide multi-RHS (#58)
-f8f324b session: 2026-05-30-01 checkpoint (#57 multi-RHS BLAS-3 + docs)
-401486e docs(book): add Scaling and Fill-reducing ordering chapters
-0fcb010 docs(book): complete the mdBook — fix stale examples, add sparse/multi-RHS/Python (#57)
+cd12735 release: v0.9.0
+c51ddfd docs: notebook + book now show the batched refined win (#58)
+2e096e9 perf(solve): drop the 0-step allocations in batched refinement (#58)
+91de86e docs: showcase the batched refined solve in the notebook + book (#58)
+1d26b9a session: 2026-05-30-01 checkpoint addendum (#58 batched refinement)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test scaling::tests::auto_solves_below_guard_matrix_correctly ... ok
-test scaling::tests::auto_falls_back_to_infnorm_on_mss1_0009 ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
+test dense::schur_kernel::tests::axpy_minus_length_mismatch_panics - should panic ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 
-test result: ok. 317 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.41s
+test result: ok. 315 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.76s
 
 ```
 
@@ -188,6 +188,7 @@ the layout (row-major `y`) was fixed.
 ## Source Files
 ```
 src/bin/alloc_probe.rs
+src/bin/bench.rs
 src/bin/bench_axpy_small.rs
 src/bin/bench_dense_multirhs.rs
 src/bin/bench_fma_phase3.rs
@@ -198,7 +199,6 @@ src/bin/bench_orderings.rs
 src/bin/bench_solver_corpus.rs
 src/bin/bench_solver_reuse.rs
 src/bin/bench_sqd.rs
-src/bin/bench.rs
 src/bin/blas3_prototype.rs
 src/bin/calibrate_par_min_flops.rs
 src/bin/d3_probe.rs
@@ -211,8 +211,8 @@ src/bin/diag_amd_substages.rs
 src/bin/diag_amf_vs_amd.rs
 src/bin/diag_cascade_default_evidence.rs
 src/bin/diag_cascade_ratio_distribution.rs
-src/bin/diag_chainwoo_profile.rs
 src/bin/diag_chainwoo.rs
+src/bin/diag_chainwoo_profile.rs
 src/bin/diag_clnlbeam_maxfromm.rs
 src/bin/diag_clnlbeam_slb.rs
 src/bin/diag_compress_costbenefit.rs
@@ -255,8 +255,8 @@ src/bin/diag_qcqp_knobs.rs
 src/bin/diag_qcqp_profile.rs
 src/bin/diag_robot1600_eigs.rs
 src/bin/diag_schur_parity.rs
-src/bin/diag_small_leaf_gate.rs
 src/bin/diag_small_leaf.rs
+src/bin/diag_small_leaf_gate.rs
 src/bin/diag_small_sparse_inventory.rs
 src/bin/diag_sparse_memory.rs
 src/bin/diag_split_tail.rs
@@ -285,17 +285,17 @@ src/bin/probe_fbrain.rs
 src/bin/probe_fma_kernel.rs
 src/bin/probe_hang_loop.rs
 src/bin/probe_ir_trajectory.rs
-src/bin/probe_issue_19.rs
-src/bin/probe_issue45_ordering.rs
 src/bin/probe_issue45.rs
+src/bin/probe_issue45_ordering.rs
+src/bin/probe_issue46.rs
 src/bin/probe_issue46_preprocess.rs
 src/bin/probe_issue46_supernode.rs
-src/bin/probe_issue46.rs
 src/bin/probe_issue49.rs
+src/bin/probe_issue54.rs
 src/bin/probe_issue54_alpha_shift.rs
 src/bin/probe_issue54_cascade.rs
 src/bin/probe_issue54_ma57_alpha.rs
-src/bin/probe_issue54.rs
+src/bin/probe_issue_19.rs
 src/bin/probe_kkt_replay.rs
 src/bin/probe_marine_shape.rs
 src/bin/probe_marine_time.rs
@@ -349,4 +349,4 @@ src/ordering/mod.rs
 src/ordering/postorder.rs
 src/ordering/schur.rs
 
-(truncated from      416 lines to 350 line budget)
+(truncated from 416 lines to 350 line budget)

--- a/dev/journal/2026-05-31-01.org
+++ b/dev/journal/2026-05-31-01.org
@@ -31,3 +31,39 @@ worst-case ratios and the 1.44× ceiling. GPU recommended against
 (small-front corpus, serial BK pivot search, GPU FP non-determinism vs
 inertia guarantee). Full note: dev/research/perf-review-2026-05-31.md.
 No code changed this session — analysis only.
+
+* 13:05 :perf-review:verification:parallelism:correction:
+Verified the Tier-1 #1 claim (intra-front parallel Schur) empirically with
+two probes (src/bin, excluded from published crate).
+
+CORRECTNESS (probe_intrafront_schur): synthetic front nrow=2048 n_elim=64,
+production schur_panel_minus_nofma_strided{,_dual,_quad} kernels, seq vs
+par_chunks_mut over disjoint trailing-column chunks. Bit-identical
+(f64::to_bits) to sequential across chunk widths {64,100,137,200,512} and
+T={1,2,4}. Chunk widths intentionally not multiples of 4 -> quad/dual/single
+grouping differs between seq and par yet every element matches. Determinism
+is structural (no cross-thread reduction), confirmed. PASS.
+
+PERFORMANCE: 3.57x on 4 cores (89% eff). Absolute GFLOP/s low (0.43 seq /
+1.53 par) because this container is bandwidth-starved (33MB clone ~1.5 GB/s);
+relative speedup is the verified quantity.
+
+PREMISE CHECK (probe_front_concentration) -- CORRECTED MY OWN REVIEW. Per-front
+cost ~ncol*nrow^2 + measured sym vs num wall time:
+- CRESC132_0000 (worst ratio 6.63): largest front 11x11, symbolic 22.2ms vs
+  numeric 5.7ms = 80% symbolic. SYMBOLIC-BOUND, not large-front. Intra-front
+  parallelism would NOT help it.
+- VESUVIOU_0030: largest front 18x18, 54% symbolic. Mixed.
+- nuffield2 (n=26649): largest front 87x501, top-16 = 43.5% flop share, 80%
+  numeric. NUMERIC/large-front-bound -> intra-front + tree parallelism pays.
+
+Conclusion: the two top levers are COMPLEMENTARY and target different
+populations -- symbolic speedups (Tier-2 2.2) for the small symbolic-bound
+tail (CRESC132/VESUVIO), intra-front parallelism (Tier-1 1.1) for the large
+numeric-bound tail (nuffield2, documented pinene_3200 14k root / issue #8).
+The earlier note over-attributed CRESC132 to intra-front; measurement
+reassigns it. Research note updated with a Verification section.
+
+Gates: cargo fmt --check clean, cargo clippy --all-targets -D warnings clean,
+cargo test --lib 315/315 pass, parallel_parity 6/6 pass (existing tree-parallel
+determinism re-confirmed).

--- a/dev/journal/2026-05-31-01.org
+++ b/dev/journal/2026-05-31-01.org
@@ -1,0 +1,33 @@
+* 12:10 :perf-review:parallelism:determinism:
+Performed a library-wide performance review under the pure-Rust +
+bit-exact constraint. Mapped four hot paths (dense factor/schur kernel,
+parallel multifrontal driver, multi-RHS solve, symbolic) via three
+parallel Explore agents + direct reads.
+
+Key findings (evidence):
+- geomean factor-time already < 1.0 vs MUMPS (sparse ~0.36); the pain is
+  the tail. Worst: KIRBY2_0007 8.76, CRESC132_0000 6.63, MUONSINE_0000
+  5.63 (context.md 2026-05-30-01).
+- Two distinct tail populations: small matrices are SYMBOLIC-dominated
+  (KIRBY2 numeric sub-ms; LdltCompress ~17× symbolic per t-a-r
+  2026-04-23); large matrices are NUMERIC-serial (wide root supernode,
+  issue #8 pinene 87s).
+- Parallel driver is tree-level only; intra-front dense factor is
+  serial. cont-201 measured 1.44×@T=8 vs 4.83× critical-path bound
+  (t-a-r 2026-05-12) — the serial root is the ceiling.
+- FMA is ~0% on ARM (nofma 4-accumulator already saturates pipes,
+  decisions.md 2026-04-14 1.87→1.86) and flips inertia on ~30/154k
+  boundary matrices (t-a-r 2026-04-14) — correctly off.
+- Parallel inertia race (1-2%) was root-caused (double-spawn from
+  pending.load()==0 mid-seed) and FIXED 2026-04-21; parallel_parity
+  green, diag_par_repeat 0/38878 (decisions.md:1578).
+
+Conclusion: the single highest-leverage, determinism-FREE lever is
+intra-front (node-level) parallelism of the trailing Schur update in
+apply_blocked_schur_panel (factor.rs:2957). par_chunks_mut over trailing
+columns is bit-exact for any thread count (each a[i,j] reduced over the
+same q-order on one thread; no cross-thread reduction). Attacks both the
+worst-case ratios and the 1.44× ceiling. GPU recommended against
+(small-front corpus, serial BK pivot search, GPU FP non-determinism vs
+inertia guarantee). Full note: dev/research/perf-review-2026-05-31.md.
+No code changed this session — analysis only.

--- a/dev/research/perf-review-2026-05-31.md
+++ b/dev/research/perf-review-2026-05-31.md
@@ -1,0 +1,146 @@
+# Performance review — determinism-constrained optimization headroom (2026-05-31)
+
+Branch: `claude/linalg-perf-review-Bib1d`. This is a survey/analysis note, not
+an implementation. It maps the hot paths, states what is already optimal, and
+prioritizes the remaining gains *under the hard constraint that they stay pure
+Rust and bit-exact* (inertia must be exactly correct — that rules out the two
+classic levers, FMA and order-dependent parallel reductions, unless they can be
+made bit-identical to the sequential reference).
+
+## 0. Where the time goes today
+
+`bench` (session 2026-05-30-01): factor-time **geomean already < 1.0 vs MUMPS**
+(sparse geomean ~0.36 — feral is faster than MUMPS on the average matrix). The
+problem is entirely in the **tail**:
+
+- p90 dense 1.34 / 1.74, sparse 1.50 / 1.50 (all PASS, but above 1.0).
+- Worst cases: `KIRBY2_0007` n=458 ratio **8.76**, `CRESC132_0000` n=5314 **6.63**,
+  `MUONSINE_0000` n=1537 **5.63**.
+- Parallel speedup ceiling: cont-201 measured **1.44× at T=8** against a 4.83×
+  critical-path bound (tried-and-rejected 2026-05-12). Tree parallelism starves
+  near the root.
+
+Two distinct tail populations, with different bottlenecks:
+
+1. **Small matrices (numeric sub-ms): symbolic-dominated.** KIRBY2 numeric is
+   tiny; its bad ratio is analysis time (ordering + the LdltCompress
+   double-Hungarian; compression adds ~17× symbolic on KIRBY2 per
+   tried-and-rejected 2026-04-23). The 154k-matrix geomean/p90 lives here.
+2. **Large matrices (CRESC132, pinene, MUONSINE roots): numeric-dominated,
+   serial.** A wide near-dense root supernode factors on one thread; this is
+   the parallel ceiling and the worst absolute times (issue #8 pinene_3200:
+   118k delayed pivots → ~14k-col root → 87s).
+
+## 1. What is already optimal (do not touch)
+
+- **Dense Schur micro-kernel** (`src/dense/schur_kernel.rs`): pulp-dispatched,
+  register-blocked, NR = 4/2/1 trailing columns sharing the L-panel load across
+  accumulators, **4 independent non-FMA accumulators**. This already harvests
+  the ILP win deterministically — separate `mul`+`sub` reproduces the scalar
+  loop's two-rounding semantics bit-for-bit (decisions.md 2026-04-14). On the
+  Apple-Silicon dev target nofma vs FMA is 1.87→1.86 (noise): the pipes are
+  already saturated.
+- **Tree-parallel multifrontal driver**
+  (`factorize_multifrontal_supernodal_parallel`): default-on, gated by
+  `N_PAR_MIN=32` supernodes / ≥2-child branching / `PAR_MIN_FLOPS=1e7`. The
+  ~1–2% inertia race was root-caused (double-spawn from `pending.load()==0`
+  mid-seed) and fixed 2026-04-21; `tests/parallel_parity.rs` is green and
+  unignored, `diag_par_repeat` = 0 mismatches over 38 878 runs. Determinism is
+  preserved by iterating children in fixed `snode.children` order (no parallel
+  FP reduction).
+- **Multi-RHS solve** (`src/numeric/solve.rs`): row-major working buffer (issue
+  #57 — fixed the stride-`n` cache-aliasing bottleneck), BLAS-3 panel kernel
+  (MR=4, NR=8) above `BLAS3_NRHS_THRESHOLD=32`, fused D-solve, active-set
+  compaction in batched refinement.
+- **Symbolic**: column counts are Gilbert-Ng-Peyton O(nnz+n·α) (Phase 2.5.1,
+  down from O(n²)); the in-tree AMD is retired in favour of the external
+  `feral-amd` crate (18–88× faster on large).
+
+## 2. Prioritized opportunities (bit-exact unless noted)
+
+### Tier 1 — highest leverage, determinism is *free*
+
+**1.1 Intra-front (node-level) parallelism for large/root supernodes.**
+This is THE ceiling. The parallel driver only does *inter-front* (tree)
+parallelism; the dense factor of a single front
+(`factor_frontal_blocked_in_place_with_scratch`) runs on one thread. Near the
+root, tree parallelism has nothing left to schedule, so the 1.44×@T=8 result is
+dominated by the serial root.
+
+The trailing Schur update `apply_blocked_schur_panel`
+(`src/dense/factor.rs:2957`) is *embarrassingly parallel across trailing-column
+blocks* and **bit-exact regardless of thread count**: each output element
+`a[i,j]` is reduced over the same pivot order `q ∈ 0..n_elim` on a single
+thread; splitting the `while j+3 < nrow` column loop with `par_chunks_mut`
+introduces **no cross-thread reduction**, so the FP result is identical for any
+T. The panel factorization (Bunch-Kaufman pivot search) stays serial — correct,
+since it is inherently sequential and a small FLOP fraction.
+
+This is exactly MUMPS/SSIDS "type-2 / node-level" parallelism and directly
+attacks CRESC132 / pinene / MUONSINE and the parallel-speedup ceiling.
+- Implementation: a per-front flop threshold (reuse `est_flops` machinery) so
+  only wide fronts go parallel; nest inside the existing `rayon::scope` or use a
+  separate dispatch when a front exceeds the threshold while the tree is starved.
+- Risk: low on correctness (no reassociation), medium on engineering
+  (rayon-inside-rayon scoping, threshold calibration). **Determinism: free.**
+
+**1.2 Cache (L2/L3) blocking + L-panel packing in the dense Schur update for
+large fronts.** Today `src_block` is read column-major at stride `nrow` and
+re-streamed per trailing-column group; `block_size=64` gives L1 reuse on the
+panel but there is no n-dimension (trailing) tiling and no packing. For the wide
+dense roots this is memory-traffic-bound. A BLIS-style packed micro-kernel with
+3-level blocking cuts traffic. **Bit-exact**: packing is a copy, not a
+reassociation; the per-element accumulation order is unchanged. Pairs naturally
+with 1.1 (pack once, parallelize the packed kernel).
+
+### Tier 2 — solid, mostly bit-exact
+
+**2.1 Put the solve/refinement on the pulp path + parallelize across RHS.** The
+solve GEMM (`gemm_panel_minus`, solve.rs:800) relies on LLVM auto-vectorization,
+not the pulp kernels used in factor; refinement `norm2` and the SpMV are scalar.
+For IPM hosts (many solves) and many-RHS workloads: (a) route forward/back GEMM
+through the deterministic nofma pulp kernels, (b) parallelize across *independent
+RHS columns* (embarrassingly parallel, bit-exact). Lower leverage for single-RHS,
+real for many-RHS / heavy refinement.
+
+**2.2 Symbolic-phase speedups for the small-matrix bulk.** The p90 vs MUMPS on
+small matrices is symbolic-dominated. Two concrete, already-flagged items
+(tried-and-rejected 2026-04-23): plumb the cached MC64 matching into the
+`ldlt_compress` path (kills the double-Hungarian), and auto-dispatch compression
+only on predicted-tail matrices (large-n + MC64 compRat ≤ 0.7), mirroring
+`ScalingStrategy::Auto`. This moves the metric the 154k corpus actually lives in.
+
+### Tier 3 — platform-dependent / low priority
+
+**3.1 FMA with a boundary-safe fallback (the open "option 2").** ~0% on ARM (4
+nofma accumulators already saturate the pipes); possibly material on x86
+AVX-512 (untested). Only viable with the detect-pivot-within-k·eps-of-zero_tol
+and fall-back-to-scalar mitigation, and only after measuring a real x86 gap.
+High complexity, conditional payoff — keep opt-in.
+
+**3.2 Wider micro-kernel NR (4→6/8).** Diminishing returns on the small fronts
+that dominate, more remainder code. Measure only after 1.1/1.2 land.
+
+### GPU — recommend against, for this workload
+
+- The corpus is dominated by small fronts (n<500); GPU kernel-launch latency
+  (~µs) dwarfs per-front compute. Only the few huge dense roots could benefit —
+  but those are gated by the inherently *serial* Bunch-Kaufman pivot search,
+  exactly what a GPU cannot accelerate.
+- **Determinism**: GPU FP (atomic reductions, non-fixed reduction trees,
+  default FMA) breaks the bit-exact inertia guarantee the library is built on.
+  Reproducing bit-exact LDLᵀ inertia on GPU is not practically achievable.
+- **Pure-Rust constraint**: wgpu/cubecl/rust-gpu drag in shader compilers and
+  drivers — a large non-Rust-toolchain surface against "zero non-Rust deps."
+- Verdict: out of scope. The same effort spent on Tier-1 CPU intra-front
+  parallelism yields a deterministic win on the matrices that actually hurt.
+
+## 3. Recommended next step
+
+Tier-1 1.1 (intra-front parallel Schur update) — highest leverage, zero
+determinism risk, hits both the worst-case ratios and the parallel ceiling.
+Per protocol: research note → a par-vs-seq bit-parity harness on the wide-root
+subset (CRESC132 / pinene_3200 / MUONSINE / nql180) → implement behind a
+per-front flop threshold → benchmark. Confirm `parallel_corpus_parity` stays at
+0 mismatches (it must, by construction) and that `bench` p90/worst improve on the
+large-n bucket without regressing the small-front geomean (guard the threshold).

--- a/dev/research/perf-review-2026-05-31.md
+++ b/dev/research/perf-review-2026-05-31.md
@@ -135,6 +135,54 @@ that dominate, more remainder code. Measure only after 1.1/1.2 land.
 - Verdict: out of scope. The same effort spent on Tier-1 CPU intra-front
   parallelism yields a deterministic win on the matrices that actually hurt.
 
+## 2b. Verification (2026-05-31, this session)
+
+Two probes (excluded `src/bin`, not wired into the library) test the Tier-1 #1
+claims empirically on this 4-core container.
+
+**Correctness + scaling of the parallel Schur update**
+(`src/bin/probe_intrafront_schur.rs`): a representative dense front (nrow=2048,
+n_elim=64) updated by the *production* `schur_panel_minus_nofma_strided{,_dual,_quad}`
+kernels, sequentially vs `par_chunks_mut` over disjoint trailing-column chunks.
+
+- **Bit-exact: PASS.** Byte-identical (`f64::to_bits`) to the sequential pass
+  across chunk widths {64,100,137,200,512} and thread counts {1,2,4}. The
+  chunk widths are deliberately not multiples of 4, so the quad/dual/single
+  grouping *differs* between serial and parallel — yet every element matches.
+  This confirms the claim structurally: no cross-thread reduction, so
+  determinism does not depend on thread count or partitioning.
+- **Scaling: 3.57× on 4 cores** (89% efficiency). Absolute GFLOP/s is low
+  because this container is memory-bandwidth-starved (a 33 MB `clone` runs at
+  ~1.5 GB/s); the *relative* speedup is the verified quantity. A real
+  workstation would show higher absolute throughput and similar scaling.
+
+**Premise check — which matrices actually have a dominant large front?**
+(`src/bin/probe_front_concentration.rs`, per-front cost ≈ ncol·nrow², plus
+measured symbolic vs numeric wall time):
+
+| matrix | n | largest front | top-16 flop share | symbolic | numeric | sym share |
+|--------|--:|---------------|------------------:|---------:|--------:|----------:|
+| CRESC132_0000 | 5314 | 11×11   |  6.4% | 22.2 ms |  5.7 ms | **80%** |
+| VESUVIOU_0030 | 3083 | 18×18   | 18.7% |  4.0 ms |  3.4 ms |  54% |
+| nuffield2     |26649 | 87×501  | 43.5% |  242 ms |  966 ms |  20% |
+
+**This corrects the §0 targeting.** CRESC132 and the VESUVIO family — two of the
+named worst-case ratios — are **symbolic/analysis-bound**, not large-front-bound:
+their largest front is tiny (11×11, 18×18) and analysis is 54–80% of the cost.
+**Intra-front parallelism would not help them** (it only touches numeric, and the
+fronts are too small to parallelize). The right lever for *that* population is
+Tier-2 §2.2 (symbolic-phase speedups).
+
+Intra-front parallelism pays on the **numeric-bound, large-front** population:
+nuffield2 (501-row fronts, 80% numeric) and the documented pinene_3200 (issue
+#8: ~14k-column root → 87 s). The synthetic 2048-front probe models exactly that
+root and shows the win is real and bit-exact.
+
+**Net:** the two highest-value levers are *complementary and target different
+matrices* — symbolic speedups (Tier-2 §2.2) for the small symbolic-bound tail,
+intra-front parallelism (Tier-1 §1.1) for the large numeric-bound tail. The
+earlier note over-attributed CRESC132 to the latter; measurement reassigns it.
+
 ## 3. Recommended next step
 
 Tier-1 1.1 (intra-front parallel Schur update) — highest leverage, zero

--- a/src/bin/probe_front_concentration.rs
+++ b/src/bin/probe_front_concentration.rs
@@ -1,0 +1,128 @@
+//! Premise check for the perf-review Tier-1 #1 recommendation: do real
+//! worst-case matrices have a few large fronts that dominate the numeric
+//! cost (and therefore serialize the tree-parallel driver near the root)?
+//!
+//! Per-front dense-factor cost scales ~ ncol * nrow^2. We report the
+//! supernode count, the largest front, and the share of total estimated
+//! factor flops carried by the top-1/top-4/top-16 fronts. A high top-1
+//! share means tree parallelism starves at the root and intra-front
+//! parallelism is the lever that matters.
+//!
+//! Run: `cargo run --release --bin probe_front_concentration -- <a.mtx> [b.mtx ...]`
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::read_mtx;
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use std::path::Path;
+use std::time::Instant;
+
+fn front_flops(ncol: usize, nrow: usize) -> f64 {
+    // Dense LDL^T of an nrow x nrow front eliminating ncol pivots:
+    // dominant term ~ ncol * nrow^2 (panel + trailing Schur update).
+    ncol as f64 * (nrow as f64) * (nrow as f64)
+}
+
+fn analyze(path: &str) {
+    let mtx = match read_mtx(Path::new(path)) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{path}: read_mtx failed: {e:?}");
+            return;
+        }
+    };
+    let csc = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("{path}: to_csc failed: {e:?}");
+            return;
+        }
+    };
+    // Best-of-3 symbolic time.
+    let mut t_sym = f64::INFINITY;
+    let mut sym = match symbolic_factorize(&csc, &SupernodeParams::default()) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("{path}: symbolic failed: {e:?}");
+            return;
+        }
+    };
+    for _ in 0..3 {
+        let t = Instant::now();
+        if let Ok(s) = symbolic_factorize(&csc, &SupernodeParams::default()) {
+            let dt = t.elapsed().as_secs_f64();
+            if dt < t_sym {
+                t_sym = dt;
+            }
+            sym = s;
+        }
+    }
+    // Best-of-3 numeric time (sequential driver).
+    let params = NumericParams::default();
+    let mut t_num = f64::INFINITY;
+    for _ in 0..3 {
+        let t = Instant::now();
+        if factorize_multifrontal(&csc, &sym, &params).is_ok() {
+            let dt = t.elapsed().as_secs_f64();
+            if dt < t_num {
+                t_num = dt;
+            }
+        }
+    }
+
+    let mut flops: Vec<(f64, usize, usize)> = sym
+        .supernodes
+        .iter()
+        .map(|s| (front_flops(s.ncol, s.nrow), s.ncol, s.nrow))
+        .collect();
+    let total: f64 = flops.iter().map(|x| x.0).sum();
+    flops.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let share = |k: usize| -> f64 {
+        if total <= 0.0 {
+            return 0.0;
+        }
+        flops.iter().take(k).map(|x| x.0).sum::<f64>() / total
+    };
+
+    let name = Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path);
+    let (top_flop, top_ncol, top_nrow) = flops.first().copied().unwrap_or((0.0, 0, 0));
+    println!(
+        "{name}: n={} nnz={} | {} supernodes | total est flops {:.3e}",
+        csc.n,
+        csc.row_idx.len(),
+        sym.supernodes.len(),
+        total
+    );
+    println!(
+        "   largest front: ncol={top_ncol} nrow={top_nrow}  ({:.3e} flops, {:.1}% of total)",
+        top_flop,
+        100.0 * share(1)
+    );
+    println!(
+        "   flop share: top-1 {:5.1}%   top-4 {:5.1}%   top-16 {:5.1}%",
+        100.0 * share(1),
+        100.0 * share(4),
+        100.0 * share(16),
+    );
+    let frac_sym = 100.0 * t_sym / (t_sym + t_num).max(1e-12);
+    println!(
+        "   time: symbolic {:8.3} ms   numeric {:8.3} ms   -> symbolic = {:.0}% of (sym+num)\n",
+        t_sym * 1e3,
+        t_num * 1e3,
+        frac_sym,
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        println!("usage: probe_front_concentration <a.mtx> [b.mtx ...]");
+        return;
+    }
+    for path in &args {
+        analyze(path);
+    }
+}

--- a/src/bin/probe_intrafront_schur.rs
+++ b/src/bin/probe_intrafront_schur.rs
@@ -1,0 +1,303 @@
+//! Verification probe for the perf-review Tier-1 #1 recommendation:
+//! intra-front (node-level) parallelism of the trailing Schur update.
+//!
+//! Claims under test (dev/research/perf-review-2026-05-31.md). CORRECTNESS:
+//! partitioning the trailing-column loop across threads is bit-exact for any
+//! thread count / chunk size, because each output element a[i,j] is reduced
+//! over the same pivot order on a single thread (no cross-thread reduction).
+//! PERFORMANCE: the trailing update (the O(ncol*nrow^2) cost of a large front)
+//! scales with cores.
+//!
+//! Method: build a representative dense front (column-major, the same layout
+//! as `src/dense/factor.rs`), then run the production Schur kernel
+//! (`schur_panel_minus_nofma_strided{,_dual,_quad}`) over the trailing columns
+//! two ways — `apply_seq` (one contiguous pass, mirrors
+//! `apply_blocked_schur_panel`) and `apply_par` (rayon `par_chunks_mut` over
+//! disjoint column chunks). The chunk width is deliberately NOT a multiple of
+//! 4 so the quad/dual/single grouping differs between the two paths; if the
+//! result is still bit-identical, determinism cannot depend on grouping.
+//!
+//! Not wired into the library. `src/bin` is excluded from the published
+//! crate. Run: `cargo run --release --bin probe_intrafront_schur`.
+
+use feral::dense::schur_kernel::{
+    schur_panel_minus_nofma_strided, schur_panel_minus_nofma_strided_dual,
+    schur_panel_minus_nofma_strided_quad,
+};
+use std::time::Instant;
+
+const MAX_N_ELIM: usize = 128;
+
+/// Deterministic LCG → reproducible "random" matrix values.
+struct Lcg(u64);
+impl Lcg {
+    fn next_f64(&mut self) -> f64 {
+        // Numerical Recipes LCG constants.
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        // map high bits to [-1, 1)
+        ((self.0 >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+    }
+}
+
+/// Build a front: column-major `nrow*nrow`. Columns `0..n_elim` are the
+/// "already factored" pivot panel (the L columns the update reads);
+/// columns `n_elim..nrow` are the trailing block the update writes.
+/// `d` holds the n_elim pivot diagonals (all nonzero so no alpha is
+/// skipped — worst-case work).
+fn build_front(nrow: usize, n_elim: usize, seed: u64) -> (Vec<f64>, Vec<f64>) {
+    let mut rng = Lcg(seed);
+    let mut a = vec![0.0f64; nrow * nrow];
+    for col in 0..nrow {
+        for row in col..nrow {
+            a[col * nrow + row] = rng.next_f64();
+        }
+    }
+    let mut d = vec![0.0f64; n_elim];
+    for v in d.iter_mut() {
+        let mut x = rng.next_f64();
+        if x.abs() < 1e-3 {
+            x += 1.0;
+        }
+        *v = x;
+    }
+    (a, d)
+}
+
+/// Process a contiguous range of trailing columns `[col_start, col_start+ncol)`
+/// of `block` (column-major, `ncol` columns each of length `nrow`), reading
+/// the read-only pivot panel `head` (length `n_elim*nrow`). Mirrors
+/// `apply_blocked_schur_panel`: quad → dual → single fall-through. `k = 0`.
+#[allow(clippy::too_many_arguments)]
+fn apply_range(
+    head: &[f64],
+    block: &mut [f64],
+    col_start: usize,
+    ncol: usize,
+    nrow: usize,
+    n_elim: usize,
+    d: &[f64],
+) {
+    let mut a0 = [0.0f64; MAX_N_ELIM];
+    let mut a1 = [0.0f64; MAX_N_ELIM];
+    let mut a2 = [0.0f64; MAX_N_ELIM];
+    let mut a3 = [0.0f64; MAX_N_ELIM];
+
+    let mut lc = 0usize; // column index local to `block`
+    while lc + 3 < ncol {
+        let j = col_start + lc;
+        for q in 0..n_elim {
+            let base = q * nrow;
+            let dq = d[q];
+            a0[q] = head[base + j] * dq;
+            a1[q] = head[base + j + 1] * dq;
+            a2[q] = head[base + j + 2] * dq;
+            a3[q] = head[base + j + 3] * dq;
+        }
+        let (_done, rest) = block.split_at_mut(lc * nrow);
+        let (c0, rest1) = rest.split_at_mut(nrow);
+        let (c1, rest2) = rest1.split_at_mut(nrow);
+        let (c2, c3) = rest2.split_at_mut(nrow);
+        schur_panel_minus_nofma_strided_quad(
+            &mut c0[j..],
+            &mut c1[j + 1..nrow],
+            &mut c2[j + 2..nrow],
+            &mut c3[j + 3..nrow],
+            head,
+            0,
+            n_elim,
+            nrow,
+            j,
+            &a0[..n_elim],
+            &a1[..n_elim],
+            &a2[..n_elim],
+            &a3[..n_elim],
+        );
+        lc += 4;
+    }
+    if lc + 1 < ncol {
+        let j = col_start + lc;
+        for q in 0..n_elim {
+            let base = q * nrow;
+            let dq = d[q];
+            a0[q] = head[base + j] * dq;
+            a1[q] = head[base + j + 1] * dq;
+        }
+        let (_done, rest) = block.split_at_mut(lc * nrow);
+        let (c0, c1) = rest.split_at_mut(nrow);
+        schur_panel_minus_nofma_strided_dual(
+            &mut c0[j..],
+            &mut c1[j + 1..nrow],
+            head,
+            0,
+            n_elim,
+            nrow,
+            j,
+            &a0[..n_elim],
+            &a1[..n_elim],
+        );
+        lc += 2;
+    }
+    if lc < ncol {
+        let j = col_start + lc;
+        for q in 0..n_elim {
+            a0[q] = head[q * nrow + j] * d[q];
+        }
+        let (_done, rest) = block.split_at_mut(lc * nrow);
+        let len = nrow - j;
+        schur_panel_minus_nofma_strided(
+            &mut rest[j..nrow],
+            head,
+            0,
+            n_elim,
+            nrow,
+            j,
+            len,
+            &a0[..n_elim],
+        );
+    }
+}
+
+/// Sequential: one pass over the whole trailing block.
+fn apply_seq(a: &mut [f64], nrow: usize, n_elim: usize, d: &[f64]) {
+    let (head, tail) = a.split_at_mut(n_elim * nrow);
+    let ncol = nrow - n_elim;
+    apply_range(head, tail, n_elim, ncol, nrow, n_elim, d);
+}
+
+/// Parallel: rayon over disjoint column chunks of the trailing block.
+/// `chunk_cols` is intentionally not a multiple of 4.
+fn apply_par(a: &mut [f64], nrow: usize, n_elim: usize, d: &[f64], chunk_cols: usize) {
+    use rayon::prelude::*;
+    let (head, tail) = a.split_at_mut(n_elim * nrow);
+    let head: &[f64] = head;
+    tail.par_chunks_mut(chunk_cols * nrow)
+        .enumerate()
+        .for_each(|(ci, block)| {
+            let col_start = n_elim + ci * chunk_cols;
+            let ncol = block.len() / nrow;
+            apply_range(head, block, col_start, ncol, nrow, n_elim, d);
+        });
+}
+
+fn bits_eq(a: &[f64], b: &[f64]) -> Option<usize> {
+    if a.len() != b.len() {
+        return Some(usize::MAX);
+    }
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        if x.to_bits() != y.to_bits() {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn min_time<F: FnMut()>(reps: usize, mut f: F) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..reps {
+        let t = Instant::now();
+        f();
+        let s = t.elapsed().as_secs_f64();
+        if s < best {
+            best = s;
+        }
+    }
+    best
+}
+
+fn main() {
+    let nrow = 2048usize;
+    let n_elim = 64usize;
+    let threads = rayon::current_num_threads();
+    let (pristine, d) = build_front(nrow, n_elim, 0x1234_5678_9abc_def0);
+
+    // FLOPs in one trailing update: sum over trailing cols of len*n_elim*2.
+    let flops: f64 = {
+        let mut f = 0.0;
+        for j in n_elim..nrow {
+            f += (nrow - j) as f64 * n_elim as f64 * 2.0;
+        }
+        f
+    };
+
+    println!("intra-front Schur update verification");
+    println!("  front: nrow={nrow} n_elim={n_elim}  rayon threads={threads}");
+    println!("  trailing-update flops/pass = {:.3e}\n", flops);
+
+    // ---- CORRECTNESS: seq vs par, across chunk sizes and thread counts ----
+    let mut ref_seq = pristine.clone();
+    apply_seq(&mut ref_seq, nrow, n_elim, &d);
+
+    let mut all_ok = true;
+    for &chunk in &[64usize, 100, 137, 200, 512] {
+        let mut buf = pristine.clone();
+        apply_par(&mut buf, nrow, n_elim, &d, chunk);
+        match bits_eq(&ref_seq, &buf) {
+            None => println!("  [OK ] bit-exact: par(chunk={chunk}, T={threads}) == seq"),
+            Some(i) => {
+                all_ok = false;
+                println!("  [BAD] chunk={chunk}: first differing element at flat index {i}");
+            }
+        }
+    }
+    // Thread-count invariance: 1, 2, 4 threads must all match seq.
+    for &t in &[1usize, 2, 4] {
+        if let Ok(pool) = rayon::ThreadPoolBuilder::new().num_threads(t).build() {
+            let mut buf = pristine.clone();
+            pool.install(|| apply_par(&mut buf, nrow, n_elim, &d, 137));
+            match bits_eq(&ref_seq, &buf) {
+                None => println!("  [OK ] bit-exact: par(chunk=137, T={t}) == seq"),
+                Some(i) => {
+                    all_ok = false;
+                    println!("  [BAD] T={t}: first differing element at flat index {i}");
+                }
+            }
+        }
+    }
+    println!(
+        "\n  CORRECTNESS: {}\n",
+        if all_ok {
+            "PASS (bit-identical across all configs)"
+        } else {
+            "FAIL"
+        }
+    );
+
+    // ---- PERFORMANCE: seq vs par wall time (best of N, fresh copy each rep) ----
+    let reps = 7;
+    let t_seq = min_time(reps, || {
+        let mut buf = pristine.clone();
+        apply_seq(&mut buf, nrow, n_elim, &d);
+        std::hint::black_box(&buf);
+    });
+    let t_par = min_time(reps, || {
+        let mut buf = pristine.clone();
+        apply_par(&mut buf, nrow, n_elim, &d, 137);
+        std::hint::black_box(&buf);
+    });
+    // Subtract clone cost so we time the update, not the memcpy.
+    let t_clone = min_time(reps, || {
+        let buf = pristine.clone();
+        std::hint::black_box(&buf);
+    });
+    let seq = (t_seq - t_clone).max(1e-9);
+    let par = (t_par - t_clone).max(1e-9);
+
+    println!("  clone-only           : {:8.3} ms", t_clone * 1e3);
+    println!(
+        "  seq update           : {:8.3} ms  ({:6.2} GFLOP/s)",
+        seq * 1e3,
+        flops / seq / 1e9
+    );
+    println!(
+        "  par update (T={threads})       : {:8.3} ms  ({:6.2} GFLOP/s)",
+        par * 1e3,
+        flops / par / 1e9
+    );
+    println!(
+        "  speedup              : {:8.2}x  (ideal {threads}x)",
+        seq / par
+    );
+}


### PR DESCRIPTION
## Summary

This is a research and verification session for Tier-1 #1 of the performance review: intra-front (node-level) parallelism of the trailing Schur update in dense factorization. No production code changes; adds analysis documentation and two verification probes (excluded from the published crate).

## Changes

### Documentation
- **`dev/research/perf-review-2026-05-31.md`**: Comprehensive performance review under the pure-Rust + bit-exact constraint. Maps four hot paths (dense factor/Schur kernel, parallel multifrontal driver, multi-RHS solve, symbolic), identifies that the parallel driver is tree-level only and the serial root is the ceiling (1.44×@T=8 vs 4.83× critical-path bound), and prioritizes opportunities. Key finding: intra-front parallelism of `apply_blocked_schur_panel` is bit-exact for any thread count (no cross-thread reduction) and directly attacks the worst-case ratios and parallel-speedup ceiling.

- **`dev/journal/2026-05-31-01.org`**: Session journal documenting the analysis process, key findings (two distinct tail populations: symbolic-bound small matrices vs numeric-bound large matrices), and verification results.

### Verification Probes (src/bin, excluded from published crate)

- **`src/bin/probe_intrafront_schur.rs`**: Correctness and performance verification of parallel Schur update. Builds a representative dense front (nrow=2048, n_elim=64), runs the production `schur_panel_minus_nofma_strided{,_dual,_quad}` kernels sequentially vs via `rayon::par_chunks_mut` over disjoint trailing-column chunks. Results:
  - **Bit-exact (PASS)**: Byte-identical (`f64::to_bits`) across chunk widths {64,100,137,200,512} and thread counts {1,2,4}. Chunk widths intentionally not multiples of 4 so quad/dual/single grouping differs between sequential and parallel paths — yet every element matches, confirming determinism is structural (no cross-thread reduction).
  - **Scaling**: 3.57× on 4 cores (89% efficiency). Absolute GFLOP/s is low due to container bandwidth constraints; relative speedup is the verified quantity.

- **`src/bin/probe_front_concentration.rs`**: Premise check — which real matrices have dominant large fronts? Analyzes per-front cost (~ncol·nrow²) and measures symbolic vs numeric wall time. Key finding: CRESC132_0000 (worst ratio 6.63) has largest front 11×11 and is 80% symbolic-bound, not large-front-bound. Intra-front parallelism would not help it; the right lever is Tier-2 symbolic speedups. Numeric-bound, large-front matrices (nuffield2 with 501-row fronts, documented pinene_3200 with ~14k-column root) are where intra-front parallelism pays.

## Notable Details

- The two highest-value levers are **complementary and target different populations**: symbolic speedups (Tier-2 §2.2) for small symbolic-bound matrices, intra-front parallelism (Tier-1 §1.1) for large numeric-bound matrices.
- The earlier review over-attributed CRESC132 to intra-front; measurement reassigns it to symbolic-phase optimization.
- All tests pass (315/315), parallel_parity remains green (0 mismatches), and no production code was modified.

https://claude.ai/code/session_018dPo1npsUakJrHnatys1hY