### PR TITLE
fix(ordering): arrow/bordered-KKT catch — route MetisND to AMF (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — arrow/bordered-KKT ordering blow-up (#64)
+
+The default ordering routed by size alone (`n > 10_000 → MetisND`). On
+**arrow / bordered-KKT** patterns — a thin body plus a handful of
+very-high-degree "border" columns (e.g. an IPM augmented system with a
+few dense inequality rows) — nested dissection cannot isolate the dense
+border and the LDLᵀ factor blows up ~7–9× vs AMF/AMD. On the LP `r05`
+iter-0 KKT (n=14842, 171 columns of degree 502 carrying 38.5% of the
+nonzeros) this was 4.4M nnz_L under the default (→ MetisND) vs 0.51M
+under AMF, and POUNCE end-to-end went from ~16 s to 0.84 s with AMF.
+
+`symbolic_factorize` now detects the arrow signature with a cheap O(n)
+degree-distribution pass (`is_arrow_bordered`): when a *small* set of
+columns (< 5% of n) concentrates a *large* share of the nonzeros
+(≥ 20%), it routes to AMF instead of MetisND. Uniformly-thin matrices
+(PoissonControl, powerflow22, bratu3d, cont-201) and matrices whose few
+high-degree columns carry a tiny nnz share (bcsstk38, 0.3%) are not
+flagged and keep their previous ordering. The detection lives in
+`choose_adaptive`, and `symbolic_factorize` now resolves through
+`OrderingMethod::Auto`, so the no-arg default and an explicit `Auto`
+caller resolve to the same concrete ordering on every matrix (they could
+previously disagree on very-large-and-sparse patterns).
+
+See `dev/research/issue-64-arrow-bordered-ordering.md`. Regression
+fixture (gitignored, regenerate with `dev/scripts/regen_r05_kkt.sh`):
+`tests/issue64_arrow_ordering.rs` asserts `nnz_L < 1.0e6` on r05's KKT.
+
 ## [0.9.0] - 2026-05-30
 
 ### Fixed — batched iterative refinement for wide multi-RHS solves (#58)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,82 +1,82 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-05-31T18:23:03Z
+Generated: 2026-06-03T11:15:02Z
 
 ## Latest Session
-File: dev/sessions/2026-05-31-03.md
+File: dev/sessions/2026-06-03-01.md
 ```
-# Session 2026-05-31-03
+# Session 2026-06-03-01
 
 ## Goal
 
-Work through the perf-review (`dev/research/perf-review-2026-05-31.md`) levers
-systematically on branch `claude/perf-levers`. For each lever: a research note,
-a with/without A/B (performance + correctness), all other tests green. User
-cadence: pause after each lever; default-ON once proven; git before/after for
-pure-kernel swaps.
+Fix issue #64: `Auto`/default ordering picks MetisND on arrow/bordered
+KKTs (a thin body plus a few very-high-degree border columns), blowing
+the LDLᵀ factor up ~7-9× vs AMF/AMD. Found via POUNCE on the LP `r05`
+(n=14842): ~16 s auto (→ MetisND) vs 0.84 s forcing AMF.
+
+User decisions up front: (1) detect with a cheap O(n) degree predicate
+(not AutoRace); (2) regenerate the r05 fixture on demand into the
+gitignored `tests/data/large/`, regression test skips when absent (no
+blob in git).
 
 ## Accomplished
 
-Six levers triaged; **one implemented**, the rest deferred-with-rationale or
-found already-done. All on `claude/perf-levers` (NOT merged to main).
+Arrow/bordered detection implemented and shipped; r05 regression test
+goes green; full suite + clippy + fmt clean.
 
-- **Lever 1.1 — intra-front parallel Schur update: IMPLEMENTED** (`fbc3136`).
-  Parallelizes the trailing Schur update of a single dense front via
-  `tail.par_chunks_mut`, gated by `INTRAFRONT_MIN_AREA = 256*256` and a new
-  `BunchKaufmanParams::intrafront_parallel` flag (default ON on the parallel
-  driver only; the sequential driver is untouched → pounce#79
-  no-oversubscription preserved). Bit-exact by construction (each trailing
-  column reduced over ascending q on one thread; no cross-thread reduction).
-  - A/B (`bench_intrafront`, FERAL_INTRAFRONT 0 vs 1, dense SPD fronts): speedup
-    **1.2×–3.1×** (load-sensitive, bandwidth-bound), bit-exact every run.
-  - Correctness: new gate `intrafront_parallel_schur_matches_serial`;
-    `parallel_corpus_parity` full KKT corpus **0 mismatch / 41 220 factored**;
-    full suite **572 passed, 0 failed**; clippy + fmt clean.
-- **Lever 1.2 — cache blocking + L-panel packing: DEFERRED** (`eafd826`).
-  Analysis + plan complete; restructures the hot bit-exact kernel for a
-  ~10–30% bandwidth gain that is below the run-to-run noise floor on this shared
-  machine. Revisit on idle hardware: 1.2a row-band blocking, then 1.2b packing.
-- **Lever 2.1 — parallel-across-RHS solve: DEFERRED** (`5336914`). Design
-  complete; bit-exactness entangled with the nrhs≥32 kernel dispatch (BLAS-3
-  back-sub not bit-identical to rank-1), risky surgery for a narrow payoff
-  (solve already < MUMPS; IPM uses nrhs=2).
-- **Lever 2.2 — symbolic speedups: ALREADY IMPLEMENTED** (`2d576c4`, verify
-  only). Both halves live since Phase 2.4.4: MC64 cached once + reused
-  (symbolic/mod.rs:608/620, scaling/mod.rs:298-300); compression auto-dispatch
-  via `OrderingPreprocess::Auto` + `pick_ordering_preprocess`. Perf-review
-  over-stated remaining work; its "compRat≤0.7" gate is circular.
-- **Levers 3.1 (FMA fallback) + 3.2 (wider NR): DEFERRED** (`56c6e48`). 3.2 is
-  the same bandwidth wall as 1.2 (sub-noise-floor). 3.1 is ~0% on this arm64 host
-  (decisions.md 2026-04-14) and flips inertia on ~30/154k matrices; already an
-  opt-in `BunchKaufmanParams::fma` field for a future x86 measurement.
+- **`is_arrow_bordered(pattern)`** (`src/symbolic/mod.rs`): O(n)
+  degree pass over the full symmetric pattern. A "heavy" column has
+  degree > max(64, 8·avg_deg); fire iff `1 ≤ heavy_count < 0.05·n` (small
+  set) AND `heavy_nnz ≥ 0.20·full_nnz` (large nnz share).
+- **Routing**: `choose_adaptive` overrides the would-be-MetisND decision
+  (`n > 10_000`) to AMF when the predicate fires. The `n ≤ 10_000 → AMF`
+  and `n > 100_000 && avg_deg < 5 → AMD` (#50) paths are untouched.
+- **Unification**: `symbolic_factorize` now resolves through
+  `OrderingMethod::Auto` instead of calling `pick_default_method`
+  directly, so the no-arg default and an explicit `Auto` caller resolve
+  to the same concrete ordering on every matrix. This also fixed a
+  latent inconsistency (only `choose_adaptive` had the #50 large-sparse
+  branch). `issue_3_auto_on_kkt_routes_via_pick_default_method` still
+  passes (PoissonControl K=58 → MetisND, uniform, no arrow).
+- **Calibration on real data** (`src/bin/probe_issue64_arrow.rs`):
 
-## Benchmark Results
+  | matrix | n | avg_deg | heavy_count | heavy_nnz% | predicate |
+  |---|---|---|---|---|---|
+  | r05_kkt | 14842 | 15.0 | 171 (1.15%) | 38.5% | **ARROW→Amf** |
+  | bratu3d | 27792 | 6.25 | 0 | 0% | no |
+  | cont-201 | 80595 | 5.44 | 0 | 0% | no |
+  | bcsstk38 | 8032 | 44.3 | 2 (0.03%) | 0.3% | no (share guard) |
 
-8-matrix `bench` (the small synthetic harness; the corpus p90 bench is the
-separate `bench_solver_corpus` walk), FERAL_INTRAFRONT OFF vs ON — all
-sub-threshold, so both take the serial refactored path:
+  r05 nnz_L: Amf=506210 Amd=607519 MetisND=4358715 (MetisND/Amf=8.61×).
+  Absolute counts drift from the issue's numbers (ordering-impl / METIS
+  seed) but the ranking and the `<1e6` test threshold are robust.
+- **Tests**: 4 unit tests for the predicate (fires on synthetic arrow;
+  rejects uniform-sparse, many-hubs (count guard), low-share border
+  (share guard)); `choose_adaptive_routes_arrow_to_amf`; regression
+  `tests/issue64_arrow_ordering.rs` (skip-if-absent, asserts
+  `nnz_L < 1.0e6` and `resolved_method != MetisND`). Verified red→green.
 ```
 
 ## Git Status
 ```
-56c6e48 docs(lever-3.x): defer FMA fallback (3.1) and wider NR (3.2) with rationale
-2d576c4 docs(lever-2.2): verify symbolic speedups already implemented (Phase 2.4.4)
-5336914 docs(lever-2.1): defer parallel-across-RHS solve with design + rationale
-eafd826 docs(lever-1.2): defer cache-blocking/packing with analysis + rationale
-dc66907 docs(lever-1.1): report speedup as a load-sensitive range, not a best run
+8877a48 docs(lever-1.2): row-band blocking measured — bit-exact but a 0.74-0.95x regression (#62)
+55f6a70 perf(dense): intra-front parallel Schur (perf-review Lever 1.1) + lever-sweep docs (#61)
+8ffdb55 docs+test(parallel): O(1) worker-stack depth, deep-tree guard (pounce#79) (#60)
+14cff66 perf-review: analysis and verification of intra-front parallelism (#59)
+cd12735 release: v0.9.0
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test scaling::tests::auto_falls_back_to_infnorm_on_mss1_0009 ... ok
 test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
@@ -86,65 +86,67 @@ test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ..
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 
-test result: ok. 317 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.42s
+test result: ok. 322 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.41s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-05-31-03.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-03-01.md)
 
 
-8-matrix `bench` (the small synthetic harness; the corpus p90 bench is the
-separate `bench_solver_corpus` walk), FERAL_INTRAFRONT OFF vs ON — all
-sub-threshold, so both take the serial refactored path:
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10           40            9     (10, 0, 0)
+spd_50             50           23            3     (50, 0, 0)
+spd_100           100           84            5    (100, 0, 0)
+spd_200           200          413           16    (200, 0, 0)
+kkt_10_3           13            3            0     (10, 3, 0)
+kkt_30_10          40           25            1    (30, 10, 0)
+kkt_50_15          65           49            2    (50, 15, 0)
+kkt_100_30        130          205            7   (100, 30, 0)
 
-spd_10   off=35  on=29     kkt_10_3   off=3   on=3
-spd_50   off=20  on=20     kkt_30_10  off=25  on=25
-spd_100  off=78  on=68     kkt_50_15  off=47  on=47
-spd_200  off=389 on=362    kkt_100_30 off=130 on=130
-
-Within noise; **inertia identical** OFF vs ON on all 8. The small-front geomean
-cannot regress from 1.1: fronts below the 65 536-area gate never enter the
-parallel branch, and the serial path is the bit-exact refactor proven by
-`parallel_corpus_parity` (0 mismatch). The full corpus p90 walk
-(`bench_solver_corpus`, 169 591 matrices vs MUMPS oracle) is an hour+ run and
-timing-noisy on this contended box; not run to completion — the structural
-argument + corpus-parity bit-exactness are the load-robust evidence.
+The 8-matrix synthetic bench is all n ≤ 200 (sub-threshold → AMF), so it
+exercises none of the arrow path; numbers are within prior-session noise
+(spd_200 413µs vs 362–389 in 2026-05-31-03) and inertia is exact. The
+arrow catch only consults `is_arrow_bordered` on the would-be-MetisND
+branch (n > 10_000), so these matrices are bit-identical to before. The
+load-robust evidence for the fix is the r05 regression test and the
+real-data calibration table above, not this bench.
 
 ```
 
 ## Recent Decisions
+degree > max(64, 8·avg_deg); fire iff 1 ≤ heavy_count < 0.05·n (a small
+set) AND heavy_nnz ≥ 0.20·full_nnz (a large nnz share). The share guard
+is the discriminator — it fires on r05 (38.5%) and rejects bcsstk38
+(0.3% share despite two degree-614 columns); the count guard rejects
+"many hub" patterns. Uniformly-thin matrices (PoissonControl,
+powerflow22, bratu3d, cont-201) have no heavy column and are untouched.
 
-## 2026-05-31 — Lever 2.2 (symbolic speedups) found already-implemented
+Routing target is AMF (the existing n≤10_000 default and the measured
+winner on r05), keeping the dispatcher coherent: small-or-arrow → AMF,
+large-uniform → MetisND, very-large-thin → AMD.
 
-The perf-lever sweep reached Tier-2 #2 (symbolic-phase speedups: cache MC64
-across compress->scale, and auto-dispatch compression on predicted-tail
-matrices). On inspection BOTH halves are already implemented in the codebase
-("Phase 2.4.4", pre-dating this sweep): the MC64 matching is computed once and
-cached (symbolic/mod.rs:605/614) and reused by the numeric phase
-(scaling/mod.rs:298-300); compression auto-dispatch is the default via
-OrderingPreprocess::Auto + pick_ordering_preprocess (mod.rs:347-369). The
-perf-review (dev/research/perf-review-2026-05-31.md), written the same day by
-the PR#59 analysis session, over-stated the remaining work by listing these as
-future. Its further "tighter gate (compRat<=0.7)" idea is not viable as stated
-(compRat requires running MC64 to compute, so it cannot gate whether to run
-MC64). No code change; verification recorded in
-dev/research/lever-2.2-symbolic-speedups.md.
+Placement: the catch lives in `choose_adaptive`, and `symbolic_factorize`
+now resolves through `OrderingMethod::Auto` instead of calling
+`pick_default_method` directly. This unifies the two entry points — the
+no-arg default and an explicit `Auto` caller now resolve to the same
+concrete ordering on every matrix. Previously they could disagree on
+very-large-and-sparse patterns (only `choose_adaptive` had the #50
+`n>100_000 && avg_deg<5 → Amd` branch), a latent inconsistency the
+docstrings claimed did not exist.
 
+This is the *opposite* routing direction from issue #50, which deleted
+escape hatches that pushed low-avg-degree patterns *toward* MetisND. Here
+the body is not uniformly thin (full avg_deg ≈ 15); the problem is a few
+dense borders. A purely synthetic arrow did not faithfully reproduce the
+fill ranking (issue #64 reporter note), so the regression fixture is the
+real regenerated r05 KKT, gitignored and skip-if-absent.
 
-## 2026-05-31 — Levers 3.1 (FMA fallback) and 3.2 (wider NR) deferred
-
-Both Tier-3 levers deferred (dev/research/lever-3.x-deferred.md). 3.2 (wider
-micro-kernel NR): perf-review says measure only after 1.1/1.2 land, but 1.2 is
-deferred and 3.2 attacks the same memory-bandwidth wall — wider arithmetic width
-does not help a bandwidth-bound kernel, and the gain is sub-noise-floor on this
-shared machine. 3.1 (FMA boundary-safe fallback): this host is arm64, where FMA
-measured ~0% (decisions.md 2026-04-14, 1.87->1.86) and flips inertia on ~30/154k
-boundary matrices; high-complexity fallback for ~zero gain on the only available
-hardware. fma is already an opt-in BunchKaufmanParams field for a future x86
-measurement. The perf-lever sweep thus implements Lever 1.1 only (1.2/2.1
-deferred-with-plan, 2.2 already implemented in Phase 2.4.4).
+Evidence: dev/research/issue-64-arrow-bordered-ordering.md,
+dev/journal/2026-06-03-01.org, src/symbolic/mod.rs is_arrow_bordered +
+choose_adaptive, tests/issue64_arrow_ordering.rs, dev/scripts/regen_r05_kkt.sh.
 
 ## Recent Tried-and-Rejected
 **c-block outer / m-tile inner** would keep a small `B`-block
@@ -282,6 +284,7 @@ src/bin/probe_issue54_alpha_shift.rs
 src/bin/probe_issue54_cascade.rs
 src/bin/probe_issue54_ma57_alpha.rs
 src/bin/probe_issue54.rs
+src/bin/probe_issue64_arrow.rs
 src/bin/probe_kkt_replay.rs
 src/bin/probe_marine_shape.rs
 src/bin/probe_marine_time.rs
@@ -345,8 +348,5 @@ src/symbolic/column_counts.rs
 src/symbolic/ldlt_compress.rs
 src/symbolic/mod.rs
 src/symbolic/profiler.rs
-src/symbolic/small_leaf.rs
-src/symbolic/supernode.rs
-```
 
-(truncated from      402 lines to 350 line budget)
+(truncated from      406 lines to 350 line budget)

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5033,3 +5033,48 @@ dev/research/lever-1.2-cache-blocking-packing.md.
 Methodological note: measuring the cheap version took ~30 min and produced a
 definite reject; the prior deferral-by-speculation should have been a
 measurement from the start.
+
+## 2026-06-03 — Arrow/bordered-KKT ordering catch (issue #64)
+
+`pick_default_method` routed the default ordering by size alone
+(`n > 10_000 → MetisND`), discarding the `_stored_nnz` it received. On
+arrow/bordered KKTs — a thin body plus a handful of very-high-degree
+border columns — nested dissection cannot isolate the dense border and
+the LDLᵀ factor blows up ~7-9× vs AMF/AMD. Measured on r05's iter-0 IPM
+KKT (n=14842, 171 of 14842 columns at degree 502 carrying 38.5% of the
+nonzeros): nnz_L Amf=506k Amd=608k MetisND=4.36M (8.6× AMF); POUNCE
+end-to-end ~16 s (auto→MetisND) vs 0.84 s (amf).
+
+Decision: detect the arrow signature with a cheap O(n) degree pass
+(`is_arrow_bordered`) on the full symmetric pattern and override the
+would-be-MetisND decision to AMF. Predicate: a heavy column has
+degree > max(64, 8·avg_deg); fire iff 1 ≤ heavy_count < 0.05·n (a small
+set) AND heavy_nnz ≥ 0.20·full_nnz (a large nnz share). The share guard
+is the discriminator — it fires on r05 (38.5%) and rejects bcsstk38
+(0.3% share despite two degree-614 columns); the count guard rejects
+"many hub" patterns. Uniformly-thin matrices (PoissonControl,
+powerflow22, bratu3d, cont-201) have no heavy column and are untouched.
+
+Routing target is AMF (the existing n≤10_000 default and the measured
+winner on r05), keeping the dispatcher coherent: small-or-arrow → AMF,
+large-uniform → MetisND, very-large-thin → AMD.
+
+Placement: the catch lives in `choose_adaptive`, and `symbolic_factorize`
+now resolves through `OrderingMethod::Auto` instead of calling
+`pick_default_method` directly. This unifies the two entry points — the
+no-arg default and an explicit `Auto` caller now resolve to the same
+concrete ordering on every matrix. Previously they could disagree on
+very-large-and-sparse patterns (only `choose_adaptive` had the #50
+`n>100_000 && avg_deg<5 → Amd` branch), a latent inconsistency the
+docstrings claimed did not exist.
+
+This is the *opposite* routing direction from issue #50, which deleted
+escape hatches that pushed low-avg-degree patterns *toward* MetisND. Here
+the body is not uniformly thin (full avg_deg ≈ 15); the problem is a few
+dense borders. A purely synthetic arrow did not faithfully reproduce the
+fill ranking (issue #64 reporter note), so the regression fixture is the
+real regenerated r05 KKT, gitignored and skip-if-absent.
+
+Evidence: dev/research/issue-64-arrow-bordered-ordering.md,
+dev/journal/2026-06-03-01.org, src/symbolic/mod.rs is_arrow_bordered +
+choose_adaptive, tests/issue64_arrow_ordering.rs, dev/scripts/regen_r05_kkt.sh.

--- a/dev/journal/2026-06-03-01.org
+++ b/dev/journal/2026-06-03-01.org
@@ -1,0 +1,52 @@
+#+TITLE: FERAL journal 2026-06-03-01
+#+STARTUP: showall
+
+* 06:45 :issue-64:ordering:arrow:setup:
+Starting issue #64: Auto ordering picks MetisND on arrow/bordered KKTs
+→ ~7× fill blow-up on r05 LP. `pick_default_method` routes by size alone
+(n>10_000 → MetisND), ignoring structure.
+
+Decisions taken with the user up front:
+- Detection: cheap O(n) degree predicate (arrow → AMF), not AutoRace.
+- Fixture: regenerate-on-demand into gitignored tests/data/large/, the
+  regression test skips cleanly when absent (no blob in git). tests/data/large/
+  is already gitignored and fetched, so committing a 1.7 MB / 429 KB-gz blob
+  would break that convention; user chose not to.
+
+* 06:50 :issue-64:fixture:repro:
+Regenerated the r05 iter-0 KKT from pounce (release 0.3.1-dev):
+
+  pounce <bench-data>/lp/nl/r05.nl --dump kkt:0 --dump-dir /tmp/r05dump max_iter=1
+  jsonl_to_mtx.py /tmp/r05dump/iter_000/kkt_solve_001.jsonl r05
+
+Output: n=14842 nnz=118968 status=Success neg_evals expected=5171 actual=5171.
+Matches the issue exactly (n=14842, stored nnz=118968). Copied to
+tests/data/large/r05_kkt.mtx (gitignored, confirmed via git check-ignore).
+
+* 07:00 :issue-64:calibration:arrow:
+Probe (src/bin/probe_issue64_arrow.rs) over the full symmetric pattern,
+candidate predicate heavy = deg > max(64, 8*avg_deg):
+
+  r05_kkt:  n=14842 full_nnz=223094 avg_deg=15.0 max_deg=502 thr=121
+            heavy_count=171 (1.15% of n)  heavy_nnz=85842 (38.5% of full_nnz)
+            nnz_L: Amf=506210 Amd=607519 MetisND=4358715  (MetisND/Amf=8.61x)
+  bratu3d:  avg_deg=6.25 max_deg=7  heavy_count=0           MetisND/Amf=1.59x
+  cont-201: avg_deg=5.44 max_deg=6  heavy_count=0           MetisND/Amf=1.32x
+  bcsstk38: avg_deg=44.3 max_deg=614 heavy_count=2 (0.025%) heavy_nnz=0.3%
+            nnz_L: Amf=726471 Amd=736620 MetisND=876960     MetisND/Amf=1.21x
+
+Conclusions:
+- The (heavy_count < 0.05*n) AND (heavy_nnz/full_nnz >= ~0.20) gate fires on
+  r05 (38.5% share) and correctly REJECTS bcsstk38 (0.3% share, despite 2
+  deg-614 columns — the nnz-share guard is doing the discriminating work,
+  not the count guard). bratu3d/cont-201 have zero heavy columns.
+- Ranking matches the issue (MetisND ~8.6x worse than AMF). Absolute nnz_L
+  drifts vs the issue's numbers (Amf 506k vs 527k, MetisND 4.36M vs 3.59M) —
+  consistent with ordering-impl / METIS-seed drift; the `< 1.0e6` regression
+  threshold is robust (AMF/AMD ~0.5-0.6M, MetisND 4.36M).
+- Side note (OUT OF SCOPE): bratu3d/cont-201 also show MetisND losing to AMF
+  on fill (1.3-1.6x) with no arrow signature. Not touching — issue #64 is
+  specifically the arrow/bordered case.
+- Detector only ever needs to flip the would-be-MetisND decision (n>10_000)
+  to AMF; it never touches the n<=10_000 → AMF path. Natural placement is the
+  large branch of pick_default_method's decision, on the symmetric pattern.

--- a/dev/research/issue-64-arrow-bordered-ordering.md
+++ b/dev/research/issue-64-arrow-bordered-ordering.md
@@ -1,0 +1,181 @@
+# Research Note: Arrow/bordered-KKT ordering routing (issue #64)
+
+**Status:** Pre-implementation
+**Date:** 2026-06-03
+**Author:** agent session 2026-06-03-01
+**Related issues:** https://github.com/jkitchin/feral/issues/64
+**Related code:** `src/symbolic/mod.rs:317` (`pick_default_method`),
+`src/symbolic/mod.rs:170` (`choose_adaptive`),
+`src/symbolic/mod.rs:395` (`symbolic_factorize`).
+**Prior art / precedent:** `dev/research/issue-50-metisnd-symbolic-cost.md`
+(the *opposite* routing direction — deleting low-avg-degree → MetisND
+escape hatches), `pick_ordering_preprocess` (an existing O(nnz)
+degree-distribution predicate in the same file).
+
+## Overview
+
+`pick_default_method` routes the default ordering by `n` alone:
+`n <= 10_000 → Amf`, else `MetisND`. It receives `_stored_nnz` and
+discards it. On **arrow / bordered-KKT** patterns — a sparse body plus a
+handful of very-high-degree "border" columns — nested dissection cannot
+isolate the dense border, so the LDLᵀ factor blows up. AMF/AMD's
+minimum-degree / min-fill heuristics naturally defer the dense border
+columns to the end of the elimination, where they cost one dense
+trailing block instead of smeared separator fill.
+
+Found via POUNCE on the LP `r05.nl` (jkitchin/pounce#95): the initial
+IPM KKT (n=14842) factors in ~16.5 s under `auto` (→ MetisND) vs 0.84 s
+forcing AMF. Ipopt-MA57 (AMD-family) solves it in ~0.9 s. The cost is
+entirely in the ordering choice, not the IPM.
+
+This is the **opposite** failure from issue #50, which *deleted* two
+escape hatches that routed *low-avg-degree* patterns *toward* MetisND.
+Here `nnz/n ≈ 8` (full avg_deg ≈ 15) and the problem is a few dense
+borders, not a uniformly thin matrix — so neither the old #50 catches
+nor the current size rule help.
+
+## Reproduction (regenerated locally, fixture NOT in repo)
+
+`tests/data/large/` is gitignored (fetched, not committed). The r05 KKT
+is a generated IPM matrix, not a SuiteSparse download, so it is
+regenerated on demand (see `dev/scripts/regen_r05_kkt.sh`):
+
+```
+pounce <bench-data>/lp/nl/r05.nl --dump kkt:0 --dump-dir /tmp/d max_iter=1
+jsonl_to_mtx.py /tmp/d/iter_000/kkt_solve_001.jsonl r05   # → r05_kkt.mtx
+```
+
+Produces `n=14842 nnz=118968` (matches the issue exactly).
+
+## Structural signature
+
+Full symmetric pattern of r05's iter-0 KKT (measured,
+`src/bin/probe_issue64_arrow.rs`):
+
+```
+n=14842 full_nnz=223094 avg_deg=15.03 max_deg=502
+171 columns of degree 502  (1.15% of n) carrying 38.5% of full_nnz
+all other columns degree <= ~20
+```
+
+The 171 degree-502 columns are r05's dense inequality rows (85 500 of
+103 955 Jacobian nonzeros live in 171 of 5171 constraints). In the
+augmented KKT each becomes a dense border column.
+
+Measured fill (default `SupernodeParams`, `col_counts.sum()`):
+
+| ordering | nnz_L (this machine) | issue's numbers | ratio vs AMF |
+|---|---|---|---|
+| Amf | 506 210 | 526 940 | 1.00× |
+| Amd | 607 519 | 568 879 | 1.20× |
+| MetisND | 4 358 715 | 3 593 887 | **8.61×** |
+
+Absolute counts drift from the issue (ordering-impl / METIS-seed
+variation; pounce 0.3.1-dev vs the 0.9.0-era dump) but the **ranking is
+robust**: MetisND is ~7–9× worse. AMF wins on this matrix, consistent
+with the issue's end-to-end POUNCE table (amf 0.84 s vs auto 16–21 s).
+
+## The predicate
+
+Route to AMF (instead of MetisND) when, on the full symmetric pattern,
+a *small set* of columns carries a *large share* of the nonzeros — the
+arrow fingerprint. All thresholds are O(n)/O(nnz) and allocation-free.
+
+```
+avg_deg   = full_nnz / n
+heavy_thr = max(HEAVY_DEG_FLOOR, HEAVY_AVG_MULT * avg_deg)   = max(64, 8*avg_deg)
+heavy     = { columns with degree > heavy_thr }
+ARROW iff  heavy.count >= 1
+       AND heavy.count  <  ARROW_COUNT_FRAC * n        (0.05*n — a *small* set)
+       AND heavy.nnz    >= ARROW_NNZ_SHARE * full_nnz  (0.20    — a *large* share)
+```
+
+Rationale for each constant:
+
+- `HEAVY_DEG_FLOOR = 64`, `HEAVY_AVG_MULT = 8`: a "heavy" column is one
+  whose degree dwarfs the body. The `max(64, …)` floor stops the
+  multiplier from flagging columns in genuinely dense small matrices
+  (e.g. bcsstk38, avg_deg 44 → thr 355). 8× is the issue's suggested
+  `8*avg_deg`; on r05 that is 121, well below the border degree 502.
+- `ARROW_COUNT_FRAC = 0.05`: the border must be a *handful* of columns.
+  r05 = 1.15%. If a large fraction of columns are high-degree the matrix
+  is just dense, and nested dissection is fine.
+- `ARROW_NNZ_SHARE = 0.20`: the border must *concentrate* the nonzeros.
+  This is the discriminating guard. r05 = 38.5% → fires; bcsstk38 = 0.3%
+  → rejected even though it has 2 columns above `heavy_thr`.
+
+### False-positive analysis (must stay on MetisND)
+
+Measured on the committed-corpus large fixtures and the test-pinned KKTs:
+
+| matrix | n | avg_deg | heavy_count | heavy_nnz share | predicate | current route |
+|---|---|---|---|---|---|---|
+| r05_kkt | 14842 | 15.0 | 171 (1.15%) | 38.5% | **ARROW→Amf** | MetisND (bug) |
+| bratu3d | 27792 | 6.25 | 0 | 0% | no | MetisND |
+| cont-201 | 80595 | 5.44 | 0 | 0% | no | MetisND |
+| bcsstk38 | 8032 | 44.3 | 2 (0.03%) | 0.3% | no | Amf (n≤10k) |
+| PoissonControl K=58 | 10092 | ~2.67 | 0 (uniform) | 0% | no | MetisND |
+| powerflow22 | 2.8M | ~3.7 | 0 (uniform) | 0% | no | Amd (#50 branch) |
+
+- bratu3d / cont-201 / PoissonControl / powerflow22 are uniformly
+  low-degree (no column exceeds `heavy_thr`) → never flagged.
+- bcsstk38 has 2 very-high-degree columns but they carry 0.3% of nnz →
+  the share guard rejects it. (It is n≤10k → AMF regardless.)
+- The `issue_3_auto_on_kkt_routes_via_pick_default_method` test
+  (PoissonControl K=58 → MetisND) is preserved: uniform avg_deg 2.67,
+  no heavy columns.
+
+Within feral's domain (IPM KKT + SuiteSparse sparse-direct matrices)
+the "small heavy set concentrating the nnz" signature is precisely the
+arrow case where deferring the border lets min-degree win. Power-law
+graphs where ND still wins despite a dense hub are not part of this
+corpus; if one appears, the regression is bounded by the share guard
+and surfaces as a fill increase caught by the corpus bench.
+
+## Placement
+
+The detector only ever needs to flip the *would-be-MetisND* decision
+(`n > 10_000`) to AMF; it never touches the `n <= 10_000 → AMF` path nor
+the `n>100_000 && avg_deg<5 → AMD` (#50) branch. Both entry points must
+benefit:
+
+1. `symbolic_factorize` → `pick_default_method(n, stored_nnz)` directly.
+2. `symbolic_factorize_with_method(Auto)` → `choose_adaptive(pattern)`.
+
+`pick_default_method` has only `(n, stored_nnz)` and cannot walk the
+pattern. `choose_adaptive` already has the full symmetric pattern.
+Cleanest unification: route `symbolic_factorize` through `Auto` so all
+adaptive logic (the new arrow detector + the existing #50 large-sparse
+branch) lives in `choose_adaptive`, the single source of truth. This
+also fixes a latent inconsistency: today `symbolic_factorize` lacks the
+`n>100k && avg_deg<5 → AMD` branch that `Auto` has, so the two can
+already disagree on very-large sparse matrices despite the docstrings
+claiming they agree.
+
+`choose_adaptive` builds nothing new — it receives `full_pattern`
+(`matrix.symmetric_pattern()`) and the detector is a single extra O(n)
+pass over `col_ptr`.
+
+## Routing target: AMF vs AMD
+
+AMF wins on r05 (506k vs AMD 607k here; 527k vs 569k in the issue) and
+is already the `n<=10_000` default, so arrow → **Amf** keeps the
+dispatcher coherent (small-or-arrow → AMF; large-uniform → MetisND;
+very-large-thin → AMD). AMD is the close runner-up; both are ~7–9×
+better than MetisND, so the choice between them is second-order against
+the bug being fixed.
+
+## Test plan (oracle is external — the issue's measured fill)
+
+- Unit: `is_arrow_bordered` fires on a synthetic arrow, rejects a
+  uniform-sparse pattern and a uniformly-dense pattern. (Pattern-shape
+  oracle, hand-constructed.)
+- Unit: `choose_adaptive` / `pick_default_method`-path returns Amf on a
+  synthetic arrow with n>10_000, and still MetisND on uniform n>10_000.
+- Regression (skip-if-absent, gitignored fixture):
+  `symbolic_factorize(r05_kkt)` yields `nnz_L < 1.0e6` and
+  `resolved_method != MetisND`. Oracle: the issue's measured AMF/AMD ≈
+  0.53–0.61M vs MetisND 3.6–4.4M; `1e6` separates them with wide margin.
+- All existing `choose_adaptive_rules`, `pick_default_method_rules`,
+  `issue_3_*`, `symbolic_factorize_default_uses_amf_for_small_matrices`
+  must stay green.

--- a/dev/scripts/regen_r05_kkt.sh
+++ b/dev/scripts/regen_r05_kkt.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regenerate the issue #64 arrow/bordered-KKT fixture.
+#
+# r05's iteration-0 IPM KKT is a *generated* matrix (not a SuiteSparse
+# download), so it cannot go through fetch_large_matrices.sh. It is the
+# regression fixture for the arrow-ordering catch: nested dissection
+# blows the LDLᵀ factor up ~7-9× vs AMF/AMD on it.
+#
+# Produces tests/data/large/r05_kkt.mtx (gitignored). The regression
+# test `tests/issue64_arrow_ordering.rs` skips cleanly when it is absent,
+# so running this is optional and local-only.
+#
+# Requires a built pounce with FERAL and the r05.nl input. Override the
+# paths via the env vars below if your checkout differs.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEST="${REPO_ROOT}/tests/data/large/r05_kkt.mtx"
+
+POUNCE_BIN="${POUNCE_BIN:-${HOME}/projects/pounce/target/release/pounce}"
+POUNCE_REPO="${POUNCE_REPO:-${HOME}/projects/pounce}"
+R05_NL="${R05_NL:-${HOME}/Dropbox/projects/pounce-bench-data/lp/nl/r05.nl}"
+CONVERTER="${CONVERTER:-${POUNCE_REPO}/benchmarks/mittelmann/feral_repro/jsonl_to_mtx.py}"
+
+for f in "${POUNCE_BIN}" "${R05_NL}" "${CONVERTER}"; do
+    if [[ ! -f "${f}" ]]; then
+        echo "error: required input not found: ${f}" >&2
+        echo "       set POUNCE_BIN / R05_NL / CONVERTER to override." >&2
+        exit 1
+    fi
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+echo "dumping r05 iter-0 KKT via pounce..."
+# pounce exits non-zero on "Maximum Number of Iterations Exceeded"
+# (expected with max_iter=1); the iter-0 dump is what we need, so the
+# solve status is ignored. The jsonl-existence check below is the real
+# success gate.
+"${POUNCE_BIN}" "${R05_NL}" --dump kkt:0 --dump-dir "${TMP}/dump" max_iter=1 >/dev/null || true
+
+JSONL="${TMP}/dump/iter_000/kkt_solve_001.jsonl"
+if [[ ! -f "${JSONL}" ]]; then
+    echo "error: pounce did not produce ${JSONL}" >&2
+    exit 1
+fi
+
+echo "converting jsonl -> MatrixMarket..."
+python3 "${CONVERTER}" "${JSONL}" "${TMP}/r05"
+
+mkdir -p "$(dirname "${DEST}")"
+mv "${TMP}/r05_kkt.mtx" "${DEST}"
+echo "wrote ${DEST} ($(wc -c <"${DEST}") bytes)"
+echo "header:"
+head -4 "${DEST}"

--- a/dev/sessions/2026-06-03-01.md
+++ b/dev/sessions/2026-06-03-01.md
@@ -1,0 +1,99 @@
+# Session 2026-06-03-01
+
+## Goal
+
+Fix issue #64: `Auto`/default ordering picks MetisND on arrow/bordered
+KKTs (a thin body plus a few very-high-degree border columns), blowing
+the LDLᵀ factor up ~7-9× vs AMF/AMD. Found via POUNCE on the LP `r05`
+(n=14842): ~16 s auto (→ MetisND) vs 0.84 s forcing AMF.
+
+User decisions up front: (1) detect with a cheap O(n) degree predicate
+(not AutoRace); (2) regenerate the r05 fixture on demand into the
+gitignored `tests/data/large/`, regression test skips when absent (no
+blob in git).
+
+## Accomplished
+
+Arrow/bordered detection implemented and shipped; r05 regression test
+goes green; full suite + clippy + fmt clean.
+
+- **`is_arrow_bordered(pattern)`** (`src/symbolic/mod.rs`): O(n)
+  degree pass over the full symmetric pattern. A "heavy" column has
+  degree > max(64, 8·avg_deg); fire iff `1 ≤ heavy_count < 0.05·n` (small
+  set) AND `heavy_nnz ≥ 0.20·full_nnz` (large nnz share).
+- **Routing**: `choose_adaptive` overrides the would-be-MetisND decision
+  (`n > 10_000`) to AMF when the predicate fires. The `n ≤ 10_000 → AMF`
+  and `n > 100_000 && avg_deg < 5 → AMD` (#50) paths are untouched.
+- **Unification**: `symbolic_factorize` now resolves through
+  `OrderingMethod::Auto` instead of calling `pick_default_method`
+  directly, so the no-arg default and an explicit `Auto` caller resolve
+  to the same concrete ordering on every matrix. This also fixed a
+  latent inconsistency (only `choose_adaptive` had the #50 large-sparse
+  branch). `issue_3_auto_on_kkt_routes_via_pick_default_method` still
+  passes (PoissonControl K=58 → MetisND, uniform, no arrow).
+- **Calibration on real data** (`src/bin/probe_issue64_arrow.rs`):
+
+  | matrix | n | avg_deg | heavy_count | heavy_nnz% | predicate |
+  |---|---|---|---|---|---|
+  | r05_kkt | 14842 | 15.0 | 171 (1.15%) | 38.5% | **ARROW→Amf** |
+  | bratu3d | 27792 | 6.25 | 0 | 0% | no |
+  | cont-201 | 80595 | 5.44 | 0 | 0% | no |
+  | bcsstk38 | 8032 | 44.3 | 2 (0.03%) | 0.3% | no (share guard) |
+
+  r05 nnz_L: Amf=506210 Amd=607519 MetisND=4358715 (MetisND/Amf=8.61×).
+  Absolute counts drift from the issue's numbers (ordering-impl / METIS
+  seed) but the ranking and the `<1e6` test threshold are robust.
+- **Tests**: 4 unit tests for the predicate (fires on synthetic arrow;
+  rejects uniform-sparse, many-hubs (count guard), low-share border
+  (share guard)); `choose_adaptive_routes_arrow_to_amf`; regression
+  `tests/issue64_arrow_ordering.rs` (skip-if-absent, asserts
+  `nnz_L < 1.0e6` and `resolved_method != MetisND`). Verified red→green.
+- **Fixture regen**: `dev/scripts/regen_r05_kkt.sh` (pounce `--dump kkt:0`
+  + `jsonl_to_mtx.py`; tolerates pounce's nonzero max-iter exit).
+
+## Benchmark Results
+
+```
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10           40            9     (10, 0, 0)
+spd_50             50           23            3     (50, 0, 0)
+spd_100           100           84            5    (100, 0, 0)
+spd_200           200          413           16    (200, 0, 0)
+kkt_10_3           13            3            0     (10, 3, 0)
+kkt_30_10          40           25            1    (30, 10, 0)
+kkt_50_15          65           49            2    (50, 15, 0)
+kkt_100_30        130          205            7   (100, 30, 0)
+```
+
+The 8-matrix synthetic bench is all n ≤ 200 (sub-threshold → AMF), so it
+exercises none of the arrow path; numbers are within prior-session noise
+(spd_200 413µs vs 362–389 in 2026-05-31-03) and inertia is exact. The
+arrow catch only consults `is_arrow_bordered` on the would-be-MetisND
+branch (n > 10_000), so these matrices are bit-identical to before. The
+load-robust evidence for the fix is the r05 regression test and the
+real-data calibration table above, not this bench.
+
+## Decisions Made
+
+- Arrow/bordered ordering catch via O(n) degree predicate, routing to
+  AMF; `symbolic_factorize` unified through `Auto`. Full rationale and
+  the false-positive analysis in `dev/decisions.md` (2026-06-03) and
+  `dev/research/issue-64-arrow-bordered-ordering.md`.
+
+## Abandoned Approaches
+
+- None. (AutoRace was considered and ruled out up front with the user in
+  favour of the cheap predicate; recorded as the chosen design, not a
+  failed attempt.)
+
+## Next Session Should
+
+- Consider whether bratu3d / cont-201 — uniformly-thin matrices where
+  MetisND still loses to AMF on fill (1.3–1.6×) with no arrow signature
+  — warrant a separate, out-of-#64-scope routing look. Not an arrow;
+  needs its own evidence before touching the size rule.
+- Optional: run the full corpus p90 walk (`bench_solver_corpus`) to
+  confirm no large-matrix fill regression from the `symbolic_factorize`
+  → `Auto` unification (the only behavior change beyond the arrow catch:
+  very-large-and-sparse default now routes to AMD, matching `Auto`).

--- a/src/bin/probe_issue64_arrow.rs
+++ b/src/bin/probe_issue64_arrow.rs
@@ -1,0 +1,128 @@
+//! Issue #64 probe: confirm the arrow/bordered fill ranking on the real
+//! r05 KKT and gather degree-distribution statistics for the candidate
+//! arrow detector, across r05 and the other large/*.mtx fixtures.
+//!
+//! Run: `cargo run --release --bin probe_issue64_arrow`
+//!
+//! Throwaway diagnostic — not a test. Reads gitignored
+//! `tests/data/large/*.mtx`.
+
+use feral::sparse::csc::CscPattern;
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use feral::{read_mtx, CscMatrix};
+use std::path::{Path, PathBuf};
+
+/// Candidate predicate stats on the full symmetric pattern.
+struct ArrowStats {
+    n: usize,
+    full_nnz: usize,
+    avg_deg: f64,
+    max_deg: usize,
+    threshold: usize,
+    heavy_count: usize,
+    heavy_nnz: usize,
+}
+
+fn arrow_stats(pat: &CscPattern) -> ArrowStats {
+    let n = pat.n;
+    let full_nnz = pat.row_idx.len();
+    let avg_deg = full_nnz as f64 / n.max(1) as f64;
+    // deg > max(64, 8*avg_deg)
+    let threshold = ((8.0 * avg_deg).ceil() as usize).max(64);
+    let mut max_deg = 0usize;
+    let mut heavy_count = 0usize;
+    let mut heavy_nnz = 0usize;
+    for j in 0..n {
+        let deg = pat.col_ptr[j + 1] - pat.col_ptr[j];
+        max_deg = max_deg.max(deg);
+        if deg > threshold {
+            heavy_count += 1;
+            heavy_nnz += deg;
+        }
+    }
+    ArrowStats {
+        n,
+        full_nnz,
+        avg_deg,
+        max_deg,
+        threshold,
+        heavy_count,
+        heavy_nnz,
+    }
+}
+
+fn nnz_l(m: &CscMatrix, method: OrderingMethod) -> usize {
+    let sp = SupernodeParams::default();
+    match symbolic_factorize_with_method(m, &sp, method) {
+        Ok(s) => s.col_counts.iter().sum(),
+        Err(e) => {
+            eprintln!("  {:?} FAILED: {:?}", method, e);
+            0
+        }
+    }
+}
+
+fn report(label: &str, m: &CscMatrix, with_fill: bool) {
+    let pat = m.symmetric_pattern();
+    let s = arrow_stats(&pat);
+    let hc_frac = s.heavy_count as f64 / s.n as f64;
+    let hn_frac = s.heavy_nnz as f64 / s.full_nnz.max(1) as f64;
+    println!("=== {label} ===");
+    println!(
+        "  n={} full_nnz={} avg_deg={:.2} max_deg={} thr={}",
+        s.n, s.full_nnz, s.avg_deg, s.max_deg, s.threshold
+    );
+    println!(
+        "  heavy_count={} ({:.3}% of n)  heavy_nnz={} ({:.1}% of full_nnz)",
+        s.heavy_count,
+        hc_frac * 100.0,
+        s.heavy_nnz,
+        hn_frac * 100.0
+    );
+    if with_fill {
+        let amf = nnz_l(m, OrderingMethod::Amf);
+        let amd = nnz_l(m, OrderingMethod::Amd);
+        let metis = nnz_l(m, OrderingMethod::MetisND);
+        println!(
+            "  nnz_L: Amf={} Amd={} MetisND={}  (MetisND/Amf={:.2}x)",
+            amf,
+            amd,
+            metis,
+            metis as f64 / amf.max(1) as f64
+        );
+    }
+}
+
+fn main() {
+    let dir = PathBuf::from("tests/data/large");
+
+    // r05: the target arrow matrix. Full fill ranking.
+    let r05 = dir.join("r05_kkt.mtx");
+    if r05.is_file() {
+        match read_mtx(&r05).and_then(|m| m.to_csc()) {
+            Ok(m) => report("r05_kkt (ARROW target)", &m, true),
+            Err(e) => eprintln!("r05_kkt read failed: {:?}", e),
+        }
+    } else {
+        eprintln!("SKIP r05_kkt.mtx (not present)");
+    }
+
+    // The other large fixtures — these must NOT look like arrows
+    // (false-positive check). Fill ranking too, where cheap.
+    for name in ["bratu3d", "cont-201", "bcsstk38"] {
+        let p = dir.join(format!("{name}.mtx"));
+        if p.is_file() {
+            match read_mtx(&p).and_then(|m| m.to_csc()) {
+                Ok(m) => report(name, &m, true),
+                Err(e) => eprintln!("{name} read failed: {:?}", e),
+            }
+        } else {
+            eprintln!("SKIP {name}.mtx (not present)");
+        }
+    }
+
+    // PoissonControl K=58 (n=10092, avg_deg~2.67): the matrix that the
+    // issue_3 test pins to MetisND. Build it via the same generator the
+    // tests use, if available as a binary helper — otherwise skipped.
+    let _ = Path::new("");
+}

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -129,10 +129,15 @@ pub enum OrderingMethod {
 /// The rule set adds one shape-bakeoff branch on top of
 /// [`pick_default_method`]:
 ///   - very-large-and-sparse (`n > 100_000`, full avg_deg < 5.0) → `Amd`
+///   - arrow/bordered (issue #64): whenever the size rule would pick
+///     `MetisND` (`n > 10_000`) but [`is_arrow_bordered`] detects a
+///     dense border concentrating the nonzeros, override to `Amf`.
 ///
-/// Anything else delegates to [`pick_default_method`], so `Auto` can't
-/// disagree with the no-arg `symbolic_factorize` default on the same
-/// matrix.
+/// Anything else delegates to [`pick_default_method`]. `symbolic_factorize`
+/// routes through `Auto`, so the no-arg default and `Auto` resolve to the
+/// same concrete method on every matrix (issue #64 unified the two paths;
+/// previously the no-arg default skipped the very-large-and-sparse and
+/// arrow catches).
 ///
 /// The large-and-sparse branch swap from `ScotchND` to `Amd` is the
 /// issue #50 fix (2026-05-23). On `powerflow22` (n=2.8 M,
@@ -185,7 +190,94 @@ fn choose_adaptive(pattern: &CscPattern, method: OrderingMethod) -> OrderingMeth
     // stored nnz) apply: stored = (full + n) / 2 when the diagonal is
     // included once on each row of the symmetric pattern.
     let stored_nnz = (full_nnz + n) / 2;
-    pick_default_method(n, stored_nnz)
+    let base = pick_default_method(n, stored_nnz);
+    // Issue #64 arrow/bordered-KKT catch. The size-only
+    // `pick_default_method` routes every `n > 10_000` matrix to MetisND,
+    // but nested dissection cannot isolate a dense border (a handful of
+    // very-high-degree columns concentrating the nonzeros) and the LDLᵀ
+    // factor blows up ~7-9× vs AMF/AMD. Override MetisND → AMF on the
+    // arrow signature. Only the would-be-MetisND decision is touched;
+    // the `n <= 10_000 → AMF` and `n > 100_000 && avg_deg < 5 → AMD`
+    // (returned above) paths are untouched. See
+    // `dev/research/issue-64-arrow-bordered-ordering.md`.
+    if base == OrderingMethod::MetisND && is_arrow_bordered(pattern) {
+        return OrderingMethod::Amf;
+    }
+    base
+}
+
+/// Detect the **arrow / bordered-KKT** sparsity signature on a full
+/// symmetric pattern: a *small set* of very-high-degree "border" columns
+/// carrying a *large share* of the nonzeros, over an otherwise thin body.
+///
+/// This is the structural fingerprint of an IPM augmented system whose
+/// inequality block has a few dense constraint rows (issue #64: r05's
+/// iter-0 KKT has 171 of 14 842 columns at degree 502, carrying 38.5% of
+/// the nonzeros). On such patterns nested dissection smears the dense
+/// border across its separators and the factor blows up, whereas
+/// minimum-degree / min-fill orderings (AMD/AMF) defer the border to the
+/// end of the elimination where it costs one dense trailing block.
+///
+/// Predicate (all O(n), allocation-free), on the full symmetric pattern:
+///
+/// ```text
+/// avg_deg   = full_nnz / n
+/// heavy_thr = max(HEAVY_DEG_FLOOR, HEAVY_AVG_MULT * avg_deg)
+/// heavy     = { columns with degree > heavy_thr }
+/// arrow iff  1 <= heavy.count < ARROW_COUNT_FRAC * n   (a *small* set)
+///        AND heavy.nnz >= ARROW_NNZ_SHARE * full_nnz   (a *large* share)
+/// ```
+///
+/// The `ARROW_NNZ_SHARE` guard is the discriminating test: it fires on
+/// r05 (38.5% share) and rejects bcsstk38 (0.3% share, despite two
+/// degree-614 columns). The `ARROW_COUNT_FRAC` guard rejects "many hub"
+/// patterns where a large fraction of columns are high-degree (the matrix
+/// is then just dense and nested dissection is appropriate). Uniformly
+/// thin matrices (PoissonControl, powerflow22, bratu3d, cont-201) have no
+/// column above `heavy_thr` and are never flagged. Calibration and the
+/// false-positive table are in
+/// `dev/research/issue-64-arrow-bordered-ordering.md`.
+fn is_arrow_bordered(pattern: &CscPattern) -> bool {
+    /// A "heavy" column has degree above this absolute floor regardless
+    /// of `avg_deg`, so genuinely dense small matrices (high uniform
+    /// degree) are not flagged.
+    const HEAVY_DEG_FLOOR: usize = 64;
+    /// ...or above this multiple of the average degree.
+    const HEAVY_AVG_MULT: f64 = 8.0;
+    /// The heavy set must be a *handful* of columns: strictly fewer than
+    /// this fraction of `n`.
+    const ARROW_COUNT_FRAC: f64 = 0.05;
+    /// ...that *concentrate* at least this fraction of the nonzeros.
+    const ARROW_NNZ_SHARE: f64 = 0.20;
+
+    let n = pattern.n;
+    if n == 0 {
+        return false;
+    }
+    let full_nnz = pattern.row_idx.len();
+    if full_nnz == 0 {
+        return false;
+    }
+    let avg_deg = full_nnz as f64 / n as f64;
+    let heavy_thr = (HEAVY_AVG_MULT * avg_deg).ceil() as usize;
+    let heavy_thr = heavy_thr.max(HEAVY_DEG_FLOOR);
+
+    let mut heavy_count = 0usize;
+    let mut heavy_nnz = 0usize;
+    for j in 0..n {
+        let deg = pattern.col_ptr[j + 1] - pattern.col_ptr[j];
+        if deg > heavy_thr {
+            heavy_count += 1;
+            heavy_nnz += deg;
+        }
+    }
+
+    if heavy_count == 0 {
+        return false;
+    }
+    let count_ok = (heavy_count as f64) < ARROW_COUNT_FRAC * n as f64;
+    let share_ok = (heavy_nnz as f64) >= ARROW_NNZ_SHARE * full_nnz as f64;
+    count_ok && share_ok
 }
 
 /// The complete output of symbolic factorization.
@@ -274,9 +366,11 @@ pub struct SymbolicFactorization {
     pub is_schur_tail: Option<usize>,
 }
 
-/// Pick a default ordering for `symbolic_factorize` from cheap matrix
-/// dimensions (no pattern walk). Narrow on purpose — see comment on
-/// `Auto` for why a broad dispatcher regressed the IPM bench.
+/// Size-only base ordering rule from cheap matrix dimensions (no pattern
+/// walk). Narrow on purpose — see comment on `Auto` for why a broad
+/// dispatcher regressed the IPM bench. `choose_adaptive` calls this for
+/// the bulk of patterns, then layers the pattern-aware catches on top
+/// (very-large-and-sparse → AMD; arrow/bordered → AMF, issue #64).
 ///
 /// Current rule (mirrors MUMPS's `ana_set_ordering.F` AMF-vs-METIS
 /// heuristic):
@@ -381,13 +475,16 @@ pub fn pick_ordering_preprocess(matrix: &CscMatrix) -> OrderingPreprocess {
 
 /// Perform symbolic factorization of a sparse symmetric matrix.
 ///
-/// Picks an ordering via [`pick_default_method`] (AMF for n ≤ 10_000,
-/// MetisND for n > 10_000). Callers who want a specific ordering with
-/// no dispatcher should call `symbolic_factorize_with_method` with an
+/// Picks the fill-reducing ordering adaptively via [`OrderingMethod::Auto`]
+/// (resolved by [`choose_adaptive`]): AMF for n ≤ 10_000 or arrow/bordered
+/// patterns, AMD for very-large-and-sparse, MetisND otherwise. Routing
+/// through `Auto` keeps this no-arg default and the explicit `Auto` caller
+/// in exact agreement (issue #64). Callers who want a specific ordering
+/// with no dispatcher should call `symbolic_factorize_with_method` with an
 /// explicit `OrderingMethod`.
 ///
 /// Steps:
-/// 1. Pick fill-reducing ordering (AMF or MetisND depending on n)
+/// 1. Pick fill-reducing ordering (resolved from `Auto` by `choose_adaptive`)
 /// 2. Build elimination tree of the permuted matrix
 /// 3. Compute column counts (fill prediction)
 /// 4. Detect and amalgamate supernodes
@@ -396,8 +493,7 @@ pub fn symbolic_factorize(
     matrix: &CscMatrix,
     snode_params: &SupernodeParams,
 ) -> Result<SymbolicFactorization, FeralError> {
-    let method = pick_default_method(matrix.n, matrix.row_idx.len());
-    symbolic_factorize_with_method(matrix, snode_params, method)
+    symbolic_factorize_with_method(matrix, snode_params, OrderingMethod::Auto)
 }
 
 /// Convert an owned-`usize` `CscPattern` into the contract's borrowed-`i32`
@@ -1646,6 +1742,116 @@ mod tests {
         assert_eq!(
             choose_adaptive(&p, OrderingMethod::MetisND),
             OrderingMethod::MetisND
+        );
+    }
+
+    /// Build a synthetic full-symmetric `CscPattern` with a prescribed
+    /// per-column degree distribution. Connectivity is irrelevant to the
+    /// degree-only arrow predicate, so row indices are filled with valid
+    /// in-range values without forming a true symmetric pattern.
+    fn pattern_with_degrees(degrees: &[usize]) -> CscPattern {
+        let n = degrees.len();
+        let mut col_ptr = Vec::with_capacity(n + 1);
+        let mut row_idx = Vec::new();
+        for (j, &d) in degrees.iter().enumerate() {
+            col_ptr.push(row_idx.len());
+            for t in 0..d {
+                row_idx.push((j + t) % n.max(1));
+            }
+        }
+        col_ptr.push(row_idx.len());
+        CscPattern {
+            n,
+            col_ptr,
+            row_idx,
+        }
+    }
+
+    #[test]
+    fn is_arrow_bordered_fires_on_synthetic_arrow() {
+        // Issue #64: a small set of very-high-degree border columns
+        // carrying a large nnz share = arrow. 11_900 body columns of
+        // degree 6 (71_400 nnz) + 100 border columns of degree 600
+        // (60_000 nnz). avg_deg≈10.95, heavy_thr=max(64,88)=88; border
+        // exceeds it. heavy_count=100 (0.83% of n < 5%); heavy_nnz share
+        // 60_000/131_400 = 45.7% >= 20% → arrow.
+        let mut degrees = vec![6usize; 11_900];
+        degrees.extend(std::iter::repeat_n(600usize, 100));
+        let pat = pattern_with_degrees(&degrees);
+        assert!(is_arrow_bordered(&pat), "r05-shaped arrow must be detected");
+    }
+
+    #[test]
+    fn is_arrow_bordered_rejects_uniform_sparse() {
+        // Uniformly thin (PoissonControl / powerflow22 / bratu3d shape):
+        // no column exceeds heavy_thr → not an arrow.
+        let pat = pattern_with_degrees(&vec![8usize; 12_000]);
+        assert!(
+            !is_arrow_bordered(&pat),
+            "uniform-sparse pattern must not be flagged as arrow"
+        );
+    }
+
+    #[test]
+    fn is_arrow_bordered_rejects_many_hubs() {
+        // Exercises the count guard: 1000 columns of degree 1000 (10% of
+        // n) carry 99% of the nnz, but a heavy set this large is not a
+        // thin border — nested dissection is not obviously wrong, so the
+        // arrow override must NOT fire. heavy_count=1000 = 10% > 5%.
+        let mut degrees = vec![1000usize; 1000];
+        degrees.extend(std::iter::repeat_n(1usize, 9000));
+        let pat = pattern_with_degrees(&degrees);
+        assert!(
+            !is_arrow_bordered(&pat),
+            "a large heavy set (10% of n) must be rejected by the count guard"
+        );
+    }
+
+    #[test]
+    fn is_arrow_bordered_rejects_low_nnz_share_border() {
+        // bcsstk38 shape: 2 very-high-degree columns but they carry a
+        // tiny nnz share (0.3%). The share guard rejects it. n must be
+        // small enough that 2 cols < 5%, which is always true here.
+        let mut degrees = vec![44usize; 8030];
+        degrees.extend([614usize, 614usize]);
+        let pat = pattern_with_degrees(&degrees);
+        // heavy_thr = max(64, 8*~44) = ~355; the two 614-degree columns
+        // are heavy but carry 1228 of ~354_548 nnz = 0.35% << 20%.
+        assert!(
+            !is_arrow_bordered(&pat),
+            "a heavy set carrying a tiny nnz share must be rejected by the share guard"
+        );
+    }
+
+    #[test]
+    fn choose_adaptive_routes_arrow_to_amf() {
+        // Issue #64: an arrow pattern with n>10_000 (which would
+        // otherwise route to MetisND via pick_default_method) must be
+        // overridden to Amf. Mirror the synthetic-arrow degree shape.
+        let mut degrees = vec![6usize; 11_900];
+        degrees.extend(std::iter::repeat_n(600usize, 100));
+        let pat = pattern_with_degrees(&degrees);
+        assert_eq!(
+            choose_adaptive(&pat, OrderingMethod::Auto),
+            OrderingMethod::Amf,
+            "arrow/bordered pattern (n>10_000) must route to Amf, not MetisND"
+        );
+        // A uniform large pattern with the same n stays on MetisND.
+        let uniform = pattern_with_degrees(&vec![16usize; 12_000]);
+        assert_eq!(
+            choose_adaptive(&uniform, OrderingMethod::Auto),
+            OrderingMethod::MetisND,
+            "uniform large pattern must remain on MetisND"
+        );
+        // The arrow override must NOT fire below the size floor: a small
+        // arrow already routes to Amf via the n<=10_000 rule, but assert
+        // the override doesn't accidentally change a non-MetisND base.
+        let mut small_arrow = vec![6usize; 4900];
+        small_arrow.extend(std::iter::repeat_n(600usize, 100));
+        let small = pattern_with_degrees(&small_arrow);
+        assert_eq!(
+            choose_adaptive(&small, OrderingMethod::Auto),
+            OrderingMethod::Amf
         );
     }
 

--- a/tests/issue64_arrow_ordering.rs
+++ b/tests/issue64_arrow_ordering.rs
@@ -1,0 +1,50 @@
+//! Issue #64 regression: the default ordering must not pick MetisND on
+//! r05's arrow/bordered IPM KKT, where nested dissection blows the LDLᵀ
+//! factor up ~7–9× vs AMF/AMD.
+//!
+//! The fixture `tests/data/large/r05_kkt.mtx` is a generated IPM KKT
+//! (n=14842, nnz=118968), not a SuiteSparse download, so it is
+//! gitignored and regenerated on demand via
+//! `dev/scripts/regen_r05_kkt.sh`. When the fixture is absent (e.g. CI),
+//! this test prints a SKIP line and passes — it is a local/opt-in
+//! regression guard, not a CI gate.
+//!
+//! Oracle (external — the issue's measured fill): AMF/AMD ≈ 0.53–0.61M,
+//! MetisND ≈ 3.6–4.4M. The `< 1.0e6` threshold separates them with wide
+//! margin and is robust to ordering-impl / METIS-seed drift.
+
+use feral::read_mtx;
+use feral::symbolic::{symbolic_factorize, OrderingMethod, SupernodeParams};
+use std::path::Path;
+
+#[test]
+fn r05_kkt_default_ordering_avoids_metis_fill_blowup() {
+    let path = Path::new("tests/data/large/r05_kkt.mtx");
+    if !path.is_file() {
+        eprintln!(
+            "SKIP: {} not present. Regenerate with dev/scripts/regen_r05_kkt.sh.",
+            path.display()
+        );
+        return;
+    }
+
+    let m = read_mtx(path)
+        .and_then(|mtx| mtx.to_csc())
+        .expect("read r05_kkt.mtx");
+    assert_eq!(m.n, 14842, "unexpected r05 KKT dimension");
+
+    let sym = symbolic_factorize(&m, &SupernodeParams::default()).expect("symbolic factorize r05");
+    let nnz_l: usize = sym.col_counts.iter().sum();
+
+    assert_ne!(
+        sym.resolved_method,
+        OrderingMethod::MetisND,
+        "issue #64: default ordering must not route r05's arrow KKT to MetisND"
+    );
+    assert!(
+        nnz_l < 1_000_000,
+        "issue #64: nnz_L = {} should be < 1.0e6 (AMF/AMD ≈ 0.5-0.6M; the \
+         MetisND regression is ≈ 3.6-4.4M)",
+        nnz_l
+    );
+}


### PR DESCRIPTION
Fixes #64.

## Problem

The default ordering routed by size alone (`n > 10_000 → MetisND`),
discarding the stored nnz it received. On **arrow / bordered KKTs** — a
thin body plus a handful of very-high-degree "border" columns (an IPM
augmented system with a few dense inequality rows) — nested dissection
cannot isolate the dense border and the LDLᵀ factor blows up ~7–9× vs
AMF/AMD.

Measured on r05's iter-0 IPM KKT (n=14842, 171 of 14842 columns at
degree 502 carrying 38.5% of the nonzeros):

| ordering | nnz_L | vs AMF |
|---|---|---|
| Amf | 506 210 | 1.00× |
| Amd | 607 519 | 1.20× |
| MetisND (old default) | 4 358 715 | **8.61×** |

POUNCE end-to-end: ~16 s (auto→MetisND) → 0.84 s (amf).

## Fix

A cheap O(n) degree pass (`is_arrow_bordered`) on the full symmetric
pattern detects the arrow signature and overrides the would-be-MetisND
decision to AMF. A "heavy" column has degree `> max(64, 8·avg_deg)`; the
catch fires iff `1 ≤ heavy_count < 0.05·n` (a small set) **and**
`heavy_nnz ≥ 0.20·full_nnz` (a large nnz share).

The share guard is the discriminator — it fires on r05 (38.5%) and
rejects bcsstk38 (0.3% share despite two degree-614 columns); the count
guard rejects "many hub" patterns. Uniformly-thin matrices
(PoissonControl, powerflow22, bratu3d, cont-201) have no heavy column
and are untouched.

The catch lives in `choose_adaptive`, and `symbolic_factorize` now
resolves through `OrderingMethod::Auto` rather than calling
`pick_default_method` directly — so the no-arg default and an explicit
`Auto` caller resolve to the same concrete ordering on every matrix.
This also closes a latent inconsistency: only `choose_adaptive` had the
#50 `n>100_000 && avg_deg<5 → AMD` branch, so the two paths could
already disagree on very-large-sparse matrices.

## Tests / evidence

- 4 predicate unit tests (synthetic arrow fires; uniform-sparse,
  many-hubs (count guard), and low-share border (share guard) rejected)
  plus `choose_adaptive_routes_arrow_to_amf`.
- Regression `tests/issue64_arrow_ordering.rs`: `symbolic_factorize(r05_kkt)`
  yields `nnz_L < 1.0e6` and `resolved_method != MetisND` (verified
  red→green). Oracle is external (the issue's measured fill). The fixture
  is a generated IPM KKT, not a SuiteSparse download, so it is gitignored
  and the test **skips when absent** (CI is unaffected); regenerate with
  `dev/scripts/regen_r05_kkt.sh`.
- Full suite green; `clippy -D warnings` + `fmt` clean. `issue_3`
  (PoissonControl K=58 → MetisND) preserved.

Research note: `dev/research/issue-64-arrow-bordered-ordering.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
