### PR TITLE
perf(dense): intra-front parallel Schur (perf-review Lever 1.1) + lever-sweep docs

### DIFF
--- a/dev/context.md
+++ b/dev/context.md
@@ -1,83 +1,83 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-05-31T15:10:34Z
+Generated: 2026-05-31T18:23:03Z
 
 ## Latest Session
-File: dev/sessions/2026-05-31-02.md
+File: dev/sessions/2026-05-31-03.md
 ```
-# Session 2026-05-31-02
+# Session 2026-05-31-03
 
 ## Goal
 
-Resolve the feral side of pounce#79: determine whether the parallel
-multifrontal driver `run_parallel_task` keeps worker-stack depth O(1) in
-elimination-tree height (or whether a deep/path-like tree can overflow a
-rayon worker's ~2 MiB stack), and either bound it or document + guard.
-Earlier in the session: review pounce#79, post the resolution comment,
-and merge feral PR #59.
+Work through the perf-review (`dev/research/perf-review-2026-05-31.md`) levers
+systematically on branch `claude/perf-levers`. For each lever: a research note,
+a with/without A/B (performance + correctness), all other tests green. User
+cadence: pause after each lever; default-ON once proven; git before/after for
+pure-kernel swaps.
 
 ## Accomplished
 
-- **pounce#79 reviewed and answered.** The per-instance parallelism
-  toggle the issue asks for already exists (`Solver::with_parallel`,
-  per-instance, Rust + Python); the only `FERAL_PARALLEL` env read is the
-  C ABI (`capi.rs:134`). The env-var dance is a pounce-side fix
-  (per-worker `with_parallel(false)`); no feral API change needed.
-  Resolution comment posted to pounce#79.
-- **feral PR #59 merged** (squash, normal merge; "perf-review: analysis
-  and verification of intra-front parallelism" — docs + two probe bins,
-  no production code).
-- **Parallel worker-stack depth: investigated → O(1) in tree height →
-  documented + guarded, no behavioral change.** The leaf→root climb in
-  `run_parallel_task` (`factorize.rs:3232`) is trampolined through
-  rayon's task queue (`scope.spawn`), not native recursion, so native
-  stack depth is O(1) in tree height. Verified structurally and by
-  measurement:
-  - c-big (n=345 241, supernode-tree height 1521 — deepest in corpus):
-    parallel factor succeeds on worker stacks all the way down to
-    **32 KiB** (~64× under the ~2 MiB default).
-  - bratu3d (height 154): factors at a requested 1 KiB stack.
-  - Every optimization/KKT corpus matrix has supernode-tree height ≤ 9.
-  Changes landed: doc section on `run_parallel_task` (`factorize.rs`);
-  regression test `deep_chain_tree_no_stack_overflow`
-  (`tests/parallel_parity.rs`, tridiagonal SPD n=8000, default ordering →
-  deep supernode chain height ~500); research note
-  `dev/research/parallel-stack-depth-pounce79.md`.
+Six levers triaged; **one implemented**, the rest deferred-with-rationale or
+found already-done. All on `claude/perf-levers` (NOT merged to main).
+
+- **Lever 1.1 — intra-front parallel Schur update: IMPLEMENTED** (`fbc3136`).
+  Parallelizes the trailing Schur update of a single dense front via
+  `tail.par_chunks_mut`, gated by `INTRAFRONT_MIN_AREA = 256*256` and a new
+  `BunchKaufmanParams::intrafront_parallel` flag (default ON on the parallel
+  driver only; the sequential driver is untouched → pounce#79
+  no-oversubscription preserved). Bit-exact by construction (each trailing
+  column reduced over ascending q on one thread; no cross-thread reduction).
+  - A/B (`bench_intrafront`, FERAL_INTRAFRONT 0 vs 1, dense SPD fronts): speedup
+    **1.2×–3.1×** (load-sensitive, bandwidth-bound), bit-exact every run.
+  - Correctness: new gate `intrafront_parallel_schur_matches_serial`;
+    `parallel_corpus_parity` full KKT corpus **0 mismatch / 41 220 factored**;
+    full suite **572 passed, 0 failed**; clippy + fmt clean.
+- **Lever 1.2 — cache blocking + L-panel packing: DEFERRED** (`eafd826`).
+  Analysis + plan complete; restructures the hot bit-exact kernel for a
+  ~10–30% bandwidth gain that is below the run-to-run noise floor on this shared
+  machine. Revisit on idle hardware: 1.2a row-band blocking, then 1.2b packing.
+- **Lever 2.1 — parallel-across-RHS solve: DEFERRED** (`5336914`). Design
+  complete; bit-exactness entangled with the nrhs≥32 kernel dispatch (BLAS-3
+  back-sub not bit-identical to rank-1), risky surgery for a narrow payoff
+  (solve already < MUMPS; IPM uses nrhs=2).
+- **Lever 2.2 — symbolic speedups: ALREADY IMPLEMENTED** (`2d576c4`, verify
+  only). Both halves live since Phase 2.4.4: MC64 cached once + reused
+  (symbolic/mod.rs:608/620, scaling/mod.rs:298-300); compression auto-dispatch
+  via `OrderingPreprocess::Auto` + `pick_ordering_preprocess`. Perf-review
+  over-stated remaining work; its "compRat≤0.7" gate is circular.
+- **Levers 3.1 (FMA fallback) + 3.2 (wider NR): DEFERRED** (`56c6e48`). 3.2 is
+  the same bandwidth wall as 1.2 (sub-noise-floor). 3.1 is ~0% on this arm64 host
+  (decisions.md 2026-04-14) and flips inertia on ~30/154k matrices; already an
+  opt-in `BunchKaufmanParams::fma` field for a future x86 measurement.
 
 ## Benchmark Results
 
-No benchmark-affecting change this session — the only source change is a
-doc comment plus a new test. `bench` numbers are unchanged from
-2026-05-31-01 (PR #59); not re-run (the test gate for doc/test-only
-changes is satisfied by the green gates below).
-
-## Decisions Made
-
-- **No behavioral change for pounce#79's feral side.** Depth is already
-  O(1) in tree height; an enlarged `ensure_parallel_pool` `stack_size`
+8-matrix `bench` (the small synthetic harness; the corpus p90 bench is the
+separate `bench_solver_corpus` walk), FERAL_INTRAFRONT OFF vs ON — all
+sub-threshold, so both take the serial refactored path:
 ```
 
 ## Git Status
 ```
-8902f0f docs+test(parallel): document O(1) worker-stack depth, add deep-tree guard (pounce#79)
-14cff66 perf-review: analysis and verification of intra-front parallelism (#59)
-cd12735 release: v0.9.0
-c51ddfd docs: notebook + book now show the batched refined win (#58)
-2e096e9 perf(solve): drop the 0-step allocations in batched refinement (#58)
+56c6e48 docs(lever-3.x): defer FMA fallback (3.1) and wider NR (3.2) with rationale
+2d576c4 docs(lever-2.2): verify symbolic speedups already implemented (Phase 2.4.4)
+5336914 docs(lever-2.1): defer parallel-across-RHS solve with design + rationale
+eafd826 docs(lever-1.2): defer cache-blocking/packing with analysis + rationale
+dc66907 docs(lever-1.1): report speedup as a load-sensitive range, not a best run
 ```
 
 ## Test Status
 ```
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::solver::tests::mc64_fallback_surfaces_via_solver_api ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test scaling::tests::auto_falls_back_to_infnorm_on_mss1_0009 ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
 test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
@@ -86,53 +86,65 @@ test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ..
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 
-test result: ok. 317 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.43s
+test result: ok. 317 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.42s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-05-31-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-05-31-03.md)
 
 
-No benchmark-affecting change this session — the only source change is a
-doc comment plus a new test. `bench` numbers are unchanged from
-2026-05-31-01 (PR #59); not re-run (the test gate for doc/test-only
-changes is satisfied by the green gates below).
+8-matrix `bench` (the small synthetic harness; the corpus p90 bench is the
+separate `bench_solver_corpus` walk), FERAL_INTRAFRONT OFF vs ON — all
+sub-threshold, so both take the serial refactored path:
+
+spd_10   off=35  on=29     kkt_10_3   off=3   on=3
+spd_50   off=20  on=20     kkt_30_10  off=25  on=25
+spd_100  off=78  on=68     kkt_50_15  off=47  on=47
+spd_200  off=389 on=362    kkt_100_30 off=130 on=130
+
+Within noise; **inertia identical** OFF vs ON on all 8. The small-front geomean
+cannot regress from 1.1: fronts below the 65 536-area gate never enter the
+parallel branch, and the serial path is the bit-exact refactor proven by
+`parallel_corpus_parity` (0 mismatch). The full corpus p90 walk
+(`bench_solver_corpus`, 169 591 matrices vs MUMPS oracle) is an hour+ run and
+timing-noisy on this contended box; not run to completion — the structural
+argument + corpus-parity bit-exactness are the load-robust evidence.
 
 ```
 
 ## Recent Decisions
-than its unrefined solve.
 
-**Decision 3 — active-column compaction each step.** Each refinement step
-gathers only the un-converged columns into the batched solve. This bounds
-the batched path at ≤ the per-column work even for heterogeneous
-convergence (most columns done in 1 step, a few needing 10), where
-solving the full batch every step would otherwise regress.
+## 2026-05-31 — Lever 2.2 (symbolic speedups) found already-implemented
 
-**Decision 4 — threshold dispatch at `BLAS3_REFINE_THRESHOLD = 16`.**
-`nrhs < 16` keeps the literal per-column loop (the IPM predictor-
-corrector, `nrhs = 2`, and other narrow refined solves stay on the
-proven, bit-identical path). 16 (below the 32 panel crossover) because
-the batched *solve* amortizes from ~16, and the batched refiner is
-provably bit-identical to the per-column loop for `16 ≤ nrhs < 32` (the
-rank-1 solve is bit-identical per column there), so there is no accuracy
-risk in that band.
+The perf-lever sweep reached Tier-2 #2 (symbolic-phase speedups: cache MC64
+across compress->scale, and auto-dispatch compression on predicted-tail
+matrices). On inspection BOTH halves are already implemented in the codebase
+("Phase 2.4.4", pre-dating this sweep): the MC64 matching is computed once and
+cached (symbolic/mod.rs:605/614) and reused by the numeric phase
+(scaling/mod.rs:298-300); compression auto-dispatch is the default via
+OrderingPreprocess::Auto + pick_ordering_preprocess (mod.rs:347-369). The
+perf-review (dev/research/perf-review-2026-05-31.md), written the same day by
+the PR#59 analysis session, over-stated the remaining work by listing these as
+future. Its further "tighter gate (compRat<=0.7)" idea is not viable as stated
+(compRat requires running MC64 to compute, so it cannot gate whether to run
+MC64). No code change; verification recorded in
+dev/research/lever-2.2-symbolic-speedups.md.
 
-**Rejected.** Global-norm refinement loop (drops per-column best-iterate
-— accuracy regression risk on near-singular columns). No compaction
-(heterogeneous-convergence perf regression). Single-pass batched SpMV for
-the residual (deferred — helps dense inputs only; per-column symv is
-cache-friendly and reuses tested code).
 
-**Measured.** Bit-identical band verified (`max|batched − per-column| ==
-0` at nrhs=24 SPD and nrhs=20 indefinite). Panel band (nrhs=64) matches
-the oracle to ≤1e-15 with per-column relative residual ≤1e-15. Lib 317
-pass; bench_multirhs refined ratio ~0.34–0.40.
+## 2026-05-31 — Levers 3.1 (FMA fallback) and 3.2 (wider NR) deferred
 
-**References.** `dev/research/issue-58-batched-refinement.md`,
-`dev/journal/2026-05-30-01.org`, issue #58.
+Both Tier-3 levers deferred (dev/research/lever-3.x-deferred.md). 3.2 (wider
+micro-kernel NR): perf-review says measure only after 1.1/1.2 land, but 1.2 is
+deferred and 3.2 attacks the same memory-bandwidth wall — wider arithmetic width
+does not help a bandwidth-bound kernel, and the gain is sub-noise-floor on this
+shared machine. 3.1 (FMA boundary-safe fallback): this host is arm64, where FMA
+measured ~0% (decisions.md 2026-04-14, 1.87->1.86) and flips inertia on ~30/154k
+boundary matrices; high-complexity fallback for ~zero gain on the only available
+hardware. fma is already an opt-in BunchKaufmanParams field for a future x86
+measurement. The perf-lever sweep thus implements Lever 1.1 only (1.2/2.1
+deferred-with-plan, 2.2 already implemented in Phase 2.4.4).
 
 ## Recent Tried-and-Rejected
 **c-block outer / m-tile inner** would keep a small `B`-block
@@ -162,6 +174,7 @@ src/bin/alloc_probe.rs
 src/bin/bench_axpy_small.rs
 src/bin/bench_dense_multirhs.rs
 src/bin/bench_fma_phase3.rs
+src/bin/bench_intrafront.rs
 src/bin/bench_issue8.rs
 src/bin/bench_multirhs.rs
 src/bin/bench_one_matrix.rs
@@ -336,17 +349,4 @@ src/symbolic/small_leaf.rs
 src/symbolic/supernode.rs
 ```
 
-## Test Files
-```
-tests/amf_corpus_oracle.rs
-tests/auto_strategy.rs
-tests/blocked_ldlt.rs
-tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering_parity.rs
-tests/column_renumbering.rs
-tests/delayed_pivoting.rs
-tests/dense_fast_path.rs
-tests/dense_ldlt.rs
-tests/factor_scratch_parity.rs
-
-(truncated from      389 lines to 350 line budget)
+(truncated from      402 lines to 350 line budget)

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -4972,3 +4972,20 @@ large-nrhs benefits, and the IPM consumer uses nrhs=2 (no benefit). Design +
 revisit plan in dev/research/lever-2.1-parallel-multirhs-solve.md. Proceeding to
 Lever 2.2 (symbolic speedups), which targets the symbolic-bound small-matrix
 p90 the corpus actually lives in.
+
+
+## 2026-05-31 — Lever 2.2 (symbolic speedups) found already-implemented
+
+The perf-lever sweep reached Tier-2 #2 (symbolic-phase speedups: cache MC64
+across compress->scale, and auto-dispatch compression on predicted-tail
+matrices). On inspection BOTH halves are already implemented in the codebase
+("Phase 2.4.4", pre-dating this sweep): the MC64 matching is computed once and
+cached (symbolic/mod.rs:605/614) and reused by the numeric phase
+(scaling/mod.rs:298-300); compression auto-dispatch is the default via
+OrderingPreprocess::Auto + pick_ordering_preprocess (mod.rs:347-369). The
+perf-review (dev/research/perf-review-2026-05-31.md), written the same day by
+the PR#59 analysis session, over-stated the remaining work by listing these as
+future. Its further "tighter gate (compRat<=0.7)" idea is not viable as stated
+(compRat requires running MC64 to compute, so it cannot gate whether to run
+MC64). No code change; verification recorded in
+dev/research/lever-2.2-symbolic-speedups.md.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -4933,3 +4933,26 @@ pass; bench_multirhs refined ratio ~0.34–0.40.
 
 **References.** `dev/research/issue-58-batched-refinement.md`,
 `dev/journal/2026-05-30-01.org`, issue #58.
+
+
+## 2026-05-31 — Lever 1.2 (cache blocking + L-panel packing) deferred
+
+The perf-lever sweep (dev/research/perf-review-2026-05-31.md) reached Tier-1 #2,
+cache blocking + L-panel packing for the dense Schur update. After tracing the
+bottleneck (L-panel re-streamed ~480x per block step at nrow=2000, ~480 MB L3
+traffic — the wall Lever 1.1 plateaued on) and writing the plan
+(dev/research/lever-1.2-cache-blocking-packing.md), the lever was DEFERRED, not
+implemented, because:
+
+1. It restructures the hot, bit-exact-tested Schur kernel (6 strided variants),
+   a higher-risk change than Lever 1.1 which wrapped the kernel unchanged.
+2. Its payoff is a ~10-30% bandwidth gain, which is below the run-to-run noise
+   floor on the shared dev machine — Lever 1.1's identical A/B swung 1.2x-2.5x
+   under contention. The win cannot be measured trustworthily here without an
+   idle machine or hardware cache-miss counters.
+
+When revisited, implement in two independently-measurable steps: 1.2a row-band
+blocking (reuse existing kernels via their src_row_offset+len params), then 1.2b
+packing only if 1.2a measurement justifies the extra copy. Lever 1.1 already
+banked the large intra-front win; 1.2 is a refinement, not a prerequisite for
+Levers 2.1/2.2/3.x. Moving on to Lever 2.1 (parallel multi-RHS solve).

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -4989,3 +4989,17 @@ future. Its further "tighter gate (compRat<=0.7)" idea is not viable as stated
 (compRat requires running MC64 to compute, so it cannot gate whether to run
 MC64). No code change; verification recorded in
 dev/research/lever-2.2-symbolic-speedups.md.
+
+
+## 2026-05-31 — Levers 3.1 (FMA fallback) and 3.2 (wider NR) deferred
+
+Both Tier-3 levers deferred (dev/research/lever-3.x-deferred.md). 3.2 (wider
+micro-kernel NR): perf-review says measure only after 1.1/1.2 land, but 1.2 is
+deferred and 3.2 attacks the same memory-bandwidth wall — wider arithmetic width
+does not help a bandwidth-bound kernel, and the gain is sub-noise-floor on this
+shared machine. 3.1 (FMA boundary-safe fallback): this host is arm64, where FMA
+measured ~0% (decisions.md 2026-04-14, 1.87->1.86) and flips inertia on ~30/154k
+boundary matrices; high-complexity fallback for ~zero gain on the only available
+hardware. fma is already an opt-in BunchKaufmanParams field for a future x86
+measurement. The perf-lever sweep thus implements Lever 1.1 only (1.2/2.1
+deferred-with-plan, 2.2 already implemented in Phase 2.4.4).

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -4956,3 +4956,19 @@ blocking (reuse existing kernels via their src_row_offset+len params), then 1.2b
 packing only if 1.2a measurement justifies the extra copy. Lever 1.1 already
 banked the large intra-front win; 1.2 is a refinement, not a prerequisite for
 Levers 2.1/2.2/3.x. Moving on to Lever 2.1 (parallel multi-RHS solve).
+
+
+## 2026-05-31 — Lever 2.1 (parallel-across-RHS solve) deferred
+
+Deferred in favour of Lever 2.2. The multi-RHS solve dispatches its kernel by
+total nrhs (use_blas3 = nrhs>=32, solve.rs:509), and the BLAS-3 back-substitution
+is not bit-identical to the rank-1 path (~1e-15 drift, documented at
+tests/multi_rhs.rs:205). Splitting the column set into sub-threshold groups for
+parallelism therefore flips the kernel and breaks bit-exactness vs the serial
+solve. A bit-exact parallel form requires threading a forced-path selector +
+column-range through all six solve kernels — risky surgery on the bit-exact
+numeric core — for a narrow payoff: the solve is already faster than MUMPS, only
+large-nrhs benefits, and the IPM consumer uses nrhs=2 (no benefit). Design +
+revisit plan in dev/research/lever-2.1-parallel-multirhs-solve.md. Proceeding to
+Lever 2.2 (symbolic speedups), which targets the symbolic-bound small-matrix
+p90 the corpus actually lives in.

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -1,0 +1,52 @@
+* 11:00 :perf:lever-1.1:plan:
+  Starting the systematic perf-lever sweep from perf-review-2026-05-31.md
+  on branch claude/perf-levers. Lever 1.1 = intra-front (node-level)
+  parallelism of the trailing Schur update in apply_blocked_schur_panel
+  (src/dense/factor.rs). Per-front dense factor is the serial ceiling
+  near the root (perf-review §0: cont-201 1.44x@T=8 vs 4.83x bound).
+  Research note: dev/research/lever-1.1-intrafront-parallel-schur.md.
+
+* 11:20 :perf:lever-1.1:design:
+  Decisions (with user): toggle is a BunchKaufmanParams field
+  (intrafront_parallel, mirrors fma), default false. Churn check: 154/164
+  BK literal sites use ..Default::default() (untouched); only ~20
+  enumerated sites needed the field (scripted insert after
+  static_pivot_floor). Coupling: ONLY the parallel driver
+  (factorize_multifrontal_supernodal_parallel) sets it true, so a serial
+  backend (with_parallel(false)) never spawns nested rayon work
+  (pounce#79 guarantee). Front-size gate INTRAFRONT_MIN_AREA=256*256 keeps
+  small fronts serial.
+
+* 11:35 :perf:lever-1.1:implement:
+  Refactored apply_blocked_schur_panel: split `a` once at j_start*nrow
+  into read-only `head` (holds the pivot panel) + mutable `tail`; the
+  per-range body apply_schur_panel_range is shared by serial and
+  par_chunks_mut dispatch. Bit-exact by construction — each trailing
+  column reduced over ascending q on one thread, no cross-thread
+  reduction (mirrors PR#59 probe_intrafront_schur, verified there across
+  chunk widths {64,100,137,200,512} and T={1,2,4}). Added FERAL_INTRAFRONT
+  env override for A/B. Lib + all targets build clean.
+
+* 11:50 :perf:lever-1.1:correctness:
+  New gate tests/parallel_parity.rs::intrafront_parallel_schur_matches_serial
+  (dense SPD n=1200 → wide root, area 72704 ≥ 65536 so the split fires;
+  forced 4-thread pool): byte-identical L/D/contrib + inertia vs sequential
+  (assert_factors_equal → assert_node_eq). PASS. parallel_corpus_parity
+  FULL kkt corpus (169591 total; 41220 factored, 128368 dense-fast-skip,
+  3 unreadable RHS-vector files): 0 mismatch. Full suite cargo test
+  --release: 572 passed, 0 failed. clippy --all-targets -D warnings clean;
+  fmt clean.
+
+* 12:05 :perf:lever-1.1:benchmark:
+  A/B (src/bin/bench_intrafront, FERAL_INTRAFRONT=0|1), 14 rayon threads,
+  synthetic dense SPD fronts:
+    dense_spd_1200: 44.93ms -> 17.97ms  2.50x  bit_exact
+    dense_spd_1600: 95.78ms -> 31.93ms  3.00x  bit_exact
+    dense_spd_2000: 183.86ms -> 62.18ms 3.08x  bit_exact
+  (idle machine; under concurrent load earlier the same A/B showed
+  1.24-2.66x — bandwidth-contended, but correctness is load-independent.)
+  Plateaus ~3x (trailing update is bandwidth-bound before the 14-thread
+  arithmetic ceiling — matches PR#59's 3.57x@4-core). Lever 1.2 (cache
+  blocking + L-panel packing) targets that bandwidth wall next.
+  Default flipped ON (parallel driver) per session decision; serial
+  driver unaffected. Lever 1.1 complete.

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -40,11 +40,16 @@
 * 12:05 :perf:lever-1.1:benchmark:
   A/B (src/bin/bench_intrafront, FERAL_INTRAFRONT=0|1), 14 rayon threads,
   synthetic dense SPD fronts:
-    dense_spd_1200: 44.93ms -> 17.97ms  2.50x  bit_exact
-    dense_spd_1600: 95.78ms -> 31.93ms  3.00x  bit_exact
-    dense_spd_2000: 183.86ms -> 62.18ms 3.08x  bit_exact
-  (idle machine; under concurrent load earlier the same A/B showed
-  1.24-2.66x — bandwidth-contended, but correctness is load-independent.)
+    dense_spd_1200: speedup 1.2-2.5x (off baseline 45-67ms across runs)
+    dense_spd_1600: speedup 2.0-3.0x
+    dense_spd_2000: speedup 2.6-3.1x
+  HONEST NOTE: speedup is load-sensitive — this is a shared bandwidth-
+  contended machine and the trailing update is memory-bandwidth-bound.
+  Repeated runs of the SAME case spanned 1.2-2.5x at n=1200. The gain is
+  real and grows with front size, but I should not present a single
+  optimistic run as definitive. Correctness is load-INDEPENDENT:
+  bit_exact=true and inertia_eq=true on every run. ~3x ceiling is
+  bandwidth, not the 14-thread arithmetic limit → Lever 1.2 target.
   Plateaus ~3x (trailing update is bandwidth-bound before the 14-thread
   arithmetic ceiling — matches PR#59's 3.57x@4-core). Lever 1.2 (cache
   blocking + L-panel packing) targets that bandwidth wall next.

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -77,3 +77,25 @@
   columns in parallel (and onto the deterministic nofma pulp path).
   Embarrassingly parallel — column c's solve is independent of column c'
   — so bit-exact by construction. A/B via bench_multirhs (already exists).
+
+* 13:00 :perf:lever-2.1:deferred:
+  Lever 2.1 (parallel-across-RHS solve) — design done
+  (dev/research/lever-2.1-parallel-multirhs-solve.md), DEFERRED in favour
+  of 2.2. Landmine: solve picks kernel by total nrhs (use_blas3 = nrhs>=32,
+  solve.rs:509) and BLAS-3 back-sub is NOT bit-identical to rank-1
+  (~1e-15 drift, documented tests/multi_rhs.rs:205). Splitting columns
+  into sub-threshold groups flips the kernel => breaks parity with serial.
+  Bit-exact form needs forced-path + column-range threaded through all 6
+  solve kernels — risky surgery on the bit-exact core, for a narrow payoff
+  (solve already < MUMPS; only helps large-nrhs; IPM uses nrhs=2 => no
+  gain). 2.2 targets the actual measured tail instead. Recorded in
+  decisions.md.
+
+* 13:05 :perf:lever-2.2:plan:
+  Starting Lever 2.2 (symbolic-phase speedups, perf-review Tier-2 #2).
+  The 154k-matrix p90-vs-MUMPS tail is symbolic-bound (KIRBY2 8.76x is
+  analysis time, not numeric; perf-review §0 + §2b). Two flagged items:
+  (a) plumb the cached MC64 matching into the ldlt_compress path to kill
+  the double-Hungarian; (b) auto-dispatch compression only on predicted-
+  tail matrices (large-n + MC64 compRat <= 0.7). Investigating the
+  symbolic/MC64/compress code now.

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -55,3 +55,25 @@
   blocking + L-panel packing) targets that bandwidth wall next.
   Default flipped ON (parallel driver) per session decision; serial
   driver unaffected. Lever 1.1 complete.
+
+* 12:40 :perf:lever-1.2:deferred:
+  Lever 1.2 (cache blocking + L-panel packing) — analysis + plan done
+  (dev/research/lever-1.2-cache-blocking-packing.md), implementation
+  DEFERRED. Traced the bottleneck: quad kernel re-streams the L-panel
+  (64 cols x nrow) once per 4 trailing cols => ~480 MB L3 traffic at
+  nrow=2000, the wall Lever 1.1 hit. Fix = row-band blocking (+ optional
+  packing), both bit-exact.
+  Deferred because (1) it restructures the hot bit-exact kernel (6 strided
+  variants) — higher risk than 1.1's wrap; (2) ~10-30% bandwidth payoff is
+  BELOW the run-to-run noise floor here (1.1's identical A/B swung 1.2-2.5x
+  under load) so it can't be measured trustworthily on this shared box.
+  Plan when revisited: 1.2a row-band blocking (reuse existing kernels via
+  src_row_offset+len), then 1.2b packing iff 1.2a justifies it. Recorded
+  in decisions.md. Moving to Lever 2.1 (parallel multi-RHS solve) — a
+  load-robust, embarrassingly-parallel-across-RHS win.
+
+* 12:45 :perf:lever-2.1:plan:
+  Starting Lever 2.1: route the multi-RHS solve across independent RHS
+  columns in parallel (and onto the deterministic nofma pulp path).
+  Embarrassingly parallel — column c's solve is independent of column c'
+  — so bit-exact by construction. A/B via bench_multirhs (already exists).

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -116,3 +116,21 @@
   compute, defeating the gate). Current cheap shape predicate is correct.
   Recorded in dev/research/lever-2.2-symbolic-speedups.md. Lever 2.2
   complete (already-done).
+
+* 13:40 :perf:lever-3.x:deferred:
+  Levers 3.2 (wider NR) and 3.1 (FMA fallback) deferred with rationale
+  (dev/research/lever-3.x-deferred.md). 3.2: same bandwidth wall as the
+  deferred 1.2 — wider arithmetic width can't help a bandwidth-bound
+  kernel until 1.2 lands, and the gain is sub-noise-floor here anyway.
+  3.1: this box is arm64 (uname -m), where FMA measured ~0% (decisions.md
+  2026-04-14, 1.87->1.86) and flips inertia on ~30/154k boundary matrices;
+  the boundary-safe fallback is high-complexity for ~zero gain on the only
+  available hardware. fma is already an opt-in BunchKaufmanParams field if
+  an x86 gap ever shows. Sweep implements 1.1 only; closing out. Recorded
+  in decisions.md.
+
+* 13:45 :perf:sweep:bench:
+  Closing the sweep: running full `cargo run --bin bench --release` to
+  confirm Lever 1.1 did not regress the small-front geomean (the gate is
+  INTRAFRONT_MIN_AREA=256*256, which should keep small fronts serial).
+  This is the evidence for the 1.1 merge decision.

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -99,3 +99,20 @@
   the double-Hungarian; (b) auto-dispatch compression only on predicted-
   tail matrices (large-n + MC64 compRat <= 0.7). Investigating the
   symbolic/MC64/compress code now.
+
+* 13:25 :perf:lever-2.2:already-done:
+  Lever 2.2 (symbolic speedups) is ALREADY IMPLEMENTED — no net-new work.
+  Verified both halves live in the codebase ("Phase 2.4.4", pre-dates this
+  sweep):
+  - Sub-A (kill double-Hungarian): MC64 computed once + cached at
+    symbolic/mod.rs:605/614; numeric reuses via scaling_from_cache
+    (scaling/mod.rs:298-300) instead of recomputing.
+  - Sub-B (auto-dispatch compression): OrderingPreprocess::Auto default
+    (supernode.rs:108,116) resolved by pick_ordering_preprocess
+    (mod.rs:347-369): compress iff n>=128 AND >=30% degree-<=2 cols.
+  The perf-review (written same day by the PR#59 session) over-stated
+  remaining work — it listed 2.2 as future but it was already landed. Its
+  "tighter gate compRat<=0.7" idea is circular (compRat needs MC64 to
+  compute, defeating the gate). Current cheap shape predicate is correct.
+  Recorded in dev/research/lever-2.2-symbolic-speedups.md. Lever 2.2
+  complete (already-done).

--- a/dev/journal/2026-05-31-03.org
+++ b/dev/journal/2026-05-31-03.org
@@ -134,3 +134,33 @@
   confirm Lever 1.1 did not regress the small-front geomean (the gate is
   INTRAFRONT_MIN_AREA=256*256, which should keep small fronts serial).
   This is the evidence for the 1.1 merge decision.
+
+* 14:05 :perf:sweep:bench:result:
+  Small-front regression check for Lever 1.1.
+  - 8-matrix `bench` (FERAL_INTRAFRONT OFF vs ON): factor times within
+    noise (spd_200 389->362us, others identical/within jitter); inertia
+    IDENTICAL on all 8 matrices. All 8 are sub-threshold (area < 256*256)
+    so both runs take the SERIAL refactored path — confirms the
+    apply_schur_panel_range refactor did not slow small fronts.
+  - Structural guarantee: fronts below INTRAFRONT_MIN_AREA never enter the
+    par_chunks_mut branch; the serial path is bit-exact to the original
+    (proven by parallel_corpus_parity: 0 mismatch / 41220 factored). So
+    the small-front geomean cannot regress from 1.1.
+  - NOTE: `cargo run --bin bench` is an 8-matrix synthetic harness, NOT
+    the corpus p90 partition. The recorded p90 numbers (small-frontal
+    1.34/1.50, medium 1.74/1.50) come from a different path; the corpus
+    walk (bench_solver_corpus / 169591 kkt matrices vs MUMPS oracle) is an
+    hour+ run and timing-noisy on this contended box, so it was not run to
+    completion — the structural argument + corpus-parity bit-exactness are
+    the load-robust evidence. CLAUDE.md's "run --bin bench" session step
+    is stale on which bin yields the partition.
+  Conclusion: 1.1 is correctness-clean with no small-front regression;
+  ready for the merge decision. Perf-lever sweep closed.
+
+* 14:10 :session:recovery:
+  Mid-checkpoint a tool-call cascade was cancelled and the branch ref
+  regressed one commit (HEAD 56c6e48 -> 2d576c4) with a clean tree — the
+  lever-3.x commit object survived intact. Recovered with `git merge
+  --ff-only 56c6e48`; verified lever-3.x-deferred.md + decisions.md
+  entries present. No work lost. Journal confirmed clean (no partial
+  heredoc writes). Session checkpoint written this entry.

--- a/dev/research/lever-1.1-intrafront-parallel-schur.md
+++ b/dev/research/lever-1.1-intrafront-parallel-schur.md
@@ -95,15 +95,22 @@ A/B via `src/bin/bench_intrafront` (`FERAL_INTRAFRONT=0|1`), synthetic dense
 diagonally-dominant SPD fronts (one wide root supernode, all 1×1 pivots — the
 Lever-1.1 fast path). Off = serial trailing update; on = `par_chunks_mut`.
 
-| matrix          | n    | off (ms) | on (ms) | speedup | bit-exact |
-|-----------------|------|---------:|--------:|--------:|-----------|
-| dense_spd_1200  | 1200 |   44.93  |  17.97  | 2.50×   | yes       |
-| dense_spd_1600  | 1600 |   95.78  |  31.93  | 3.00×   | yes       |
-| dense_spd_2000  | 2000 |  183.86  |  62.18  | 3.08×   | yes       |
+Speedup is **load-sensitive** (this is a shared, bandwidth-contended machine and
+the trailing Schur update is memory-bandwidth-bound). Across repeated runs the
+same n=1200 case ranged 1.2×–2.5×; the off-baseline itself varied 45–67 ms. The
+gain grows with front size (larger fronts amortize the fork and have more
+parallel work). Representative bracket:
 
-(Idle machine; a concurrent-load run earlier showed 1.24–2.66× — the gain is
-real but contends for memory bandwidth, so absolute speedup depends on machine
-load. Correctness is load-independent: bit-exact on every run.)
+| matrix          | n    | speedup (range over runs) | bit-exact |
+|-----------------|------|---------------------------|-----------|
+| dense_spd_1200  | 1200 | 1.2× – 2.5×                | yes       |
+| dense_spd_1600  | 1600 | 2.0× – 3.0×                | yes       |
+| dense_spd_2000  | 2000 | 2.6× – 3.1×                | yes       |
+
+Speedup magnitude depends on machine load; **correctness is load-independent —
+bit-exact and inertia-equal on every run.** The ~3× ceiling (bandwidth, not the
+14-thread arithmetic limit) is what Lever 1.2 (cache blocking + L-panel packing)
+targets next.
 
 (Speedup plateaus ~3× because the trailing update becomes memory-bandwidth-bound
 well before the 14-thread arithmetic ceiling — consistent with PR #59's

--- a/dev/research/lever-1.1-intrafront-parallel-schur.md
+++ b/dev/research/lever-1.1-intrafront-parallel-schur.md
@@ -1,0 +1,133 @@
+# Lever 1.1 — intra-front (node-level) parallel Schur update
+
+Source: `dev/research/perf-review-2026-05-31.md` §2 Tier-1 #1. This note plans
+the implementation per the FERAL feature lifecycle (research → tests → implement
+→ benchmark).
+
+## Goal
+
+The parallel multifrontal driver only parallelizes *across* fronts (tree-level).
+The dense factor of a single front runs on one thread, so near the root — where
+tree parallelism has nothing left to schedule — throughput is bounded by the
+serial root supernode (perf-review §0: cont-201 measured 1.44×@T=8 vs a 4.83×
+critical-path bound; issue #8 pinene_3200 ~14k-col root → 87 s). Adding
+*intra-front* parallelism to the trailing Schur update attacks exactly that
+serial tail.
+
+## Where
+
+`apply_blocked_schur_panel` (`src/dense/factor.rs`), the rank-`n_elim`
+all-1×1-pivot fast path reached from `apply_blocked_schur` when the panel has no
+2×2 pivots and no zero pivots. It walks trailing columns `[j_start, nrow)` in a
+quad → dual → single fall-through, each column an independent rank-`n_elim`
+update reading the read-only pivot panel `[k, k+n_elim)`.
+
+The 2×2/zero-pivot fallback in `apply_blocked_schur` stays serial: it is the
+minority case and not the throughput bottleneck on the wide near-dense roots
+(those are 1×1-dominated after pivoting).
+
+## Why it is bit-exact for any thread count
+
+Each output element `a[i,j]` is reduced over the same pivot order `q ∈ 0..n_elim`
+on a single thread. Splitting the trailing-column loop across threads introduces
+**no cross-thread reduction** — column `j` is touched by exactly one task. So the
+FP result is identical to the sequential pass regardless of how columns are
+partitioned or how many threads run. This was verified empirically in PR #59's
+`src/bin/probe_intrafront_schur.rs`: byte-identical (`f64::to_bits`) to the
+sequential pass across chunk widths {64,100,137,200,512} and T={1,2,4}, with
+chunk widths deliberately not multiples of 4 so the quad/dual/single grouping
+differs between serial and parallel yet every element matches. This
+implementation reuses that exact `apply_range` structure.
+
+## Design
+
+1. **`BunchKaufmanParams::intrafront_parallel: bool`** (default `false`), mirroring
+   `fma`. The split `a.split_at_mut(j_start * nrow)` gives a read-only `head`
+   (pivot panel + already-done columns) and a mutable `tail` (trailing columns);
+   `tail.par_chunks_mut(chunk * nrow)` runs disjoint column blocks via the same
+   per-column kernels. `fma` is honored inside each chunk.
+
+2. **Front-size gate.** Even with the flag on, only parallelize when the trailing
+   work is large enough to amortize rayon: `(nrow - j_start) * n_elim >=
+   INTRAFRONT_MIN_AREA` (calibrated in the benchmark step; start at a
+   conservative value so small fronts keep the zero-overhead serial path).
+
+3. **Coupling to the driver (no oversubscription).** Only the *parallel*
+   multifrontal driver sets `bk.intrafront_parallel = true` per front; the
+   sequential driver (reached via `Solver::with_parallel(false)`) leaves it
+   `false`. This guarantees a serial backend stays fully serial — the exact
+   property pounce#79 needs — so we never reintroduce the oversubscription that
+   issue fixed. (rayon's work-stealing makes the nested `par_chunks_mut` benign
+   when other fronts are also running: it only finds idle workers near the root,
+   which is the target.)
+
+4. **A/B knob.** `intrafront_parallel` defaults `false`, so the *with/without*
+   benchmark is one flag. Once proven bit-exact + faster, flip the parallel
+   driver to set it `true` by default (per the session decision "default ON once
+   proven").
+
+## Churn
+
+`intrafront_parallel` is added to `BunchKaufmanParams` with a `Default` value, so
+the 154 `..Default::default()` construction sites are unaffected; only the ~7
+fully-enumerated literal sites need the field.
+
+## Tests (written before implement)
+
+- `tests/parallel_parity.rs` (or a dense unit test): factor a wide front (e.g.
+  n≈600, dense SPD and an indefinite KKT front) with `intrafront_parallel`
+  off vs on; assert **bit-exact** L, D, and contrib (`f64::to_bits`) and equal
+  inertia. Run under a multi-thread pool so the parallel path actually fires.
+- All existing suites stay green, especially `parallel_parity` corpus tests and
+  `solver_parallel_factor_matches_sequential` (the bit-exact gate).
+
+## Benchmark (A/B)
+
+Wide-root subset (CRESC132 / pinene_3200 / MUONSINE / a synthetic dense root)
+and the `bench` large-n bucket: factor time with `intrafront_parallel` off vs
+on, plus a correctness check (inertia + residual identical). Record per-matrix
+speedup and confirm no regression on the small-front geomean (the gate must
+protect it). `parallel_corpus_parity` must stay at 0 mismatches by construction.
+
+## Results (2026-05-31, this machine: 14 rayon threads)
+
+A/B via `src/bin/bench_intrafront` (`FERAL_INTRAFRONT=0|1`), synthetic dense
+diagonally-dominant SPD fronts (one wide root supernode, all 1×1 pivots — the
+Lever-1.1 fast path). Off = serial trailing update; on = `par_chunks_mut`.
+
+| matrix          | n    | off (ms) | on (ms) | speedup | bit-exact |
+|-----------------|------|---------:|--------:|--------:|-----------|
+| dense_spd_1200  | 1200 |   44.93  |  17.97  | 2.50×   | yes       |
+| dense_spd_1600  | 1600 |   95.78  |  31.93  | 3.00×   | yes       |
+| dense_spd_2000  | 2000 |  183.86  |  62.18  | 3.08×   | yes       |
+
+(Idle machine; a concurrent-load run earlier showed 1.24–2.66× — the gain is
+real but contends for memory bandwidth, so absolute speedup depends on machine
+load. Correctness is load-independent: bit-exact on every run.)
+
+(Speedup plateaus ~3× because the trailing update becomes memory-bandwidth-bound
+well before the 14-thread arithmetic ceiling — consistent with PR #59's
+probe_intrafront_schur 3.57×@4-core observation. Lever 1.2 cache blocking +
+packing targets exactly this bandwidth wall.)
+
+**Correctness.** `inertia_eq=true` and byte-identical L on every A/B row.
+`parallel_corpus_parity` over the **full** `data/matrices/kkt` corpus (169 591
+total; 41 220 factored through the multifrontal path, 128 368 routed to the
+dense fast-path, 3 unreadable RHS-vector `.mtx` files): **0 mismatch**. New gate
+`tests/parallel_parity.rs::intrafront_parallel_schur_matches_serial` (dense
+n=1200, forced 4-thread pool so the split fires) asserts byte-identical L, D,
+and inertia vs the sequential driver (via `assert_factors_equal` →
+`assert_node_eq`, which covers L / d_diag / d_subdiag / contrib per supernode).
+Full suite: **572 passed, 0 failed**; `clippy --all-targets -D warnings` clean;
+`fmt --check` clean.
+
+**Default.** Per the session decision, the parallel driver now sets
+`intrafront_parallel = true` by default (ON once proven); `FERAL_INTRAFRONT=0`
+disables it for A/B and as a safety override. The sequential driver
+(`with_parallel(false)`) is unaffected — it never sets the flag.
+
+**Small-front protection.** The `INTRAFRONT_MIN_AREA = 256*256 = 65_536` gate
+keeps fronts narrower than ~1024 trailing columns (at block_size 64) on the
+zero-overhead serial path, so the small-front geomean cannot regress. The full
+`bench` was not re-run (no small-front code path changed; the serial trailing
+update is the same `apply_schur_panel_range` body, refactored bit-exactly).

--- a/dev/research/lever-1.2-cache-blocking-packing.md
+++ b/dev/research/lever-1.2-cache-blocking-packing.md
@@ -1,0 +1,106 @@
+# Lever 1.2 — cache blocking + L-panel packing for the dense Schur update
+
+**STATUS: DEFERRED (2026-05-31).** Analysis + plan complete; implementation not
+started. Deferred for two reasons documented below under "Scope, risk, and
+measurement honesty": (1) it restructures the hot, bit-exact-tested Schur kernel
+(higher risk than Lever 1.1, which only wrapped it), and (2) its payoff is a
+~10–30% *bandwidth* gain that is **below the run-to-run noise floor** on this
+shared dev machine (Lever 1.1's identical A/B swung 1.2×–2.5× under contention),
+so it cannot be measured trustworthily here. Revisit when an idle machine or a
+hardware cache-miss counter is available, implementing **1.2a (row-band
+blocking, reusing existing kernels) first, 1.2b (packing) only if 1.2a's
+measurement justifies it**. Lever 1.1 already banked the large intra-front win;
+1.2 is a refinement, not a prerequisite for the other levers.
+
+Source: `dev/research/perf-review-2026-05-31.md` §2 Tier-1 #2. Follows Lever 1.1
+(intra-front parallelism), which hit a ~3× bandwidth ceiling this note targets.
+
+## The traffic problem (measured-by-analysis)
+
+The trailing Schur update applies an `n_elim`-wide pivot panel (default
+`block_size = 64`) to every trailing column. The quad kernel
+(`schur_panel_minus_nofma_strided_quad`, `src/dense/schur_kernel.rs:1650`)
+processes trailing columns in groups of 4 and, **per group**, streams all
+`n_elim` pivot columns of `src_block` at stride `col_stride = nrow`.
+
+For a front with `nrow` rows and `n_elim = 64`:
+
+- **L-panel** = 64 columns × `nrow` × 8 B. At `nrow = 2000` ≈ **1 MB** — larger
+  than a typical 512 KB–1 MB L2, so it lives in L3, not L2.
+- The panel is re-read once per 4 trailing columns → `(nrow - 64)/4 ≈ 484`
+  times at `nrow = 2000`. That is ≈ **480 MB** of L3-bandwidth panel reads for a
+  single block step, versus ≈ 32 MB of trailing-block touch. Panel
+  re-streaming dominates — this is the bandwidth wall Lever 1.1 plateaued on.
+
+## The fix (standard GEBP-style blocking)
+
+Block the **row dimension** so a horizontal band of the panel stays L2-resident
+across all trailing columns before moving to the next band:
+
+```
+for row-band [r0, r0+RB) of the front:          # RB chosen so RB*n_elim*8 <= L2
+    # panel band  = src_block[*, r0..r0+RB]      (RB*n_elim*8 bytes, L2-resident)
+    for each trailing column j:                  # (or quad group)
+        dst[j][r0..r0+RB] -= sum_q alpha_q[j] * panel[q][r0..r0+RB]
+```
+
+Each panel band is streamed from L3→L2 once, then reused across all trailing
+columns from L2. Optionally **pack** the panel band into a contiguous
+`RB × n_elim` buffer so the inner reads are unit-stride instead of `col_stride`
+— a copy, removing the strided-gather penalty.
+
+## Bit-exactness (the hard constraint)
+
+Both transforms are bit-exact with the current kernel — and that is the whole
+reason this lever is viable:
+
+- **Row-band blocking**: reorders *which rows of which column* are computed when,
+  but each output element `dst[j][i]` is still reduced over the same ascending
+  `q = 0..n_elim` on one thread. No accumulation-order change → identical
+  IEEE-754 result. (Same argument as Lever 1.1's column partition, applied to
+  the row axis.)
+- **Packing**: a `copy` of panel entries into a contiguous buffer. The kernel
+  reads the same f64 values in the same per-element order; only their addresses
+  change. No arithmetic, no reassociation.
+
+So `parallel_corpus_parity` must stay at 0 mismatch by construction, and the
+existing `schur_kernel` bit-exactness tests remain the reference.
+
+## Scope, risk, and measurement honesty
+
+This is the **highest-risk lever** in the sweep:
+
+1. It restructures a hot, bit-exact-tested kernel (vs Lever 1.1, which wrapped
+   the kernel unchanged). Every one of the quad/dual/single + fma/nofma variants
+   (`schur_kernel.rs` has 6 strided kernels) would need a blocked form, or a
+   shared blocking layer above them.
+2. The payoff is **bandwidth**, which on this shared/contended dev machine I
+   cannot measure reliably — Lever 1.1's *same* A/B swung 1.2×–2.5× run to run.
+   A 10–30% bandwidth win (the realistic target) is below that noise floor here.
+   Trustworthy numbers need an idle machine or a controlled `perf`/cache-miss
+   counter, not wall-clock on a loaded box.
+3. RB and the pack threshold are tuning parameters that need calibration on the
+   target hardware — values picked here may not transfer.
+
+### Recommended increment (smallest bit-exact step)
+
+Do **row-band blocking first, packing second**, as two separate commits:
+
+- **1.2a — row-band blocking**, no packing. A blocking layer in
+  `apply_schur_panel_range` that loops row-bands and calls the *existing*
+  kernels on `dst[r0..r0+RB]` sub-slices with the panel addressed at the band
+  offset. Reuses the proven kernels verbatim (kernels already take a
+  `src_row_offset` + `len`, so a band is just a different offset/len — minimal
+  new code, maximal bit-exactness confidence). Calibrate `RB` for L2.
+- **1.2b — panel packing**, only if 1.2a's measurement justifies the extra copy.
+
+This keeps each step independently revertible and independently measurable, and
+front-loads the low-risk half.
+
+## A/B plan
+
+Per the session decision, kernel-swap levers use **git before/after** (no
+runtime toggle): measure `bench_intrafront` (dense fronts) and the full
+`cargo run --bin bench --release` (small-front geomean must not regress) on the
+commit before vs after, ideally on an idle machine. Gate: `parallel_corpus_parity`
+0 mismatch; full test suite green.

--- a/dev/research/lever-2.1-parallel-multirhs-solve.md
+++ b/dev/research/lever-2.1-parallel-multirhs-solve.md
@@ -1,0 +1,59 @@
+# Lever 2.1 — parallel-across-RHS multi-RHS solve
+
+**STATUS: DEFERRED (2026-05-31).** Design complete; not implemented. Deferred in
+favour of Lever 2.2 (symbolic speedups), which targets the actual measured tail.
+Rationale below.
+
+Source: `dev/research/perf-review-2026-05-31.md` §2 Tier-2 #1.
+
+## Idea
+
+The multi-RHS solve `solve_sparse_core_many_into` (`src/numeric/solve.rs:495`)
+processes all `nrhs` columns through one pass of the supernodal forward / D /
+backward substitution. RHS columns are mathematically independent, so the column
+set could be split into groups and solved on separate rayon workers.
+
+The internal working buffers `y` (`n*nrhs`) and `w` (`max_nrow*nrhs`) are
+**row-major** (issue #57), so a contiguous column *range* is not contiguous —
+but a worker could own a disjoint column range and run the full node sequence
+for just those columns with its own `w`/`acc` scratch.
+
+## Why it is deferred (not implemented)
+
+1. **Bit-exactness is entangled with the dispatch threshold.** The solve picks
+   its kernel by *total* nrhs: `use_blas3 = nrhs >= BLAS3_NRHS_THRESHOLD (32)`
+   (`solve.rs:509`). Splitting a 64-column solve into, say, 4 groups of 16 makes
+   every group fall **below** the threshold and flip to the rank-1 path.
+   Critically, the existing tests document that the BLAS-3 back-substitution is
+   **not** bit-identical to the rank-1 / single-RHS path — only "close" at
+   ~1e-15 (`tests/multi_rhs.rs:205-211`: "back-sub reorders the panel vs trailing
+   reduction, so a ~1e-15 drift is expected"). So a naive column split changes
+   the result vs the serial solve. Staying bit-exact requires threading a
+   *forced-path* selector **and** a column-range through all six solve kernels
+   (`fwd_rank1`/`fwd_blas3`/`back_rank1`/`back_blas3`/`dsolve_node` + the
+   gather/scatter) — real surgery on the bit-exact-tested numeric core.
+
+2. **Narrow payoff.** The solve is already faster than MUMPS (the perf-review
+   pain is the *factor* tail, not the solve). Parallel-across-RHS only helps
+   **large-nrhs** solves; the primary consumer — the IPM predictor-corrector —
+   uses **nrhs = 2**, which gets nothing. The perf-review itself rates this
+   "Tier-2, lower leverage for single-RHS, real for many-RHS / heavy
+   refinement."
+
+3. **Better alternative available now.** Lever 2.2 (symbolic-phase speedups)
+   targets the population the 154k-matrix p90-vs-MUMPS tail actually lives in
+   (symbolic-bound small matrices; KIRBY2 8.76× is analysis time), is
+   load-robust (removes work rather than adding threads), and does not touch the
+   numeric bit-exact path.
+
+## If revisited
+
+Implement as: an outer `solve_sparse_many_into` that, when `nrhs` is large and a
+worker pool is available, partitions columns into `g` groups, **each group sized
+to keep its own dispatch decision identical to the serial whole** (i.e. either
+keep all groups ≥ threshold, or force every group onto the same kernel the
+serial call would use), runs `solve_sparse_core_many_into` per group on disjoint
+column slices with per-group `w`/`acc` scratch, via `rayon::scope`. Gate on a
+min-nrhs and min-work threshold. Verify against `tests/multi_rhs.rs` parity plus
+a new "parallel == serial bit-exact" test that pins the forced path. A/B via
+`bench_multirhs`.

--- a/dev/research/lever-2.2-symbolic-speedups.md
+++ b/dev/research/lever-2.2-symbolic-speedups.md
@@ -1,0 +1,51 @@
+# Lever 2.2 — symbolic-phase speedups
+
+**STATUS: ALREADY IMPLEMENTED (verified 2026-05-31). No net-new work.**
+
+Source: `dev/research/perf-review-2026-05-31.md` §2 Tier-2 #2. The perf-review
+listed two symbolic-speedup items as future work; on inspection **both are
+already implemented** ("Phase 2.4.4", landed before this lever sweep began). The
+perf-review over-stated the remaining work. This note records the verification.
+
+## Sub-item A — kill the "double-Hungarian" (cache MC64 across compress→scale)
+
+**Implemented.** When the `LdltCompress` ordering preprocess runs its MC64
+symmetric matching, the matching is computed **once** and cached on the returned
+`SymbolicFactorization`, and the numeric phase reuses it for `Mc64Symmetric`
+scaling instead of recomputing:
+
+- compute once + cache: `src/symbolic/mod.rs:605` (`compute_mc64_cache`) →
+  `:614` (`cached_mc64 = Some(cache)`).
+- consume in numeric: `src/scaling/mod.rs:298-300` —
+  `ScalingStrategy::Mc64Symmetric => match cache { Some(c) =>
+  mc64::scaling_from_cache(c) /* O(n) */, None => compute_symmetric(matrix) }`.
+
+So on matrices where compression runs **and** scaling resolves to
+`Mc64Symmetric`, the Hungarian runs once, not twice. (Residual: when `Auto`
+scaling picks `InfNorm` instead, the compression MC64 has no sharing partner —
+but that is inherent, not a missing optimization; the cache cannot help a path
+that does not run MC64.)
+
+## Sub-item B — auto-dispatch compression on predicted-tail matrices
+
+**Implemented.** `OrderingPreprocess::Auto` is the default
+(`src/symbolic/supernode.rs:108,116`) and resolves per-matrix via
+`pick_ordering_preprocess` (`src/symbolic/mod.rs:347-369`): compress only when
+`n >= 128` **and** ≥30% of columns are degree-≤2 (the arrow-KKT slack
+signature). This mirrors `pick_scaling_strategy`'s `Auto`. Cheap O(nnz) shape
+scan; no MC64 needed to decide.
+
+## The perf-review's "tighter gate (compRat ≤ 0.7)" is not viable as stated
+
+The perf-review floated gating on the *MC64 compression ratio* (compRat ≤ 0.7).
+That is circular: the compression ratio is only known **after** running the MC64
+matching, so using it to decide *whether* to run MC64 defeats the purpose. The
+implemented cheap shape predicate (degree-≤2 fraction, computable without MC64)
+is the correct design. No change recommended.
+
+## Conclusion
+
+Lever 2.2 requires no implementation — it is done and on `main`. Calibration
+evidence and the geomean-stability check are in
+`dev/research/phase-2.4.4-compression-auto-dispatch.md` and the 2026-04-23
+session. Marking the lever complete (already-landed).

--- a/dev/research/lever-3.x-deferred.md
+++ b/dev/research/lever-3.x-deferred.md
@@ -1,0 +1,53 @@
+# Levers 3.1 (FMA fallback) and 3.2 (wider micro-kernel NR) — deferred
+
+**STATUS: DEFERRED (2026-05-31).** Both Tier-3 levers from
+`dev/research/perf-review-2026-05-31.md` are deferred with rationale; neither
+implemented. They are the lowest effort/reward in the sweep on this hardware.
+
+## Lever 3.2 — wider micro-kernel NR (4 → 6/8)
+
+The perf-review (§2 Tier-3 #2) already qualifies this: *"diminishing returns on
+the small fronts that dominate, more remainder code. Measure only after 1.1/1.2
+land."* Two reasons it is deferred:
+
+1. **Gated on 1.2, which is itself deferred.** Wider NR shares more of the
+   L-panel load across accumulators — but the trailing Schur update is
+   *memory-bandwidth-bound* (the wall Lever 1.1 hit and Lever 1.2 was written to
+   address). Adding arithmetic-throughput width does not help a bandwidth-bound
+   kernel until the bandwidth problem (1.2: cache blocking + packing) is solved.
+2. **Sub-noise-floor + unmeasurable here.** Like 1.2, any gain is in the 10–20%
+   band, below the run-to-run noise floor on this shared/contended machine
+   (Lever 1.1's identical A/B swung 1.2×–2.5× under load). Cannot be validated.
+
+Revisit alongside 1.2 on idle hardware with hardware counters.
+
+## Lever 3.1 — FMA with a boundary-safe fallback
+
+The perf-review (§2 Tier-3 #1) rates this "platform-dependent / low priority,
+high complexity, conditional payoff — keep opt-in." On **this** machine it is
+worse than low-priority — it is ~zero-gain with real correctness risk:
+
+1. **~0% payoff on arm64 (this box).** `uname -m` = `arm64`. Prior measurement
+   (decisions.md 2026-04-14): nofma vs FMA is 1.87 → 1.86 on the Apple-Silicon
+   target — noise. The 4 non-FMA accumulators already saturate the NEON pipes.
+   FMA is only *potentially* material on x86 AVX-512, which cannot be tested
+   here.
+2. **Correctness risk.** FMA changes rounding (single rounding of `a*b+c` vs
+   two), which flips inertia on ~30/154k boundary matrices
+   (tried-and-rejected 2026-04-14). A boundary-safe fallback
+   (detect-pivot-within-k·eps, fall back to scalar) is *required* and is
+   high-complexity — a lot of careful code to defend a benefit that is ~0% on
+   the only hardware available.
+3. **Already opt-in.** `BunchKaufmanParams::fma` exists and defaults `false`;
+   the infrastructure is present should an x86 gap ever be measured. Nothing to
+   build now.
+
+Revisit only if/when an x86 AVX-512 host shows a measured factor-time gap large
+enough to justify the boundary-safe fallback work.
+
+## Net
+
+The perf-lever sweep implements **Lever 1.1** (intra-front parallel Schur);
+1.2/2.1 are deferred-with-plan, 2.2 was already implemented (Phase 2.4.4), and
+3.1/3.2 are deferred here. 1.1 is the one net-new win and the right stopping
+point for this hardware.

--- a/dev/sessions/2026-05-31-03.md
+++ b/dev/sessions/2026-05-31-03.md
@@ -1,0 +1,95 @@
+# Session 2026-05-31-03
+
+## Goal
+
+Work through the perf-review (`dev/research/perf-review-2026-05-31.md`) levers
+systematically on branch `claude/perf-levers`. For each lever: a research note,
+a with/without A/B (performance + correctness), all other tests green. User
+cadence: pause after each lever; default-ON once proven; git before/after for
+pure-kernel swaps.
+
+## Accomplished
+
+Six levers triaged; **one implemented**, the rest deferred-with-rationale or
+found already-done. All on `claude/perf-levers` (NOT merged to main).
+
+- **Lever 1.1 — intra-front parallel Schur update: IMPLEMENTED** (`fbc3136`).
+  Parallelizes the trailing Schur update of a single dense front via
+  `tail.par_chunks_mut`, gated by `INTRAFRONT_MIN_AREA = 256*256` and a new
+  `BunchKaufmanParams::intrafront_parallel` flag (default ON on the parallel
+  driver only; the sequential driver is untouched → pounce#79
+  no-oversubscription preserved). Bit-exact by construction (each trailing
+  column reduced over ascending q on one thread; no cross-thread reduction).
+  - A/B (`bench_intrafront`, FERAL_INTRAFRONT 0 vs 1, dense SPD fronts): speedup
+    **1.2×–3.1×** (load-sensitive, bandwidth-bound), bit-exact every run.
+  - Correctness: new gate `intrafront_parallel_schur_matches_serial`;
+    `parallel_corpus_parity` full KKT corpus **0 mismatch / 41 220 factored**;
+    full suite **572 passed, 0 failed**; clippy + fmt clean.
+- **Lever 1.2 — cache blocking + L-panel packing: DEFERRED** (`eafd826`).
+  Analysis + plan complete; restructures the hot bit-exact kernel for a
+  ~10–30% bandwidth gain that is below the run-to-run noise floor on this shared
+  machine. Revisit on idle hardware: 1.2a row-band blocking, then 1.2b packing.
+- **Lever 2.1 — parallel-across-RHS solve: DEFERRED** (`5336914`). Design
+  complete; bit-exactness entangled with the nrhs≥32 kernel dispatch (BLAS-3
+  back-sub not bit-identical to rank-1), risky surgery for a narrow payoff
+  (solve already < MUMPS; IPM uses nrhs=2).
+- **Lever 2.2 — symbolic speedups: ALREADY IMPLEMENTED** (`2d576c4`, verify
+  only). Both halves live since Phase 2.4.4: MC64 cached once + reused
+  (symbolic/mod.rs:608/620, scaling/mod.rs:298-300); compression auto-dispatch
+  via `OrderingPreprocess::Auto` + `pick_ordering_preprocess`. Perf-review
+  over-stated remaining work; its "compRat≤0.7" gate is circular.
+- **Levers 3.1 (FMA fallback) + 3.2 (wider NR): DEFERRED** (`56c6e48`). 3.2 is
+  the same bandwidth wall as 1.2 (sub-noise-floor). 3.1 is ~0% on this arm64 host
+  (decisions.md 2026-04-14) and flips inertia on ~30/154k matrices; already an
+  opt-in `BunchKaufmanParams::fma` field for a future x86 measurement.
+
+## Benchmark Results
+
+8-matrix `bench` (the small synthetic harness; the corpus p90 bench is the
+separate `bench_solver_corpus` walk), FERAL_INTRAFRONT OFF vs ON — all
+sub-threshold, so both take the serial refactored path:
+
+```
+spd_10   off=35  on=29     kkt_10_3   off=3   on=3
+spd_50   off=20  on=20     kkt_30_10  off=25  on=25
+spd_100  off=78  on=68     kkt_50_15  off=47  on=47
+spd_200  off=389 on=362    kkt_100_30 off=130 on=130
+```
+
+Within noise; **inertia identical** OFF vs ON on all 8. The small-front geomean
+cannot regress from 1.1: fronts below the 65 536-area gate never enter the
+parallel branch, and the serial path is the bit-exact refactor proven by
+`parallel_corpus_parity` (0 mismatch). The full corpus p90 walk
+(`bench_solver_corpus`, 169 591 matrices vs MUMPS oracle) is an hour+ run and
+timing-noisy on this contended box; not run to completion — the structural
+argument + corpus-parity bit-exactness are the load-robust evidence.
+
+## Decisions Made
+
+- Implement Lever 1.1 only; defer 1.2/2.1/3.1/3.2 with documented rationale;
+  2.2 already done. All deferrals recorded in `dev/decisions.md` (2026-05-31
+  entries) with revisit conditions. The sweep is bounded by this machine's
+  memory bandwidth (most remaining levers are bandwidth-bound, sub-noise-floor
+  here) and arm64 (FMA ~0%).
+- 1.1 stays committed default-ON on the branch, **not yet merged**; evaluate
+  this checkpoint before merging.
+
+## Abandoned Approaches
+
+None abandoned mid-implementation. 1.2/2.1/3.1/3.2 were triaged out before
+coding on effort/reward and measurability grounds, each with a revisit plan in
+`dev/decisions.md` and a `dev/research/lever-*.md` note.
+
+## Next Session Should
+
+- Decide whether to merge `claude/perf-levers` (Lever 1.1) to main; open a PR if
+  accepted.
+- If an idle machine / hardware counters become available: revisit Lever 1.2
+  (1.2a row-band blocking first) — the highest-value deferred item, since it
+  lifts the ~3× bandwidth ceiling 1.1 hit.
+
+## Tests
+
+- `cargo test --release`: 572 passed, 0 failed.
+- `parallel_corpus_parity` (full KKT corpus): 0 mismatch / 41 220 factored.
+- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean.

--- a/src/bin/bench_intrafront.rs
+++ b/src/bin/bench_intrafront.rs
@@ -1,0 +1,147 @@
+//! Lever 1.1 A/B benchmark: intra-front parallel Schur update.
+//!
+//! Times the parallel multifrontal driver on wide-front matrices with
+//! the intra-front parallelism OFF vs ON, and checks the results are
+//! bit-identical (inertia + a residual). The toggle is the
+//! `FERAL_INTRAFRONT` env var honored by
+//! `factorize_multifrontal_supernodal_parallel`.
+//!
+//! Two matrix sources:
+//!   * synthetic dense diagonally-dominant SPD fronts (n given by
+//!     `SIZES`, default 1200,1600,2000) — a single wide root supernode,
+//!     the case Lever 1.1 targets;
+//!   * any `.mtx` paths passed as CLI args (e.g. a wide-root KKT).
+//!
+//! Run:
+//!   cargo run --release --bin bench_intrafront
+//!   cargo run --release --bin bench_intrafront -- path/to/a.mtx ...
+
+use std::path::Path;
+use std::time::Instant;
+
+use feral::numeric::factorize::{factorize_multifrontal_supernodal_parallel, NumericParams};
+use feral::read_mtx;
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::CscMatrix;
+
+fn dense_spd(n: usize) -> CscMatrix {
+    let cap = n * (n + 1) / 2;
+    let mut rows = Vec::with_capacity(cap);
+    let mut cols = Vec::with_capacity(cap);
+    let mut vals = Vec::with_capacity(cap);
+    for c in 0..n {
+        rows.push(c);
+        cols.push(c);
+        vals.push(n as f64 + 1.0);
+        for r in (c + 1)..n {
+            rows.push(r);
+            cols.push(c);
+            vals.push(1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("dense SPD triplets")
+}
+
+fn min_time<F: FnMut()>(reps: usize, mut f: F) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..reps {
+        let t = Instant::now();
+        f();
+        let s = t.elapsed().as_secs_f64();
+        if s < best {
+            best = s;
+        }
+    }
+    best
+}
+
+fn bench_one(label: &str, a: &CscMatrix) {
+    let sym = match symbolic_factorize(a, &SupernodeParams::default()) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("{label}: symbolic failed: {e:?}");
+            return;
+        }
+    };
+    let params = NumericParams::default();
+    let reps = 3;
+
+    // OFF
+    std::env::set_var("FERAL_INTRAFRONT", "0");
+    let (off_f, off_i) = factorize_multifrontal_supernodal_parallel(a, &sym, &params)
+        .expect("factor (intrafront off)");
+    let t_off = min_time(reps, || {
+        let _ = factorize_multifrontal_supernodal_parallel(a, &sym, &params).unwrap();
+    });
+
+    // ON
+    std::env::set_var("FERAL_INTRAFRONT", "1");
+    let (on_f, on_i) = factorize_multifrontal_supernodal_parallel(a, &sym, &params)
+        .expect("factor (intrafront on)");
+    let t_on = min_time(reps, || {
+        let _ = factorize_multifrontal_supernodal_parallel(a, &sym, &params).unwrap();
+    });
+    std::env::remove_var("FERAL_INTRAFRONT");
+
+    // Correctness: inertia equal, per-supernode L bit-identical.
+    let inertia_ok = off_i == on_i;
+    let mut bits_ok = true;
+    let (offc, onc) = (&off_f.node_factors, &on_f.node_factors);
+    if offc.len() != onc.len() {
+        bits_ok = false;
+    } else {
+        for (s, p) in offc.iter().zip(onc.iter()) {
+            let (sl, pl) = (&s.frontal_factors.l, &p.frontal_factors.l);
+            if sl.len() != pl.len()
+                || sl
+                    .iter()
+                    .zip(pl.iter())
+                    .any(|(x, y)| x.to_bits() != y.to_bits())
+            {
+                bits_ok = false;
+                break;
+            }
+        }
+    }
+
+    let speedup = t_off / t_on;
+    println!(
+        "{label:<22} n={:<7} off={:8.2}ms on={:8.2}ms  speedup={:5.2}x  inertia_eq={} bit_exact={}",
+        a.n,
+        t_off * 1e3,
+        t_on * 1e3,
+        speedup,
+        inertia_ok,
+        bits_ok,
+    );
+}
+
+fn main() {
+    let threads = rayon::current_num_threads();
+    println!("intra-front Schur A/B (rayon threads = {threads})\n");
+    println!("matrix                 n              off          on         speedup correctness");
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        let sizes = std::env::var("SIZES").unwrap_or_else(|_| "1200,1600,2000".to_string());
+        for tok in sizes.split(',') {
+            if let Ok(n) = tok.trim().parse::<usize>() {
+                let a = dense_spd(n);
+                bench_one(&format!("dense_spd_{n}"), &a);
+            }
+        }
+    } else {
+        for path in &args {
+            match read_mtx(Path::new(path)).and_then(|m| m.to_csc()) {
+                Ok(a) => {
+                    let name = Path::new(path)
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(path);
+                    bench_one(name, &a);
+                }
+                Err(e) => println!("{path}: load failed: {e:?}"),
+            }
+        }
+    }
+}

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -585,7 +585,33 @@ pub struct BunchKaufmanParams {
     ///
     /// See `dev/research/static-pivot-perturbation-2026-05-17.md`.
     pub static_pivot_floor: f64,
+
+    /// Opt-in intra-front (node-level) parallelism for the trailing
+    /// Schur update of a single dense front. Default `false` keeps the
+    /// serial trailing update. When `true` **and** the trailing work
+    /// clears `INTRAFRONT_MIN_AREA`, the all-1×1-pivot fast path
+    /// (`apply_blocked_schur_panel`) splits its trailing-column loop
+    /// across rayon workers with `par_chunks_mut`.
+    ///
+    /// Bit-exact regardless of thread count: each trailing column is
+    /// reduced over the same pivot order on a single thread, so there
+    /// is no cross-thread reduction (verified in
+    /// `src/bin/probe_intrafront_schur.rs`, PR #59). Mirrors `fma`: the
+    /// sparse multifrontal *parallel* driver copies a per-call value
+    /// here; the *sequential* driver leaves it `false`, so a serial
+    /// backend (`Solver::with_parallel(false)`) never spawns nested
+    /// rayon work (pounce#79 oversubscription guarantee). See
+    /// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
+    pub intrafront_parallel: bool,
 }
+
+/// Minimum trailing-update area `(nrow - j_start) * n_elim` below which
+/// the intra-front parallel Schur path stays serial even when
+/// [`BunchKaufmanParams::intrafront_parallel`] is set. Small fronts do
+/// not amortize the rayon fork/join; this floor keeps them on the
+/// zero-overhead serial path. Calibrated in
+/// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
+pub const INTRAFRONT_MIN_AREA: usize = 256 * 256;
 
 /// Action to take when a near-zero pivot is encountered.
 #[derive(Debug, Clone)]
@@ -709,6 +735,7 @@ impl Default for BunchKaufmanParams {
             fma: false,
             tpp_method: TppMethod::Plain,
             static_pivot_floor: 0.0,
+            intrafront_parallel: false,
         }
     }
 }
@@ -2002,7 +2029,15 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
         };
         let _pt = phase_timing::start();
         apply_blocked_schur(
-            &mut *a, nrow, k, n_elim, j_start, &*d_panel, &*subdiag, params.fma,
+            &mut *a,
+            nrow,
+            k,
+            n_elim,
+            j_start,
+            &*d_panel,
+            &*subdiag,
+            params.fma,
+            params.intrafront_parallel,
         );
         phase_timing::stop(&phase_timing::SCHUR_NS, _pt);
         k += n_elim;
@@ -2855,6 +2890,7 @@ fn apply_blocked_schur(
     d_panel: &[f64],
     subdiag: &[f64],
     fma: bool,
+    intrafront_parallel: bool,
 ) {
     if n_elim == 0 || j_start >= nrow {
         return;
@@ -2873,7 +2909,16 @@ fn apply_blocked_schur(
     let has_2x2 = subdiag[k..k + n_elim].iter().any(|&s| s != 0.0);
 
     if !any_zero_d && !has_2x2 && n_elim >= W2_RANK_BS_MIN {
-        apply_blocked_schur_panel(a, nrow, k, n_elim, j_start, d_panel, fma);
+        apply_blocked_schur_panel(
+            a,
+            nrow,
+            k,
+            n_elim,
+            j_start,
+            d_panel,
+            fma,
+            intrafront_parallel,
+        );
         return;
     }
 
@@ -2954,6 +2999,7 @@ fn apply_blocked_schur(
 /// Bit-exactness contract: per-element, the SIMD body issues
 /// `acc <- round(acc - round(alpha_q * src_q[i]))` for q in ascending
 /// order, the same sequence as the rank-1 reference.
+#[allow(clippy::too_many_arguments)]
 fn apply_blocked_schur_panel(
     a: &mut [f64],
     nrow: usize,
@@ -2962,6 +3008,7 @@ fn apply_blocked_schur_panel(
     j_start: usize,
     d_panel: &[f64],
     fma: bool,
+    intrafront_parallel: bool,
 ) {
     // Stack-friendly upper bound on n_elim. Sized at 128 to cover
     // the default `params.block_size = 64` and the larger panels
@@ -2975,46 +3022,103 @@ fn apply_blocked_schur_panel(
     // panic from the `[..n_elim]` slice below. The named assertion
     // gives a clear failure mode if anyone ever raises block_size
     // past this new ceiling.
+    // The trailing columns [j_start, nrow) are each an independent
+    // rank-`n_elim` update reading only the pivot panel columns
+    // [k, k+n_elim) -- all of which precede `j_start` in column-major
+    // memory. Split once at `j_start * nrow`: `head` is the read-only
+    // source prefix (it contains the panel) and `tail` the mutable
+    // trailing block. The per-range body is bit-exact regardless of how
+    // `tail` is partitioned (each column reduced over ascending q on a
+    // single thread; no cross-thread reduction), so the serial pass and
+    // any `par_chunks_mut` split produce byte-identical results --
+    // verified in `src/bin/probe_intrafront_schur.rs` (PR #59).
+    let (head, tail) = a.split_at_mut(j_start * nrow);
+    let head: &[f64] = head;
+
+    let area = (nrow - j_start).saturating_mul(n_elim);
+    if intrafront_parallel && area >= INTRAFRONT_MIN_AREA {
+        use rayon::prelude::*;
+        let ncol = nrow - j_start;
+        let nthreads = rayon::current_num_threads().max(1);
+        // ~4 chunks per worker for load balance. Bit-exactness does not
+        // depend on chunk size (each column reduced on one thread), so
+        // this is purely a scheduling knob.
+        let chunk_cols = ncol.div_ceil(nthreads * 4).max(1);
+        tail.par_chunks_mut(chunk_cols * nrow)
+            .enumerate()
+            .for_each(|(ci, block)| {
+                let col_start = j_start + ci * chunk_cols;
+                apply_schur_panel_range(head, block, col_start, nrow, k, n_elim, d_panel, fma);
+            });
+    } else {
+        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, fma);
+    }
+}
+
+/// Apply the panel's deferred rank-`n_elim` updates to one contiguous
+/// block of trailing columns `[col_start, col_start + block.len()/nrow)`.
+///
+/// `head` is the read-only front prefix `a[0 .. j_start*nrow]` holding
+/// the pivot panel columns `[k, k+n_elim)`; `block` is the mutable slice
+/// of trailing columns to update. Shared per-range body for the serial
+/// and intra-front-parallel dispatch in [`apply_blocked_schur_panel`].
+///
+/// Bit-exact with the pre-refactor single-pass loop: identical alpha
+/// values (`l * d`, same order), identical quad/dual/single kernel
+/// dispatch, identical ascending-`q` accumulation, identical all-zero
+/// skip. Because `head` always covers the full panel
+/// (`col_start >= j_start >= k + n_elim`), the kernels read the same
+/// source bytes for every column regardless of which column is written --
+/// that is what makes any column partition valid.
+///
+/// `MAX_N_ELIM = 128` upper-bounds the on-stack alpha buffers. The
+/// `assert!` (not `debug_assert!`) is intentional: prior to issue #36 a
+/// release build with `block_size > 64` produced a cryptic out-of-range
+/// slice panic; the named assertion gives a clear failure mode if anyone
+/// ever raises `block_size` past this ceiling.
+#[allow(clippy::too_many_arguments)]
+fn apply_schur_panel_range(
+    head: &[f64],
+    block: &mut [f64],
+    col_start: usize,
+    nrow: usize,
+    k: usize,
+    n_elim: usize,
+    d_panel: &[f64],
+    fma: bool,
+) {
     const MAX_N_ELIM: usize = 128;
     assert!(
         n_elim <= MAX_N_ELIM,
-        "apply_blocked_schur_panel: n_elim {} exceeds MAX_N_ELIM {}",
+        "apply_schur_panel_range: n_elim {} exceeds MAX_N_ELIM {}",
         n_elim,
         MAX_N_ELIM
     );
+    let ncol = block.len() / nrow;
 
     let mut alphas0_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas1_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas2_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas3_buf = [0.0f64; MAX_N_ELIM];
 
-    // Phase 2.4.3 (issue #9, re-scoped): walk trailing columns in
-    // groups of 4, dispatching the quad-column kernel that shares
-    // each src-vector load across 4 destination accumulators. Each
-    // quad is bit-exact with four sequential single-column dispatches
-    // (verified by the quad kernel's bit-exactness sweep).
-    //
-    // Fall-through: 2-or-3-column remainder uses dual + (optional)
-    // single; 0-or-1-column remainder uses single.
-    let mut j = j_start;
-    while j + 3 < nrow {
+    // Walk this block's trailing columns in groups of 4 (quad kernel),
+    // then a 2-column dual remainder, then a 1-column single remainder --
+    // the same fall-through as the original single-pass loop.
+    let mut lc = 0usize;
+    while lc + 3 < ncol {
+        let j = col_start + lc;
         let alphas0 = &mut alphas0_buf[..n_elim];
         let alphas1 = &mut alphas1_buf[..n_elim];
         let alphas2 = &mut alphas2_buf[..n_elim];
         let alphas3 = &mut alphas3_buf[..n_elim];
         let mut all_zero = true;
         for q in 0..n_elim {
-            let q_col = k + q;
-            let base = q_col * nrow;
-            let l_jk0 = a[base + j];
-            let l_jk1 = a[base + j + 1];
-            let l_jk2 = a[base + j + 2];
-            let l_jk3 = a[base + j + 3];
+            let base = (k + q) * nrow;
             let d_q = d_panel[q];
-            let alpha0 = l_jk0 * d_q;
-            let alpha1 = l_jk1 * d_q;
-            let alpha2 = l_jk2 * d_q;
-            let alpha3 = l_jk3 * d_q;
+            let alpha0 = head[base + j] * d_q;
+            let alpha1 = head[base + j + 1] * d_q;
+            let alpha2 = head[base + j + 2] * d_q;
+            let alpha3 = head[base + j + 3] * d_q;
             alphas0[q] = alpha0;
             alphas1[q] = alpha1;
             alphas2[q] = alpha2;
@@ -3024,12 +3128,7 @@ fn apply_blocked_schur_panel(
             }
         }
         if !all_zero {
-            // Carve out four disjoint mutable slices. The src pivot
-            // columns [k, k+n_elim) all precede column j in memory,
-            // so a single split at j*nrow gives src in `before`.
-            // Three nested splits inside `rest` separate columns
-            // j, j+1, j+2, j+3.
-            let (before, rest) = a.split_at_mut(j * nrow);
+            let (_done, rest) = block.split_at_mut(lc * nrow);
             let (col_j, rest1) = rest.split_at_mut(nrow);
             let (col_j1, rest2) = rest1.split_at_mut(nrow);
             let (col_j2, col_j3_and_after) = rest2.split_at_mut(nrow);
@@ -3039,32 +3138,29 @@ fn apply_blocked_schur_panel(
             let dst3 = &mut col_j3_and_after[(j + 3)..nrow];
             if fma {
                 schur_kernel::schur_panel_minus_fma_strided_quad(
-                    dst0, dst1, dst2, dst3, before, k, n_elim, nrow, j, alphas0, alphas1, alphas2,
+                    dst0, dst1, dst2, dst3, head, k, n_elim, nrow, j, alphas0, alphas1, alphas2,
                     alphas3,
                 );
             } else {
                 schur_kernel::schur_panel_minus_nofma_strided_quad(
-                    dst0, dst1, dst2, dst3, before, k, n_elim, nrow, j, alphas0, alphas1, alphas2,
+                    dst0, dst1, dst2, dst3, head, k, n_elim, nrow, j, alphas0, alphas1, alphas2,
                     alphas3,
                 );
             }
         }
-        j += 4;
+        lc += 4;
     }
 
-    // 2-or-3-column remainder: use dual to consume the next pair, if
-    // any. After this, at most 1 column remains.
-    if j + 1 < nrow {
+    if lc + 1 < ncol {
+        let j = col_start + lc;
         let alphas0 = &mut alphas0_buf[..n_elim];
         let alphas1 = &mut alphas1_buf[..n_elim];
         let mut all_zero = true;
         for q in 0..n_elim {
-            let q_col = k + q;
-            let l_jk0 = a[q_col * nrow + j];
-            let l_jk1 = a[q_col * nrow + j + 1];
+            let base = (k + q) * nrow;
             let d_q = d_panel[q];
-            let alpha0 = l_jk0 * d_q;
-            let alpha1 = l_jk1 * d_q;
+            let alpha0 = head[base + j] * d_q;
+            let alpha1 = head[base + j + 1] * d_q;
             alphas0[q] = alpha0;
             alphas1[q] = alpha1;
             if alpha0 != 0.0 || alpha1 != 0.0 {
@@ -3072,33 +3168,30 @@ fn apply_blocked_schur_panel(
             }
         }
         if !all_zero {
-            let (before, rest) = a.split_at_mut(j * nrow);
+            let (_done, rest) = block.split_at_mut(lc * nrow);
             let (col_j, after_j) = rest.split_at_mut(nrow);
             let dst0 = &mut col_j[j..];
             let dst1 = &mut after_j[(j + 1)..nrow];
             if fma {
                 schur_kernel::schur_panel_minus_fma_strided_dual(
-                    dst0, dst1, before, k, n_elim, nrow, j, alphas0, alphas1,
+                    dst0, dst1, head, k, n_elim, nrow, j, alphas0, alphas1,
                 );
             } else {
                 schur_kernel::schur_panel_minus_nofma_strided_dual(
-                    dst0, dst1, before, k, n_elim, nrow, j, alphas0, alphas1,
+                    dst0, dst1, head, k, n_elim, nrow, j, alphas0, alphas1,
                 );
             }
         }
-        j += 2;
+        lc += 2;
     }
 
-    if j < nrow {
-        // Odd remainder: one trailing column. Fall back to the
-        // single-column kernel.
+    if lc < ncol {
+        let j = col_start + lc;
         let alphas = &mut alphas0_buf[..n_elim];
         let mut all_zero_alpha = true;
         for q in 0..n_elim {
-            let q_col = k + q;
-            let l_jk = a[q_col * nrow + j];
-            let d_q = d_panel[q];
-            let alpha = l_jk * d_q;
+            let base = (k + q) * nrow;
+            let alpha = head[base + j] * d_panel[q];
             alphas[q] = alpha;
             if alpha != 0.0 {
                 all_zero_alpha = false;
@@ -3106,12 +3199,12 @@ fn apply_blocked_schur_panel(
         }
         if !all_zero_alpha {
             let trailing_len = nrow - j;
-            let (before, rest) = a.split_at_mut(j * nrow);
+            let (_done, rest) = block.split_at_mut(lc * nrow);
             let dst = &mut rest[j..nrow];
             if fma {
                 schur_kernel::schur_panel_minus_fma_strided(
                     dst,
-                    before,
+                    head,
                     k,
                     n_elim,
                     nrow,
@@ -3122,7 +3215,7 @@ fn apply_blocked_schur_panel(
             } else {
                 schur_kernel::schur_panel_minus_nofma_strided(
                     dst,
-                    before,
+                    head,
                     k,
                     n_elim,
                     nrow,

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -2801,6 +2801,30 @@ pub fn factorize_multifrontal_supernodal_parallel(
     use std::sync::atomic::Ordering;
     use std::sync::Mutex;
 
+    // Lever 1.1: enable intra-front (node-level) parallelism in the
+    // per-front dense Schur update. This is set ONLY here, on the
+    // parallel driver, so a serial backend — `Solver::with_parallel(false)`,
+    // which routes to `factorize_multifrontal_supernodal_with_workspace`
+    // — leaves `intrafront_parallel = false` and never spawns nested
+    // rayon work (the pounce#79 oversubscription guarantee). The dense
+    // kernel further gates on `INTRAFRONT_MIN_AREA`, so only wide fronts
+    // actually fork. Bit-exact regardless of thread count (see
+    // `apply_schur_panel_range`). See
+    // `dev/research/lever-1.1-intrafront-parallel-schur.md`.
+    // `FERAL_INTRAFRONT=0|off|false` disables Lever 1.1 for A/B
+    // benchmarking and as a safety override; default on. Read once per
+    // factorization (negligible beside the factor cost), mirroring the
+    // `FERAL_PARALLEL` diagnostic affordance.
+    let intrafront_on = !matches!(
+        std::env::var("FERAL_INTRAFRONT").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("no")
+    );
+    let params = &{
+        let mut p = params.clone();
+        p.bk.intrafront_parallel = intrafront_on;
+        p
+    };
+
     let n = symbolic.n;
     let n_snodes = symbolic.supernodes.len();
     let telemetry = params.parallel_telemetry.as_deref();

--- a/tests/parallel_parity.rs
+++ b/tests/parallel_parity.rs
@@ -233,3 +233,66 @@ fn deep_chain_tree_no_stack_overflow() {
     assert_inertia_eq(&seq_inertia, &par_inertia, "deep-chain/total");
     assert_factors_equal(&seq_factors, &par_factors, "deep-chain");
 }
+
+/// Lever 1.1 gate: the intra-front parallel Schur update must be
+/// bit-exact with the serial path, and the parallel path must actually
+/// fire (a front wide enough to clear `INTRAFRONT_MIN_AREA = 256*256`).
+///
+/// A dense, diagonally dominant SPD matrix factorizes into a single wide
+/// root supernode of all-1×1 pivots — exactly the
+/// `apply_blocked_schur_panel` fast path that Lever 1.1 parallelizes.
+/// With `n = 1200`, the first 64-wide panel has trailing area
+/// `(1200 - 64) * 64 = 72_704 >= 65_536`, so the `par_chunks_mut` branch
+/// runs. We force a 4-thread pool so the split executes even on a
+/// single-core CI, then assert the parallel driver (intra-front ON, set
+/// internally) is byte-identical to the sequential driver (intra-front
+/// OFF) on L, D, and inertia. Bit-exactness is structural — each
+/// trailing column is reduced on one thread — so any thread count or
+/// chunk partition must match. See
+/// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
+#[test]
+fn intrafront_parallel_schur_matches_serial() {
+    let n = 1200usize;
+    // Dense lower triangle (row >= col). Diagonally dominant ⇒ SPD ⇒
+    // all 1×1 pivots, no 2×2, no zero pivots — routes through the
+    // rank-`n_elim` panel fast path that Lever 1.1 parallelizes.
+    let mut rows = Vec::with_capacity(n * (n + 1) / 2);
+    let mut cols = Vec::with_capacity(n * (n + 1) / 2);
+    let mut vals = Vec::with_capacity(n * (n + 1) / 2);
+    for c in 0..n {
+        rows.push(c);
+        cols.push(c);
+        vals.push(n as f64 + 1.0); // diagonal dominates the n-1 unit off-diagonals
+        for r in (c + 1)..n {
+            rows.push(r);
+            cols.push(c);
+            vals.push(1.0);
+        }
+    }
+    let a = CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("dense SPD triplets");
+    let sym = symbolic_factorize(&a, &SupernodeParams::default()).expect("symbolic");
+
+    // Sequential driver: intra-front stays false (serial Schur).
+    let (seq_factors, seq_inertia) =
+        factorize_multifrontal(&a, &sym, &NumericParams::default()).expect("sequential factor");
+
+    // Parallel driver (sets intra-front true internally), forced onto a
+    // 4-thread pool so the `par_chunks_mut` split is actually exercised.
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .expect("4-thread pool");
+    let (par_factors, par_inertia) = pool.install(|| {
+        factorize_multifrontal_supernodal_parallel(&a, &sym, &NumericParams::default())
+            .expect("parallel factor")
+    });
+
+    assert_eq!(par_inertia.positive, n, "SPD: all positive");
+    assert_eq!(par_inertia.negative, 0, "SPD: none negative");
+    assert_eq!(par_inertia.zero, 0, "SPD: no zero pivots");
+    assert_inertia_eq(&seq_inertia, &par_inertia, "intrafront/total");
+    // `assert_factors_equal` -> `assert_node_eq` already checks L, d_diag,
+    // d_subdiag, and contrib bit-exact per supernode, so this single call
+    // covers the full factor (not just L).
+    assert_factors_equal(&seq_factors, &par_factors, "intrafront");
+}


### PR DESCRIPTION
## Summary

Systematic pass over the perf-review levers (`dev/research/perf-review-2026-05-31.md`). **One performance change** (Lever 1.1); the rest are deferral/verification docs with rationale.

## Lever 1.1 — intra-front parallel Schur update (the one code change)

Parallelizes the trailing Schur update of a single dense front across rayon workers — the serial-root ceiling the perf-review flagged as the #1 lever (tree parallelism starves near the root; issue #8 pinene ~14k-col root 87s).

- `apply_blocked_schur_panel` splits the front at the pivot panel into a read-only `head` + mutable `tail`, then runs `tail.par_chunks_mut(...)` via the shared per-range body `apply_schur_panel_range`.
- **Bit-exact regardless of thread count**: each trailing column is reduced over ascending `q` on one thread — no cross-thread reduction (the structure verified in PR #59's `probe_intrafront_schur`).
- Gated by `INTRAFRONT_MIN_AREA = 256*256` (small fronts stay on the zero-overhead serial path → small-front geomean protected) and a new `BunchKaufmanParams::intrafront_parallel` flag.
- **Coupling/safety**: only the *parallel* driver sets the flag; the sequential driver (`with_parallel(false)`) never does, so a serial backend never spawns nested rayon work — preserves the pounce#79 no-oversubscription guarantee. `FERAL_INTRAFRONT=0` disables it (A/B + safety override).

### A/B (`bench_intrafront`, `FERAL_INTRAFRONT` 0 vs 1, dense SPD fronts)

Speedup **1.2×–3.1×** (load-sensitive; the trailing update is memory-bandwidth-bound, so the same case varies run-to-run on a contended machine). Reported as a range deliberately, not a best run. Correctness is load-independent — **bit-exact + inertia-equal on every run**.

### Correctness

- New gate `tests/parallel_parity.rs::intrafront_parallel_schur_matches_serial` (dense n=1200, forced 4-thread pool so the split fires): byte-identical L/D/contrib + inertia vs the sequential driver.
- `parallel_corpus_parity` over the full KKT corpus: **0 mismatch / 41,220 factored**.
- Full suite **572 passed, 0 failed**; `clippy --all-targets -D warnings` clean; `fmt --check` clean.
- Small-front regression: 8-matrix `bench` OFF vs ON within noise, **inertia identical**; small fronts are structurally excluded from the parallel branch by the area gate.

## The other five levers (docs only, no code)

- **1.2** cache blocking + L-panel packing — **deferred**: restructures the hot bit-exact kernel for a ~10–30% bandwidth gain below the run-to-run noise floor on this machine. Plan written (1.2a row-band blocking first).
- **2.1** parallel-across-RHS solve — **deferred**: bit-exactness entangled with the nrhs≥32 kernel dispatch; narrow payoff (solve already < MUMPS; IPM uses nrhs=2).
- **2.2** symbolic speedups — **already implemented** (Phase 2.4.4): MC64 cached across compress→scale; compression auto-dispatch via `OrderingPreprocess::Auto`. Verified only.
- **3.1** FMA fallback / **3.2** wider NR — **deferred**: 3.2 is the same bandwidth wall as 1.2; 3.1 is ~0% on this arm64 host and carries inertia-flip risk (already an opt-in field).

Each deferral has a `dev/research/lever-*.md` note + a `dev/decisions.md` entry with revisit conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
