### PR TITLE
docs(readme): document the feral-diagnostics crate invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,19 @@ family-grouped failure analysis and dense ∩ sparse cross-comparison.
 The KKT matrices are not committed — generate them via ripopt's
 `collect_kkt` tool.
 
+### Diagnostic binaries
+
+The `bench` binary lives in the root `feral` package. The ~140
+throwaway investigation probes (`diag_*`, `probe_*`, `bench_*`, …)
+live in a separate non-default workspace crate, `feral-diagnostics`,
+so they are excluded from the default `cargo build` / `cargo test` /
+`cargo clippy`. Run one with `-p`:
+
+```sh
+cargo run -p feral-diagnostics --bin <name> [-- args...]
+cargo build -p feral-diagnostics            # compile them all
+```
+
 ## Using FERAL inside Ipopt
 
 FERAL ships with everything needed to build [Ipopt


### PR DESCRIPTION
## Summary

Docs-only. Adds a **Diagnostic binaries** subsection to `README.md` (under
"Running the KKT benchmark") documenting that the ~140 investigation probes
now live in the `feral-diagnostics` workspace crate and are run with
`cargo run -p feral-diagnostics --bin <name>`.

This is the optional README follow-up noted in the session-2026-06-03-05
checkpoint, after #71 moved the probes out of the root package's `src/bin/`.
The CHANGELOG #71 entry and the crate `Cargo.toml` comment already covered
it, but not anywhere a reader hunting a moved probe would look first.

## Why

After #71, `cargo run --bin probe_issue67_thin` no longer resolves from the
root (the probe moved to a non-default member crate). Without a README line,
the first thing a reader hits is a "no bin named X" error.

## Scope

No library, kernel, or solver source touched — 13 added lines in `README.md`.
The Rust pre-commit hooks (`cargo fmt --check`, `cargo clippy`) correctly
skip (no Rust files in the diff).

Closes the README item from the #71 / session-05 follow-up list (tracked
alongside #73, the n>100k thin-regime investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
