### PR TITLE
docs(lever-1.2): row-band blocking measured — bit-exact but a 0.74-0.95x regression

### DIFF
--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5003,3 +5003,33 @@ boundary matrices; high-complexity fallback for ~zero gain on the only available
 hardware. fma is already an opt-in BunchKaufmanParams field for a future x86
 measurement. The perf-lever sweep thus implements Lever 1.1 only (1.2/2.1
 deferred-with-plan, 2.2 already implemented in Phase 2.4.4).
+
+
+## 2026-05-31 — Lever 1.2a (row-band blocking) measured and rejected
+
+Earlier this session Lever 1.2 was deferred with the rationale "its ~10-30%
+bandwidth gain is below the noise floor, so it can't be measured here." That
+rationale was unverified speculation. Prompted to actually measure rather than
+predict, 1.2a (row-band blocking) was implemented and benchmarked A/B
+(ROW_BAND_ENABLED off vs on, sequential factor, dense SPD fronts):
+
+  n=800 0.89x, n=1200 0.79-0.95x, n=1600 0.75-0.80x, n=2000 0.74-0.76x (3 runs).
+
+Both prior claims were wrong: the effect is clearly MEASURABLE (not noise) and
+it is a REGRESSION (~10-25% slower), not a gain. Correctness held — the
+bit-exact gate (row_band_blocking_matches_non_banded) passed byte-identically.
+
+Root cause: the naive banding replaced the SIMD quad kernel (one src load shared
+across 4 dst columns = register blocking) with per-column scalar-alpha axpy,
+trading 4x register reuse for cache reuse; register-reuse loss dominated.
+
+Decision: REJECTED, reverted (not shipped). A viable 1.2 must band WHILE
+preserving the quad kernel (call the strided quad/dual/single kernels on
+row-band sub-slices via src_row_offset/len) — more code, fiddly at the diagonal
+band; deferred as a larger evidence-backed effort. The cheap "reuse existing
+kernels" plan is disproven. Full writeup in
+dev/research/lever-1.2-cache-blocking-packing.md.
+
+Methodological note: measuring the cheap version took ~30 min and produced a
+definite reject; the prior deferral-by-speculation should have been a
+measurement from the start.

--- a/dev/journal/2026-05-31-04.org
+++ b/dev/journal/2026-05-31-04.org
@@ -1,0 +1,27 @@
+* 14:55 :perf:lever-1.2a:measured:correction:
+  Implemented and MEASURED Lever 1.2a (row-band blocking) instead of
+  continuing to predict it — prompted by the user pointing out that both
+  my "unmeasurable" and "~20% gain" claims were unverified.
+  RESULT: both predictions were WRONG.
+  - Measurable: yes, clearly and repeatably (not noise).
+  - Direction: SLOWER, not faster. dense SPD sequential factor, A/B via
+    ROW_BAND_ENABLED off vs on, bit-exact every run:
+      n=800  0.89x   n=1200 0.79-0.95x
+      n=1600 0.75-0.80x   n=2000 0.74-0.76x (3 runs)
+    Monotonic ~0.75x at n=2000 — a real ~10-25% regression.
+  - Correctness prediction held: row_band_blocking_matches_non_banded test
+    passed, byte-identical factor+inertia every size.
+  Root cause: my cheap banding replaced the SIMD quad kernel (shares one
+  src load across 4 dst columns = register blocking) with per-column
+  scalar-alpha axpy, trading 4x register reuse for cache reuse; the
+  register-reuse loss dominated.
+  ACTION: reverted all 1.2a production code (factor.rs, test, bench) — a
+  measured regression does not ship. Recorded the measured result in
+  dev/research/lever-1.2-cache-blocking-packing.md. A winning 1.2 must
+  band WHILE preserving the quad kernel (call strided quad on band
+  sub-slices via src_row_offset/len) — more code, deferred as an
+  evidence-backed effort. Branch claude/lever-1.2a-row-band-blocking holds
+  only this docs update now.
+  Lesson: measuring the cheap version (~30 min) beat speculating about
+  sign and magnitude. Should have measured before deferring with a
+  confident rationale.

--- a/dev/research/lever-1.2-cache-blocking-packing.md
+++ b/dev/research/lever-1.2-cache-blocking-packing.md
@@ -1,5 +1,59 @@
 # Lever 1.2 — cache blocking + L-panel packing for the dense Schur update
 
+**STATUS: 1.2a IMPLEMENTED, MEASURED, REJECTED (2026-05-31). Naive row-band
+blocking is bit-exact but a 0.74-0.95x REGRESSION, not a gain. Reverted, not
+shipped. See "Measured result" below.**
+
+## Measured result (2026-05-31) — supersedes the original prediction
+
+This note originally *predicted* a ~10-30% bandwidth gain that would be "below
+the noise floor." Prompted to verify rather than predict, 1.2a (row-band
+blocking) was implemented on branch `claude/lever-1.2a-row-band-blocking` and
+benchmarked A/B (`ROW_BAND_ENABLED` off vs on, sequential factor, dense SPD
+fronts). Both prior claims were WRONG:
+
+- **Measurable**: yes, clearly and repeatably (not noise).
+- **Slower, not faster**:
+
+  | matrix | off (ms) | on (ms) | speedup |
+  |--------|---------:|--------:|--------:|
+  | dense_spd_800  |  22-24 |  24-27 | 0.89x |
+  | dense_spd_1200 |  68-74 |  78-91 | 0.79-0.95x |
+  | dense_spd_1600 | 151-160 | 189-213 | 0.75-0.80x |
+  | dense_spd_2000 | 294-302 | 386-411 | 0.74-0.76x (3 runs) |
+
+  Monotonic with size; a real ~10-25% regression.
+
+- **Correctness prediction held**: the gate test
+  `row_band_blocking_matches_non_banded` passed byte-identically (factor +
+  inertia) at every size. The bit-exactness argument was sound; the performance
+  argument was wrong in sign and magnitude.
+
+### Why it regressed
+
+The non-banded path uses the SIMD quad kernel
+(`schur_panel_minus_nofma_strided_quad`), which shares each pivot-column `src`
+load across 4 destination columns (register blocking). The naive 1.2a loop
+replaced that with a per-column scalar-alpha `axpy_minus_unroll4`, trading 4x
+register reuse for cache reuse; the register-reuse loss dominated the bandwidth
+saving.
+
+### What a winning 1.2 would require
+
+Band WHILE preserving the quad kernel: within each row band `[r0, r1)`, call the
+strided quad/dual/single kernels on band sub-slices (`src_row_offset = r0`,
+`len = r1 - r0`), keeping register blocking AND adding cache blocking. Materially
+more code, fiddly at the diagonal band. Deferred as a larger evidence-backed
+effort; the cheap "reuse existing kernels via a scalar axpy" plan is disproven.
+
+### Methodological note
+
+The original "deferred because unmeasurable" rationale was unverified
+speculation. Implementing + measuring took ~30 min and gave a definite reject.
+Measure the cheap version before asserting a lever's magnitude or even its sign.
+
+---
+
 **STATUS: DEFERRED (2026-05-31).** Analysis + plan complete; implementation not
 started. Deferred for two reasons documented below under "Scope, risk, and
 measurement honesty": (1) it restructures the hot, bit-exact-tested Schur kernel


### PR DESCRIPTION
## Summary

**Docs only — no solver code change.** Records the measured outcome of Lever 1.2a (row-band blocking of the dense trailing Schur update).

Lever 1.2 had been deferred earlier with the rationale "its ~10–30% bandwidth gain is below the noise floor, so it can't be measured here." That was unverified speculation. This implements 1.2a, benchmarks it A/B, and records the result — both prior claims were wrong.

## Measured result

A/B via a runtime toggle (`ROW_BAND_ENABLED` off vs on), sequential factor, dense SPD fronts:

| matrix | off (ms) | on (ms) | speedup | bit-exact |
|---|---:|---:|---:|---|
| dense_spd_800 | 22–24 | 24–27 | 0.89× | yes |
| dense_spd_1200 | 68–74 | 78–91 | 0.79–0.95× | yes |
| dense_spd_1600 | 151–160 | 189–213 | 0.75–0.80× | yes |
| dense_spd_2000 | 294–302 | 386–411 | **0.74–0.76×** (3 runs) | yes |

- **Measurable** (clear, repeatable, monotonic with size — not noise).
- **A ~10–25% regression**, not a gain.
- **Correctness held**: the bit-exact gate test passed byte-identically (factor + inertia) at every size.

## Why it regressed

The naive banding dropped the SIMD quad kernel (which shares one pivot-column load across 4 destination columns — register blocking) in favour of a per-column scalar `axpy`, trading 4× register reuse for cache reuse; the register-reuse loss dominated. A viable 1.2 must band *while preserving* the quad kernel (strided kernels on band sub-slices via `src_row_offset`/`len`) — deferred as a larger evidence-backed effort.

## What's in this PR

Docs only — the implementation was reverted (a measured regression does not ship). Updates `dev/research/lever-1.2-cache-blocking-packing.md`, `dev/decisions.md`, `dev/journal/2026-05-31-04.org` so all three agree. Solver source unchanged (Lever 1.1 from #61 remains the only perf change on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
