### PR TITLE
feat(ordering): route Auto to AMF at every size, drop AMF_BAND_MAX (closes #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `Auto` now prefers AMF over MetisND at every size (#73)
+
+Extends the #67 thin-large reroute past its `n ≤ 100_000` ceiling: the
+`AMF_BAND_MAX` bound is **removed**, so whenever the size rule would pick
+MetisND, `choose_adaptive` now routes to AMF at **every** `n`. The earlier
+`n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+catches still fire first, so the powerflow-class guardrail and dense-border
+catch are unchanged — only the uniformly-thin would-be-MetisND population
+above 100k is affected.
+
+#67 deferred this regime as under-sampled. The #73 investigation closed it
+with a real **factor + solve** A/B (`probe_issue67_thin`) on the n>100k
+families: AMF wins on **every measured matrix** — dtoc2 2.49×, pinene 1.18×,
+cont5_1_l 2.75×, nql180 2.05×, YATP1NE 2.13×. The decisive case is **nql180**,
+where MetisND has 2% *smaller* symbolic fill yet AMF is 2.05× faster on the
+real factor+solve — proving that fill (`factor_nnz_estimate` / flop_proxy) is
+not a reliable speed predictor at this scale. A fill-guarded race was
+therefore **rejected** in favor of the unconditional reroute (see
+`dev/tried-and-rejected.md`).
+
+See `dev/research/issue-73-n100k-thin-regime.md` and `dev/decisions.md`.
+
 ### Changed — diagnostic binaries moved out of the default build/test set (#71)
 
 The root `feral` package's `src/bin/` held 145 binaries, 144 of them

--- a/crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs
@@ -1,0 +1,148 @@
+//! Issue #73 step 1: is the n>100k thin AMF-vs-MetisND question a *symbolic*
+//! (ordering/fill) blowup or a *numeric* (factorization) cost difference?
+//!
+//! #67 bounded the AMF reroute at `n <= 100_000` because, just above the band,
+//! `pinene_3200` (n≈128k) still favored AMF but `RDW2D51U` (n≈195k) did not
+//! finish a single full factor+solve A/B in ~10 min. That timeout came from
+//! the *full* `Solver` path (ordering + symbolic + numeric + solve), so it
+//! cannot tell us whether the cost lives in the ordering/fill or in the dense
+//! numeric kernels.
+//!
+//! This probe runs **symbolic only** — no numeric factorization, no solve —
+//! for AMF and MetisND, and reports the cheap predictors that drive numeric
+//! cost:
+//!
+//! - `sym_ms`: wall time of `symbolic_factorize_with_method` (ordering +
+//!   analysis). Cheap; isolates the ordering cost itself.
+//! - `nnz_L_est`: `factor_nnz_estimate` (predicted L nonzeros = fill).
+//! - `max_front`: largest frontal `nrow` (dimension of the biggest dense
+//!   block the numeric phase must factor).
+//! - `flop_proxy`: Σ ncol·nrow² over supernodes — a dense-multifrontal work
+//!   proxy (panel factor + Schur update), the dominant term in numeric
+//!   wall-time.
+//! - `peak_MB`: `peak_contrib_bytes` / 1e6 (peak contribution pool).
+//!
+//! Interpretation: if AMF's symbolic finishes in seconds with smaller
+//! nnz_L/flop_proxy than MetisND, the #67 RDW2D51U timeout was numeric, and
+//! AMF is the cheaper ordering there too (supporting a band extension). If
+//! AMF's flop_proxy is *larger* than MetisND's, the bound is doing real work
+//! and should stay.
+//!
+//! Run:
+//!   cargo run -p feral-diagnostics --release --bin probe_issue73_symbolic -- <matrix.mtx>...
+//!
+//! Throwaway diagnostic, not a test.
+
+use feral::read_mtx;
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use std::time::Instant;
+
+/// Cheap symbolic predictors for one (matrix, method) pair.
+struct SymStats {
+    sym_ms: f64,
+    nnz_l_est: usize,
+    max_front: usize,
+    flop_proxy: f64,
+    peak_mb: f64,
+}
+
+fn measure(
+    m: &feral::sparse::csc::CscMatrix,
+    method: OrderingMethod,
+) -> Result<SymStats, feral::FeralError> {
+    let params = SupernodeParams::default();
+    let t = Instant::now();
+    let sym = symbolic_factorize_with_method(m, &params, method)?;
+    let sym_ms = t.elapsed().as_secs_f64() * 1e3;
+
+    let mut max_front = 0usize;
+    let mut flop_proxy = 0f64;
+    for s in &sym.supernodes {
+        if s.nrow > max_front {
+            max_front = s.nrow;
+        }
+        // Dense-multifrontal work proxy: panel factor + Schur update on an
+        // nrow × ncol front is ~ ncol · nrow². f64 to avoid usize overflow on
+        // large fronts (nrow² alone can exceed u32, and the sum exceeds u64
+        // headroom only in extreme cases — f64 is the safe accumulator here).
+        flop_proxy += s.ncol as f64 * (s.nrow as f64) * (s.nrow as f64);
+    }
+
+    Ok(SymStats {
+        sym_ms,
+        nnz_l_est: sym.factor_nnz_estimate,
+        max_front,
+        flop_proxy,
+        peak_mb: sym.peak_contrib_bytes as f64 / 1e6,
+    })
+}
+
+fn main() {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: probe_issue73_symbolic <matrix.mtx>...");
+        eprintln!("  symbolic-only AMF vs MetisND predictors for n>100k thin (#73)");
+        return;
+    }
+
+    println!(
+        "{:<22} {:>9} {:>7} {:>12} {:>10} {:>13} {:>10}",
+        "matrix/method", "n", "sym_ms", "nnz_L_est", "max_front", "flop_proxy", "peak_MB"
+    );
+
+    for p in &paths {
+        let pb = std::path::Path::new(p);
+        let name = pb.file_stem().and_then(|s| s.to_str()).unwrap_or("?");
+        let m = match read_mtx(pb).and_then(|x| x.to_csc()) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("skip {name}: read/convert failed: {e:?}");
+                continue;
+            }
+        };
+
+        let mut amf_nnz = 0f64;
+        let mut metis_nnz = 0f64;
+        let mut amf_flop = 0f64;
+        let mut metis_flop = 0f64;
+        for (label, method) in [
+            ("AMF", OrderingMethod::Amf),
+            ("MetisND", OrderingMethod::MetisND),
+        ] {
+            match measure(&m, method) {
+                Ok(s) => {
+                    println!(
+                        "{:<22} {:>9} {:>7.1} {:>12} {:>10} {:>13.3e} {:>10.1}",
+                        format!("{name}/{label}"),
+                        m.n,
+                        s.sym_ms,
+                        s.nnz_l_est,
+                        s.max_front,
+                        s.flop_proxy,
+                        s.peak_mb,
+                    );
+                    if label == "AMF" {
+                        amf_nnz = s.nnz_l_est as f64;
+                        amf_flop = s.flop_proxy;
+                    } else {
+                        metis_nnz = s.nnz_l_est as f64;
+                        metis_flop = s.flop_proxy;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("{name}/{label}: symbolic failed: {e:?}");
+                }
+            }
+        }
+        // Ratios MetisND/AMF: >1 means AMF is the cheaper ordering (the #67
+        // hypothesis above the band). <1 means MetisND wins and the bound earns
+        // its keep.
+        if amf_nnz > 0.0 && metis_nnz > 0.0 {
+            println!(
+                "  -> MetisND/AMF  nnz_L {:.3}x  flop_proxy {:.3}x",
+                metis_nnz / amf_nnz,
+                metis_flop / amf_flop,
+            );
+        }
+    }
+}

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,163 +1,185 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-03T18:01:39Z
+Generated: 2026-06-03T19:36:56Z
 
 ## Latest Session
-File: dev/sessions/2026-06-03-05.md
+File: dev/sessions/2026-06-03-06.md
 ```
-# Session 2026-06-03-05
+# Session 2026-06-03-06
 
 ## Goal
-Issue #71 (follow-up to session-04's "Next Session Should"): relocate the 144
-throwaway `src/bin` diagnostic binaries out of the default build/test set so
-root `cargo build` / `cargo test` / `cargo clippy` stop compiling them on
-every invocation. Keep the single keeper (`bench.rs`) and the protocol
-command `cargo run --bin bench --release` unchanged.
+Issue #73 (the n>100k thin-regime follow-up to #67, opened from session-05's
+"Next Session Should"): settle whether the regime above `AMF_BAND_MAX`
+(100_000) should keep MetisND or reroute to AMF, and implement the outcome.
+Also merged the two session-05 follow-ups (#67/#71 housekeeping) on the way in.
 
 ## Accomplished
-- **New crate `crates/feral-diagnostics/`** (`publish = false`,
-  `autobins = true`, depends on `feral` + the six ordering crates + serde/
-  serde_json/pulp/rayon). All 144 diagnostics `git mv`'d into its `src/bin/`
-  (history preserved); only `bench.rs` remains in the root package.
-- **Workspace member** added in root `Cargo.toml`. Because the diagnostics
-  crate is a member but **not** a dependency of `feral`, root commands
-  without `-p`/`--workspace` compile the `feral` package only. Verified:
-  root `cargo build` compiles **zero** diagnostics.
-- **CI updated** (`.github/workflows/ci.yml`):
-  - `stress-smoke` now selects `bench_one_matrix` (build) and
-    `probe_fma_kernel` (run) with `-p feral-diagnostics`.
-  - `check` job adds `cargo clippy -p feral-diagnostics --all-targets
-    -- -D warnings` and `cargo test -p feral-diagnostics`, keeping the
-    diagnostics lint-clean and their 2 test sets running where it is cheap
-    (Linux), having dropped them from the slow local path.
-- **Verification** (all green):
-  - root `cargo build`: no diagnostics compiled.
-  - `cargo build -p feral-diagnostics`: all 144 compile, **zero warnings**
-    (after adding the six ordering-crate deps — see Abandoned/fix below).
-  - `cargo clippy -p feral-diagnostics --all-targets -- -D warnings`: clean.
-  - diag tests (targeted): `diag_cond_parity` 5 passed, `diag_schur_parity`
-    4 passed.
-  - `cargo build --bin bench` from root: resolves (protocol cmd unchanged).
-  - `cargo run -p feral-diagnostics --bin probe_issue67_thin`: runs (usage).
-  - root `cargo clippy -- -D warnings`: clean (now lib + `bench` only).
-  - root `cargo test`: <RESULT PENDING — recorded below>.
+
+### Housekeeping (start of session)
+- **PR #74** (docs(readme): document the `feral-diagnostics` crate invocation,
+  the session-05 follow-up #2) — CI green, squash-merged → main `caf4120`.
+- **Issue #73** opened to track the n>100k investigation (follow-up #1).
+
+### Issue #73 — investigation (3 steps)
+- **Step 1 — symbolic diagnosis** (`probe_issue73_symbolic`, committed
+  `49b153e`): the #67 RDW2D51U ">10 min, did not complete" was **numeric**,
+  not an AMF fill blowup. AMF's symbolic finishes in **167 ms** (n=195k) and
+  AMF is the *cheaper* ordering there (1.26× fewer nnz_L, 1.55× less flop_proxy
+  than MetisND). The band was guarding nothing.
+- **Step 2 — symbolic sweep:** over the affected `n>100k && avg_deg ≥ 5`
+  non-arrow population, AMF wins or ties 6/7 on nnz_L / flop_proxy; the lone
+  predicted MetisND win was **nql180** (nnz_L 0.98×, flop_proxy 0.86×).
+- **Step 3 — real factor+solve A/B** (`probe_issue67_thin --reps 1`): AMF wins
+  factor+solve on **every measured matrix** — dtoc2 2.49×, pinene 1.18×,
+  cont5_1_l 2.75×, nql180 2.05×, YATP1NE 2.13×. **nql180 is the
+  design-breaker:** MetisND has 2% *smaller* fill yet AMF is 2.05× faster
+  (fac 1903 ms vs 3949 ms). So nnz_L / flop_proxy mispredict real speed — a
+  fill-guarded race would have demoted nql180 and forfeited the 2×.
+
+### Issue #73 — implementation (commit `4c49745`)
+- **Dropped `AMF_BAND_MAX`.** `choose_adaptive` now overrides every
+  would-be-MetisND `Auto` decision to AMF at **every** `n`. The
+  `n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+  catches fire first and are untouched.
+- **Tests updated** (oracle = the real A/B, external to the change):
+  `choose_adaptive_rules` n=150_000 → Amf (was MetisND);
+  `choose_adaptive_routes_arrow_to_amf` n=120_000 non-arrow → Amf.
+- **Verification:** `cargo test --lib` → **322 passed, 0 failed** (6 ignored);
+  `cargo clippy --lib -- -D warnings` → clean; pre-commit fmt+clippy passed.
+  CI is the authoritative gate (PR #75).
+- PR #75 reframed from "investigation only" to the full change, **closes #73**.
 
 ## Benchmark Results
-Not run. #71 is a **build-layout change only** — no library, kernel, or
-solver source was modified (the move is `git mv` of binary crates plus
-manifest/CI edits). The benchmark exercises the `feral` library, whose code
-is byte-for-byte unchanged, so its inertia / residual / timing columns
-cannot move. The last recorded numbers are session-04's #67 filtered bench
-(137/137 inertia match vs MUMPS, worst residual 4.22e-12) and remain valid.
-
-```
-(no bench run — see rationale above; library unchanged from session-04)
-```
-
-## Decisions Made
+`cargo run --bin bench --release` (captured tail — the harness retains the
+final summary). Both Phase 2.8.1 partition gates **PASS**; worst factor-ratios
+are tiny-n fixed-cost-dominated matrices (KIRBY2 n=458, etc.) consistent with
+prior sessions. The bench corpus is dominated by small matrices (n ≤ ~5k), so
+the n>100k reroute is essentially orthogonal to it — this run is a
 ```
 
 ## Git Status
 ```
+4c49745 feat(ordering): route Auto to AMF at every size, drop AMF_BAND_MAX (#73)
+49b153e investigate(#73): symbolic-only AMF-vs-MetisND probe for the n>100k thin regime
+caf4120 docs(readme): document the feral-diagnostics crate invocation (#74)
+2ef751f refactor(build): move 144 diagnostic binaries to crates/feral-diagnostics (closes #71) (#72)
 3391d6a fix(ordering): thin-large default prefers AMF up to n≤100k (closes #67) (#70)
-5bcfecc Merge pull request #68 from jkitchin/claude/issue-63-diagnosis
-892d7ef Merge remote-tracking branch 'origin/main' into claude/issue-63-diagnosis
-0673f1b Merge pull request #69 from jkitchin/claude/issue-65-mc64-scaling
-cfd8f68 docs(session): checkpoint 2026-06-03-03 — MC64 scaling fallback (#65)
 ```
 
 ## Test Status
 ```
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test scaling::tests::auto_falls_back_to_infnorm_on_mss1_0009 ... ok
 test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 
-test result: ok. 322 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.41s
+test result: ok. 322 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.44s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-03-05.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-03-06.md)
 
-Not run. #71 is a **build-layout change only** — no library, kernel, or
-solver source was modified (the move is `git mv` of binary crates plus
-manifest/CI edits). The benchmark exercises the `feral` library, whose code
-is byte-for-byte unchanged, so its inertia / residual / timing columns
-cannot move. The last recorded numbers are session-04's #67 filtered bench
-(137/137 inertia match vs MUMPS, worst residual 4.22e-12) and remain valid.
+`cargo run --bin bench --release` (captured tail — the harness retains the
+final summary). Both Phase 2.8.1 partition gates **PASS**; worst factor-ratios
+are tiny-n fixed-cost-dominated matrices (KIRBY2 n=458, etc.) consistent with
+prior sessions. The bench corpus is dominated by small matrices (n ≤ ~5k), so
+the n>100k reroute is essentially orthogonal to it — this run is a
+no-regression confirmation, not where the #73 win shows up (that is the
+factor+solve A/B above).
 
-(no bench run — see rationale above; library unchanged from session-04)
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(μs)    mumps(μs)      ratio
+KIRBY2_0007                    458          940          119       7.90
+KIRBY2_0006                    458          889          127       7.00
+CRESC132_0000                 5314        80529        12266       6.57
+KIRBY2_0008                    458          772          122       6.33
+KIRBY2_0009                    458          742          128       5.80
+MUONSINE_0000                 1537         1978          376       5.26
+KIRBY2_0010                    458          683          133       5.14
+KIRBY2_0011                    458          585          120       4.88
+GROUPING_0219                  225          525          114       4.61
+GROUPING_0179                  225          452          114       3.96
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.34     <= 2.0     PASS
+medium (<500)            152145     1.74     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.50     <= 2.0     PASS
+medium (<500)            153560     1.51     <= 3.0     PASS
 
 ```
 
 ## Recent Decisions
-  disabled and all 144 binaries enumerated as explicit `[[bin]]` blocks
-  with `required-features` — verbose and brittle. A separate crate is the
-  idiomatic non-default-build mechanism.
-- Deleting the diagnostics: they are the audit trail behind shipped
-  decisions (probe_issue67_thin, probe_issue65_corpus, …) and are cheap to
-  keep once out of the default build.
+`n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+catches fire first and are untouched, so the powerflow-class guardrail and
+the dense-border catch still hold; only the uniformly-thin would-be-MetisND
+population is rerouted.
 
-Constraints preserved:
-- `bench.rs` stays in the root package so `cargo run --bin bench --release`
-  (the session protocol command) is unchanged.
-- CI `stress-smoke` selects `bench_one_matrix` / `probe_fma_kernel` with
-  `-p feral-diagnostics`. The `check` job adds
-  `cargo clippy -p feral-diagnostics --all-targets -- -D warnings` and
-  `cargo test -p feral-diagnostics` so the diagnostics stay lint-clean and
-  their 2 test sets keep running — the bar is kept where it is cheap
-  (Linux CI) and dropped only on the slow local path (pre-commit clippy /
-  local `cargo test`).
-- `feral-diagnostics` is absent from the explicit release publish list and
-  is marked `publish = false`.
+Rejected alternative — **fill-guarded reroute** (route above 100k to AMF
+only when AMF `factor_nnz_estimate ≤ MetisND's`): this was the design
+proposed in the #73 research note *before* the real A/B and the one
+originally requested. It is wrong: Finding 3 shows nql180's fill predicate
+is *anti-correlated* with real speed (MetisND smaller fill, AMF 2× faster),
+so the guard would have kept nql180 on MetisND and forfeited the 2× win.
+Fill is not a speed proxy here; a guard keyed on it adds a per-solve
+symbolic-race cost to make the *wrong* call. Logged in
+`dev/tried-and-rejected.md`.
 
-No library or solver source changed; this is a build-layout change only.
+Scope / generalization: the mechanism is the same as #67 (AMF's cheaper
+symbolic + competitive-or-better numeric on uniformly-thin patterns), now
+shown to hold above 100k too. The `n>100k && avg_deg<5 → Amd` powerflow
+guardrail (#50) is the one place broad thin-matrix reroutes were shown to
+regress, and it is preserved by firing first. RDW2D51U + QUADCOPTER did not
+finish the real A/B on the loaded test machine; their symbolic predictors
+(AMF 1.55× cheaper / tie) and Finding 1 already favor AMF and do not change
+the conclusion.
 
-Evidence: crates/feral-diagnostics/Cargo.toml, root Cargo.toml workspace
-members, .github/workflows/ci.yml, dev/journal/2026-06-03-05.org. Verified:
-root `cargo build` compiles no diagnostics; `cargo build -p
-feral-diagnostics` compiles all 144 cleanly; `cargo clippy -p
-feral-diagnostics --all-targets -- -D warnings` clean; the 2 diag test sets
-pass (5 + 4); root `cargo clippy -- -D warnings` clean; `cargo run --bin
-bench` and `cargo run -p feral-diagnostics --bin probe_issue67_thin` both
-resolve.
+Evidence: dev/research/issue-73-n100k-thin-regime.md (Findings 1–3 +
+Decision), dev/journal/2026-06-03-06.org (:issue-73:ab:factor-solve:),
+src/symbolic/mod.rs choose_adaptive (AMF_BAND_MAX removed) +
+choose_adaptive_rules / choose_adaptive_routes_arrow_to_amf tests,
+crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs,
+crates/feral-diagnostics/src/bin/probe_issue67_thin.rs.
 
 ## Recent Tried-and-Rejected
-   destroyed), inertia scrambled. Strictly worse. Force-accept-and-report-zeros
-   is the useful behavior: it signals singularity so pounce escalates δ_w.
 
-3. Any principled "better inertia" change. The ordering that wins (metis)
-   reports a MORE pessimistic, LESS correct inertia (neg 255 ≠ 252 expected) on
-   the singular matrix; that makes pounce regularize earlier and escape a frozen
-   2.30e-8 fixed point. There is no known-correct inertia change that fixes
-   scrs8 — "correct" inertia (amf) is what under-regularizes into the stall.
+Rejected by the real factor+solve A/B (`probe_issue67_thin --reps 1`). The
+guard's predicate is **anti-correlated with real speed on nql180**: MetisND has
+2% *smaller* fill (fill_r 0.98) yet AMF is **2.05× faster** on the actual
+factor+solve (fac_amf 1903 ms vs fac_met 3949 ms). The fill guard would have
+read "MetisND fill is smaller → keep MetisND" and **forfeited a 2× speedup**.
+nnz_L and the Σ ncol·nrow² flop_proxy do not predict factor+solve wall-time at
+this scale (the numeric phase's cache/critical-path behavior dominates), so any
+routing guard keyed on symbolic fill makes the wrong call exactly where it
+matters — and adds a per-solve symbolic-race cost to do it.
 
-4. Ordering-class heuristic (route this KKT class to metis/scotch). Not pursued:
-   the issue itself calls it "papering over the symptom," and it risks the
-   cascade-break don't-regress set (robot_1600, NARX_CFy, marine_1600,
-   rocket_12800, pinene_3200).
-
-Conclusion: the durable fix is the δ_w / inertia-acceptance interaction
-(pounce-side or joint), not FERAL factorization accuracy. Full analysis:
-dev/research/issue-63-nearsingular-ordering-diagnosis.md;
-dev/journal/2026-06-03-02.org; probe src/bin/probe_issue63_nearsingular.rs.
-Future sessions: do NOT re-attempt a FERAL-only fix for scrs8 without first
-re-checking these four dead ends.
+Symptoms / evidence of the failure: on real factor+solve AMF wins ALL 5
+measured n>100k families (dtoc2 2.49×, pinene 1.18×, cont5_1_l 2.75×, nql180
+2.05×, YATP1NE 2.13×), including the matrix the guard would have demoted.
+Superseded by the **unconditional** AMF extension (drop `AMF_BAND_MAX`; route
+every would-be-MetisND decision to AMF), recorded in `dev/decisions.md`
+(2026-06-03, issue #73). Future sessions: do NOT reintroduce a fill / nnz_L /
+flop_proxy guard on the n>100k AMF reroute — nql180 is the standing
+counterexample. Data: dev/research/issue-73-n100k-thin-regime.md (Finding 3),
+dev/journal/2026-06-03-06.org (:issue-73:ab:factor-solve:surprise:).
 
 ## Source Files
 ```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5223,3 +5223,63 @@ feral-diagnostics --all-targets -- -D warnings` clean; the 2 diag test sets
 pass (5 + 4); root `cargo clippy -- -D warnings` clean; `cargo run --bin
 bench` and `cargo run -p feral-diagnostics --bin probe_issue67_thin` both
 resolve.
+
+## 2026-06-03 — Unconditional AMF above 100k: `AMF_BAND_MAX` dropped, fill-guard rejected (issue #73)
+
+Issue #73 is the n>100k follow-up to #67. #67 bounded the thin-large
+reroute at `n ≤ AMF_BAND_MAX = 100_000` because, just above the band,
+`RDW2D51U` (n≈195k) "did not complete a single Auto+AMF+MetisND pass in ~10
+min" on the full Solver path — an **unattributed** timeout. The open
+question: is the >100k regime an AMF *fill* blowup (keep the bound) or just
+expensive *numeric* cost (the bound is leaving wins on the table)?
+
+Evidence, three steps:
+1. **Symbolic diagnosis** (`probe_issue73_symbolic`): RDW2D51U's AMF
+   symbolic finishes in **167 ms** — the #67 timeout was the *numeric*
+   factor, not ordering, and AMF is the *cheaper* ordering there (1.26×
+   fewer nnz_L, 1.55× less flop_proxy than MetisND). The bound was guarding
+   nothing.
+2. **Symbolic sweep** over the affected population (`n>100k && avg_deg ≥ 5`,
+   non-arrow — the only matrices the bound moves): AMF wins or ties 6/7 on
+   nnz_L / flop_proxy. The lone exception was **nql180** (MetisND nnz_L
+   0.98×, flop_proxy 0.86× — predicted MetisND win).
+3. **Real factor+solve A/B** (`probe_issue67_thin --reps 1`, mirroring #67's
+   methodology): AMF wins factor+solve on **every measured matrix** —
+   dtoc2 2.49×, pinene 1.18×, cont5_1_l 2.75×, nql180 2.05×, YATP1NE 2.13×.
+   **nql180 is the design-breaker:** MetisND has 2% *smaller* fill yet AMF
+   is **2.05× faster** on the real factor+solve (fac 1.90 s vs 3.95 s). So
+   nnz_L and the flop_proxy **mispredict** real speed at this scale.
+
+Decision: drop `AMF_BAND_MAX` entirely. In `choose_adaptive`, the
+would-be-MetisND decision is overridden to AMF at **every** `n`:
+`if base == OrderingMethod::MetisND { return Amf; }`. The earlier
+`n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+catches fire first and are untouched, so the powerflow-class guardrail and
+the dense-border catch still hold; only the uniformly-thin would-be-MetisND
+population is rerouted.
+
+Rejected alternative — **fill-guarded reroute** (route above 100k to AMF
+only when AMF `factor_nnz_estimate ≤ MetisND's`): this was the design
+proposed in the #73 research note *before* the real A/B and the one
+originally requested. It is wrong: Finding 3 shows nql180's fill predicate
+is *anti-correlated* with real speed (MetisND smaller fill, AMF 2× faster),
+so the guard would have kept nql180 on MetisND and forfeited the 2× win.
+Fill is not a speed proxy here; a guard keyed on it adds a per-solve
+symbolic-race cost to make the *wrong* call. Logged in
+`dev/tried-and-rejected.md`.
+
+Scope / generalization: the mechanism is the same as #67 (AMF's cheaper
+symbolic + competitive-or-better numeric on uniformly-thin patterns), now
+shown to hold above 100k too. The `n>100k && avg_deg<5 → Amd` powerflow
+guardrail (#50) is the one place broad thin-matrix reroutes were shown to
+regress, and it is preserved by firing first. RDW2D51U + QUADCOPTER did not
+finish the real A/B on the loaded test machine; their symbolic predictors
+(AMF 1.55× cheaper / tie) and Finding 1 already favor AMF and do not change
+the conclusion.
+
+Evidence: dev/research/issue-73-n100k-thin-regime.md (Findings 1–3 +
+Decision), dev/journal/2026-06-03-06.org (:issue-73:ab:factor-solve:),
+src/symbolic/mod.rs choose_adaptive (AMF_BAND_MAX removed) +
+choose_adaptive_rules / choose_adaptive_routes_arrow_to_amf tests,
+crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs,
+crates/feral-diagnostics/src/bin/probe_issue67_thin.rs.

--- a/dev/journal/2026-06-03-06.org
+++ b/dev/journal/2026-06-03-06.org
@@ -1,0 +1,74 @@
+#+TITLE: FERAL Journal 2026-06-03-06
+#+STARTUP: showall
+
+* 23:30 :issue-73:followup:merge:
+Merged the two #67/#71 follow-ups from the session-05 checkpoint:
+- PR #74 (docs(readme): document feral-diagnostics crate invocation) —
+  CI green, squash-merged, main → caf4120. The optional README line for
+  the moved probes (#2 from the checkpoint follow-up list).
+- Opened issue #73 to track the n>100k thin-regime investigation (#1).
+
+* 23:45 :issue-73:diagnose:symbolic-only:
+Step 1 of #73: settle whether the #67 RDW2D51U ">10 min, did not complete"
+was an AMF *fill* blowup or raw *numeric* cost. The #67 A/B used the full
+Solver path (ordering+symbolic+numeric+solve, reps=1, all three orderings),
+so the timeout was unattributed.
+
+Wrote crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs —
+symbolic-only (no numeric factor, no solve). For AMF and MetisND it reports
+sym_ms, nnz_L_est (=factor_nnz_estimate), max_front (largest supernode nrow),
+flop_proxy (Σ ncol·nrow², dense-multifrontal work proxy), peak_MB.
+
+RDW2D51U (n=195075):
+  AMF:     sym 167ms  nnz_L 28.19M  max_front 1398  flop 1.147e10  peak 40.1MB
+  MetisND: sym 944ms  nnz_L 35.59M  max_front 1608  flop 1.782e10  peak 44.9MB
+  -> MetisND/AMF nnz_L 1.263x, flop 1.554x.
+pinene_3200 (n=127995):
+  AMF:     sym 608ms  nnz_L 2.00M   max_front  29   flop 3.39e7
+  MetisND: sym 1020ms nnz_L 2.42M   max_front 346   flop 8.24e7
+  -> MetisND/AMF nnz_L 1.207x, flop 2.433x.
+
+CONCLUSION: RDW2D51U symbolic finishes in 167ms — the #67 timeout was
+NUMERIC, not an AMF ordering/fill blowup. And AMF is the *cheaper* ordering
+on RDW2D51U (1.26x fewer nnz_L, 1.55x less flop_proxy than MetisND). The #67
+A/B blew its 10-min budget on MetisND's heavier numeric factor (35.6M nnz_L,
+1608-wide front), not on AMF. So above the band the bound is leaving AMF wins
+on the table, not guarding a blowup — at least here.
+
+* 00:05 :issue-73:sweep:symbolic:
+Step 2 (partial): symbolic-only sweep over the locally-available n>100k
+families, filtered to the MetisND-routed population (full_avg_deg >= 5; the
+n>100k && avg_deg<5 ones route to AMD and are unaffected by AMF_BAND_MAX).
+flop_proxy ratio = MetisND/AMF (>1 => AMF cheaper):
+
+  matrix      n      avg_deg  nnz_L M/A  flop M/A   verdict
+  dtoc2       104k   17.5     1.92       4.36       AMF wins big
+  pinene_3200 128k    9.42    1.21       2.43       AMF wins
+  cont5_1_l   181k    6.96    1.43       1.99       AMF wins
+  RDW2D51U    195k   18.24    1.26       1.55       AMF wins
+  RDW2D52U    195k   18.24    1.26       1.55       AMF wins (identical to 51U)
+  YATP1NE     246k    5.97    1.66      17.55       AMF wins big
+  QUADCOPTER  280k    5.14    1.00       1.00       tie (near-diagonal)
+  nql180      260k    5.74    0.98       0.86       MetisND wins  <-- counterexample
+  optmass     110k    3.55    (avg_deg<5 -> AMD-routed, unaffected)
+
+AMF wins or ties 6/7 of the affected population on symbolic predictors;
+nql180 is the lone MetisND win (MetisND ~14% less flop_proxy, ~2% fewer
+nnz_L). nql180 is a known matrix (cascade-break mode, decisions.md).
+
+CAVEATS before any AMF_BAND_MAX change:
+- nnz_L_est / flop_proxy are PREDICTIONS, not measured factor+solve wall
+  time. The #67 methodology weighs real factor+solve; e.g. pinene's measured
+  time_r was 1.18 while flop_proxy says 2.43 — direction agrees, magnitude
+  overstated. nql180 specifically needs the real number, not the proxy.
+- This is 8 families on one machine, one iterate each — under-sampled for a
+  routing-default change. #50's powerflow lesson warns against broad reroutes
+  on thin/low-avg-deg matrices.
+- avg_deg<5 (powerflow-class) stays AMD-routed regardless; an AMF_BAND_MAX
+  raise only moves avg_deg>=5 n>100k matrices from MetisND to AMF.
+
+DECISION: do NOT change AMF_BAND_MAX yet. Recorded the symbolic evidence in
+dev/research/issue-73-n100k-thin-regime.md and on issue #73. The next phase
+(if pursued) is a real factor+solve A/B on these 7 MetisND-routed families
+(esp. nql180) mirroring #67's validation, then decide. Logged as the open
+question on #73.

--- a/dev/journal/2026-06-03-06.org
+++ b/dev/journal/2026-06-03-06.org
@@ -72,3 +72,62 @@ dev/research/issue-73-n100k-thin-regime.md and on issue #73. The next phase
 (if pursued) is a real factor+solve A/B on these 7 MetisND-routed families
 (esp. nql180) mirroring #67's validation, then decide. Logged as the open
 question on #73.
+
+* 00:45 :issue-73:ab:factor-solve:surprise:
+Real factor+solve A/B (probe_issue67_thin --reps 1) on the n>100k MetisND-
+routed families. Columns: fill_r = nnzL_met/nnzL_amf; time_r = (fac+slv)_met /
+(fac+slv)_amf (>1 => AMF faster). First 5:
+
+  matrix      n      fill_r  fac_amf   fac_met  time_r
+  dtoc2       104k   1.92    264ms     671ms    2.49
+  pinene      128k   1.20    896ms    1054ms    1.18
+  cont5_1_l   181k   1.35    215ms     620ms    2.75
+  nql180      260k   0.98   1903ms    3949ms    2.05   <-- !!
+  YATP1NE     246k   1.44   1922ms    4104ms    2.13
+
+SURPRISE / DESIGN-BREAKER: nql180. The symbolic probe predicted MetisND wins
+(nnz_L 0.98x, flop_proxy 0.86x), and indeed MetisND has 2% SMALLER fill here.
+But on REAL factor+solve, AMF is 2.05x FASTER (fac 1.90s vs 3.95s). So the
+fill predictor (nnz_L) — and even my flop_proxy — MISPREDICT nql180. A
+fill-guarded reroute (route to AMF only when AMF nnz_L <= MetisND nnz_L) would
+WRONGLY keep nql180 on MetisND and forfeit a 2x speedup.
+
+Implication: the fill-guarded reroute (the design proposed in the #73 note and
+requested) is the WRONG guard. The real A/B says AMF wins factor+solve on ALL
+5 so far (1.18x–2.75x), including the lone "fill counterexample". This argues
+for the SIMPLE unconditional extension — route n>100k && avg_deg>=5 &&
+non-arrow Auto to AMF outright (raise/relax AMF_BAND_MAX), NOT a fill race.
+Waiting on RDW2D51U + QUADCOPTER to complete the population before finalizing.
+
+* 01:30 :issue-73:implement:routing:
+Implemented the unconditional AMF reroute (decision confirmed by user).
+src/symbolic/mod.rs choose_adaptive: dropped the `&& n <= AMF_BAND_MAX`
+condition from the #67 thin-large catch, so the would-be-MetisND decision
+now becomes `if base == MetisND { return Amf; }` at every n. Removed the now-
+dead AMF_BAND_MAX const entirely. The earlier avg_deg<5 → Amd (#50) and
+arrow → Amf (#64) catches return first, so the powerflow guardrail and dense-
+border catch are untouched — only the uniformly-thin would-be-MetisND
+population above 100k is rerouted.
+
+Tests updated (oracle = the real factor+solve A/B in /tmp/ab73.log, external
+to this change):
+- choose_adaptive_rules: the n=150_000 avg_deg=10 case now asserts Amf (was
+  MetisND). Comment updated to cite #73.
+- choose_adaptive_routes_arrow_to_amf: the n=120_000 non-arrow uniform sub-
+  assertion now asserts Amf (was MetisND) — it lands on AMF via the #73 catch
+  rather than MetisND; the arrow-specific assertion (arrow n>10k → Amf) is
+  unchanged.
+Both pass: `cargo test --lib choose_adaptive` → 2 passed, 0 failed (7m32s
+cold compile under XProtect load; the tests themselves run in 0.06s).
+
+RDW2D51U + QUADCOPTER never finished the real A/B on this machine (RDW2D51U
+blocked at 0% CPU under corespotlightd/Dropbox/syspolicyd contention). Not a
+blocker: their symbolic predictors already favor AMF (RDW2D51U 1.55× cheaper
+flop_proxy and the cheaper ordering per Finding 1; QUADCOPTER a near-diagonal
+tie), and the 5 matrices that DID finish all favor AMF including the fill
+counterexample. Recorded the gap honestly in the research note + decision.
+
+Docs updated: dev/research/issue-73-n100k-thin-regime.md (Finding 3 + Decision,
+with a read-this-first banner marking the fill-guard rejected), dev/decisions.md
+(unconditional-AMF decision + fill-guard rejection), dev/tried-and-rejected.md
+(fill-guarded reroute, nql180 standing counterexample), CHANGELOG.md Unreleased.

--- a/dev/research/issue-73-n100k-thin-regime.md
+++ b/dev/research/issue-73-n100k-thin-regime.md
@@ -1,9 +1,20 @@
 # Issue #73 — Characterizing the n>100k thin regime above AMF_BAND_MAX
 
-**Status:** Step 1 (diagnose) and partial Step 2 (widen sample) complete on
-**symbolic predictors**. No code change made. A real factor+solve A/B is the
-required next step before touching `AMF_BAND_MAX`. Follow-up to #67.
+**Status:** RESOLVED. Real factor+solve A/B (Step 3) ran; it **contradicted the
+fill-guard design** and motivated the simpler **unconditional AMF extension**
+(drop `AMF_BAND_MAX`). Implemented in `choose_adaptive`. Follow-up to #67.
 **Date:** 2026-06-03 (session 06).
+
+> **Outcome (read this first):** The fill-guarded reroute proposed in the
+> "Recommendation" section below — option (b), route to AMF above 100k only
+> when AMF's `factor_nnz_estimate ≤ MetisND's` — is **WRONG and was rejected**.
+> The real factor+solve A/B (Finding 3) shows **nql180** has *smaller* MetisND
+> fill yet AMF is **2.05× faster** on the actual factor+solve. Fill (nnz_L) and
+> flop_proxy do **not** reliably predict speed, so a fill guard would forfeit a
+> 2× win. The shipped change routes **every** would-be-MetisND `Auto` decision
+> to AMF at all `n` (the avg_deg<5 → AMD #50 and arrow → AMF #64 catches still
+> fire first). The original-status/recommendation text below is preserved as
+> the pre-A/B reasoning; Finding 3 is the decisive evidence.
 
 ## Question
 
@@ -72,7 +83,54 @@ AMF wins clearly on 5, ties 1 (QUADCOPTER, identical predictors), loses on 1.
 **nql180** is the lone MetisND win: ~14% less flop_proxy, ~2% fewer nnz_L.
 nql180 is a known matrix (cascade-break Free-mode case, see `decisions.md`).
 
-## Why no code change yet
+## Finding 3 — real factor+solve A/B: AMF wins ALL, fill mispredicts nql180
+
+Step 3: the actual factor+solve A/B via `probe_issue67_thin --reps 1` on the
+MetisND-routed n>100k families. `fill_r = nnzL_met / nnzL_amf`;
+`time_r = (fac+slv)_met / (fac+slv)_amf` (>1 ⇒ AMF faster on the real workload):
+
+| matrix    |    n | fill_r | fac_amf | fac_met | time_r |
+|-----------|-----:|-------:|--------:|--------:|-------:|
+| dtoc2     | 104k |  1.92  |  264 ms |  671 ms |  2.49  |
+| pinene    | 128k |  1.20  |  896 ms | 1054 ms |  1.18  |
+| cont5_1_l | 181k |  1.35  |  215 ms |  620 ms |  2.75  |
+| nql180    | 260k |**0.98**| 1903 ms | 3949 ms |**2.05**|
+| YATP1NE   | 246k |  1.44  | 1922 ms | 4104 ms |  2.13  |
+
+(RDW2D51U + QUADCOPTER did not finish the A/B on the loaded test machine; their
+symbolic predictors from Finding 2 already favor AMF 1.55× / tie respectively,
+and RDW2D51U's symbolic is the cheaper ordering — see Finding 1. They do not
+change the conclusion.)
+
+**The design-breaker is nql180.** The symbolic probe (Finding 2) predicted
+MetisND *wins* nql180 (nnz_L 0.98×, flop_proxy 0.86× — MetisND has 2% smaller
+fill and ~14% less predicted work). On the **real** factor+solve, AMF is
+**2.05× faster** (fac 1.90 s vs 3.95 s). So nnz_L — and even the flop_proxy —
+**mispredict** nql180. A fill-guarded reroute (route to AMF only when AMF nnz_L
+≤ MetisND nnz_L) would have **kept nql180 on MetisND and forfeited the 2×**.
+
+Conclusion: AMF wins factor+solve on **every measured matrix** (1.18×–2.75×),
+including the lone fill "counterexample". Fill is not a speed proxy at this
+scale, so the correct change is the **unconditional** extension — not a race.
+
+## Decision — unconditional AMF, fill-guard rejected
+
+Drop `AMF_BAND_MAX` entirely. In `choose_adaptive`, the would-be-MetisND
+decision is overridden to AMF at **every** `n`:
+
+```rust
+if base == OrderingMethod::MetisND {
+    return OrderingMethod::Amf;
+}
+```
+
+The earlier `n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and
+arrow → AMF (#64) catches fire first and are untouched — the powerflow-class
+guardrail still holds. The fill-guarded race (option (b) below) is rejected:
+nql180 proves the guard's predicate is anti-correlated with real speed there.
+See `dev/decisions.md` and `dev/tried-and-rejected.md`.
+
+## Why no code change yet *(pre-A/B reasoning — superseded by Finding 3)*
 
 1. `nnz_L_est` / `flop_proxy` are **predictions**, not measured factor+solve
    wall time. #67's methodology weighs the real number — e.g. pinene's

--- a/dev/research/issue-73-n100k-thin-regime.md
+++ b/dev/research/issue-73-n100k-thin-regime.md
@@ -1,0 +1,111 @@
+# Issue #73 — Characterizing the n>100k thin regime above AMF_BAND_MAX
+
+**Status:** Step 1 (diagnose) and partial Step 2 (widen sample) complete on
+**symbolic predictors**. No code change made. A real factor+solve A/B is the
+required next step before touching `AMF_BAND_MAX`. Follow-up to #67.
+**Date:** 2026-06-03 (session 06).
+
+## Question
+
+#67 shipped the thin-large reroute (would-be-MetisND → AMF) but bounded it at
+`n ≤ AMF_BAND_MAX = 100_000` (`src/symbolic/mod.rs:225,237`). The bound was set
+because, just above the band, `pinene_3200` (n≈128k) favored AMF but
+`RDW2D51U` (n≈195k) "did not complete a single Auto+AMF+MetisND pass in ~10
+min" and was killed. That measurement used the **full** Solver path (ordering
++ symbolic + numeric + solve, reps=1, all three orderings), so the timeout was
+**unattributed**: we could not tell whether RDW2D51U was an AMF *fill* blowup
+(a reason to keep the bound) or just an expensive *numeric* factorization
+(orthogonal to the ordering choice).
+
+## Method
+
+`crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs` — **symbolic
+only**, no numeric factor, no solve. For each matrix under AMF and MetisND it
+reports cheap numeric-cost predictors:
+
+- `sym_ms` — wall time of `symbolic_factorize_with_method` (ordering +
+  analysis). Isolates the ordering cost itself.
+- `nnz_L_est` — `factor_nnz_estimate` (predicted L nonzeros = fill).
+- `max_front` — largest supernode `nrow` (dimension of the biggest dense
+  block the numeric phase factors).
+- `flop_proxy` — Σ over supernodes of `ncol·nrow²`, a dense-multifrontal work
+  proxy (panel factor + Schur update); the dominant term in numeric wall-time.
+- `peak_MB` — `peak_contrib_bytes` / 1e6.
+
+Run on the locally-available n>100k KKT families (one iterate, `_0000`).
+
+## Finding 1 — the RDW2D51U #67 timeout was NUMERIC, not an AMF fill blowup
+
+| RDW2D51U (n=195075) | sym_ms | nnz_L_est | max_front | flop_proxy | peak_MB |
+|---------------------|-------:|----------:|----------:|-----------:|--------:|
+| AMF                 |  167   |  28.19 M  |    1398   |  1.147e10  |  40.1   |
+| MetisND             |  944   |  35.59 M  |    1608   |  1.782e10  |  44.9   |
+
+AMF's symbolic analysis finishes in **167 ms**. The #67 ">10 min" was the
+**numeric** factorization (28 M nnz_L, a 1398-wide dense front, ~11 GFLOP
+proxy) — genuinely expensive, but unrelated to whether AMF or MetisND ordered
+it. Moreover AMF is the **cheaper** ordering on RDW2D51U: 1.26× fewer nonzeros
+and 1.55× less numeric work than MetisND. The #67 A/B blew its budget on
+MetisND's *heavier* factor, not on AMF. Above the band, the bound is leaving
+an AMF win on the table here — it is not guarding against an AMF blowup.
+
+## Finding 2 — AMF wins or ties 6/7 of the affected population (symbolic)
+
+Only `n>100k && avg_deg ≥ 5` matrices route to MetisND today (avg_deg<5 →
+AMD, the #50 powerflow-class path, unaffected by `AMF_BAND_MAX`). Sweep over
+that population (flop_proxy ratio = MetisND/AMF; >1 ⇒ AMF cheaper):
+
+| matrix      |    n | avg_deg | nnz_L M/A | flop_proxy M/A | verdict        |
+|-------------|-----:|--------:|----------:|---------------:|----------------|
+| dtoc2       | 104k |   17.5  |   1.92    |     4.36       | AMF wins big   |
+| pinene_3200 | 128k |    9.42 |   1.21    |     2.43       | AMF wins       |
+| cont5_1_l   | 181k |    6.96 |   1.43    |     1.99       | AMF wins       |
+| RDW2D51U    | 195k |   18.24 |   1.26    |     1.55       | AMF wins       |
+| RDW2D52U    | 195k |   18.24 |   1.26    |     1.55       | AMF wins       |
+| YATP1NE     | 246k |    5.97 |   1.66    |    17.55       | AMF wins big   |
+| QUADCOPTER  | 280k |    5.14 |   1.00    |     1.00       | tie (near-diag)|
+| **nql180**  | 260k |    5.74 |   0.98    |   **0.86**     | **MetisND wins** |
+
+(`optmass`, n=110k avg_deg 3.55, is AMD-routed → unaffected.)
+
+AMF wins clearly on 5, ties 1 (QUADCOPTER, identical predictors), loses on 1.
+**nql180** is the lone MetisND win: ~14% less flop_proxy, ~2% fewer nnz_L.
+nql180 is a known matrix (cascade-break Free-mode case, see `decisions.md`).
+
+## Why no code change yet
+
+1. `nnz_L_est` / `flop_proxy` are **predictions**, not measured factor+solve
+   wall time. #67's methodology weighs the real number — e.g. pinene's
+   measured `time_r` was 1.18 while flop_proxy reads 2.43 (direction agrees,
+   magnitude overstated). **nql180 specifically needs the real measurement**,
+   not the proxy, before we trust that MetisND truly wins it.
+2. 8 families, one machine, one iterate each — under-sampled for a
+   routing-**default** change. #50's powerflow lesson warns against broad
+   reroutes on thin matrices.
+3. A default change must mirror #67's validation: real factor+solve A/B on the
+   affected population + a no-powerflow-regression check.
+
+## Recommendation / next step
+
+The symbolic evidence is strong enough to **justify a full factor+solve A/B**
+on the 7 MetisND-routed n>100k families (extending `probe_issue67_thin` to
+this regime, with a generous per-matrix timeout since these are minutes-scale
+numeric factorizations). Decision rule for a band change:
+
+- If the real A/B confirms AMF wins or ties on factor+solve across the
+  population **except** isolated cases like nql180, consider either (a) raising
+  `AMF_BAND_MAX`, or (b) gating the extension on a cheap symbolic-fill check
+  (route to AMF above 100k only when AMF's `factor_nnz_estimate` is ≤ MetisND's
+  — which would correctly keep nql180 on MetisND).
+- Record the outcome in `dev/decisions.md` either way.
+
+Option (b) is attractive: the symbolic probe shows the fill predictor already
+separates the AMF-wins cases from nql180 at ~zero cost relative to the numeric
+factor, so a fill-guarded reroute would capture the wins without the nql180
+regression. But that is a design for the next phase, pending the real A/B.
+
+## Artifacts
+
+- `crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs` (this note's data)
+- Journal: `dev/journal/2026-06-03-06.org` (:issue-73:)
+- Guardrail unchanged: `n>100k && avg_deg<5 → Amd` (#50) untouched throughout.

--- a/dev/sessions/2026-06-03-06.md
+++ b/dev/sessions/2026-06-03-06.md
@@ -1,0 +1,109 @@
+# Session 2026-06-03-06
+
+## Goal
+Issue #73 (the n>100k thin-regime follow-up to #67, opened from session-05's
+"Next Session Should"): settle whether the regime above `AMF_BAND_MAX`
+(100_000) should keep MetisND or reroute to AMF, and implement the outcome.
+Also merged the two session-05 follow-ups (#67/#71 housekeeping) on the way in.
+
+## Accomplished
+
+### Housekeeping (start of session)
+- **PR #74** (docs(readme): document the `feral-diagnostics` crate invocation,
+  the session-05 follow-up #2) — CI green, squash-merged → main `caf4120`.
+- **Issue #73** opened to track the n>100k investigation (follow-up #1).
+
+### Issue #73 — investigation (3 steps)
+- **Step 1 — symbolic diagnosis** (`probe_issue73_symbolic`, committed
+  `49b153e`): the #67 RDW2D51U ">10 min, did not complete" was **numeric**,
+  not an AMF fill blowup. AMF's symbolic finishes in **167 ms** (n=195k) and
+  AMF is the *cheaper* ordering there (1.26× fewer nnz_L, 1.55× less flop_proxy
+  than MetisND). The band was guarding nothing.
+- **Step 2 — symbolic sweep:** over the affected `n>100k && avg_deg ≥ 5`
+  non-arrow population, AMF wins or ties 6/7 on nnz_L / flop_proxy; the lone
+  predicted MetisND win was **nql180** (nnz_L 0.98×, flop_proxy 0.86×).
+- **Step 3 — real factor+solve A/B** (`probe_issue67_thin --reps 1`): AMF wins
+  factor+solve on **every measured matrix** — dtoc2 2.49×, pinene 1.18×,
+  cont5_1_l 2.75×, nql180 2.05×, YATP1NE 2.13×. **nql180 is the
+  design-breaker:** MetisND has 2% *smaller* fill yet AMF is 2.05× faster
+  (fac 1903 ms vs 3949 ms). So nnz_L / flop_proxy mispredict real speed — a
+  fill-guarded race would have demoted nql180 and forfeited the 2×.
+
+### Issue #73 — implementation (commit `4c49745`)
+- **Dropped `AMF_BAND_MAX`.** `choose_adaptive` now overrides every
+  would-be-MetisND `Auto` decision to AMF at **every** `n`. The
+  `n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+  catches fire first and are untouched.
+- **Tests updated** (oracle = the real A/B, external to the change):
+  `choose_adaptive_rules` n=150_000 → Amf (was MetisND);
+  `choose_adaptive_routes_arrow_to_amf` n=120_000 non-arrow → Amf.
+- **Verification:** `cargo test --lib` → **322 passed, 0 failed** (6 ignored);
+  `cargo clippy --lib -- -D warnings` → clean; pre-commit fmt+clippy passed.
+  CI is the authoritative gate (PR #75).
+- PR #75 reframed from "investigation only" to the full change, **closes #73**.
+
+## Benchmark Results
+`cargo run --bin bench --release` (captured tail — the harness retains the
+final summary). Both Phase 2.8.1 partition gates **PASS**; worst factor-ratios
+are tiny-n fixed-cost-dominated matrices (KIRBY2 n=458, etc.) consistent with
+prior sessions. The bench corpus is dominated by small matrices (n ≤ ~5k), so
+the n>100k reroute is essentially orthogonal to it — this run is a
+no-regression confirmation, not where the #73 win shows up (that is the
+factor+solve A/B above).
+
+```
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(μs)    mumps(μs)      ratio
+KIRBY2_0007                    458          940          119       7.90
+KIRBY2_0006                    458          889          127       7.00
+CRESC132_0000                 5314        80529        12266       6.57
+KIRBY2_0008                    458          772          122       6.33
+KIRBY2_0009                    458          742          128       5.80
+MUONSINE_0000                 1537         1978          376       5.26
+KIRBY2_0010                    458          683          133       5.14
+KIRBY2_0011                    458          585          120       4.88
+GROUPING_0219                  225          525          114       4.61
+GROUPING_0179                  225          452          114       3.96
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.34     <= 2.0     PASS
+medium (<500)            152145     1.74     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.50     <= 2.0     PASS
+medium (<500)            153560     1.51     <= 3.0     PASS
+```
+
+## Decisions Made
+- **Unconditional AMF above 100k; `AMF_BAND_MAX` dropped; fill-guard rejected
+  (#73)** — appended to `dev/decisions.md`. The fill-guarded reroute (route to
+  AMF only when AMF `factor_nnz_estimate ≤ MetisND's`) was the originally
+  requested next step; it is rejected because nql180's fill predicate is
+  anti-correlated with real speed (smaller MetisND fill, 2× faster AMF).
+
+## Abandoned Approaches
+- **Fill-guarded AMF reroute above 100k (#73)** — appended to
+  `dev/tried-and-rejected.md`. Symptom: on the real factor+solve A/B, nql180
+  (MetisND fill 0.98×) ran 2.05× faster under AMF, so a guard keyed on
+  `nnz_L`/`flop_proxy` makes the wrong call exactly where it matters. nql180 is
+  the standing counterexample; do not reintroduce a fill guard on this reroute.
+
+## Next Session Should
+- **Watch for any n>100k corpus regression** from the unconditional reroute.
+  The powerflow guardrail (`avg_deg<5 → Amd`, #50) is preserved by firing
+  first, but the change is now broad above 100k; if a future corpus run shows a
+  genuinely-large-dense 3-D matrix that MetisND should own, that is the
+  signal to re-introduce a *structural* (not fill-based) key.
+- **Optional:** complete the RDW2D51U + QUADCOPTER real-A/B data points (they
+  never finished under this machine's XProtect/Spotlight load) and fold them
+  into the #73 note for a full 7-matrix record. Their symbolic predictors
+  already favor AMF / tie, so this is documentation, not a gating result.
+- **Optional:** an opt-in `tests/` regression fixture (SKIP-when-absent, like
+  `tests/issue67_thin_ordering.rs`) asserting `resolved_method == Amf` on an
+  n>100k matrix (e.g. cont5_1_l or nql180). The synthetic
+  `choose_adaptive_rules` n=150_000 unit test already pins the routing in CI;
+  a fixture test would add an end-to-end check.
+- **User pending:** restart Terminal to clear the XProtect/syspolicyd
+  throttling that makes cold `cargo` builds take 7–9 min locally.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -2240,3 +2240,35 @@ dev/research/issue-63-nearsingular-ordering-diagnosis.md;
 dev/journal/2026-06-03-02.org; probe src/bin/probe_issue63_nearsingular.rs.
 Future sessions: do NOT re-attempt a FERAL-only fix for scrs8 without first
 re-checking these four dead ends.
+
+## 2026-06-03 — Fill-guarded AMF reroute above 100k (issue #73)
+
+The plan for extending the #67 AMF reroute past `AMF_BAND_MAX` (100k) was a
+**fill-guarded race**: above 100k, route a would-be-MetisND `Auto` matrix to
+AMF only when AMF's predicted fill `factor_nnz_estimate ≤ MetisND's`,
+otherwise keep MetisND. The appeal: the symbolic probe (`probe_issue73_symbolic`)
+showed nnz_L / flop_proxy already separated the AMF-wins families from the lone
+predicted-MetisND-win (nql180) at ~zero cost relative to the numeric factor, so
+a fill guard looked like it would capture the wins without an nql180 regression.
+This design is recorded in the #73 research note's "Recommendation" (option b)
+and was the originally-requested next step.
+
+Rejected by the real factor+solve A/B (`probe_issue67_thin --reps 1`). The
+guard's predicate is **anti-correlated with real speed on nql180**: MetisND has
+2% *smaller* fill (fill_r 0.98) yet AMF is **2.05× faster** on the actual
+factor+solve (fac_amf 1903 ms vs fac_met 3949 ms). The fill guard would have
+read "MetisND fill is smaller → keep MetisND" and **forfeited a 2× speedup**.
+nnz_L and the Σ ncol·nrow² flop_proxy do not predict factor+solve wall-time at
+this scale (the numeric phase's cache/critical-path behavior dominates), so any
+routing guard keyed on symbolic fill makes the wrong call exactly where it
+matters — and adds a per-solve symbolic-race cost to do it.
+
+Symptoms / evidence of the failure: on real factor+solve AMF wins ALL 5
+measured n>100k families (dtoc2 2.49×, pinene 1.18×, cont5_1_l 2.75×, nql180
+2.05×, YATP1NE 2.13×), including the matrix the guard would have demoted.
+Superseded by the **unconditional** AMF extension (drop `AMF_BAND_MAX`; route
+every would-be-MetisND decision to AMF), recorded in `dev/decisions.md`
+(2026-06-03, issue #73). Future sessions: do NOT reintroduce a fill / nnz_L /
+flop_proxy guard on the n>100k AMF reroute — nql180 is the standing
+counterexample. Data: dev/research/issue-73-n100k-thin-regime.md (Finding 3),
+dev/journal/2026-06-03-06.org (:issue-73:ab:factor-solve:surprise:).

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -132,11 +132,14 @@ pub enum OrderingMethod {
 ///   - arrow/bordered (issue #64): whenever the size rule would pick
 ///     `MetisND` (`n > 10_000`) but [`is_arrow_bordered`] detects a
 ///     dense border concentrating the nonzeros, override to `Amf`.
-///   - thin-large (issue #67): whenever the size rule would pick `MetisND`
-///     and `n <= AMF_BAND_MAX` (100_000), override to `Amf`. A corpus A/B
-///     on factor+solve wall-time found AMF wins or ties MetisND across the
-///     entire `(10_000, 100_000]` band; the genuinely-large-dense
-///     `n > 100_000 && avg_deg >= 5` regime keeps `MetisND`.
+///   - thin-large (issues #67 + #73): whenever the size rule would still
+///     pick `MetisND` (after the avg_deg<5 → AMD and arrow → AMF catches),
+///     override to `Amf` at every `n`. Corpus A/Bs on real factor+solve
+///     wall-time found AMF wins or ties MetisND across the whole population
+///     — 36/36 in the `(10_000, 100_000]` band (#67) and every measured
+///     `n > 100_000 && avg_deg >= 5` non-arrow family (#73), including the
+///     one matrix (nql180) where MetisND has smaller fill but AMF is still
+///     2× faster on the real factor+solve.
 ///
 /// Anything else delegates to [`pick_default_method`]. `symbolic_factorize`
 /// routes through `Auto`, so the no-arg default and `Auto` resolve to the
@@ -208,33 +211,33 @@ fn choose_adaptive(pattern: &CscPattern, method: OrderingMethod) -> OrderingMeth
     if base == OrderingMethod::MetisND && is_arrow_bordered(pattern) {
         return OrderingMethod::Amf;
     }
-    // Issue #67 thin-large catch. The size-only `pick_default_method` routes
-    // every `n > 10_000` matrix to MetisND, but a full corpus A/B (54 n>10_000
-    // KKT/SuiteSparse families, factor+solve wall-time, not nnz_L alone) found
-    // that across the entire `(10_000, 100_000]` band AMF wins or ties MetisND
-    // on factor+solve — 36/36 in-scope matrices with worst case 0.99× (noise),
-    // median ~1.5×, up to 4.5×. MetisND's separators do not pay off on these
-    // uniformly-thin discretization patterns at this scale, and its symbolic
-    // ordering is 2–5× more expensive than AMF's, so racing the two is a net
-    // loss (50–255% overhead). Raise the AMF band to `n <= 100_000`. Only the
-    // would-be-MetisND decision is touched; the `n > 100_000 && avg_deg < 5 →
-    // Amd` (above) path and the genuinely-large-dense `n > 100_000 &&
-    // avg_deg >= 5 → MetisND` regime (where the evidence is thin and #50 warns
-    // against broad reroutes) are left unchanged. See
-    // `dev/research/issue-67-thin-large-ordering.md`.
-    if base == OrderingMethod::MetisND && n <= AMF_BAND_MAX {
+    // Issue #67 + #73 thin-large catch. The size-only `pick_default_method`
+    // routes every `n > 10_000` matrix to MetisND, but corpus A/Bs on real
+    // factor+solve wall-time (not nnz_L alone) show AMF wins or ties MetisND
+    // across the whole would-be-MetisND population:
+    //   - #67: 36/36 in-scope `(10_000, 100_000]` families, worst case 0.99×
+    //     (noise), median ~1.5×, up to 4.5×.
+    //   - #73: the `n > 100_000 && avg_deg >= 5` non-arrow families — dtoc2
+    //     2.49×, pinene 1.18×, cont5_1_l 2.75×, nql180 2.05×, YATP1NE 2.13× —
+    //     AMF wins factor+solve on every measured matrix. Critically nql180 is
+    //     the lone case where MetisND has *smaller* symbolic fill (nnz_L 0.98×)
+    //     yet AMF is still 2.05× faster on real factor+solve, so fill (nnz_L /
+    //     flop_proxy) is NOT a reliable speed predictor and a fill-guarded race
+    //     would wrongly demote nql180. The simple unconditional reroute is the
+    //     one the evidence supports — see `dev/research/issue-73-n100k-thin-
+    //     regime.md` and `dev/research/issue-67-thin-large-ordering.md`.
+    //
+    // MetisND's separators do not pay off on these uniformly-thin discretization
+    // patterns, and its symbolic ordering is 2–5× more expensive than AMF's, so
+    // racing the two is a net loss. Route every would-be-MetisND decision to AMF
+    // outright. Only the would-be-MetisND decision is touched; the earlier
+    // `n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
+    // catches fire first and are untouched.
+    if base == OrderingMethod::MetisND {
         return OrderingMethod::Amf;
     }
     base
 }
-
-/// Issue #67: upper bound on `n` for the non-arrow AMF band in
-/// [`choose_adaptive`]. Below this, `Auto` prefers AMF over MetisND; above
-/// it, the `pick_default_method` MetisND default (or the `n > 100_000 &&
-/// avg_deg < 5 → Amd` catch) stands. Calibrated on a corpus A/B — see the
-/// catch comment in `choose_adaptive` and
-/// `dev/research/issue-67-thin-large-ordering.md`.
-const AMF_BAND_MAX: usize = 100_000;
 
 /// Detect the **arrow / bordered-KKT** sparsity signature on a full
 /// symmetric pattern: a *small set* of very-high-degree "border" columns
@@ -1765,9 +1768,12 @@ mod tests {
             choose_adaptive(&p, OrderingMethod::Auto),
             OrderingMethod::Amf
         );
-        // Genuinely-large-dense (n > 100_000, avg_deg >= 5) is left on
-        // MetisND — above the #67 AMF band and above the #50 avg_deg < 5
-        // AMD catch. (n=150_000, avg_deg=10, uniform.)
+        // Large-dense (n > 100_000, avg_deg >= 5, non-arrow) now also routes
+        // to AMF (issue #73): the real factor+solve A/B found AMF wins on
+        // every measured matrix in this regime, so the would-be-MetisND
+        // decision is overridden to AMF at every n. The #50 avg_deg < 5 → AMD
+        // catch fires first and is unaffected. (n=150_000, avg_deg=10, uniform
+        // → not arrow.)
         let (cp, ri) = pat_bufs(150_000, 10);
         let p = CscPattern {
             n: 150_000,
@@ -1776,7 +1782,7 @@ mod tests {
         };
         assert_eq!(
             choose_adaptive(&p, OrderingMethod::Auto),
-            OrderingMethod::MetisND
+            OrderingMethod::Amf
         );
         // Non-Auto passes through.
         let (cp, ri) = pat_bufs(500, 6);
@@ -1882,16 +1888,17 @@ mod tests {
             OrderingMethod::Amf,
             "arrow/bordered pattern (n>10_000) must route to Amf, not MetisND"
         );
-        // A uniform large-dense pattern *above* the #67 AMF band
-        // (n > 100_000, avg_deg >= 5) stays on MetisND — neither the arrow
-        // catch nor the #67 thin-large catch fires. (n=120_000 below the
-        // band would now route to AMF via #67; the point here is that the
-        // arrow catch itself does not over-fire on a non-arrow shape.)
+        // A uniform large-dense pattern (n > 100_000, avg_deg >= 5,
+        // non-arrow) now routes to AMF via the #73 thin-large catch (the
+        // would-be-MetisND decision is overridden to AMF at every n). This
+        // does not exercise the arrow catch — the point is only that a
+        // non-arrow shape still lands on AMF, just through #73 rather than
+        // #64.
         let uniform = pattern_with_degrees(&vec![16usize; 120_000]);
         assert_eq!(
             choose_adaptive(&uniform, OrderingMethod::Auto),
-            OrderingMethod::MetisND,
-            "uniform large-dense pattern (above #67 band) must remain on MetisND"
+            OrderingMethod::Amf,
+            "uniform large-dense non-arrow pattern routes to AMF via the #73 catch"
         );
         // The arrow override must NOT fire below the size floor: a small
         // arrow already routes to Amf via the n<=10_000 rule, but assert


### PR DESCRIPTION
## Summary

Resolves #73 (the n>100k thin-regime follow-up to #67). After a symbolic
diagnosis and a real **factor+solve** A/B, this PR **drops `AMF_BAND_MAX`**:
`choose_adaptive` now routes every would-be-MetisND `Auto` decision to AMF at
**every** `n`. The `n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and
arrow → AMF (#64) catches still fire first, so the powerflow guardrail and
dense-border catch are untouched.

## How we got here

**Step 1 — symbolic diagnosis** (`probe_issue73_symbolic`, commit 49b153e):
The #67 RDW2D51U ">10 min, did not complete" was **numeric**, not an AMF fill
blowup — AMF's symbolic finishes in 167 ms (n=195k) and AMF is the *cheaper*
ordering there (1.26× fewer nnz_L, 1.55× less flop_proxy than MetisND). So the
band was guarding nothing.

**Step 2 — symbolic sweep:** over the affected `n>100k && avg_deg ≥ 5`
non-arrow population, AMF wins or ties 6/7 on nnz_L / flop_proxy. The lone
predicted MetisND win was **nql180** (nnz_L 0.98×, flop_proxy 0.86×).

**Step 3 — real factor+solve A/B** (`probe_issue67_thin --reps 1`): AMF wins
factor+solve on **every measured matrix**:

| matrix    |    n | fill_r | fac_amf | fac_met | time_r |
|-----------|-----:|-------:|--------:|--------:|-------:|
| dtoc2     | 104k |  1.92  |  264 ms |  671 ms |  2.49  |
| pinene    | 128k |  1.20  |  896 ms | 1054 ms |  1.18  |
| cont5_1_l | 181k |  1.35  |  215 ms |  620 ms |  2.75  |
| nql180    | 260k |**0.98**| 1903 ms | 3949 ms |**2.05**|
| YATP1NE   | 246k |  1.44  | 1922 ms | 4104 ms |  2.13  |

**The design-breaker is nql180.** MetisND has 2% *smaller* fill yet AMF is
**2.05× faster** on the real factor+solve. So `nnz_L` / `flop_proxy` do **not**
predict factor+solve wall-time at this scale — a fill-guarded race (route to
AMF only when AMF fill ≤ MetisND's) would have kept nql180 on MetisND and
forfeited the 2×. The unconditional reroute is the design the evidence
supports; the fill guard is recorded as rejected.

(RDW2D51U + QUADCOPTER did not finish the real A/B on the loaded test machine;
their symbolic predictors already favor AMF / tie and don't change the
conclusion — noted honestly in the research note.)

## Change

```rust
// choose_adaptive, after avg_deg<5 → Amd and arrow → Amf:
if base == OrderingMethod::MetisND {
    return OrderingMethod::Amf;   // was: && n <= AMF_BAND_MAX
}
```

`AMF_BAND_MAX` removed. Tests updated (oracle = the real A/B):
`choose_adaptive_rules` n=150_000 → Amf (was MetisND);
`choose_adaptive_routes_arrow_to_amf` n=120_000 non-arrow → Amf.

## Artifacts

- `crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs` — symbolic-only
  AMF-vs-MetisND probe (Step 1/2).
- `dev/research/issue-73-n100k-thin-regime.md` — Findings 1–3 + Decision.
- `dev/decisions.md`, `dev/tried-and-rejected.md` (fill-guard rejected),
  `CHANGELOG.md`, journal.

## Verification

- `cargo test --lib`: 322 passed, 0 failed.
- `cargo clippy --lib -- -D warnings`: clean.
- Pre-commit (`cargo fmt --check`, `cargo clippy -- -D warnings`): passed.
- CI is the gate.

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
