### PR TITLE
Add unsymmetric LU factorization family for simplex basis (issue #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ unsymmetric LU with first-class rank-1 column-replacement updates and warm
   (dense Bartels–Golub: spike → upper-Hessenberg → Gauss sweep, maintaining an
   explicit column permutation).
 - **Sparse path** — `SparseColMatrix` (general CSC) and `SparseLu`: left-looking
-  Gilbert–Peierls LU with threshold partial pivoting, sparse `ftran`/`btran`,
-  and a product-form `U`-update rank-1 column replacement. `SparseLuSymbolic`
+  Gilbert–Peierls LU (output-sensitive depth-first reach, sub-quadratic factor)
+  with threshold partial pivoting, sparse `ftran`/`btran`, and a **Forrest–Tomlin
+  / Bartels–Golub–Reid** rank-1 column-replacement update — in-place sparse
+  Gaussian elimination of the bump with partial pivoting, recorded as a
+  replayable eta (bump-local warm solves, no `O(k·n)` chain). `SparseLuSymbolic`
   computes the fill-reducing column order by running `feral_amd` on the `AᵀA`
   pattern (reusable symbolic handle).
 - **Routing** — `should_use_dense_lu(m, nnz, params)` auto-routes dense vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ unsymmetric LU with first-class rank-1 column-replacement updates and warm
   with threshold partial pivoting, sparse `ftran`/`btran`, and a **Forrest–Tomlin
   / Bartels–Golub–Reid** rank-1 column-replacement update — in-place sparse
   Gaussian elimination of the bump with partial pivoting, recorded as a
-  replayable eta (bump-local warm solves, no `O(k·n)` chain). `SparseLuSymbolic`
+  replayable eta (bump-local warm solves, no `O(k·n)` chain). The update itself
+  is bump-local — Gilbert–Peierls reach for the spike, a `u_above` column index
+  for the replacement, save/restore of only the changed rows (no `O(nnz)`
+  clone) — ~14–17× faster than a refactor. `SparseLuSymbolic`
   computes the fill-reducing column order by running `feral_amd` on the `AᵀA`
   pattern (reusable symbolic handle).
 - **Routing** — `should_use_dense_lu(m, nnz, params)` auto-routes dense vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — unsymmetric LU basis engine (`feral::lu`, issue #81)
+
+A new, separate factorization family for **simplex basis factorization** —
+unsymmetric LU with first-class rank-1 column-replacement updates and warm
+`ftran`/`btran` solves, built independently of the symmetric LDLᵀ solver
+(which is untouched). Module `feral::lu`:
+
+- **Dense path** — `GeneralMatrix` (general column-major dense) and `DenseLu`:
+  right-looking LU with threshold partial pivoting (`P B Q = L U`),
+  `ftran`/`btran`/`ftran_partial`, and a rank-1 column-replacement `update()`
+  (dense Bartels–Golub: spike → upper-Hessenberg → Gauss sweep, maintaining an
+  explicit column permutation).
+- **Sparse path** — `SparseColMatrix` (general CSC) and `SparseLu`: left-looking
+  Gilbert–Peierls LU with threshold partial pivoting, sparse `ftran`/`btran`,
+  and a product-form `U`-update rank-1 column replacement. `SparseLuSymbolic`
+  computes the fill-reducing column order by running `feral_amd` on the `AᵀA`
+  pattern (reusable symbolic handle).
+- **Routing** — `should_use_dense_lu(m, nnz, params)` auto-routes dense vs
+  sparse (mirrors the LDLᵀ `should_use_dense_fast_path`), with a `LuParams`
+  override.
+- **Robustness** — two-sided ∞-norm equilibration and unsymmetric MC64 scaling
+  (`LuScaling`, reusing the existing `hungarian_match` kernel), plus iterative
+  refinement (`ftran_refined`/`btran_refined`). Singular bases report
+  `FeralError::SingularBasis`; the update budget reports
+  `FeralError::NeedsRefactor`.
+
+There is no inertia for LU (the basis is unsymmetric). Validated by
+`tests/lu_dense.rs`, `tests/lu_sparse.rs`, and `tests/lu_scaling.rs` with
+hand-worked exact factors, equation-residual property checks, dense↔sparse
+agreement, and adversarial/ill-scaled/ill-conditioned cases. The downstream
+`pounce-simplex` `BasisEngine` integration and reference (UMFPACK/KLU)
+benchmarks are deferred (see `dev/plans/unsymmetric-lu-epic.md`).
+
 ### Added — on-disk dense-column regression fixture for issue #80
 
 `cargo run --bin bench` now regenerates two synthetic dense-coupling-column

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 # rmumps = { path = "../ripopt/rmumps" }  # uncomment when needed
 
 [[bench]]
+name = "lu"
+harness = false
+
+[[bench]]
 name = "dense_factor"
 harness = false
 

--- a/benches/lu.rs
+++ b/benches/lu.rs
@@ -1,0 +1,193 @@
+//! Criterion benchmarks for the unsymmetric LU basis engine (issue #81).
+//!
+//! Three stories:
+//!   * `dense_*` / `sparse_*` — factor + warm-solve (`ftran`) baselines.
+//!   * `update` — the cost of one rank-1 column-replacement (dense
+//!     Bartels–Golub, sparse Forrest–Tomlin).
+//!   * `update_vs_refactor` — the crossover the whole feature exists for:
+//!     a single FT update vs a full refactor of the same basis. The ratio is
+//!     how much the in-place update saves over re-factoring.
+#![allow(clippy::needless_range_loop)]
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{DenseLu, LuParams, SparseLu, SparseLuSymbolic};
+
+/// Reproducible xorshift64 for bench inputs.
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(if seed == 0 {
+            0x9E37_79B9_7F4A_7C15
+        } else {
+            seed
+        })
+    }
+    fn f64(&mut self) -> f64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        (x >> 11) as f64 / (1u64 << 53) as f64 - 0.5
+    }
+}
+
+/// Dense diagonally-dominant `m`×`m` basis as column vectors.
+fn dense_basis(m: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut rng = Rng::new(seed);
+    let mut cols = vec![vec![0.0; m]; m];
+    for j in 0..m {
+        for i in 0..m {
+            cols[j][i] = rng.f64();
+        }
+        cols[j][j] += m as f64;
+    }
+    cols
+}
+
+/// Block-diagonal sparse basis: `nblocks` dense diagonally-dominant blocks of
+/// size `bs`. Within-block column replacements have localized spikes.
+fn block_diag(nblocks: usize, bs: usize, seed: u64) -> SparseColMatrix {
+    let n = nblocks * bs;
+    let mut rng = Rng::new(seed);
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for b in 0..nblocks {
+        let base = b * bs;
+        for cc in 0..bs {
+            for rr in 0..bs {
+                let v = if rr == cc {
+                    bs as f64 + rng.f64().abs()
+                } else {
+                    rng.f64()
+                };
+                cols[base + cc].push((base + rr, v));
+            }
+        }
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("block_diag")
+}
+
+/// A within-block diagonally-dominant replacement column for `slot`.
+fn within_block_col(n: usize, bs: usize, slot: usize, seed: u64) -> Vec<f64> {
+    let mut rng = Rng::new(seed);
+    let base = (slot / bs) * bs;
+    let mut c = vec![0.0; n];
+    for rr in 0..bs {
+        let i = base + rr;
+        c[i] = if i == slot { bs as f64 } else { rng.f64() };
+    }
+    c
+}
+
+fn bench_dense(c: &mut Criterion) {
+    let mut g = c.benchmark_group("dense");
+    for &m in &[16usize, 64, 256] {
+        let cols = dense_basis(m, 1);
+        g.bench_with_input(BenchmarkId::new("factor", m), &m, |b, _| {
+            b.iter(|| {
+                let lu = DenseLu::factor(black_box(&cols), m, LuParams::default());
+                black_box(lu.is_ok())
+            })
+        });
+        let lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        let rhs: Vec<f64> = (0..m).map(|i| 1.0 + (i % 7) as f64).collect();
+        g.bench_with_input(BenchmarkId::new("ftran", m), &m, |b, _| {
+            b.iter_batched(
+                || (lu.clone(), rhs.clone()),
+                |(mut lu, mut r)| {
+                    lu.ftran(&mut r).expect("ftran");
+                    black_box(r[0])
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        let new_col: Vec<f64> = (0..m).map(|i| 1.0 + (i % 3) as f64).collect();
+        g.bench_with_input(BenchmarkId::new("update", m), &m, |b, _| {
+            b.iter_batched(
+                || lu.clone(),
+                |mut lu| {
+                    let _ = lu.update(black_box(m / 2), black_box(&new_col));
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    g.finish();
+}
+
+fn bench_sparse(c: &mut Criterion) {
+    let bs = 25;
+    let mut g = c.benchmark_group("sparse");
+    for &nblocks in &[8usize, 40, 200] {
+        let n = nblocks * bs;
+        let a = block_diag(nblocks, bs, 7);
+        let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+        g.bench_with_input(BenchmarkId::new("factor", n), &n, |b, _| {
+            b.iter(|| {
+                let lu = SparseLu::factor(black_box(&a), &sym, LuParams::default());
+                black_box(lu.is_ok())
+            })
+        });
+        let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+        let rhs: Vec<f64> = (0..n).map(|i| 1.0 + (i % 7) as f64).collect();
+        g.bench_with_input(BenchmarkId::new("ftran", n), &n, |b, _| {
+            b.iter_batched(
+                || (lu.clone(), rhs.clone()),
+                |(mut lu, mut r)| {
+                    lu.ftran(&mut r).expect("ftran");
+                    black_box(r[0])
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        let slot = n / 2;
+        let col = within_block_col(n, bs, slot, 99);
+        g.bench_with_input(BenchmarkId::new("ft_update", n), &n, |b, _| {
+            b.iter_batched(
+                || lu.clone(),
+                |mut lu| {
+                    let _ = lu.update(black_box(slot), black_box(&col));
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    g.finish();
+}
+
+fn bench_update_vs_refactor(c: &mut Criterion) {
+    let bs = 25;
+    let mut g = c.benchmark_group("update_vs_refactor");
+    for &nblocks in &[40usize, 200] {
+        let n = nblocks * bs;
+        let a = block_diag(nblocks, bs, 13);
+        let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+        let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+        let slot = n / 2;
+        let col = within_block_col(n, bs, slot, 31);
+
+        g.bench_with_input(BenchmarkId::new("ft_update", n), &n, |b, _| {
+            b.iter_batched(
+                || lu.clone(),
+                |mut lu| {
+                    let _ = lu.update(black_box(slot), black_box(&col));
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        g.bench_with_input(BenchmarkId::new("refactor", n), &n, |b, _| {
+            b.iter_batched(
+                || lu.clone(),
+                |mut lu| {
+                    lu.refactor(black_box(&a), &sym).expect("refactor");
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_dense, bench_sparse, bench_update_vs_refactor);
+criterion_main!(benches);

--- a/benches/lu.rs
+++ b/benches/lu.rs
@@ -167,11 +167,26 @@ fn bench_update_vs_refactor(c: &mut Criterion) {
         let slot = n / 2;
         let col = within_block_col(n, bs, slot, 31);
 
+        let sparse_col: Vec<(usize, f64)> = col
+            .iter()
+            .enumerate()
+            .filter(|&(_, &v)| v != 0.0)
+            .map(|(i, &v)| (i, v))
+            .collect();
         g.bench_with_input(BenchmarkId::new("ft_update", n), &n, |b, _| {
             b.iter_batched(
                 || lu.clone(),
                 |mut lu| {
                     let _ = lu.update(black_box(slot), black_box(&col));
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        g.bench_with_input(BenchmarkId::new("ft_update_sparse", n), &n, |b, _| {
+            b.iter_batched(
+                || lu.clone(),
+                |mut lu| {
+                    let _ = lu.update_sparse(black_box(slot), black_box(&sparse_col));
                 },
                 BatchSize::SmallInput,
             )

--- a/crates/feral-diagnostics/src/bin/lu_reference.rs
+++ b/crates/feral-diagnostics/src/bin/lu_reference.rs
@@ -184,7 +184,17 @@ fn check(path: &Path) -> String {
         Err(e) => format!("upd={e}"),
     };
 
-    let verdict = if err < 1e-6 { "OK " } else { "BAD" };
+    // A large forward error with a machine-precision residual is matrix
+    // conditioning, not a solver fault: the solve is backward-stable
+    // (‖Bx−a‖/‖a‖ tiny) but the near-singular matrix can't recover x_true.
+    // Label that ILL so it is not conflated with a genuine BAD solve.
+    let verdict = if err < 1e-6 {
+        "OK "
+    } else if resid < 1e-8 {
+        "ILL"
+    } else {
+        "BAD"
+    };
     format!(
         "{name:24}  n={n:<7} nnz={:<9} {verdict} err={err:.2e} resid={resid:.2e} ref={resid_ref:.2e} fill={fill:.1} {update_note} ({factor_us:.0}µs)",
         mtx.nnz
@@ -219,16 +229,27 @@ fn main() {
         return;
     }
     let mut ok = 0usize;
+    let mut ill = 0usize;
     let mut total = 0usize;
     for f in files.iter() {
         let line = check(f);
         if line.contains(" OK ") {
             ok += 1;
         }
-        if line.contains(" OK ") || line.contains(" BAD ") || line.contains("FAIL") {
+        if line.contains(" ILL ") {
+            ill += 1;
+        }
+        if line.contains(" OK ")
+            || line.contains(" ILL ")
+            || line.contains(" BAD ")
+            || line.contains("FAIL")
+        {
             total += 1;
         }
         println!("{line}");
     }
-    println!("\n{ok}/{total} solved to err < 1e-6 (known-x oracle).");
+    println!(
+        "\n{ok}/{total} solved to err < 1e-6 (known-x oracle); \
+         {ill} ILL (backward-stable, resid < 1e-8, but large forward error from conditioning)."
+    );
 }

--- a/crates/feral-diagnostics/src/bin/lu_reference.rs
+++ b/crates/feral-diagnostics/src/bin/lu_reference.rs
@@ -1,0 +1,234 @@
+//! Real-world unsymmetric LU validation harness (issue #81, epic Phase 7).
+//!
+//! Reads square general (unsymmetric) Matrix Market files — e.g. the
+//! SuiteSparse square-unsymmetric matrices fetched by
+//! `scripts/fetch_lu_corpus.py` — and validates the sparse LU on each against a
+//! KNOWN solution oracle: pick `x_true`, form `a = B·x_true`, solve `B x = a`,
+//! and report `‖x − x_true‖/‖x_true‖` and `‖Bx − a‖/‖a‖`. Also exercises a
+//! self-replace rank-1 update (must leave the basis unchanged). No external
+//! solver is required (the known-x oracle is self-contained); a companion
+//! `scripts/lu_reference_scipy.py` cross-checks against SciPy's SuperLU.
+//!
+//! Run: `cargo run -p feral-diagnostics --release --bin lu_reference -- [DIR]`
+//! (DIR defaults to `data/matrices/lu-corpus`).
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{LuParams, LuScaling, LuSingularAction, SparseLu, SparseLuSymbolic};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// Parsed general Matrix Market matrix (square).
+struct Mtx {
+    n: usize,
+    nnz: usize,
+    triplets: Vec<(usize, usize, f64)>,
+}
+
+/// Parse a real `coordinate` Matrix Market file (`general` or `symmetric`).
+/// Symmetric files are expanded to both triangles. Requires a square matrix.
+fn parse_general_mtx(text: &str) -> Result<Mtx, String> {
+    let mut lines = text.lines();
+    let header = lines.next().ok_or("empty file")?.to_ascii_lowercase();
+    if !header.starts_with("%%matrixmarket matrix coordinate real") {
+        return Err(format!("unsupported header: {header}"));
+    }
+    let symmetric = header.contains("symmetric");
+    if header.contains("pattern") || header.contains("complex") {
+        return Err("pattern/complex not supported".into());
+    }
+    // Skip comments and find the size line.
+    let mut size_line = None;
+    for line in lines.by_ref() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('%') {
+            continue;
+        }
+        size_line = Some(t.to_string());
+        break;
+    }
+    let size_line = size_line.ok_or("missing size line")?;
+    let mut it = size_line.split_whitespace();
+    let rows: usize = it.next().and_then(|s| s.parse().ok()).ok_or("bad rows")?;
+    let cols: usize = it.next().and_then(|s| s.parse().ok()).ok_or("bad cols")?;
+    let nnz: usize = it.next().and_then(|s| s.parse().ok()).ok_or("bad nnz")?;
+    if rows != cols {
+        return Err(format!("not square: {rows}x{cols}"));
+    }
+    let mut triplets = Vec::with_capacity(if symmetric { 2 * nnz } else { nnz });
+    for line in lines {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('%') {
+            continue;
+        }
+        let mut p = t.split_whitespace();
+        let r: usize = p.next().and_then(|s| s.parse().ok()).ok_or("bad row idx")?;
+        let c: usize = p.next().and_then(|s| s.parse().ok()).ok_or("bad col idx")?;
+        let v: f64 = p.next().and_then(|s| s.parse().ok()).ok_or("bad value")?;
+        let (r0, c0) = (r - 1, c - 1); // 1-based -> 0-based
+        triplets.push((r0, c0, v));
+        if symmetric && r0 != c0 {
+            triplets.push((c0, r0, v));
+        }
+    }
+    Ok(Mtx {
+        n: rows,
+        nnz: triplets.len(),
+        triplets,
+    })
+}
+
+fn to_sparse_cols(m: &Mtx) -> Result<SparseColMatrix, String> {
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); m.n];
+    for &(r, c, v) in m.triplets.iter() {
+        cols[c].push((r, v));
+    }
+    SparseColMatrix::from_sparse_columns(m.n, &cols).map_err(|e| format!("{e}"))
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+fn rel(num: f64, den: f64) -> f64 {
+    num / den.max(1e-300)
+}
+
+/// Validate one matrix; returns a one-line report.
+fn check(path: &Path) -> String {
+    let name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("?");
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) => return format!("{name:24}  READ-ERR {e}"),
+    };
+    let mtx = match parse_general_mtx(&text) {
+        Ok(m) => m,
+        Err(e) => return format!("{name:24}  SKIP {e}"),
+    };
+    let b = match to_sparse_cols(&mtx) {
+        Ok(b) => b,
+        Err(e) => return format!("{name:24}  SKIP {e}"),
+    };
+    let n = b.m;
+    // Known solution oracle.
+    let x_true: Vec<f64> = (0..n).map(|i| 1.0 + (i % 7) as f64).collect();
+    let mut a = vec![0.0; n];
+    b.matvec(&x_true, &mut a);
+
+    // Factor with MC64 scaling + PerturbToEps (so near-singular reals survive).
+    let params = LuParams {
+        scaling: LuScaling::Mc64,
+        on_singular: LuSingularAction::PerturbToEps { abs_floor: 1e-12 },
+        refine_steps: 2,
+        refine_tol: 1e-14,
+        ..LuParams::default()
+    };
+    let symbolic = match SparseLuSymbolic::analyze(&b) {
+        Ok(s) => s,
+        Err(e) => return format!("{name:24}  SKIP analyze {e}"),
+    };
+    let t0 = Instant::now();
+    let mut lu = match SparseLu::factor(&b, &symbolic, params) {
+        Ok(lu) => lu,
+        Err(e) => return format!("{name:24}  n={n:<7} FACTOR-FAIL {e}"),
+    };
+    let factor_us = t0.elapsed().as_secs_f64() * 1e6;
+    let fill = lu.factor_nnz() as f64 / (mtx.nnz.max(1) as f64);
+
+    // Plain solve.
+    let mut x = a.clone();
+    if lu.ftran(&mut x).is_err() {
+        return format!("{name:24}  n={n:<7} FTRAN-ERR");
+    }
+    let err = rel(
+        inf_norm(
+            &x.iter()
+                .zip(&x_true)
+                .map(|(&a, &b)| a - b)
+                .collect::<Vec<_>>(),
+        ),
+        inf_norm(&x_true),
+    );
+    let mut bx = vec![0.0; n];
+    b.matvec(&x, &mut bx);
+    let resid = rel(
+        inf_norm(&bx.iter().zip(&a).map(|(&p, &q)| p - q).collect::<Vec<_>>()),
+        inf_norm(&a),
+    );
+    // Refined solve.
+    let mut xr = a.clone();
+    let _ = lu.ftran_refined(&b, &mut xr);
+    let mut bxr = vec![0.0; n];
+    b.matvec(&xr, &mut bxr);
+    let resid_ref = rel(
+        inf_norm(&bxr.iter().zip(&a).map(|(&p, &q)| p - q).collect::<Vec<_>>()),
+        inf_norm(&a),
+    );
+
+    // Self-replace rank-1 update: replacing a column with itself must leave the
+    // factorization solving the same system.
+    let slot = n / 2;
+    let (rows, vals) = b.column(slot);
+    let same_col: Vec<(usize, f64)> = rows.iter().copied().zip(vals.iter().copied()).collect();
+    let update_note = match lu.update_sparse(slot, &same_col) {
+        Ok(()) => {
+            let mut xu = a.clone();
+            let _ = lu.ftran(&mut xu);
+            let mut bxu = vec![0.0; n];
+            b.matvec(&xu, &mut bxu);
+            let ru = rel(
+                inf_norm(&bxu.iter().zip(&a).map(|(&p, &q)| p - q).collect::<Vec<_>>()),
+                inf_norm(&a),
+            );
+            format!("upd={ru:.1e}")
+        }
+        Err(e) => format!("upd={e}"),
+    };
+
+    let verdict = if err < 1e-6 { "OK " } else { "BAD" };
+    format!(
+        "{name:24}  n={n:<7} nnz={:<9} {verdict} err={err:.2e} resid={resid:.2e} ref={resid_ref:.2e} fill={fill:.1} {update_note} ({factor_us:.0}µs)",
+        mtx.nnz
+    )
+}
+
+fn main() {
+    let dir: PathBuf = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("data/matrices/lu-corpus"));
+    println!("LU reference harness — corpus dir: {}", dir.display());
+    let mut files: Vec<PathBuf> = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("mtx"))
+            .collect(),
+        Err(e) => {
+            eprintln!(
+                "cannot read {}: {e}\nFetch matrices first: python scripts/fetch_lu_corpus.py",
+                dir.display()
+            );
+            return;
+        }
+    };
+    files.sort();
+    if files.is_empty() {
+        eprintln!(
+            "no .mtx files in {} — run scripts/fetch_lu_corpus.py",
+            dir.display()
+        );
+        return;
+    }
+    let mut ok = 0usize;
+    let mut total = 0usize;
+    for f in files.iter() {
+        let line = check(f);
+        if line.contains(" OK ") {
+            ok += 1;
+        }
+        if line.contains(" OK ") || line.contains(" BAD ") || line.contains("FAIL") {
+            total += 1;
+        }
+        println!("{line}");
+    }
+    println!("\n{ok}/{total} solved to err < 1e-6 (known-x oracle).");
+}

--- a/crates/feral-diagnostics/src/bin/lu_scale_probe.rs
+++ b/crates/feral-diagnostics/src/bin/lu_scale_probe.rs
@@ -1,0 +1,113 @@
+//! Scaling probe for the unsymmetric sparse LU (issue #81).
+//!
+//! Factors increasingly large genuinely-sparse bases (a diagonally-dominant
+//! tridiagonal matrix: O(n) nonzeros, O(n) ideal factor work) and reports
+//! factor / analyze / ftran time vs n, plus the empirical log-log exponent
+//! between consecutive sizes. A scalable factor should show an exponent well
+//! below 2.
+//!
+//! Run: `cargo run -p feral-diagnostics --release --bin lu_scale_probe`
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{LuParams, SparseLu, SparseLuSymbolic};
+use std::time::Instant;
+
+/// Diagonally-dominant tridiagonal basis with `n` columns (≈3n nonzeros, no
+/// fill — isolates the factor traversal cost).
+fn tridiagonal(n: usize) -> SparseColMatrix {
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for (j, col) in cols.iter_mut().enumerate() {
+        if j > 0 {
+            col.push((j - 1, -1.0));
+        }
+        col.push((j, 4.0));
+        if j + 1 < n {
+            col.push((j + 1, -1.0));
+        }
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("tridiagonal")
+}
+
+/// 5-point 2D Laplacian on a `g×g` grid (`n = g²`, ≈5n nonzeros). Bandwidth
+/// `√n` induces genuine fill — a realistic sub-quadratic sparse stress case.
+fn grid2d(g: usize) -> SparseColMatrix {
+    let n = g * g;
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    let idx = |r: usize, c: usize| r * g + c;
+    for r in 0..g {
+        for c in 0..g {
+            let j = idx(r, c);
+            cols[j].push((j, 4.0));
+            if r > 0 {
+                cols[j].push((idx(r - 1, c), -1.0));
+            }
+            if r + 1 < g {
+                cols[j].push((idx(r + 1, c), -1.0));
+            }
+            if c > 0 {
+                cols[j].push((idx(r, c - 1), -1.0));
+            }
+            if c + 1 < g {
+                cols[j].push((idx(r, c + 1), -1.0));
+            }
+        }
+    }
+    for col in cols.iter_mut() {
+        col.sort_by_key(|&(i, _)| i);
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("grid2d")
+}
+
+fn measure(name: &str, mats: Vec<(usize, SparseColMatrix)>) {
+    println!("\n=== {name} ===");
+    println!(
+        "{:>8}  {:>8}  {:>12}  {:>12}  {:>12}  {:>10}  {:>10}",
+        "n", "nnz", "analyze(µs)", "factor(µs)", "ftran(µs)", "factor_exp", "Lnnz"
+    );
+    let mut prev: Option<(f64, f64)> = None; // (n, factor_us)
+    for (n, a) in mats {
+        let nnz = a.nnz();
+        let t0 = Instant::now();
+        let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+        let analyze_us = t0.elapsed().as_secs_f64() * 1e6;
+
+        let t1 = Instant::now();
+        let mut lu = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+        let factor_us = t1.elapsed().as_secs_f64() * 1e6;
+
+        let mut rhs: Vec<f64> = (0..n).map(|i| 1.0 + (i % 7) as f64).collect();
+        let t2 = Instant::now();
+        lu.ftran(&mut rhs).expect("ftran");
+        let ftran_us = t2.elapsed().as_secs_f64() * 1e6;
+
+        let exp = match prev {
+            Some((pn, pf)) if pf > 0.0 => (factor_us / pf).ln() / (n as f64 / pn).ln(),
+            _ => f64::NAN,
+        };
+        prev = Some((n as f64, factor_us));
+        println!(
+            "{:>8}  {:>8}  {:>12.0}  {:>12.0}  {:>12.0}  {:>10.2}  {:>10}",
+            n,
+            nnz,
+            analyze_us,
+            factor_us,
+            ftran_us,
+            exp,
+            lu.factor_nnz()
+        );
+    }
+}
+
+fn main() {
+    let tri: Vec<(usize, SparseColMatrix)> = [1000usize, 2000, 4000, 8000, 16000, 32000, 64000]
+        .iter()
+        .map(|&n| (n, tridiagonal(n)))
+        .collect();
+    measure("tridiagonal (no fill)", tri);
+
+    let grid: Vec<(usize, SparseColMatrix)> = [16usize, 24, 32, 48, 64, 90, 128]
+        .iter()
+        .map(|&g| (g * g, grid2d(g)))
+        .collect();
+    measure("2D 5-point grid (fill)", grid);
+}

--- a/crates/feral-diagnostics/src/bin/lu_update_probe.rs
+++ b/crates/feral-diagnostics/src/bin/lu_update_probe.rs
@@ -1,0 +1,85 @@
+//! Warm-solve scaling probe for the sparse LU under update chains (issue #81).
+//!
+//! The current sparse rank-1 update stores a product-form eta with a *dense*
+//! `τ` vector (length n) per update, so each `ftran`/`btran` costs `O(k·n)`
+//! after `k` updates and the eta file grows `O(k·n)` in memory. This probe
+//! measures `ftran` time and eta storage vs the update-chain length `k` on a
+//! large sparse basis, to size the case for a true Forrest–Tomlin sparse
+//! row-eta.
+//!
+//! Run: `cargo run -p feral-diagnostics --release --bin lu_update_probe`
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{LuParams, SparseLu, SparseLuSymbolic};
+use std::time::Instant;
+
+fn tridiagonal(n: usize) -> SparseColMatrix {
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for (j, col) in cols.iter_mut().enumerate() {
+        if j > 0 {
+            col.push((j - 1, -1.0));
+        }
+        col.push((j, 4.0));
+        if j + 1 < n {
+            col.push((j + 1, -1.0));
+        }
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("tridiagonal")
+}
+
+/// A fresh, diagonally-dominant sparse replacement column for slot `j`.
+fn replacement_col(n: usize, j: usize) -> Vec<f64> {
+    let mut c = vec![0.0; n];
+    c[j] = 5.0;
+    if j > 0 {
+        c[j - 1] = -0.7;
+    }
+    if j + 1 < n {
+        c[j + 1] = -0.6;
+    }
+    c
+}
+
+fn avg_ftran_us(lu: &mut SparseLu, n: usize, reps: usize) -> f64 {
+    let mut total = 0.0;
+    for t in 0..reps {
+        let mut rhs: Vec<f64> = (0..n).map(|i| 1.0 + ((i + t) % 7) as f64).collect();
+        let t0 = Instant::now();
+        lu.ftran(&mut rhs).expect("ftran");
+        total += t0.elapsed().as_secs_f64() * 1e6;
+    }
+    total / reps as f64
+}
+
+fn main() {
+    let n = 5000;
+    let a = tridiagonal(n);
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let params = LuParams {
+        max_updates: 100_000,
+        ..LuParams::default()
+    };
+    let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
+
+    println!("n = {n}, base factor nnz = {}", lu.factor_nnz());
+    println!(
+        "{:>8}  {:>14}  {:>12}",
+        "updates", "ftran(µs/avg)", "eta_nnz"
+    );
+    let base = avg_ftran_us(&mut lu, n, 50);
+    println!("{:>8}  {:>14.2}  {:>12}", 0, base, 0);
+
+    let checkpoints = [10usize, 25, 50, 100, 200, 400];
+    let mut done = 0usize;
+    for &k in &checkpoints {
+        while done < k {
+            let slot = (done * 37 + 11) % n;
+            let col = replacement_col(n, slot);
+            lu.update(slot, &col).expect("update");
+            done += 1;
+        }
+        let ft = avg_ftran_us(&mut lu, n, 50);
+        // eta storage = updates × n (dense τ each).
+        println!("{:>8}  {:>14.2}  {:>12}", done, ft, done * n);
+    }
+}

--- a/crates/feral-diagnostics/src/bin/lu_update_probe.rs
+++ b/crates/feral-diagnostics/src/bin/lu_update_probe.rs
@@ -1,11 +1,12 @@
 //! Warm-solve scaling probe for the sparse LU under update chains (issue #81).
 //!
-//! The current sparse rank-1 update stores a product-form eta with a *dense*
-//! `τ` vector (length n) per update, so each `ftran`/`btran` costs `O(k·n)`
-//! after `k` updates and the eta file grows `O(k·n)` in memory. This probe
-//! measures `ftran` time and eta storage vs the update-chain length `k` on a
-//! large sparse basis, to size the case for a true Forrest–Tomlin sparse
-//! row-eta.
+//! The Forrest–Tomlin update stores a bump-local eta (the elimination of the
+//! spike), so warm `ftran` cost grows with the *bump* size, not `O(k·n)` like
+//! the old product-form (dense `τ`). This probe demonstrates that on a
+//! block-diagonal basis (localized spikes — the realistic LP regime): with a
+//! fixed block size, the per-update eta and the `ftran` cost are independent of
+//! `n`. A tridiagonal basis (dense `L⁻¹` ⇒ dense spike) is the honest worst
+//! case where the bump spans the tail.
 //!
 //! Run: `cargo run -p feral-diagnostics --release --bin lu_update_probe`
 
@@ -13,29 +14,46 @@ use feral::lu::sparse_matrix::SparseColMatrix;
 use feral::lu::{LuParams, SparseLu, SparseLuSymbolic};
 use std::time::Instant;
 
-fn tridiagonal(n: usize) -> SparseColMatrix {
+/// Block-diagonal basis: `nblocks` diagonally-dominant dense blocks of size
+/// `bs`. With natural ordering, `L` is block-diagonal so a within-block update
+/// has a spike confined to its block.
+fn block_diag(nblocks: usize, bs: usize, seed: u64) -> SparseColMatrix {
+    let n = nblocks * bs;
+    let mut state = seed;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0
+    };
     let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
-    for (j, col) in cols.iter_mut().enumerate() {
-        if j > 0 {
-            col.push((j - 1, -1.0));
-        }
-        col.push((j, 4.0));
-        if j + 1 < n {
-            col.push((j + 1, -1.0));
+    for b in 0..nblocks {
+        let base = b * bs;
+        for cc in 0..bs {
+            let j = base + cc;
+            for rr in 0..bs {
+                let i = base + rr;
+                let v = if rr == cc { 5.0 + rng().abs() } else { rng() };
+                cols[j].push((i, v));
+            }
         }
     }
-    SparseColMatrix::from_sparse_columns(n, &cols).expect("tridiagonal")
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("block_diag")
 }
 
-/// A fresh, diagonally-dominant sparse replacement column for slot `j`.
-fn replacement_col(n: usize, j: usize) -> Vec<f64> {
+fn within_block_col(n: usize, bs: usize, slot: usize, seed: u64) -> Vec<f64> {
+    let mut state = seed;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0
+    };
+    let base = (slot / bs) * bs;
     let mut c = vec![0.0; n];
-    c[j] = 5.0;
-    if j > 0 {
-        c[j - 1] = -0.7;
-    }
-    if j + 1 < n {
-        c[j + 1] = -0.6;
+    for rr in 0..bs {
+        let i = base + rr;
+        c[i] = if base + (slot - base) == i {
+            5.0 + rng().abs()
+        } else {
+            rng()
+        };
     }
     c
 }
@@ -52,34 +70,38 @@ fn avg_ftran_us(lu: &mut SparseLu, n: usize, reps: usize) -> f64 {
 }
 
 fn main() {
-    let n = 5000;
-    let a = tridiagonal(n);
-    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
-    let params = LuParams {
-        max_updates: 100_000,
-        ..LuParams::default()
-    };
-    let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
-
-    println!("n = {n}, base factor nnz = {}", lu.factor_nnz());
+    let bs = 25;
+    let k = 50; // updates
+    println!("Block-diagonal basis, block size {bs}, {k} within-block updates:");
     println!(
-        "{:>8}  {:>14}  {:>12}",
-        "updates", "ftran(µs/avg)", "eta_nnz"
+        "{:>8}  {:>14}  {:>14}  {:>16}",
+        "n", "ftran@0(µs)", "ftran@k(µs)", "eta_ops_total"
     );
-    let base = avg_ftran_us(&mut lu, n, 50);
-    println!("{:>8}  {:>14.2}  {:>12}", 0, base, 0);
-
-    let checkpoints = [10usize, 25, 50, 100, 200, 400];
-    let mut done = 0usize;
-    for &k in &checkpoints {
-        while done < k {
-            let slot = (done * 37 + 11) % n;
-            let col = replacement_col(n, slot);
-            lu.update(slot, &col).expect("update");
-            done += 1;
+    for &nblocks in &[40usize, 80, 160, 320] {
+        let n = nblocks * bs;
+        let a = block_diag(nblocks, bs, 0x100 + nblocks as u64);
+        let symbolic = SparseLuSymbolic::natural(n);
+        let params = LuParams {
+            max_updates: 100_000,
+            ..LuParams::default()
+        };
+        let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
+        let ft0 = avg_ftran_us(&mut lu, n, 30);
+        for s in 0..k {
+            let slot = ((s * 53 + 7) % nblocks) * bs + (s % bs);
+            let col = within_block_col(n, bs, slot, 0xABC + s as u64);
+            // Some updates may legitimately hit a singular within-block basis;
+            // skip those for the timing demo.
+            let _ = lu.update(slot, &col);
         }
-        let ft = avg_ftran_us(&mut lu, n, 50);
-        // eta storage = updates × n (dense τ each).
-        println!("{:>8}  {:>14.2}  {:>12}", done, ft, done * n);
+        let ftk = avg_ftran_us(&mut lu, n, 30);
+        println!(
+            "{:>8}  {:>14.2}  {:>14.2}  {:>16}",
+            n,
+            ft0,
+            ftk,
+            lu.eta_ops()
+        );
     }
+    println!("(ftran@k and eta_ops should be ~flat in n — FT cost is bump-local, not O(n).)");
 }

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-08T01:07:37Z
+Generated: 2026-06-08T12:36:33Z
 
 ## Latest Session
 File: dev/sessions/2026-06-08-01.md
@@ -59,34 +59,34 @@ spd_10..spd_200, kkt_10_3..kkt_100_30 — 8 matrices, all inertia exact.
 
 ## Git Status
 ```
-a781ad4 feat(lu): scaling robustness layer — equilibration + unsymmetric MC64 (#81)
-258db84 feat(lu): sparse rank-1 update (product-form U update) + unified update API (#81)
-2128e1a feat(lu): sparse Gilbert–Peierls LU factor, solves, AMD-on-AᵀA ordering (#81)
-7d914e9 feat(lu): dense LU factor, solves, and rank-1 update (#81)
-f4bf2c2 feat(lu): LU module scaffold — GeneralMatrix, LuParams, router, errors (#81)
+2b5a5f5 test(lu): prove FT warm-solve is bump-local, independent of n (#81)
+0fc767c feat(lu): true sparse Forrest–Tomlin update with in-bump partial pivoting (#81)
+8738279 refactor(lu): store sparse U as mutable per-row vectors for FT (#81)
+9cbc8c1 docs(lu): scope sparse Forrest–Tomlin (P6.5) with the zero-pivot subtlety (#81)
+23af110 refactor(lu): store sparse U row-wise (CSR) for the Forrest–Tomlin update (#81)
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
 test symbolic::tests::schur_symbolic_single_schur_index ... ok
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 324 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
+test result: ok. 324 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.81s
 
 ```
 
@@ -109,36 +109,36 @@ changed no symmetric code path.)
 ```
 
 ## Recent Decisions
-  `U' = U·F`, `F = I + (τ−e_q)e_qᵀ`, so `U'⁻¹ = F⁻¹U⁻¹`; one eta `(q, τ)` per
-  update, applied after the `U`-solve (transposed-in-reverse in `btran`).
-  `τ[q]` is the stability pivot. This is correct and genuinely sparse with a
-  clean refactor budget; a full Forrest–Tomlin row-eta file (keeping the eta
-  sparser than the dense `τ`) is deferred as an optimization, not a correctness
-  gap.
+Decision and rationale:
 
-- **Sparse factor.** Gilbert–Peierls left-looking LU. The forward-substitution
-  variant used is correct but not yet output-sensitive (no DFS reach); the
-  depth-first symbolic reach that makes it O(flops) is deferred.
+- **In-place bump elimination with partial pivoting.** The spike `ρ = G⁻¹L⁻¹P·aₙₑw` is set
+  into `U`'s column `r`; the bump `[r, h]` (`h` = max spike support) is re-triangularized by
+  sparse Gaussian elimination. **Partial pivoting is mandatory** and is the resolution of the
+  zero-pivot landmine documented when this was deferred: the naive column-shift Bartels–Golub
+  makes the Hessenberg diagonal pivots the old superdiagonal `U[k,k+1]`, which are frequently
+  zero in a sparse `U`; partial pivoting instead uses a nonzero sub-diagonal spike entry as
+  the pivot via a row interchange.
 
-- **Column ordering.** Reuse `feral_amd::amd_order` on the explicitly-formed
-  `AᵀA` (column-intersection) pattern as a stand-in for COLAMD. The `AᵀA`
-  pattern is invariant under the row permutation/scaling, so the ordering is
-  also valid for the scaled matrix `Ã`.
+- **Swaps go into the eta, not the base `L`.** The unit-lower base `L` is never permuted
+  (permuting the fully-formed `L` would break its triangularity). The bump elimination's
+  elementary operations — `FtOp::Swap` (partial-pivot interchange) and `FtOp::Axpy`
+  (`row -= mult·row`) — are recorded as a `FtEta` and replayed on the solve vector between the
+  `L`-solve and `U`-solve in `ftran` (transposed, reversed, between `Uᵀ` and `Lᵀ` in `btran`).
+  `U` is updated in place. Maintained invariant: `P A Q = L G U`, `G = E₁⁻¹…Eₜ⁻¹`.
 
-- **Scaling.** Unsymmetric MC64 is a thin driver over the existing
-  `crate::scaling::hungarian_match` (already an unsymmetric bipartite matcher),
-  not a new algorithm; ∞-norm equilibration adapts the two-sided Knight–Ruiz
-  idea. `params.scaling` drives `factor()`, which factors
-  `Ã = D_row Π B D_col`; solves wrap the scaling around a core solve.
+- **`U` stored as mutable per-row vectors** (`Vec<Vec<(col,val)>>`, diagonal first) rather than
+  flat CSR, so the in-place row operations / swaps / merges are tractable.
 
-- **API.** `update(leaving_slot, entering_col)` takes the raw entering column
-  (computes the spike internally) on both paths, matching the simplex
-  "swap column" operation and the `BasisEngine` seam shape.
+- **Consequence.** Warm-solve cost is bump-local (`O(Σ bump)`), independent of `n` for
+  localized spikes (the realistic LP regime) — demonstrated flat across n=1000..8000. The
+  inherent worst case is a dense spike (e.g. tridiagonal, where `L⁻¹` is dense), where the
+  bump spans the tail and the cost degrades toward the old product-form; this is fundamental
+  to any update scheme and bounded by the `max_updates` refactor budget.
 
-- **Out of scope (deferred).** The `pounce-simplex` `BasisEngine` integration
-  and GLOBALLib/netlib end-to-end benchmarks cannot be done here (pounce is not
-  in this environment); reference (UMFPACK/KLU) benchmarks and the GP
-  reach / full FT optimizations are Phase 7 in `dev/plans/unsymmetric-lu-epic.md`.
+- **Stability/budget.** Growth monitor over elimination multipliers → `NeedsRefactor` on
+  `max_growth`; no acceptable bump pivot → `SingularBasis`; update count → `NeedsRefactor` on
+  `max_updates`. Work is done on a clone of `U`, committed only on success, so failures leave
+  `self` unchanged.
 
 ## Recent Tried-and-Rejected
    the scaling choice and unpredicted by max_col_deg / MC64 cost / n

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,148 +1,144 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-06T18:06:39Z
+Generated: 2026-06-08T01:07:37Z
 
 ## Latest Session
-File: dev/sessions/2026-06-06-04.md
+File: dev/sessions/2026-06-08-01.md
 ```
-# Session 2026-06-06-04
+# Session 2026-06-08-01
 
 ## Goal
 
-Implement the dense-column follow-up "safe win" (scaling audit §8.1 option
-(b)): skip the speculative MC64 in symbolic `LdltCompress` when the resolved
-numeric scaling will not reuse the cache.
+Implement issue #81: a new **unsymmetric LU factorization family** for feral,
+designed as a revised-simplex basis engine — dense + sparse LU with first-class
+rank-1 column-replacement updates, `ftran`/`btran`, auto routing, and the full
+robustness layer (equilibration + unsymmetric MC64 + iterative refinement).
 
 ## Accomplished
 
-**Investigated the proposed scaling-aware gate and rejected it on empirical
-evidence — the premise is refuted. No `src/` change landed.**
+All six in-scope phases landed, each with green oracle tests and clippy clean.
+The symmetric LDLᵀ solver is untouched (additive `feral::lu` module).
 
-Two design facts established first (by reading solver.rs + symbolic/mod.rs +
-ldlt_compress.rs):
+- **Docs first (mandatory).** Research note `dev/research/unsymmetric-lu.md` and
+  epic plan `dev/plans/unsymmetric-lu-epic.md`; 6 LU references added to
+  `dev/references.bib`.
+- **Dense path** (`src/lu/dense_*`). `GeneralMatrix`; `DenseLu` right-looking
+  LU with threshold partial pivoting (`P B Q = L U`, explicit `L`/`U`);
+  `ftran`/`btran`/`ftran_partial`; refinement; rank-1 Bartels–Golub `update()`
+  maintaining `P B Q = L U` via an explicit column permutation.
+  `tests/lu_dense.rs` (11 tests).
+- **Sparse path** (`src/lu/sparse_*`). `SparseColMatrix` (general CSC) +
+  `ata_pattern`; `SparseLuSymbolic` (AMD-on-AᵀA via `feral_amd`); `SparseLu`
+  Gilbert–Peierls factor; sparse solves + refinement; product-form `U`-update
+  rank-1 column replacement. `tests/lu_sparse.rs` (10 tests).
+- **Router.** `should_use_dense_lu` mirroring `should_use_dense_fast_path`.
+- **Scaling** (`src/lu/scaling.rs`). Two-sided ∞-norm equilibration +
+  unsymmetric MC64 (over the existing `hungarian_match`); `params.scaling`
+  drives `factor()`; solves wrap scaling around a core solve.
+  `tests/lu_scaling.rs` (5 tests).
+- **Errors.** `FeralError::SingularBasis { column }` and `NeedsRefactor`.
 
-1. Symbolic runs at `factor()` Step 3 (solver.rs:805), **on a cache miss
-   only**, and is cached per pattern fingerprint — so the `LdltCompress` MC64
-   runs **once per pattern**. Scaling resolves later (Steps 3.75/3.8). Making
-   symbolic scaling-aware is feasible (compute `pick_scaling_strategy` before
-   the symbolic call), but —
-2. **The MC64 in `LdltCompress` is load-bearing for compression, not
-   speculative.** `build_supermap` (ldlt_compress.rs:39-77) walks the MC64
-   matching permutation's cycle structure to form super-variables (MUMPS
-   `ICNTL(12)=2` / Duff-Pralet). Skipping MC64 = skipping compression =
-   **changing the ordering**. So the win is real only if compression is not
-   worth its MC64 cost — an empirical question.
+Test evidence (all green): equation residuals `‖Bx−a‖/‖a‖` < 1e-8 after
+single/chained updates (dense and sparse), update-with-row-swap (perm
+composition), reconstruction `‖PAQ−LU‖` < 1e-10, dense↔sparse agreement < 1e-9
+(factor + post-update), budget→`NeedsRefactor` with `self` unchanged,
+ill-conditioned refinement < 1e-12, and ill-scaled (16 orders) correctness
+under InfNorm/Mc64 with the matrix equilibrated into [0.1,10] and MC64 placing
+order-1 entries on the diagonal. `cargo clippy --all-targets -- -D warnings`
+clean throughout; `pre-commit` installed and enforcing fmt/clippy on every
+commit.
 
-Empirical findings (two new diagnostic probes):
+## Benchmark Results
 
-- `probe_compress_scaling_bucket` (3 roots, 1006 families): 376 `LdltCompress`,
-  of which 118 reuse MC64 (keep) and **258 do not** (target bucket). The target
-  bucket is **not vacuous and not all small**: it includes large dense-column
-  matrices — INDEFM (n=100000, deg=100000), SINQUAD2 (5000/5000),
-  ex8_2_3 (18791/3132), ex8_2_2 (9453/1894), ORTHREGF (6405/1601),
-  ROSEPETAL (3000/2001), all `InfNorm`.
-- `probe_compress_costbenefit_argv` (symbolic+numeric, None vs LdltCompress,
-  5-run median, release) refutes the premise. Crux = **ROSEPETAL vs ORTHREGF**,
-  both large near-dense-column `InfNorm` (won't-reuse), opposite verdicts:
-  - **ROSEPETAL** −75.7% (5.97 s → 1.45 s): pays 0.68 s MC64 but the compressed
-    ordering gives an **8× numeric speedup** (5.72 s → 0.77 s). Reproducible.
-  - **ORTHREGF** +91.8% (6.2 ms → 11.9 ms): MC64 pure overhead, zero numeric
-    benefit. Reproducible.
+The LU module is additive; the symmetric LDLᵀ corpus is unaffected. `cargo run
+--bin bench --release` (no external corpus present — synthetic SPD/KKT only):
 
-**Conclusion:** the value of `LdltCompress` is its numeric fill reduction,
-which is independent of the scaling choice and unpredicted by max_col_deg /
-MC64 cost / n (ROSEPETAL's MC64 is 68× ORTHREGF's, yet ROSEPETAL is the win).
-The scaling-reuse signal carries no information about whether compression pays
-off. A gate keyed on it would regress the fill-reduction wins (ROSEPETAL ~4×,
-ex8_2_2) to save milliseconds on the overhead-only losses. **Not a safe win.**
+```
+spd_10..spd_200, kkt_10_3..kkt_100_30 — 8 matrices, all inertia exact.
 ```
 
 ## Git Status
 ```
-bb74821 docs(research): MC64 dense-column fast path — definitive negative result
-98f85e0 fix(diagnostics): clippy needless_range_loop in scaling_sweep generators
-2ef38d5 docs(research): scaling audit report — MC64 is the sole super-linear phase
-402630e feat(scaling): localize MC64 dense-column cost; resolve debug/release (#80)
-503af96 docs(session): checkpoint 2026-06-06-02 — scaling audit Steps 0-2 (#80)
+a781ad4 feat(lu): scaling robustness layer — equilibration + unsymmetric MC64 (#81)
+258db84 feat(lu): sparse rank-1 update (product-form U update) + unified update API (#81)
+2128e1a feat(lu): sparse Gilbert–Peierls LU factor, solves, AMD-on-AᵀA ordering (#81)
+7d914e9 feat(lu): dense LU factor, solves, and rank-1 update (#81)
+f4bf2c2 feat(lu): LU module scaffold — GeneralMatrix, LuParams, router, errors (#81)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
+test symbolic::tests::schur_symbolic_single_schur_index ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_resolves_to_amd_when_bisection_degenerates ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 317 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.48s
+test result: ok. 324 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-06-04.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-08-01.md)
 
 
-`bench --release` NOT re-run: no `src/` (solver) code changed this session.
-The only additions are two diagnostic binaries in the non-default
-`feral-diagnostics` crate plus docs. No performance delta to track.
+The LU module is additive; the symmetric LDLᵀ corpus is unaffected. `cargo run
+--bin bench --release` (no external corpus present — synthetic SPD/KKT only):
 
-Targeted measurement (the session's actual result):
-probe_compress_costbenefit_argv (None vs LdltCompress, 5-run median, release)
-matrix       n      deg   tot_None     tot_Compress   delta%   verdict
-ROSEPETAL   3000   2001   5 965 926us  1 452 187us    -75.7%   compress WINS
-ex8_2_2     9453   1894     215 758us    214 777us     -0.5%   compress
-ex8_2_3    18791   3132     957 786us    968 299us     +1.1%   neutral
-INDEFM    100000 100000   5 030 355us  5 147 508us     +2.3%   neutral
-SINQUAD2    5000   5000      17 232us     18 210us     +5.7%   None
-ORTHREGF    6405   1601       6 224us     11 936us    +91.8%   None wins
-  → scaling-reuse does NOT predict the verdict; gate is unsafe
+spd_10..spd_200, kkt_10_3..kkt_100_30 — 8 matrices, all inertia exact.
+KKT summary: Inertia match 1/1, Residual pass 1/1, worst 1.14e-15.
+Sparse solver: 2/2 inertia match vs MUMPS, 2/2 residual pass, worst 1.26e-16.
+Dense/Sparse failure analysis: no failures.
+
+(No prior-session comparison applies — this session added a disjoint module and
+changed no symmetric code path.)
 
 ```
 
 ## Recent Decisions
-`n > 100_000 && avg_deg < 5 → Amd` (#50 powerflow) and arrow → AMF (#64)
-catches fire first and are untouched, so the powerflow-class guardrail and
-the dense-border catch still hold; only the uniformly-thin would-be-MetisND
-population is rerouted.
+  `U' = U·F`, `F = I + (τ−e_q)e_qᵀ`, so `U'⁻¹ = F⁻¹U⁻¹`; one eta `(q, τ)` per
+  update, applied after the `U`-solve (transposed-in-reverse in `btran`).
+  `τ[q]` is the stability pivot. This is correct and genuinely sparse with a
+  clean refactor budget; a full Forrest–Tomlin row-eta file (keeping the eta
+  sparser than the dense `τ`) is deferred as an optimization, not a correctness
+  gap.
 
-Rejected alternative — **fill-guarded reroute** (route above 100k to AMF
-only when AMF `factor_nnz_estimate ≤ MetisND's`): this was the design
-proposed in the #73 research note *before* the real A/B and the one
-originally requested. It is wrong: Finding 3 shows nql180's fill predicate
-is *anti-correlated* with real speed (MetisND smaller fill, AMF 2× faster),
-so the guard would have kept nql180 on MetisND and forfeited the 2× win.
-Fill is not a speed proxy here; a guard keyed on it adds a per-solve
-symbolic-race cost to make the *wrong* call. Logged in
-`dev/tried-and-rejected.md`.
+- **Sparse factor.** Gilbert–Peierls left-looking LU. The forward-substitution
+  variant used is correct but not yet output-sensitive (no DFS reach); the
+  depth-first symbolic reach that makes it O(flops) is deferred.
 
-Scope / generalization: the mechanism is the same as #67 (AMF's cheaper
-symbolic + competitive-or-better numeric on uniformly-thin patterns), now
-shown to hold above 100k too. The `n>100k && avg_deg<5 → Amd` powerflow
-guardrail (#50) is the one place broad thin-matrix reroutes were shown to
-regress, and it is preserved by firing first. RDW2D51U + QUADCOPTER did not
-finish the real A/B on the loaded test machine; their symbolic predictors
-(AMF 1.55× cheaper / tie) and Finding 1 already favor AMF and do not change
-the conclusion.
+- **Column ordering.** Reuse `feral_amd::amd_order` on the explicitly-formed
+  `AᵀA` (column-intersection) pattern as a stand-in for COLAMD. The `AᵀA`
+  pattern is invariant under the row permutation/scaling, so the ordering is
+  also valid for the scaled matrix `Ã`.
 
-Evidence: dev/research/issue-73-n100k-thin-regime.md (Findings 1–3 +
-Decision), dev/journal/2026-06-03-06.org (:issue-73:ab:factor-solve:),
-src/symbolic/mod.rs choose_adaptive (AMF_BAND_MAX removed) +
-choose_adaptive_rules / choose_adaptive_routes_arrow_to_amf tests,
-crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs,
-crates/feral-diagnostics/src/bin/probe_issue67_thin.rs.
+- **Scaling.** Unsymmetric MC64 is a thin driver over the existing
+  `crate::scaling::hungarian_match` (already an unsymmetric bipartite matcher),
+  not a new algorithm; ∞-norm equilibration adapts the two-sided Knight–Ruiz
+  idea. `params.scaling` drives `factor()`, which factors
+  `Ã = D_row Π B D_col`; solves wrap the scaling around a core solve.
+
+- **API.** `update(leaving_slot, entering_col)` takes the raw entering column
+  (computes the spike internally) on both paths, matching the simplex
+  "swap column" operation and the `BasisEngine` seam shape.
+
+- **Out of scope (deferred).** The `pounce-simplex` `BasisEngine` integration
+  and GLOBALLib/netlib end-to-end benchmarks cannot be done here (pounce is not
+  in this environment); reference (UMFPACK/KLU) benchmarks and the GP
+  reach / full FT optimizations are Phase 7 in `dev/plans/unsymmetric-lu-epic.md`.
 
 ## Recent Tried-and-Rejected
    the scaling choice and unpredicted by max_col_deg / MC64 cost / n
@@ -184,6 +180,17 @@ src/io/mod.rs
 src/io/mtx.rs
 src/io/sidecar.rs
 src/lib.rs
+src/lu/dense_factor.rs
+src/lu/dense_matrix.rs
+src/lu/dense_solve.rs
+src/lu/dense_update.rs
+src/lu/mod.rs
+src/lu/scaling.rs
+src/lu/sparse_factor.rs
+src/lu/sparse_matrix.rs
+src/lu/sparse_solve.rs
+src/lu/sparse_symbolic.rs
+src/lu/sparse_update.rs
 src/numeric/condition.rs
 src/numeric/factorize.rs
 src/numeric/mod.rs
@@ -215,8 +222,8 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/delayed_pivoting.rs
 tests/dense_fast_path.rs
 tests/dense_ldlt.rs
@@ -225,6 +232,10 @@ tests/factor_workspace_parity.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs
@@ -233,14 +244,13 @@ tests/issue_38_static_pivot.rs
 tests/issue_46_saddle_kkt_cascade.rs
 tests/issue_55_delay_budget.rs
 tests/issue_55_n_tiny_counter.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
+tests/lu_dense.rs
+tests/lu_scaling.rs
+tests/lu_sparse.rs
 tests/maxfromm_parity.rs
 tests/mc64_end_to_end.rs
 tests/mc64_scaling.rs
@@ -251,8 +261,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5283,3 +5283,56 @@ src/symbolic/mod.rs choose_adaptive (AMF_BAND_MAX removed) +
 choose_adaptive_rules / choose_adaptive_routes_arrow_to_amf tests,
 crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs,
 crates/feral-diagnostics/src/bin/probe_issue67_thin.rs.
+
+---
+
+## 2026-06-08 — Unsymmetric LU basis engine as a new factorization family (issue #81)
+
+feral grows a second, **separate** factorization family: an unsymmetric LU
+(`feral::lu`) designed as a revised-simplex basis engine. It is additive — the
+symmetric LDLᵀ / inertia solver and all its code paths are untouched (the bench
+confirms the symmetric corpus is unaffected). LU has no inertia.
+
+Decisions made this session (rationale in `dev/research/unsymmetric-lu.md`):
+
+- **Dense update representation.** The dense rank-1 update maintains the
+  invariant `P B Q = L U` with an *explicit column permutation* `Q` and
+  in-place Bartels–Golub re-triangularization (spike → cyclic column shift to
+  upper-Hessenberg → no-pivot Gauss sweep; row op on `U`, column op on `L`).
+  We deliberately did **not** use an eta-replay file on the dense path — it is
+  cleaner and provably keeps `L` unit-lower / `U` upper. In-bump instability or
+  budget overflow returns `NeedsRefactor` with `self` unchanged (work on
+  clones, commit on success).
+
+- **Sparse update representation.** The sparse rank-1 update is a **product-form
+  update of `U`**: replacing column `q` by the transformed spike `τ` gives
+  `U' = U·F`, `F = I + (τ−e_q)e_qᵀ`, so `U'⁻¹ = F⁻¹U⁻¹`; one eta `(q, τ)` per
+  update, applied after the `U`-solve (transposed-in-reverse in `btran`).
+  `τ[q]` is the stability pivot. This is correct and genuinely sparse with a
+  clean refactor budget; a full Forrest–Tomlin row-eta file (keeping the eta
+  sparser than the dense `τ`) is deferred as an optimization, not a correctness
+  gap.
+
+- **Sparse factor.** Gilbert–Peierls left-looking LU. The forward-substitution
+  variant used is correct but not yet output-sensitive (no DFS reach); the
+  depth-first symbolic reach that makes it O(flops) is deferred.
+
+- **Column ordering.** Reuse `feral_amd::amd_order` on the explicitly-formed
+  `AᵀA` (column-intersection) pattern as a stand-in for COLAMD. The `AᵀA`
+  pattern is invariant under the row permutation/scaling, so the ordering is
+  also valid for the scaled matrix `Ã`.
+
+- **Scaling.** Unsymmetric MC64 is a thin driver over the existing
+  `crate::scaling::hungarian_match` (already an unsymmetric bipartite matcher),
+  not a new algorithm; ∞-norm equilibration adapts the two-sided Knight–Ruiz
+  idea. `params.scaling` drives `factor()`, which factors
+  `Ã = D_row Π B D_col`; solves wrap the scaling around a core solve.
+
+- **API.** `update(leaving_slot, entering_col)` takes the raw entering column
+  (computes the spike internally) on both paths, matching the simplex
+  "swap column" operation and the `BasisEngine` seam shape.
+
+- **Out of scope (deferred).** The `pounce-simplex` `BasisEngine` integration
+  and GLOBALLib/netlib end-to-end benchmarks cannot be done here (pounce is not
+  in this environment); reference (UMFPACK/KLU) benchmarks and the GP
+  reach / full FT optimizations are Phase 7 in `dev/plans/unsymmetric-lu-epic.md`.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5336,3 +5336,42 @@ Decisions made this session (rationale in `dev/research/unsymmetric-lu.md`):
   and GLOBALLib/netlib end-to-end benchmarks cannot be done here (pounce is not
   in this environment); reference (UMFPACK/KLU) benchmarks and the GP
   reach / full FT optimizations are Phase 7 in `dev/plans/unsymmetric-lu-epic.md`.
+
+---
+
+## 2026-06-08 — Sparse rank-1 update: Forrest–Tomlin via in-place bump elimination (issue #81, P6.5)
+
+The sparse `SparseLu` rank-1 column-replacement update is a true Forrest–Tomlin /
+Bartels–Golub–Reid update, replacing the interim product-form-on-`U` (which stored a dense
+`τ` per eta and degraded warm `ftran` as `O(k·n)` — measured).
+
+Decision and rationale:
+
+- **In-place bump elimination with partial pivoting.** The spike `ρ = G⁻¹L⁻¹P·aₙₑw` is set
+  into `U`'s column `r`; the bump `[r, h]` (`h` = max spike support) is re-triangularized by
+  sparse Gaussian elimination. **Partial pivoting is mandatory** and is the resolution of the
+  zero-pivot landmine documented when this was deferred: the naive column-shift Bartels–Golub
+  makes the Hessenberg diagonal pivots the old superdiagonal `U[k,k+1]`, which are frequently
+  zero in a sparse `U`; partial pivoting instead uses a nonzero sub-diagonal spike entry as
+  the pivot via a row interchange.
+
+- **Swaps go into the eta, not the base `L`.** The unit-lower base `L` is never permuted
+  (permuting the fully-formed `L` would break its triangularity). The bump elimination's
+  elementary operations — `FtOp::Swap` (partial-pivot interchange) and `FtOp::Axpy`
+  (`row -= mult·row`) — are recorded as a `FtEta` and replayed on the solve vector between the
+  `L`-solve and `U`-solve in `ftran` (transposed, reversed, between `Uᵀ` and `Lᵀ` in `btran`).
+  `U` is updated in place. Maintained invariant: `P A Q = L G U`, `G = E₁⁻¹…Eₜ⁻¹`.
+
+- **`U` stored as mutable per-row vectors** (`Vec<Vec<(col,val)>>`, diagonal first) rather than
+  flat CSR, so the in-place row operations / swaps / merges are tractable.
+
+- **Consequence.** Warm-solve cost is bump-local (`O(Σ bump)`), independent of `n` for
+  localized spikes (the realistic LP regime) — demonstrated flat across n=1000..8000. The
+  inherent worst case is a dense spike (e.g. tridiagonal, where `L⁻¹` is dense), where the
+  bump spans the tail and the cost degrades toward the old product-form; this is fundamental
+  to any update scheme and bounded by the `max_updates` refactor budget.
+
+- **Stability/budget.** Growth monitor over elimination multipliers → `NeedsRefactor` on
+  `max_growth`; no acceptable bump pivot → `SingularBasis`; update count → `NeedsRefactor` on
+  `max_updates`. Work is done on a clone of `U`, committed only on success, so failures leave
+  `self` unchanged.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -102,3 +102,26 @@ budget→NeedsRefactor + refactor clears the chain, singular update detected.
 Caught a self-inflicted bug: replacing two slots with the SAME column is
 genuinely singular (τ_q→0) — the engine correctly returned SingularBasis;
 fixed the test to use distinct columns. Full suite green; clippy clean.
+
+* 16:30 :lu:scaling:robustness:
+Added the scaling robustness layer: src/lu/scaling.rs with LuScale {rperm,
+d_row, d_col}, two-sided ∞-norm equilibration (Knight–Ruiz), and unsymmetric
+MC64 as a thin driver over crate::scaling::hungarian_match (build the
+column-normalized log-cost CostGraph from the general basis, read rperm from
+the matching and d_row/d_col from the duals u,v; partial matching → InfNorm
+fallback). Mc64ThenInfNorm composes both.
+
+Integration: params.scaling drives factor() on both dense and sparse — they
+factor Ã = D_row Π B D_col (AᵀA pattern is invariant under row perm/scaling,
+so the column ordering still applies). ftran/btran wrap the scaling around a
+renamed core solve (ftran_core/btran_core); identity scaling short-circuits
+to the core (no overhead, existing tests unchanged). update() scales the
+entering column into the Ã frame first. Iterative refinement
+(ftran_refined/btran_refined) was already in place from the solve commits and
+calls the scaled wrappers against the original B.
+
+Verified tests/lu_scaling.rs (5 tests): InfNorm/Mc64/Mc64ThenInfNorm preserve
+correctness (residual < 1e-8) on a 16-orders-of-magnitude ill-scaled basis
+(dense + sparse), dense↔sparse agreement under MC64, equilibration drives all
+row/col ∞-norms into [0.1,10], and MC64 puts order-1 entries on the diagonal.
+Full suite green; clippy -D warnings clean.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -53,3 +53,29 @@ update-with-row-swap (perm composition), refactor-matches-updated-factor
 parity < 1e-9, budget→NeedsRefactor with self unchanged < 1e-14, and
 ill-conditioned refinement < 1e-12. All green; full suite (55 bins) green;
 clippy -D warnings clean.
+
+* 13:30 :lu:sparse:gilbert-peierls:
+Implemented sparse LU: SparseColMatrix (general CSC, from_dense/sparse
+columns, matvec, ata_pattern = column-intersection graph), SparseLuSymbolic
+(column order Q via feral_amd::amd_order on the AᵀA pattern, i32-contract
+conversion à la symbolic/mod.rs:535-569; plus a natural() fallback), and
+SparseLu factor (left-looking, threshold partial pivoting, PAQ=LU) with
+sparse ftran/btran/ftran_partial and refinement.
+
+Factor stores L (unit lower, strict-lower CSC, pivot-position rows) and U
+(strict-upper CSC + explicit u_diag). Forward substitution in pivot order:
+processing p=0..k-1 in increasing order is correct because column p only
+fills rows that pivot at positions >p (proof: L(:,p) rows are unpivoted at
+step p). L stored with original rows, remapped to pivot positions via pinv
+after the factor completes. Note: this is correct but O(m²)-ish, not yet
+output-sensitive — the GP depth-first reach is a documented follow-up.
+
+btran reads Uᵀ/Lᵀ directly off the CSC columns (no explicit transpose).
+
+Verified tests/lu_sparse.rs (7 tests): ‖PAQ−LU‖ < 1e-10 reconstruction,
+ftran/btran residual < 1e-10, AMD and natural ordering both green,
+dense↔sparse agreement < 1e-9, singular→SingularBasis, PerturbToEps,
+refinement < 1e-12. Full suite green; clippy -D warnings clean.
+
+Deferred to next commit: the sparse rank-1 update (Forrest–Tomlin). The
+perm_inv/qcol_inv fields and update state land with it.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -251,3 +251,30 @@ of issue #81's update machinery, now measured. (The update still carries an
 O(m) component from set_column's row scan and the lsolve loop; a fully
 output-sensitive update via the GP reach + bump-local set_column is a noted
 optimization, separate from the already-bump-local SOLVE/eta cost.)
+
+* 23:30 :lu:sparse:update:bump-local:
+Made the sparse FT update fully bump-local (user request: GP reach in lsolve +
+bump-local set_column). Three changes:
+1. Spike via Gilbert–Peierls depth-first reach over L (compute_spike): only the
+   reachable L-columns are touched, not the whole O(m) lsolve loop. Result is a
+   sparse spike in a dedicated zeroed work buffer.
+2. set_column via a new u_above column index (rows<col with an entry): finds
+   column r's existing entries without scanning all rows. u_above maintained
+   incrementally (unindex saved-old / index new) over the changed rows only.
+3. No more O(nnz) clone of U: save only the changed rows ([r,h] ∪ supp(ρ) ∪
+   u_above[r]); roll back on failure (u_above updated only on success).
+
+Debugging: hit a stale-buffer bug — compute_spike's SPARSE scatter assumes a
+zeroed buffer, but ftran/btran use self.scratch as their work buffer and leave
+it dirty (they overwrite via full gather, never re-zero). The old dense
+spike_space didn't care (full gather). Fix: dedicated ft_work buffer for the
+update, kept zeroed (cleared via the touched list each update); the solves keep
+using self.scratch. Found via a stale-w assertion at compute_spike entry.
+
+Result (criterion update_vs_refactor): ft_update 206→95µs at n=1000, 829→405µs
+at n=5000 — ~2× faster than the clone version, now ~14–17× faster than a full
+refactor (was 8–10×). ft_update_is_bump_local guard still passes (eta size
+independent of n). Full suite (635) green; clippy -D warnings clean.
+
+Remaining O(m): one scan of the dense entering column (inherent to the dense
+API) — not the heavy clone/lsolve/scan that was removed.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -125,3 +125,31 @@ correctness (residual < 1e-8) on a 16-orders-of-magnitude ill-scaled basis
 (dense + sparse), dense↔sparse agreement under MC64, equilibration drives all
 row/col ∞-norms into [0.1,10], and MC64 puts order-1 entries on the diagonal.
 Full suite green; clippy -D warnings clean.
+
+* 17:30 :lu:sparse:scalability:gilbert-peierls-reach:
+User asked to verify the sparse factor scales < O(n²). Wrote a scaling
+probe (crates/feral-diagnostics/src/bin/lu_scale_probe.rs) factoring
+tridiagonal (no-fill) and 2D 5-point grid (fill) bases at increasing n.
+
+BEFORE (the deferred-DFS O(m²) forward-substitution scan): factor time on
+tridiagonal went 203→558→2197→8167→31714→127004→513105 µs as n doubled
+500→32000, empirical exponent → 2.00. Confirmed quadratic.
+
+FIX: implemented the deferred Gilbert–Peierls depth-first reach. Per column,
+DFS over the graph of L from the nonzeros of A(:,qcol[k]) (edges col→pivot
+positions of its already-pivoted rows; all edges point to larger positions,
+so ascending position order is a valid topological order). Numeric solve now
+runs only over the reach (sorted ascending), not all p<k. Reuses w/touched
+logic unchanged; same numeric result (all reconstruction/residual/dense↔sparse
+tests still green).
+
+AFTER: tridiagonal factor 51→96→289→452→826→1692→3143→6281 µs for
+n=500..64000, exponent ~1.0 (156× faster at n=32000: 513ms→3.3ms). 2D grid
+(Lnnz growing ~n^1.33) factor ~O(n^1.6) overall — fill-dominated but firmly
+sub-quadratic. analyze and ftran were already ~linear.
+
+Added a deterministic (timing-free) regression guard: SparseLu.reach_visits()
+counts total reach nodes (O(nnz(U)), not O(n²)); test
+factor_traversal_is_subquadratic asserts doubling n on a tridiagonal less than
+triples the reach work (linear ≈ 2×; the old scan would 4×). Full suite (631)
+green; clippy -D warnings clean.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -29,3 +29,27 @@ dev/references.bib (gilbert1988sparse, forrest1972updated, bartels1969stable,
 reid1982sparsity, suhl1990computing, davis2004colamd). duff2001mc64 and
 knight2014symmetry already present. Baseline `cargo build` green;
 pre-commit installed (pip install pre-commit) and hooks present.
+
+* 11:30 :lu:dense:implementation:
+Implemented the full dense LU path: GeneralMatrix, DenseLu factor/refactor
+(right-looking, threshold partial pivoting, separate explicit L/U storage),
+ftran/btran/ftran_partial, ftran_refined/btran_refined, and the rank-1
+column-replacement update.
+
+Design decision: dropped the eta-replay representation for the dense path
+in favor of maintaining the invariant P B Q = L U with an explicit column
+permutation Q (qcol/qcol_inv). The dense Bartels–Golub update overwrites
+column q with the spike, does a cyclic column shift to upper-Hessenberg,
+then a no-pivot Gauss sweep eliminating the subdiagonal — each step a row
+op on U and a column op on L (col_k += mult*col_{k+1}), which provably
+keeps L unit-lower and U upper. No in-bump pivoting; instability/budget →
+NeedsRefactor (work done on clones, committed only on success, so self is
+unchanged on failure). Eta files are deferred to the SPARSE Forrest–Tomlin
+path where they actually pay.
+
+Verified hand-derived update algebra with tests/lu_dense.rs (11 tests):
+equation residuals ‖Bx−a‖ < 1e-8 after single update, 5-update chains,
+update-with-row-swap (perm composition), refactor-matches-updated-factor
+parity < 1e-9, budget→NeedsRefactor with self unchanged < 1e-14, and
+ill-conditioned refinement < 1e-12. All green; full suite (55 bins) green;
+clippy -D warnings clean.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -298,3 +298,30 @@ ft_update_sparse ≈ equal: 462µs vs 462µs at n=5000). The benefit is asymptot
 (grows with the n/bump ratio — large n, tiny localized spike); here it's an
 API-completeness + correctness win, not a visible speedup. The update is now
 O(bump + nnz(aₙₑw)) with no O(n) term.
+
+* 01:30 :lu:reference:suitesparse-harness:
+Built the real-world LU validation harness (epic Phase 7 start), to close the
+"no external reference / no real matrices" gap.
+
+- scripts/fetch_lu_corpus.py: ssgetpy download of a curated set of square
+  UNSYMMETRIC SuiteSparse matrices into data/matrices/lu-corpus/ (gitignored).
+  Curated mix incl. bp_* (real LP simplex bases — the actual target), chemical
+  (west*, fs_*), circuit (add20/32, memplus), reservoir/fluid (sherman*,
+  saylr*, pores*, lns*), economic/powerflow (orani678, gre_*, gemat*).
+- crates/feral-diagnostics/src/bin/lu_reference: general-MTX parser (feral's
+  read_mtx only accepts 'symmetric'); known-x oracle a=B·x_true, solve, report
+  ‖x−x_true‖/‖x_true‖, ‖Bx−a‖/‖a‖, refined residual, fill ratio, + a
+  self-replace rank-1 update (must leave the basis unchanged). MC64 scaling +
+  PerturbToEps so near-singular reals survive.
+- scripts/lu_reference_scipy.py: independent scipy.sparse.linalg.splu (SuperLU)
+  cross-check, same x_true and metrics → external baseline.
+
+End-to-end verified on a synthetic 50×50 unsymmetric tridiag+: feral
+err=2.54e-16 resid=3.9e-16 upd=3.9e-16; scipy SuperLU err=2.54e-16 — bit
+identical, so feral matches the reference. clippy clean.
+
+LIMITATION: sparse.tamu.edu is unreachable from this sandbox (ssgetpy index
+refresh fails — network policy), so the real corpus couldn't be downloaded
+here. The harness/scripts are ready; run fetch where outbound HTTPS is allowed,
+then `cargo run -p feral-diagnostics --release --bin lu_reference` and
+`python scripts/lu_reference_scipy.py` to compare.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -325,3 +325,38 @@ refresh fails — network policy), so the real corpus couldn't be downloaded
 here. The harness/scripts are ready; run fetch where outbound HTTPS is allowed,
 then `cargo run -p feral-diagnostics --release --bin lu_reference` and
 `python scripts/lu_reference_scipy.py` to compare.
+
+* 2026-06-08 review :review:lu:corpus:robustness:
+Code review of PR #82 + corpus run that the previous session's network policy
+blocked. sparse.tamu.edu IS reachable from this host, so fetched the full
+34-matrix corpus and ran both reference harnesses on the PR branch.
+
+feral lu_reference (MC64 + PerturbToEps + 2 refine steps):
+  32/34 OK, residual ‖Bx−a‖/‖a‖ at machine precision (≤~1e-12) on ALL 34.
+  Two non-OK: fs_183_1 (err=7.6e-5, resid=1.9e-16) and saylr3 (err=7.1e-1,
+  resid=9.5e-16) — both tiny residual + large forward error = conditioning,
+  not a solver fault.
+scipy SuperLU cross-check confirms: fs_183_1 also fails (err=2.3e-5) → ill-
+conditioned both engines; saylr3 → SuperLU "Factor is exactly singular" (feral
+degrades gracefully via MC64+PerturbToEps where SuperLU can't factor at all);
+sherman2 → feral OK (err=1.5e-11) but plain SuperLU err=1.7e-6 (feral's
+scaling+refinement wins). Net: feral 32/34 vs SuperLU 31/34.
+
+Fixed 5 review findings on the PR branch (all green: 333 lib tests + integration,
+clippy -D warnings, fmt):
+1. Stale research note §3.3 — it still described the dense update as an eta file
+   with in-bump pivoting + a `update_with_row_swap_residual` test; the impl (and
+   decisions.md 2026-06-08) is an in-place O(m²) L/U re-fold with NO in-bump
+   pivoting. Rewrote §3.3 to match reality.
+2. usolve/ut_solve (sparse_solve.rs) divided by the stored U diagonal with no
+   guard — a degenerate post-update bump pivot could emit silent ±Inf. Now
+   return SingularBasis on an absent/zero/non-finite diagonal; threaded Result
+   through solve_colspace/ftran_core/btran_core (scratch restored on the error
+   path). Added regression test zero_u_diagonal_errors_instead_of_inf.
+3. should_use_dense_lu: m*m / nnz*4 could overflow usize for a caller-set huge
+   dense_threshold → saturating_mul.
+4. lu_reference + scipy script: residual-aware verdict — large err with
+   resid<1e-8 now labels ILL (backward-stable, ill-conditioned), not BAD, so
+   conditioning isn't conflated with a solver bug. fs_183_1/saylr3 now ILL.
+5. sparse_matrix.rs module doc claimed a "transpose" method that doesn't exist
+   (only matvec_transpose + ata_pattern's internal row-wise pass) — corrected.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -171,3 +171,33 @@ updates, unbounded until refactor. This is the PFI "eta chain grows" problem
 the issue cites as the reason to graduate to true Forrest–Tomlin, where the
 spike folds into U and only a SPARSE row-eta is stored, so solves stay cheap.
 Confirms the need; implementing FT next.
+
+* 19:30 :lu:sparse:forrest-tomlin:blocked-on-zero-pivots:
+Attempted the full FT in two stages. Stage 1 (convert U to row-wise CSR so
+the update can do row ops) landed cleanly, committed (23af110), all sparse +
+scaling tests still green — a pure storage change, and the right foundation
+for FT.
+
+Stage 2 (the in-place column-replacement update) hit a genuine correctness
+subtlety I had not accounted for. The naive column-shift Bartels–Golub
+(move the leaving column to the end → upper-Hessenberg → eliminate the
+subdiagonal) produces a Hessenberg whose DIAGONAL pivots are the OLD
+SUPERDIAGONAL entries U[k,k+1], and the subdiagonal to eliminate is the old
+DIAGONAL U[k+1,k+1]. In a DENSE U the superdiagonals are nonzero (so the
+dense update works without in-bump pivoting), but in a SPARSE U the
+superdiagonal is frequently zero → zero Hessenberg pivot → division by zero.
+
+This is the crux of sparse basis updates that production LP solvers engineer
+carefully: it needs either the symmetric-permutation FT (which then needs
+careful permutation-of-stored-state bookkeeping, since physically permuting U
+each update staleness the relation L σᵀ, not lower-triangular) OR in-bump
+partial pivoting with row-permutation tracking (Reid's sparse BGR). Both are
+substantial, delicate pieces; I will not ship a subtly-wrong factorization
+(correctness-first). Reverted the Stage-2 scaffolding (restored the working
+product-form on top of Stage-1 row-wise U); tree correct, tests green.
+
+Net for this session: Stage 1 (row-wise U) committed as the FT foundation;
+the correct Stage-2 update is scoped with the exact subtlety documented for a
+focused follow-up. The product-form update remains correct and bounded by
+max_updates; its O(k·n) warm-solve cost (measured, fbbcece) is the thing FT
+will fix once Stage 2 lands correctly.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -278,3 +278,23 @@ independent of n). Full suite (635) green; clippy -D warnings clean.
 
 Remaining O(m): one scan of the dense entering column (inherent to the dense
 API) — not the heavy clone/lsolve/scan that was removed.
+
+* 00:30 :lu:sparse:update:sparse-entering-column-api:
+Added the sparse entering-column API to remove the last O(n) term in the FT
+update. SparseLu::update_sparse(leaving_slot, &[(row,val)]) seeds the spike
+directly from the entering column's nonzeros (no O(n) scan). The dense
+update() is now a thin wrapper: scans aₙₑw once for nonzeros, delegates.
+Needed scale_rperm_inv (inverse of the scaling row permutation, precomputed at
+factor) to map an original row → scaled-row position without scanning;
+identity for the unscaled case.
+
+Verified: sparse_update_api_matches_dense_update — update_sparse on unsorted
+(row,val) pairs gives bit-identical solves to dense update() (diff < 1e-14)
+across all RHS. Full suite (634) green; clippy clean.
+
+Honest perf note: in the AMD-ordered block-diagonal crossover bench the BUMP
+dominates, so removing the O(n) scan is within noise (ft_update vs
+ft_update_sparse ≈ equal: 462µs vs 462µs at n=5000). The benefit is asymptotic
+(grows with the n/bump ratio — large n, tiny localized spike); here it's an
+API-completeness + correctness win, not a visible speedup. The update is now
+O(bump + nnz(aₙₑw)) with no O(n) term.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -232,3 +232,22 @@ n=8000) and 40× solve degradation. Full suite green; clippy -D warnings clean.
 Honest note: for a DENSE-spike basis (tridiagonal, L⁻¹ dense) the bump spans
 the tail and FT degrades to product-form-like cost — inherent worst case; the
 FT win is for localized spikes (the realistic LP regime), as demonstrated.
+
+* 22:00 :lu:benchmark:criterion:
+Added benches/lu.rs (criterion, harness=false, registered [[bench]] name="lu").
+Groups: dense {factor,ftran,update} m∈{16,64,256}; sparse {factor,ftran,
+ft_update} on block-diagonal n∈{200,1000,5000}; and update_vs_refactor — the
+headline crossover.
+
+Numbers (release, this host; reduced-sample run):
+  dense  factor/256   ≈ 2.34 ms   ftran/256 ≈ 121 µs   update/256 ≈ 202 µs
+  sparse factor/5000  ≈ 318 µs    ftran/5000 ≈ 18 µs   ft_update/5000 ≈ 89 µs
+  update_vs_refactor (block-diag, within-block update):
+     n=1000:  ft_update 206 µs   vs  refactor 1.68 ms   → ~8.2× faster
+     n=5000:  ft_update 829 µs   vs  refactor 8.81 ms   → ~10.6× faster
+
+So the rank-1 FT update is ~8–11× cheaper than re-factoring — the whole point
+of issue #81's update machinery, now measured. (The update still carries an
+O(m) component from set_column's row scan and the lsolve loop; a fully
+output-sensitive update via the GP reach + bump-local set_column is a noted
+optimization, separate from the already-bump-local SOLVE/eta cost.)

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -1,0 +1,31 @@
+#+TITLE: Session 2026-06-08-01 — Unsymmetric LU basis engine (issue #81)
+
+* 09:00 :lu:planning:issue-81:
+Started issue #81: a new unsymmetric LU factorization family for simplex
+bases. Confirmed feral is symmetric-only today (no LU/unsymmetric math to
+reuse). Confirmed pounce-simplex (the downstream BasisEngine consumer) is
+NOT in this environment — only /home/user/feral exists — so the end-to-end
+acceptance criteria (BasisEngine drop-in, GLOBALLib/netlib benchmarks) are
+out of scope here, deferred to a later pounce-repo phase.
+
+Scope agreed with user (expanded twice): this PR delivers the WHOLE solver
+substance — dense LU + Bartels–Golub update, sparse Gilbert–Peierls LU +
+Forrest–Tomlin update, AMD-on-AᵀA ordering, auto router, AND the full
+robustness layer (∞-norm equilibration + unsymmetric MC64 + iterative
+refinement). Only SuiteSparse benchmarking and the pounce integration are
+deferred.
+
+Key reuse finding: hungarian_match (src/scaling/hungarian.rs:448,
+pub(crate)) is ALREADY a general unsymmetric bipartite matcher returning
+perm[j]=row matched to col j plus duals u,v. So unsymmetric MC64 is a thin
+driver, not a new matching algorithm. feral_amd::amd_order is callable on
+any full-symmetric i32 CscPattern (conversion pattern at
+src/symbolic/mod.rs:535-569).
+
+* 09:30 :lu:docs:
+Wrote the mandatory research note dev/research/unsymmetric-lu.md and the
+epic plan dev/plans/unsymmetric-lu-epic.md, added 6 LU references to
+dev/references.bib (gilbert1988sparse, forrest1972updated, bartels1969stable,
+reid1982sparsity, suhl1990computing, davis2004colamd). duff2001mc64 and
+knight2014symmetry already present. Baseline `cargo build` green;
+pre-commit installed (pip install pre-commit) and hooks present.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -79,3 +79,26 @@ refinement < 1e-12. Full suite green; clippy -D warnings clean.
 
 Deferred to next commit: the sparse rank-1 update (Forrest–Tomlin). The
 perm_inv/qcol_inv fields and update state land with it.
+
+* 15:00 :lu:sparse:update:forrest-tomlin:
+Implemented the sparse rank-1 column-replacement update. After deriving the
+algebra, chose a product-form update of U: replacing column q by the spike
+gives U' = U·F with F = I + (τ−e_q)e_qᵀ, τ = the ftran of the entering
+column in column-position space, so U'⁻¹ = F⁻¹U⁻¹. Each update stores one
+eta (q, τ) applied after the U-solve in ftran (transposed-reverse before the
+Uᵀ-solve in btran). τ[q] is the update pivot → SingularBasis if it vanishes;
+1/|τ[q]| feeds the growth monitor → NeedsRefactor on budget. This is a
+correct, genuinely sparse first-class rank-1 update; full Forrest–Tomlin
+row-eta sparsity (keeping the eta sparser than the dense τ) is documented as
+the optimization.
+
+Also unified the update API: both dense and sparse update() now take the raw
+entering column and compute the spike internally (cleaner, matches the
+simplex "swap column" op, self-contained). Refactored dense update + tests.
+
+Verified tests/lu_sparse.rs (10 tests): single-update residual < 1e-8,
+4-update chain < 1e-7, dense↔sparse post-update agreement < 1e-9,
+budget→NeedsRefactor + refactor clears the chain, singular update detected.
+Caught a self-inflicted bug: replacing two slots with the SAME column is
+genuinely singular (τ_q→0) — the engine correctly returned SingularBasis;
+fixed the test to use distinct columns. Full suite green; clippy clean.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -153,3 +153,21 @@ counts total reach nodes (O(nnz(U)), not O(n²)); test
 factor_traversal_is_subquadratic asserts doubling n on a tridiagonal less than
 triples the reach work (linear ≈ 2×; the old scan would 4×). Full suite (631)
 green; clippy -D warnings clean.
+
+* 18:15 :lu:sparse:update:degradation-measured:
+Measured warm-solve scaling under update chains (lu_update_probe.rs), n=5000
+tridiagonal. The product-form update stores a DENSE τ (length n) per eta, so
+ftran is O(k·n) after k updates:
+
+  updates  ftran(µs)  eta_nnz
+        0      75       0
+       10     134       50000
+       50     412       250000
+      100     780       500000
+      400    3033      2000000
+
+Linear in k (≈7.4µs/update ≈ n ops), eta file = k·n. 40× slowdown at 400
+updates, unbounded until refactor. This is the PFI "eta chain grows" problem
+the issue cites as the reason to graduate to true Forrest–Tomlin, where the
+spike folds into U and only a SPARSE row-eta is stored, so solves stay cheap.
+Confirms the need; implementing FT next.

--- a/dev/journal/2026-06-08-01.org
+++ b/dev/journal/2026-06-08-01.org
@@ -201,3 +201,34 @@ the correct Stage-2 update is scoped with the exact subtlety documented for a
 focused follow-up. The product-form update remains correct and bounded by
 max_updates; its O(k·n) warm-solve cost (measured, fbbcece) is the thing FT
 will fix once Stage 2 lands correctly.
+
+* 21:00 :lu:sparse:forrest-tomlin:complete:
+P6.5 DONE. Implemented the true sparse Forrest–Tomlin / Bartels–Golub–Reid
+update, resolving the zero-pivot landmine that blocked the earlier attempt.
+
+Staged: (1) U → mutable per-row vectors (diagonal first), product-form kept
+working, tests green, committed; (2) replaced product-form with in-place
+sparse Gaussian elimination of the bump WITH PARTIAL PIVOTING. The spike
+G⁻¹L⁻¹P·aₙₑw is set into U's column r; the bump [r,h] (h=max spike support) is
+re-triangularized; the zero-superdiagonal-pivot problem is solved by partial
+pivoting (a sub-diagonal spike entry is a nonzero pivot; the row swap goes
+into the eta, so the unit-lower base L is never permuted). The elimination
+ops (FtOp::Swap / Axpy) are stored as a replayable FtEta, applied between the
+L- and U-solves in ftran (transposed-reversed between Uᵀ and Lᵀ in btran). U
+updated in place. No dense τ.
+
+Maintained invariant: P A Q = L G U, G = E₁⁻¹…Eₜ⁻¹; ftran applies L⁻¹, etas
+forward (E₁..Eₜ), U⁻¹, Q; spike for the next update = spike_space (L⁻¹P + etas
+forward, no U-solve).
+
+Verified: tests/lu_sparse.rs (13) — 25-update FT chain with ftran AND btran
+residuals < 1e-7 after every update; dense↔sparse post-update agreement
+< 1e-9; ft_update_is_bump_local asserts the eta size is identical for n=24 vs
+n=400 and ≤ block² (independent of n). lu_update_probe (block-diagonal,
+localized spikes): eta_ops_total ≈ 5100 and per-chain ftran overhead ≈ 10µs
+FLAT for n=1000..8000 — vs the old product-form's k·n storage (400k at
+n=8000) and 40× solve degradation. Full suite green; clippy -D warnings clean.
+
+Honest note: for a DENSE-spike basis (tridiagonal, L⁻¹ dense) the bump spans
+the tail and FT degrades to product-form-like cost — inherent worst case; the
+FT win is for localized spikes (the realistic LP regime), as demonstrated.

--- a/dev/plans/unsymmetric-lu-epic.md
+++ b/dev/plans/unsymmetric-lu-epic.md
@@ -44,23 +44,22 @@ Correctness gate (all in this PR): hand-worked exact cases + equation-residuals 
 dense↔sparse agreement + scaling/refinement recovery + adversarial, in `tests/lu_dense.rs`
 and `tests/lu_sparse.rs`.
 
+### P6.5 Sparse Forrest–Tomlin update — DONE
+
+The sparse update is now a true Forrest–Tomlin / Bartels–Golub–Reid update: the spike is
+folded into `U`'s column `r` and the bump `[r,h]` is re-triangularized by **in-place sparse
+Gaussian elimination with partial pivoting**, recorded as a replayable `FtEta` (swaps +
+axpys) applied between the `L`- and `U`-solves. Partial pivoting resolved the zero-pivot
+landmine (the spiked column's diagonal pivot is often zero in a sparse `U`; a sub-diagonal
+spike entry is a nonzero pivot, and the swap goes into the eta so the base `L` is never
+permuted). `U` is updated in place; the base `L` is fixed; no dense `τ`, no `O(k·n)`
+chain. Warm-solve cost is **bump-local, independent of `n`** for localized spikes (probe:
+eta work flat ≈5100 and ftran overhead flat ≈10µs across n=1000..8000; guard test asserts
+n-independence). Worst case (dense spike, e.g. tridiagonal) degrades to product-form-like
+cost — inherent. Commits: 8738279 (storage), 0fc767c (update), 2b5a5f5 (proof).
+
 ### Deferred (follow-up sessions)
 
-- **P6.5 Sparse Forrest–Tomlin update (the warm-solve scalability fix).** The sparse update
-  is currently a product-form update of `U` storing a *dense* `τ` per eta, so warm `ftran`
-  degrades `O(k·n)` over `k` updates (measured: `crates/feral-diagnostics/src/bin/lu_update_probe.rs`,
-  75µs→3033µs at n=5000, k=0→400). **Stage 1 is done** (`U` stored row-wise CSR, commit
-  23af110) — the storage FT needs. **Stage 2 (the in-place update) is the hard part**, with a
-  documented correctness landmine: the naive column-shift Bartels–Golub produces an
-  upper-Hessenberg `U` whose diagonal pivots are the *old superdiagonal* `U[k,k+1]`, which are
-  frequently **zero in a sparse `U`** (a dense `U` always has them, which is why the dense
-  `DenseLu` update works without in-bump pivoting). A correct sparse update therefore needs
-  **either** the symmetric-permutation FT (pivots = the original nonzero `U` diagonals, but
-  the bottom-row elimination must be folded as an L-side row-eta and the accumulating
-  permutation tracked) **or** in-bump threshold partial pivoting with row-permutation tracking
-  (Reid sparse BGR, citep:reid1982sparsity). Both keep solves `O(nnz)` (no eta chain) and the
-  update `O(bump)`. This is the genuine graduation; the product-form remains correct and
-  `max_updates`-bounded until it lands.
 - **P7 Reference benchmarks.** SuiteSparse unsymmetric corpus; factor time + solve accuracy
   vs UMFPACK/KLU/SuperLU where licensing allows (the way the LDLᵀ side checks vs MUMPS). The
   update-vs-refactor crossover microbench (`m ∈ {10,100,1k,10k}`, sparsity sweep) is seeded

--- a/dev/plans/unsymmetric-lu-epic.md
+++ b/dev/plans/unsymmetric-lu-epic.md
@@ -60,11 +60,17 @@ cost — inherent. Commits: 8738279 (storage), 0fc767c (update), 2b5a5f5 (proof)
 
 ### Deferred (follow-up sessions)
 
-- **P7 Reference benchmarks.** SuiteSparse unsymmetric corpus; factor time + solve accuracy
-  vs UMFPACK/KLU/SuperLU where licensing allows (the way the LDLᵀ side checks vs MUMPS). The
-  update-vs-refactor crossover microbench (`m ∈ {10,100,1k,10k}`, sparsity sweep) is seeded
-  in P1–P6 and matured here. Also: faithful COLAMD (replace the AMD-on-AᵀA stand-in), and
-  optional Markowitz pivoting (citep:suhl1990computing) for fill on large bases.
+- **P7 Reference benchmarks — STARTED.** Real-world validation harness in place:
+  `scripts/fetch_lu_corpus.py` (ssgetpy → curated square unsymmetric SuiteSparse matrices,
+  incl. the `bp_*` LP simplex bases, into `data/matrices/lu-corpus/`),
+  `crates/feral-diagnostics/src/bin/lu_reference` (known-x oracle: `a = B x_true`, solve,
+  report `‖x−x_true‖`/`‖Bx−a‖`/refined/fill + a self-replace update), and
+  `scripts/lu_reference_scipy.py` (independent SciPy SuperLU cross-check, same metrics).
+  Verified end-to-end on a synthetic unsymmetric matrix (feral err 2.54e-16 == SciPy
+  2.54e-16). Remaining: run on the downloaded corpus where outbound network is allowed
+  (blocked in the dev sandbox), the update-vs-refactor crossover sparsity sweep, faithful
+  COLAMD (replace the AMD-on-AᵀA stand-in), and optional Markowitz pivoting
+  (citep:suhl1990computing) for fill on large bases.
 - **P8 Downstream (pounce repo, OUT OF SCOPE here).** Implement `BasisEngine` behind the
   feral LU engine; `DenseBasis` as the correctness oracle; no GLOBALLib small-regime
   regression; measured netlib large-regime win; peak fill + refactor-count reporting.

--- a/dev/plans/unsymmetric-lu-epic.md
+++ b/dev/plans/unsymmetric-lu-epic.md
@@ -46,6 +46,21 @@ and `tests/lu_sparse.rs`.
 
 ### Deferred (follow-up sessions)
 
+- **P6.5 Sparse Forrest–Tomlin update (the warm-solve scalability fix).** The sparse update
+  is currently a product-form update of `U` storing a *dense* `τ` per eta, so warm `ftran`
+  degrades `O(k·n)` over `k` updates (measured: `crates/feral-diagnostics/src/bin/lu_update_probe.rs`,
+  75µs→3033µs at n=5000, k=0→400). **Stage 1 is done** (`U` stored row-wise CSR, commit
+  23af110) — the storage FT needs. **Stage 2 (the in-place update) is the hard part**, with a
+  documented correctness landmine: the naive column-shift Bartels–Golub produces an
+  upper-Hessenberg `U` whose diagonal pivots are the *old superdiagonal* `U[k,k+1]`, which are
+  frequently **zero in a sparse `U`** (a dense `U` always has them, which is why the dense
+  `DenseLu` update works without in-bump pivoting). A correct sparse update therefore needs
+  **either** the symmetric-permutation FT (pivots = the original nonzero `U` diagonals, but
+  the bottom-row elimination must be folded as an L-side row-eta and the accumulating
+  permutation tracked) **or** in-bump threshold partial pivoting with row-permutation tracking
+  (Reid sparse BGR, citep:reid1982sparsity). Both keep solves `O(nnz)` (no eta chain) and the
+  update `O(bump)`. This is the genuine graduation; the product-form remains correct and
+  `max_updates`-bounded until it lands.
 - **P7 Reference benchmarks.** SuiteSparse unsymmetric corpus; factor time + solve accuracy
   vs UMFPACK/KLU/SuperLU where licensing allows (the way the LDLᵀ side checks vs MUMPS). The
   update-vs-refactor crossover microbench (`m ∈ {10,100,1k,10k}`, sparsity sweep) is seeded

--- a/dev/plans/unsymmetric-lu-epic.md
+++ b/dev/plans/unsymmetric-lu-epic.md
@@ -1,0 +1,71 @@
+# Epic: Unsymmetric LU as a Simplex Basis Engine (issue #81)
+
+**Created:** 2026-06-08
+**Research note:** `dev/research/unsymmetric-lu.md` (read first)
+**Tracking issue:** #81
+
+## Why this plan exists
+
+feral is a symmetric indefinite LDLᵀ solver. Issue #81 adds a *new factorization family*: an
+unsymmetric LU built to drive a revised-simplex basis — cheap rank-1 column-replacement
+updates and warm ftran/btran, not just one-shot factor/solve. The downstream consumer is the
+`BasisEngine` trait in `pounce-simplex` (a separate repo). The eta/product-form approach
+`pounce-simplex` uses today is correct for tiny OBBT LPs but degrades at scale; this epic is
+the large-scale graduation, worked independently in feral, which already owns the
+sparse-ordering / scaling / robustness machinery this reuses.
+
+## Bounding reality
+
+`pounce-simplex` is **not present** in this environment (only `/home/user/feral`). The
+end-to-end acceptance criteria of #81 (BasisEngine drop-in, GLOBALLib no-regression, netlib
+win) therefore cannot be built or run here. feral delivers the self-contained engine with an
+API *shaped* to the BasisEngine seam; the integration is Phase 8, done later in the pounce
+repo.
+
+## Phases
+
+### Phases 1–6 — THIS PR (`claude/open-issue-review-UCoRw`)
+
+- **P1 Dense LU + Bartels–Golub update.** `GeneralMatrix`; right-looking LU with threshold
+  partial pivoting (`PB Q = LU`, `Q=I` dense); ftran/btran/ftran_partial; rank-1 dense
+  column-replacement update with eta replay; `SingularBasis`/`NeedsRefactor`.
+- **P2 Sparse LU (Gilbert–Peierls).** General `SparseColMatrix`; DFS-symbolic + numeric
+  left-looking LU with partial pivoting; sparse ftran/btran.
+- **P3 Column ordering.** `transpose_pattern`/`ata_pattern`; `Q` via `feral_amd::amd_order`
+  on the AᵀA pattern (reusable symbolic handle). Stand-in for true COLAMD.
+- **P4 Sparse Forrest–Tomlin update.** Row-eta file on row-wise U; spike→Hessenberg
+  bump→single row eta; refactor budget.
+- **P5 Scaling.** Two-sided ∞-norm equilibration (adapt `infnorm.rs`) + unsymmetric MC64 as a
+  driver over the existing `hungarian_match` kernel, with partial-matching→InfNorm fallback.
+- **P6 Iterative refinement.** `ftran_refined`/`btran_refined` looping on `r = a − Bx`.
+- **Router** (cross-cutting): `should_use_dense_lu(m, nnz)` with `LuParams` override.
+
+Correctness gate (all in this PR): hand-worked exact cases + equation-residuals +
+dense↔sparse agreement + scaling/refinement recovery + adversarial, in `tests/lu_dense.rs`
+and `tests/lu_sparse.rs`.
+
+### Deferred (follow-up sessions)
+
+- **P7 Reference benchmarks.** SuiteSparse unsymmetric corpus; factor time + solve accuracy
+  vs UMFPACK/KLU/SuperLU where licensing allows (the way the LDLᵀ side checks vs MUMPS). The
+  update-vs-refactor crossover microbench (`m ∈ {10,100,1k,10k}`, sparsity sweep) is seeded
+  in P1–P6 and matured here. Also: faithful COLAMD (replace the AMD-on-AᵀA stand-in), and
+  optional Markowitz pivoting (citep:suhl1990computing) for fill on large bases.
+- **P8 Downstream (pounce repo, OUT OF SCOPE here).** Implement `BasisEngine` behind the
+  feral LU engine; `DenseBasis` as the correctness oracle; no GLOBALLib small-regime
+  regression; measured netlib large-regime win; peak fill + refactor-count reporting.
+
+## API shape (matches `BasisEngine`, for P8)
+
+    factor(cols, m, params) -> Result<Self, FeralError>
+    ftran(&mut self, rhs)    /  btran(&mut self, rhs)        (in-place, reusable scratch)
+    ftran_partial(&mut self, rhs)                            (the spike for update)
+    ftran_refined / btran_refined                            (opt-in refinement)
+    update(&mut self, leaving_row, entering_col_ftran) -> Result<(), FeralError(NeedsRefactor)>
+    refactor(&mut self, cols)  /  updates_since_refactor()
+    (sparse) reusable symbolic handle across structurally-similar bases
+
+## Non-goals
+
+Inertia (LU is unsymmetric). Symmetric KKT solves stay on the LDLᵀ path. No change to any
+existing symmetric code path — the `lu` module is purely additive.

--- a/dev/references.bib
+++ b/dev/references.bib
@@ -1001,3 +1001,120 @@
                1e-10 constant is derived; this is a framing reference.
                No local copy in dev/refs/.}
 }
+
+% ─────────────────────────────────────────────────────────────────────
+% Unsymmetric LU factorization and simplex basis updates (issue #81)
+% ─────────────────────────────────────────────────────────────────────
+
+@article{gilbert1988sparse,
+  author    = {Gilbert, John R. and Peierls, Tim},
+  title     = {Sparse Partial Pivoting in Time Proportional to Arithmetic
+               Operations},
+  journal   = {{SIAM} Journal on Scientific and Statistical Computing},
+  year      = {1988},
+  volume    = {9},
+  number    = {5},
+  pages     = {862--874},
+  doi       = {10.1137/0909058},
+  url       = {https://doi.org/10.1137/0909058},
+  note      = {The left-looking sparse LU with partial pivoting used by
+               SuperLU/KLU. Key idea: for each column j, the nonzero pattern
+               of the column of L is the set of vertices reachable from the
+               nonzeros of A(:,j) in the directed graph of L (a depth-first
+               search / topological order), so the sparse triangular solve
+               and the symbolic prediction cost O(flops). This is the
+               factorization kernel for feral's sparse LU. Read sections 2-3.}
+}
+
+@article{forrest1972updated,
+  author    = {Forrest, J. J. H. and Tomlin, J. A.},
+  title     = {Updated Triangular Factors of the Basis to Maintain Sparsity
+               in the Product Form Simplex Method},
+  journal   = {Mathematical Programming},
+  year      = {1972},
+  volume    = {2},
+  number    = {1},
+  pages     = {263--278},
+  doi       = {10.1007/BF01584548},
+  url       = {https://doi.org/10.1007/BF01584548},
+  note      = {The Forrest-Tomlin update. On a column replacement, the entering
+               column's spike enters U; the spike column is permuted to the end
+               of the bump and its row to the bottom, leaving an upper-Hessenberg
+               bump whose single subdiagonal is eliminated by ONE row eta appended
+               to a row-eta file. ftran replays etas forward, btran transposed in
+               reverse. Maintains sparsity far better than product-form eta.
+               This is the sparse rank-1 update for feral's simplex basis.}
+}
+
+@article{bartels1969stable,
+  author    = {Bartels, Richard H. and Golub, Gene H.},
+  title     = {The Simplex Method of Linear Programming Using {LU}
+               Decomposition},
+  journal   = {Communications of the {ACM}},
+  year      = {1969},
+  volume    = {12},
+  number    = {5},
+  pages     = {266--268},
+  doi       = {10.1145/362946.362974},
+  url       = {https://doi.org/10.1145/362946.362974},
+  note      = {The Bartels-Golub basis update: keep PA = LU; on a column swap,
+               re-triangularize the spiked U by eliminating the resulting
+               Hessenberg subdiagonal with row operations and stability-driven
+               row interchanges. The dense analogue feral uses for the dense
+               LU path's rank-1 update (Forrest-Tomlin is its sparsity-preserving
+               specialization).}
+}
+
+@article{reid1982sparsity,
+  author    = {Reid, J. K.},
+  title     = {A Sparsity-Exploiting Variant of the {Bartels--Golub}
+               Decomposition for Linear Programming Bases},
+  journal   = {Mathematical Programming},
+  year      = {1982},
+  volume    = {24},
+  number    = {1},
+  pages     = {55--69},
+  doi       = {10.1007/BF01585094},
+  url       = {https://doi.org/10.1007/BF01585094},
+  note      = {Reid's sparse Bartels-Golub-Reid (BGR) update: a sparsity- and
+               stability-aware variant that chooses among permissible row/column
+               permutations to limit fill in the bump while bounding growth.
+               The reference for feral's refactor-budget heuristics (fill and
+               round-off triggers) on the sparse update chain.}
+}
+
+@article{suhl1990computing,
+  author    = {Suhl, Uwe H. and Suhl, Leena M.},
+  title     = {Computing Sparse {LU} Factorizations for Large-Scale Linear
+               Programming Bases},
+  journal   = {{ORSA} Journal on Computing},
+  year      = {1990},
+  volume    = {2},
+  number    = {4},
+  pages     = {325--335},
+  doi       = {10.1287/ijoc.2.4.325},
+  url       = {https://doi.org/10.1287/ijoc.2.4.325},
+  note      = {Practical engineering of LP-basis LU factor/refactor: Markowitz
+               pivoting for fill, threshold stability tests, and the refactor
+               cadence relative to the update chain. Background for feral's
+               dense/sparse routing and refactorization policy.}
+}
+
+@article{davis2004colamd,
+  author    = {Davis, Timothy A. and Gilbert, John R. and Larimore, Stefan I.
+               and Ng, Esmond G.},
+  title     = {A Column Approximate Minimum Degree Ordering Algorithm},
+  journal   = {{ACM} Transactions on Mathematical Software},
+  year      = {2004},
+  volume    = {30},
+  number    = {3},
+  pages     = {353--376},
+  doi       = {10.1145/1024074.1024079},
+  url       = {https://doi.org/10.1145/1024074.1024079},
+  note      = {COLAMD: approximate minimum degree on the column-intersection
+               graph (the pattern of A^T A) without forming A^T A explicitly,
+               for fill reduction in unsymmetric LU with partial pivoting.
+               feral's first sparse-LU ordering reuses the in-tree symmetric
+               feral-amd run on the explicitly formed A^T A pattern as a
+               stand-in; this paper is the faithful target for a later phase.}
+}

--- a/dev/research/unsymmetric-lu.md
+++ b/dev/research/unsymmetric-lu.md
@@ -1,0 +1,254 @@
+# Unsymmetric LU Factorization as a Simplex Basis Engine
+
+**Status:** Pre-implementation research note (mandatory before any LU code, per CLAUDE.md)
+**Date:** 2026-06-08
+**Issue:** #81 (Unsymmetric LU with rank-1 factorization updates for large-scale simplex bases)
+**Related spec sections:** new factorization family — not covered by the symmetric spec
+**Key references:** citep:gilbert1988sparse, citep:forrest1972updated, citep:bartels1969stable,
+citep:reid1982sparsity, citep:suhl1990computing, citep:davis2004colamd, citep:duff2001mc64,
+citep:knight2014symmetry, citep:higham2002accuracy
+
+---
+
+## 1. Overview and motivation
+
+feral is today a *symmetric* indefinite LDLᵀ solver with certified inertia. Issue #81 adds a
+**new, separate factorization family**: an *unsymmetric* LU designed from the start to drive
+a **revised-simplex basis**. The distinguishing requirement is not the one-shot factor/solve
+but the **rank-1 factorization update**: the simplex replaces one basic column per iteration
+and must update `B⁻¹` cheaply (≈O(nnz)) rather than refactor (O(factor)).
+
+The two hot operations in revised simplex are
+
+    ftran:  solve  B x = a      (forward transformation, B⁻¹a)
+    btran:  solve  Bᵀ x = a     (backward transformation, B⁻ᵀa)
+
+and the structural operation is
+
+    update: swap basic column q out for an entering column, folding the change
+            into the factors in place.
+
+This note covers the algorithmic foundation for the dense path, the sparse path, both update
+mechanisms, ordering, scaling, and refinement. Inertia is **not** part of LU — an unsymmetric
+basis has no symmetric eigenvalue structure to certify.
+
+Non-goals here: the downstream `BasisEngine` integration in `pounce-simplex` (a different
+repo, absent from this environment); benchmarking against UMFPACK/KLU. Those are later phases.
+
+---
+
+## 2. The factorization: PAQ = LU with threshold partial pivoting
+
+For a square nonsingular basis `B` (m×m), we compute
+
+    P B Q = L U
+
+where `P` is a row permutation (from partial pivoting, for stability), `Q` is a column
+permutation (from fill-reducing ordering, sparse path only — `Q = I` on the dense path), `L`
+is unit lower triangular, and `U` is upper triangular. With `B = P⁻¹ L U Q⁻¹`, solves become
+
+    ftran  B x = a:   z = P a;  L y = z;  U w = y;  x = Q w
+    btran  Bᵀ x = a:  Bᵀ = Q⁻ᵀ Uᵀ Lᵀ P⁻ᵀ;  solve in reverse with transposed triangles.
+
+### 2.1 Threshold partial pivoting
+
+Strict partial pivoting selects, at step k, the row of maximum magnitude in column k and
+swaps it to the diagonal — element growth bounded by `2^(m-1)` (rarely attained). For a
+*sparse* factorization, always taking the row-max can force unnecessary fill. **Threshold
+partial pivoting** relaxes this: accept any candidate pivot `|a_pk|` satisfying
+
+    |a_pk| ≥ u · max_i |a_ik|,   u ∈ (0, 1]
+
+where `u` is the pivot threshold. `u = 1` is strict partial pivoting (max stability); smaller
+`u` trades a controlled growth factor (≤ `1 + 1/u` per step, citep:higham2002accuracy) for
+freedom to pick a sparser pivot row. Phase-1 default `u = 1.0` on the dense path; the sparse
+path uses `u` to prefer the diagonal/sparser pivot when it is within threshold. Singularity:
+if no candidate exceeds `zero_pivot_tol`, the column is numerically null → `SingularBasis` or
+a `PerturbToEps` floor (mirrors `ZeroPivotAction`).
+
+---
+
+## 3. Dense LU and the dense rank-1 update (Bartels–Golub)
+
+### 3.1 Dense factorization
+
+Right-looking outer-product LU into a single packed `m·m` column-major buffer: the strict
+lower triangle holds the unit-`L` multipliers, the diagonal and upper triangle hold `U`. At
+step k: pivot search in column k (rows k..m), threshold test, row swap across the whole row
+(and record in `perm`), compute multipliers `L(i,k) = a(i,k)/a(k,k)`, rank-1 trailing update
+`A(k+1:,k+1:) -= L(k+1:,k) · U(k,k+1:)`. Chosen for clarity and ease of hand-verification;
+this is the correct-but-not-yet-optimal dense kernel.
+
+### 3.2 The spike
+
+Replacing basic column at position `q` by a new column `aₙₑw`: the entering column expressed
+in the current `L`-coordinate system is the **spike**
+
+    s = L⁻¹ P aₙₑw
+
+i.e. ftran *stopped before the U-solve* (`ftran_partial`). Overwriting column `q` of `U` with
+`s` makes `U` upper-triangular **except** column `q`, which now has entries below the diagonal
+down to row m−1.
+
+### 3.3 Re-triangularization (Bartels–Golub, citep:bartels1969stable)
+
+Cyclically shift columns `q+1..m−1` of `U` left by one and move the spike column to position
+m−1. The result is **upper-Hessenberg**: one nonzero subdiagonal on positions `q..m−1`. Sweep
+`k = q..m−1` eliminating each subdiagonal entry `H(k+1,k)` with a 2-row Gauss elimination and
+a threshold row interchange when `|H(k+1,k)| > u·|H(k,k)|`. Each elementary operation (the
+Gauss multiplier and whether a swap occurred) is recorded as one `EtaUpdate`. The updated
+factorization is implicitly
+
+    B_new = P⁻¹ L (Π_t L_t⁻¹ ⋯ Π_1 L_1⁻¹) U_new
+
+— L stays the *original* L, and the spike-elimination deltas live in the eta list. ftran
+replays the etas forward between the L-solve and U-solve; btran replays them transposed in
+reverse. Storing the deltas as etas (O(m) per update) rather than re-folding into the dense
+buffer (O(m²)) is exactly what makes the update cheap.
+
+**Correctness landmine — permutation composition.** Update-time row swaps must NOT be folded
+into `perm`: `perm` defines the original `PB Q = LU`, and folding would desynchronize the
+unmodified original `L`. Update swaps are recorded *inside the eta replay*. A dedicated test
+(`update_with_row_swap_residual`) exercises this.
+
+### 3.4 Refactor trigger
+
+`update` returns `NeedsRefactor` (leaving `self` unchanged so the caller can `refactor`) when
+`updates_since_refactor + 1 ≥ max_updates` OR the growth monitor exceeds `max_growth`. A
+degenerate spike pivot under `Fail` returns `SingularBasis{column: q}` so the simplex can
+repair the basis rather than receive a garbage solve.
+
+---
+
+## 4. Sparse LU (Gilbert–Peierls) and the sparse Forrest–Tomlin update
+
+### 4.1 Gilbert–Peierls left-looking LU (citep:gilbert1988sparse)
+
+Factor column by column. For column j, the nonzero pattern of column j of L is the set of
+rows reachable from `nnz(A(:,j))` in the directed graph of the already-computed L — found by
+a depth-first search yielding a topological order. The sparse triangular solve `L(:,1:j-1) x =
+A(:,j)` is then performed only over that reachable set, giving the column of U (above the
+pivot) and the candidate column of L (below). Threshold partial pivoting picks the pivot from
+the candidate L entries; the chosen row is recorded in `P`. Total cost is O(flops) — the
+defining property that makes sparse partial pivoting practical. This is the KLU/SuperLU
+kernel.
+
+### 4.2 Column ordering Q (fill reduction)
+
+Partial pivoting precludes a purely a-priori symbolic factorization, but a good **column**
+order still bounds fill. The faithful tool is COLAMD (citep:davis2004colamd): approximate
+minimum degree on the column-intersection graph `pattern(AᵀA)` *without forming AᵀA*. Phase-1
+reuses what feral already owns: form the `AᵀA` pattern explicitly and run the in-tree
+symmetric `feral_amd::amd_order` on it (the Hungarian/contract plumbing at
+`src/symbolic/mod.rs:535-569` is the template for the i32-contract conversion). Documented as
+a stand-in for true COLAMD. `Q` is the **reusable symbolic handle**: across numerically
+different but structurally identical bases, recompute only the numeric factor.
+
+### 4.3 Forrest–Tomlin update (citep:forrest1972updated)
+
+The sparse specialization of Bartels–Golub that preserves sparsity. U is held with a row-wise
+view (and row/column permutations) so the spike's elimination touches only the spike row and
+the eliminated rows. On a column replacement: the spike enters U; permute the spike column to
+the right end of the bump and its row to the bottom (upper-Hessenberg bump); eliminate the
+single resulting subdiagonal with **one row eta** appended to a growing **row-eta file**.
+ftran applies the row etas forward, btran transposed in reverse. Refactor when the eta-file
+size or a fill/round-off budget (`max_updates`/`max_growth`) trips, or a stability monitor
+demands it (citep:reid1982sparsity gives the sparsity/stability-aware permutation choice and
+the budget rationale; citep:suhl1990computing gives the practical refactor cadence).
+
+The dense (§3) and sparse (§4) updates share the `EtaUpdate`/replay control flow deliberately:
+the sparse phase swaps the *storage* (sparse row-eta vectors vs dense Gauss records), not the
+solve structure.
+
+---
+
+## 5. Robustness layer
+
+### 5.1 Scaling
+
+Two-sided scaling `D_row B D_col` puts the factorization on a well-balanced matrix. Two
+strategies, selected by `LuScaling`:
+
+- **∞-norm equilibration** (Knight–Ruiz, citep:knight2014symmetry): iterate row and column
+  ∞-norm balancing until convergence. The unsymmetric case keeps *separate* `d_row`, `d_col`
+  (the symmetric `src/scaling/infnorm.rs` collapses them); we adapt that code.
+- **Unsymmetric MC64** (citep:duff2001mc64): a maximum-weight bipartite matching on the
+  per-column log-magnitude graph that places large entries on the diagonal and yields
+  `D_row = diag(exp u)`, `D_col = diag(exp v)/cmax` from the matching duals, plus a row
+  permutation. **Key reuse:** feral's Hungarian solver `hungarian_match(&CostGraph) ->
+  Matching` (`src/scaling/hungarian.rs:448`, `pub(crate)`) is *already a general unsymmetric
+  bipartite matcher* — it returns `perm[j] = row matched to column j` and the duals `u`, `v`.
+  Unsymmetric MC64 is therefore a thin *driver*: build the cost graph from the general basis,
+  call the existing kernel, read off the permutation and duals. (The symmetric MC64 in
+  `src/scaling/mc64.rs` symmetrizes the matching per citep:knight2014symmetry — we skip that
+  symmetrization for the unsymmetric basis.) Partial matching ⇒ fall back to ∞-norm
+  (mirrors the symmetric `Mc64FallbackToInfnorm` policy).
+
+The factor consumes a `LuScale { row_perm, d_row, d_col }` and factors `D_row P B D_col`;
+ftran/btran apply the scaling around the solve. The MC64 row permutation composes with the
+pivot permutation — a flagged correctness point with a dedicated test.
+
+The wrong-answer bugs that historically bit `pounce-simplex` were *all* scaling/tolerance,
+never the update math (per the issue), so this layer is load-bearing, not optional.
+
+### 5.2 Iterative refinement
+
+For ill-conditioned bases a single solve loses digits. Refinement loops on the true residual:
+
+    x = ftran(a)
+    repeat up to refine_steps:
+        r = a − B x            (computed with the matrix, not the factors)
+        if ‖r‖/‖a‖ < refine_tol: stop
+        δ = ftran(r);  x += δ
+
+`r` uses `GeneralMatrix`/`SparseColMatrix` `matvec` — an oracle-free convergence check, since
+it drives the *actual* residual down rather than comparing to a self-computed truth. btran is
+symmetric. Exposed as opt-in `ftran_refined`/`btran_refined`.
+
+---
+
+## 6. Auto dense/sparse routing
+
+Mirror `should_use_dense_fast_path` (`src/numeric/factorize.rs:1296`): `should_use_dense_lu(m,
+nnz)` returns dense for tiny `m` unconditionally and for small dense-enough bases (density
+gate), sparse otherwise, with a `LuParams` override. The simplex hits the dense regime
+constantly via OBBT (GLOBALLib LPs are 1–43 vars), so the engine must not pay sparse overhead
+on a 15×15 basis.
+
+---
+
+## 7. Test and oracle plan
+
+Per CLAUDE.md, implementation and oracle cannot both be authored this session unless the
+oracle is *external*. Two authoritative external oracles plus oracle-free property checks:
+
+1. **Hand-worked exact** (factors/solutions computed on paper, hardcoded):
+   - 2×2 `B=[[0,2],[3,4]]` — forces a pivot swap; known `P`, `L`, `U`, and `x` for a chosen
+     RHS.
+   - 3×3 `[[2,1,1],[4,3,3],[8,7,9]]` — textbook getrf, `P=I`, integer `L`,`U`.
+   - 3×3 needing a mid-factor swap — assert `‖PBQ − LU‖ < 1e-12`.
+2. **Equation-residual property checks** (verify the equation, not a self-computed truth):
+   ftran `‖Bx−a‖/‖a‖ < 1e-10`; btran `‖Bᵀx−a‖/‖a‖ < 1e-10`; post-update `< 1e-8`;
+   k-update chain; `ftran_partial` == hand-built spike; refactor-matches-updated-factor.
+3. **Dense↔sparse agreement** — same basis through both paths agrees to ~1e-9 (a consistency
+   check; not the sole oracle, since both paths are new this session).
+4. **Robustness** — ill-scaled basis: `None` gives a large residual, `InfNorm`/`Mc64` recover
+   it; ill-conditioned basis: `ftran_refined` drives the residual below `refine_tol`; MC64
+   partial-matching → InfNorm fallback.
+5. **Adversarial** — repeated columns → `SingularBasis`; near-singular `PerturbToEps`
+   succeeds finite; `max_updates` budget → `NeedsRefactor` with `self` unchanged.
+
+Files: `tests/lu_dense.rs`, `tests/lu_sparse.rs` (structure mirrors `tests/dense_ldlt.rs`).
+
+---
+
+## 8. Why this reuses feral, and what is genuinely new
+
+Reused: error type, column-major/CSC storage idioms, the AMD ordering entry + i32-contract
+conversion, the `should_use_dense_fast_path` router idiom, and — crucially — the Hungarian
+matching kernel (already unsymmetric-capable) and the ∞-norm equilibration code.
+
+New: the general (unsymmetric) dense and CSC basis types; the LU factor structs; Gilbert–
+Peierls symbolic+numeric; the two rank-1 update mechanisms and their eta replay; the
+unsymmetric MC64 *driver*; the two-sided equilibration adaptation; refinement; the router.
+Inertia is absent by design.

--- a/dev/research/unsymmetric-lu.md
+++ b/dev/research/unsymmetric-lu.md
@@ -93,23 +93,29 @@ down to row m−1.
 ### 3.3 Re-triangularization (Bartels–Golub, citep:bartels1969stable)
 
 Cyclically shift columns `q+1..m−1` of `U` left by one and move the spike column to position
-m−1. The result is **upper-Hessenberg**: one nonzero subdiagonal on positions `q..m−1`. Sweep
-`k = q..m−1` eliminating each subdiagonal entry `H(k+1,k)` with a 2-row Gauss elimination and
-a threshold row interchange when `|H(k+1,k)| > u·|H(k,k)|`. Each elementary operation (the
-Gauss multiplier and whether a swap occurred) is recorded as one `EtaUpdate`. The updated
-factorization is implicitly
+m−1 (tracked in the explicit column permutation `Q = qcol`). The result is **upper-Hessenberg**:
+one nonzero subdiagonal on positions `q..m−1`. Sweep `k = q..m−2` eliminating each subdiagonal
+entry `H(k+1,k)` with a 2-row Gauss elimination.
 
-    B_new = P⁻¹ L (Π_t L_t⁻¹ ⋯ Π_1 L_1⁻¹) U_new
+**As implemented (supersedes the eta sketch above):** the dense path does **not** keep an
+eta-replay file. Each elimination is folded *in place* into the factors — the row op
+`row_{k+1} -= mult·row_k` on `U`, and the matching column op `col_k += mult·col_{k+1}` on `L`
+(this is `L ← L·M⁻¹`, `U ← M·U` for the elementary `M = I − mult·e_{k+1}e_kᵀ`). Because
+`col_{k+1}` of unit-lower `L` is supported on rows `≥ k+1`, the column op leaves `L`'s unit
+diagonal intact and keeps it unit-lower; `U` stays upper-triangular. The cost is therefore the
+dense `O(m²)` re-fold per update, not `O(m)` — still well below an `O(m³)` refactor, and the
+dense regime (tiny OBBT bases) does not need the sparser eta file that the **sparse** path (§4)
+uses. The work is done on clones of `L`, `U`, `Q`, committed only on success, so a
+`NeedsRefactor` leaves `self` unchanged. This choice is recorded in `dev/decisions.md`
+(2026-06-08, "Dense update representation").
 
-— L stays the *original* L, and the spike-elimination deltas live in the eta list. ftran
-replays the etas forward between the L-solve and U-solve; btran replays them transposed in
-reverse. Storing the deltas as etas (O(m) per update) rather than re-folding into the dense
-buffer (O(m²)) is exactly what makes the update cheap.
-
-**Correctness landmine — permutation composition.** Update-time row swaps must NOT be folded
-into `perm`: `perm` defines the original `PB Q = LU`, and folding would desynchronize the
-unmodified original `L`. Update swaps are recorded *inside the eta replay*. A dedicated test
-(`update_with_row_swap_residual`) exercises this.
+**No in-bump pivoting on the dense path.** The dense sweep takes the diagonal as the pivot with
+no threshold row interchange; instability is caught by the growth monitor (`max_growth`) and a
+vanishing bump pivot returns `NeedsRefactor`, rather than being repaired by a swap. Consequently
+the original `perm` is never touched by an update (it still defines the factor-time `P B Q = L U`),
+so the permutation-composition landmine that an eta-with-swaps scheme would face does not arise
+here. (The **sparse** Forrest–Tomlin path §4 *does* pivot inside the bump and records the swaps
+in its eta — see §4.3.)
 
 ### 3.4 Refactor trigger
 

--- a/dev/sessions/2026-06-08-01.md
+++ b/dev/sessions/2026-06-08-01.md
@@ -1,0 +1,90 @@
+# Session 2026-06-08-01
+
+## Goal
+
+Implement issue #81: a new **unsymmetric LU factorization family** for feral,
+designed as a revised-simplex basis engine — dense + sparse LU with first-class
+rank-1 column-replacement updates, `ftran`/`btran`, auto routing, and the full
+robustness layer (equilibration + unsymmetric MC64 + iterative refinement).
+
+## Accomplished
+
+All six in-scope phases landed, each with green oracle tests and clippy clean.
+The symmetric LDLᵀ solver is untouched (additive `feral::lu` module).
+
+- **Docs first (mandatory).** Research note `dev/research/unsymmetric-lu.md` and
+  epic plan `dev/plans/unsymmetric-lu-epic.md`; 6 LU references added to
+  `dev/references.bib`.
+- **Dense path** (`src/lu/dense_*`). `GeneralMatrix`; `DenseLu` right-looking
+  LU with threshold partial pivoting (`P B Q = L U`, explicit `L`/`U`);
+  `ftran`/`btran`/`ftran_partial`; refinement; rank-1 Bartels–Golub `update()`
+  maintaining `P B Q = L U` via an explicit column permutation.
+  `tests/lu_dense.rs` (11 tests).
+- **Sparse path** (`src/lu/sparse_*`). `SparseColMatrix` (general CSC) +
+  `ata_pattern`; `SparseLuSymbolic` (AMD-on-AᵀA via `feral_amd`); `SparseLu`
+  Gilbert–Peierls factor; sparse solves + refinement; product-form `U`-update
+  rank-1 column replacement. `tests/lu_sparse.rs` (10 tests).
+- **Router.** `should_use_dense_lu` mirroring `should_use_dense_fast_path`.
+- **Scaling** (`src/lu/scaling.rs`). Two-sided ∞-norm equilibration +
+  unsymmetric MC64 (over the existing `hungarian_match`); `params.scaling`
+  drives `factor()`; solves wrap scaling around a core solve.
+  `tests/lu_scaling.rs` (5 tests).
+- **Errors.** `FeralError::SingularBasis { column }` and `NeedsRefactor`.
+
+Test evidence (all green): equation residuals `‖Bx−a‖/‖a‖` < 1e-8 after
+single/chained updates (dense and sparse), update-with-row-swap (perm
+composition), reconstruction `‖PAQ−LU‖` < 1e-10, dense↔sparse agreement < 1e-9
+(factor + post-update), budget→`NeedsRefactor` with `self` unchanged,
+ill-conditioned refinement < 1e-12, and ill-scaled (16 orders) correctness
+under InfNorm/Mc64 with the matrix equilibrated into [0.1,10] and MC64 placing
+order-1 entries on the diagonal. `cargo clippy --all-targets -- -D warnings`
+clean throughout; `pre-commit` installed and enforcing fmt/clippy on every
+commit.
+
+## Benchmark Results
+
+The LU module is additive; the symmetric LDLᵀ corpus is unaffected. `cargo run
+--bin bench --release` (no external corpus present — synthetic SPD/KKT only):
+
+```
+spd_10..spd_200, kkt_10_3..kkt_100_30 — 8 matrices, all inertia exact.
+KKT summary: Inertia match 1/1, Residual pass 1/1, worst 1.14e-15.
+Sparse solver: 2/2 inertia match vs MUMPS, 2/2 residual pass, worst 1.26e-16.
+Dense/Sparse failure analysis: no failures.
+```
+
+(No prior-session comparison applies — this session added a disjoint module and
+changed no symmetric code path.)
+
+## Decisions Made
+
+Appended to `dev/decisions.md` (2026-06-08): new LU family; dense update via
+explicit column permutation (no eta file); sparse update via product-form `U`
+update (full Forrest–Tomlin row-eta deferred as optimization); Gilbert–Peierls
+factor (DFS reach deferred); AMD-on-AᵀA ordering; MC64 as a `hungarian_match`
+driver; `update()` takes the raw entering column; downstream integration +
+reference benchmarks out of scope.
+
+## Abandoned Approaches
+
+None abandoned outright. Two design pivots, recorded in the journal and
+decisions rather than as failures: (1) dropped eta-replay for the dense update
+in favor of explicit-`Q` Bartels–Golub (cleaner, provably triangular);
+(2) chose product-form-on-`U` over a full row-eta Forrest–Tomlin for the sparse
+update to guarantee correctness this session, with FT sparsity as a documented
+optimization. One self-inflicted test bug caught and fixed: replacing two slots
+with the *same* column is genuinely singular — the engine correctly returned
+`SingularBasis`; the test was using identical columns.
+
+## Next Session Should
+
+- **Forrest–Tomlin row-eta refinement** of the sparse update (keep the eta
+  sparse vs the current dense `τ`) and the **Gilbert–Peierls DFS reach** to make
+  the sparse factor output-sensitive (epic Phase 7).
+- **Reference benchmarks** vs UMFPACK/KLU on SuiteSparse unsymmetric matrices,
+  and the update-vs-refactor crossover microbench (epic Phase 7).
+- **Downstream**: once `pounce-simplex` is available, implement the `BasisEngine`
+  behind `feral::lu` and validate no GLOBALLib regression + netlib win
+  (epic Phase 8).
+- Unrelated prior thread (not #81): the `LdltCompress` cost/benefit gate noted
+  in the previous checkpoint remains open.

--- a/dev/sessions/2026-06-08-01.md
+++ b/dev/sessions/2026-06-08-01.md
@@ -76,13 +76,35 @@ optimization. One self-inflicted test bug caught and fixed: replacing two slots
 with the *same* column is genuinely singular — the engine correctly returned
 `SingularBasis`; the test was using identical columns.
 
+## Addendum — Gilbert–Peierls reach + sparse Forrest–Tomlin (later in session)
+
+After the initial checkpoint, two follow-ups landed (driven by "test scaling"
+and "do P6.5"):
+
+- **Gilbert–Peierls depth-first reach** made the sparse factor output-sensitive:
+  tridiagonal factor went from `O(n²)` (exponent → 2.0) to `O(n^1.0)` (156×
+  faster at n=32000), 2D grid `~O(n^1.6)` — both sub-quadratic. Deterministic
+  guard `factor_traversal_is_subquadratic`.
+- **P6.5 sparse Forrest–Tomlin update — DONE.** Replaced the interim
+  product-form (which degraded warm `ftran` `O(k·n)`) with in-place sparse
+  Gaussian elimination of the bump with **partial pivoting** (the zero-pivot
+  resolution), recorded as a replayable `FtEta`; base `L` untouched, `U` updated
+  in place, `U` stored as mutable per-row vectors. Warm-solve cost is now
+  bump-local and **independent of `n`** for localized spikes (probe flat across
+  n=1000..8000; guard `ft_update_is_bump_local`). 25-update chains keep
+  ftran/btran residuals < 1e-7; dense↔sparse post-update agreement < 1e-9.
+
+The full unsymmetric LU engine (issue #81) is now feature-complete in feral:
+dense + sparse LU, both rank-1 updates (dense Bartels–Golub, sparse FT/BGR),
+AMD-on-AᵀA ordering, auto router, equilibration + unsymmetric MC64 scaling,
+iterative refinement, sub-quadratic factor.
+
 ## Next Session Should
 
-- **Forrest–Tomlin row-eta refinement** of the sparse update (keep the eta
-  sparse vs the current dense `τ`) and the **Gilbert–Peierls DFS reach** to make
-  the sparse factor output-sensitive (epic Phase 7).
 - **Reference benchmarks** vs UMFPACK/KLU on SuiteSparse unsymmetric matrices,
   and the update-vs-refactor crossover microbench (epic Phase 7).
+- **Nested-dissection ordering** (`feral-metis`) to cut fill vs the AMD-on-AᵀA
+  stand-in; faithful COLAMD (epic Phase 7).
 - **Downstream**: once `pounce-simplex` is available, implement the `BasisEngine`
   behind `feral::lu` and validate no GLOBALLib regression + netlib win
   (epic Phase 8).

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -78,6 +78,15 @@ fn map_feral_err(e: RustFeralError) -> PyErr {
             "delayed-pivot budget exceeded at supernode {supernode}: \
              required {required} delayed columns, capacity {capacity}"
         )),
+        // Unsymmetric LU basis-engine variants (issue #81). The LU engine is
+        // not yet exposed through the Python API, but the mapping must be
+        // exhaustive.
+        RustFeralError::SingularBasis { column } => {
+            SingularError::new_err(format!("LU basis is singular at column {column}"))
+        }
+        RustFeralError::NeedsRefactor => FactorError::new_err(
+            "LU basis update requires a refactor (update or stability budget reached)",
+        ),
     }
 }
 

--- a/scripts/fetch_lu_corpus.py
+++ b/scripts/fetch_lu_corpus.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fetch real-world square *unsymmetric* matrices from the SuiteSparse Matrix
+Collection for the LU validation harness (issue #81, epic Phase 7).
+
+Downloads a curated set of square, real, structurally-unsymmetric matrices —
+including circuit-simulation, chemical-process, economic, and (crucially)
+``bp_*`` *simplex basis* matrices — as Matrix Market ``.mtx`` files into
+``data/matrices/lu-corpus/`` (gitignored). Then run the Rust harness:
+
+    cargo run -p feral-diagnostics --release --bin lu_reference
+
+Requires ``ssgetpy`` (``pip install ssgetpy``). Network access to
+``sparse.tamu.edu`` is needed; if the environment blocks it, download the
+matrices manually and drop the ``.mtx`` files into the corpus dir.
+
+The ``bp_*`` group is the most relevant: those ARE basis matrices extracted
+from a linear program, i.e. exactly the kind of matrix this engine factors.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import sys
+
+# Curated square unsymmetric matrices. Mix of sizes and domains; the bp_*
+# entries are real LP simplex bases (Harwell-Boeing "basis problem" set).
+CURATED = [
+    # --- LP simplex bases (the real target) ---
+    "bp_200", "bp_600", "bp_1000", "bp_1400", "bp_1600",
+    # --- chemical process (square, very unsymmetric) ---
+    "west0067", "west0479", "west2021", "fs_183_1", "fs_541_1",
+    # --- circuit simulation ---
+    "add20", "add32", "memplus",
+    # --- oil reservoir / fluid (unsymmetric square) ---
+    "sherman1", "sherman2", "sherman3", "sherman5",
+    "saylr1", "saylr3", "saylr4", "pores_2", "pores_3",
+    "lns_131", "lns_511", "lnsp_511",
+    # --- economic / power flow ---
+    "orani678", "mahindas", "gre_115", "gre_343", "gre_1107",
+    "gemat11", "gemat12", "watt_1", "watt_2",
+]
+
+CORPUS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data", "matrices", "lu-corpus",
+)
+RAW = os.path.join(CORPUS, "_raw")
+
+
+def main() -> int:
+    try:
+        import ssgetpy
+    except ImportError:
+        print("ssgetpy not installed. Run: pip install ssgetpy", file=sys.stderr)
+        return 1
+    except Exception as e:  # noqa: BLE001 — ssgetpy refreshes its index on import
+        print(
+            f"ssgetpy could not initialize ({e!r}).\n"
+            "This usually means no network access to sparse.tamu.edu. Run this "
+            "script where outbound HTTPS is allowed, or download the .mtx files "
+            "manually into data/matrices/lu-corpus/.",
+            file=sys.stderr,
+        )
+        return 1
+
+    os.makedirs(RAW, exist_ok=True)
+    fetched, skipped = 0, 0
+    for name in CURATED:
+        dest = os.path.join(CORPUS, f"{name}.mtx")
+        if os.path.exists(dest):
+            print(f"  have   {name}")
+            fetched += 1
+            continue
+        try:
+            results = ssgetpy.search(name=name, limit=5)
+        except Exception as e:  # noqa: BLE001 — network/lookup best-effort
+            print(f"  search-fail {name}: {e}", file=sys.stderr)
+            skipped += 1
+            continue
+        # Prefer an exact square match.
+        match = None
+        for m in results:
+            if m.name == name and m.rows == m.cols:
+                match = m
+                break
+        if match is None:
+            match = next((m for m in results if m.rows == m.cols), None)
+        if match is None:
+            print(f"  no-square {name}")
+            skipped += 1
+            continue
+        try:
+            match.download(format="MM", destpath=RAW, extract=True)
+        except Exception as e:  # noqa: BLE001
+            print(f"  download-fail {name}: {e}", file=sys.stderr)
+            skipped += 1
+            continue
+        # ssgetpy extracts to RAW/<name>/<name>.mtx — find and flatten it.
+        hits = glob.glob(os.path.join(RAW, "**", f"{match.name}.mtx"), recursive=True)
+        if not hits:
+            print(f"  no-mtx {name}")
+            skipped += 1
+            continue
+        shutil.copyfile(hits[0], dest)
+        print(f"  fetched {name}  ({match.rows}x{match.cols}, nnz={match.nnz})")
+        fetched += 1
+
+    print(f"\n{fetched} matrices in {CORPUS} ({skipped} skipped).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lu_reference_scipy.py
+++ b/scripts/lu_reference_scipy.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Independent reference cross-check for the LU validation harness (issue #81).
+
+For each ``.mtx`` in the corpus, solves the SAME known-x system the Rust
+``lu_reference`` harness uses (``x_true[i] = 1 + (i % 7)``, ``a = B x_true``) but
+with **SciPy's SuperLU** (``scipy.sparse.linalg.splu``). Reporting the same
+``err``/``resid`` metrics gives an external baseline: feral's numbers should
+match SciPy's to within conditioning, confirming the Rust engine isn't
+systematically biased.
+
+    python scripts/lu_reference_scipy.py [DIR]   # DIR defaults to the corpus
+
+Requires ``scipy``.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+import numpy as np
+
+try:
+    import scipy.io
+    import scipy.sparse as sp
+    import scipy.sparse.linalg as spla
+except ImportError:
+    print("scipy not installed. Run: pip install scipy", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def check(path: str) -> str:
+    name = os.path.splitext(os.path.basename(path))[0]
+    try:
+        m = scipy.io.mmread(path)
+    except Exception as e:  # noqa: BLE001
+        return f"{name:24}  READ-ERR {e}"
+    if m.shape[0] != m.shape[1]:
+        return f"{name:24}  SKIP non-square {m.shape}"
+    n = m.shape[0]
+    b = sp.csc_matrix(m)
+    x_true = np.array([1.0 + (i % 7) for i in range(n)])
+    a = b @ x_true
+    try:
+        lu = spla.splu(b)
+        x = lu.solve(a)
+    except Exception as e:  # noqa: BLE001
+        return f"{name:24}  n={n:<7} SUPERLU-FAIL {e}"
+    err = np.max(np.abs(x - x_true)) / max(np.max(np.abs(x_true)), 1e-300)
+    resid = np.max(np.abs(b @ x - a)) / max(np.max(np.abs(a)), 1e-300)
+    verdict = "OK " if err < 1e-6 else "BAD"
+    return f"{name:24}  n={n:<7} nnz={b.nnz:<9} {verdict} err={err:.2e} resid={resid:.2e}"
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    corpus = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        here, "data", "matrices", "lu-corpus"
+    )
+    files = sorted(glob.glob(os.path.join(corpus, "*.mtx")))
+    if not files:
+        print(f"no .mtx in {corpus} — run scripts/fetch_lu_corpus.py", file=sys.stderr)
+        return 1
+    print(f"SciPy SuperLU reference — corpus: {corpus}")
+    ok = total = 0
+    for f in files:
+        line = check(f)
+        if " OK " in line:
+            ok += 1
+        if " OK " in line or " BAD " in line or "FAIL" in line:
+            total += 1
+        print(line)
+    print(f"\n{ok}/{total} solved to err < 1e-6 (SciPy SuperLU).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lu_reference_scipy.py
+++ b/scripts/lu_reference_scipy.py
@@ -48,7 +48,14 @@ def check(path: str) -> str:
         return f"{name:24}  n={n:<7} SUPERLU-FAIL {e}"
     err = np.max(np.abs(x - x_true)) / max(np.max(np.abs(x_true)), 1e-300)
     resid = np.max(np.abs(b @ x - a)) / max(np.max(np.abs(a)), 1e-300)
-    verdict = "OK " if err < 1e-6 else "BAD"
+    # ILL = backward-stable solve (tiny residual) whose large forward error is
+    # matrix conditioning, not a solver fault. Mirrors the Rust harness verdict.
+    if err < 1e-6:
+        verdict = "OK "
+    elif resid < 1e-8:
+        verdict = "ILL"
+    else:
+        verdict = "BAD"
     return f"{name:24}  n={n:<7} nnz={b.nnz:<9} {verdict} err={err:.2e} resid={resid:.2e}"
 
 
@@ -62,15 +69,20 @@ def main() -> int:
         print(f"no .mtx in {corpus} — run scripts/fetch_lu_corpus.py", file=sys.stderr)
         return 1
     print(f"SciPy SuperLU reference — corpus: {corpus}")
-    ok = total = 0
+    ok = ill = total = 0
     for f in files:
         line = check(f)
         if " OK " in line:
             ok += 1
-        if " OK " in line or " BAD " in line or "FAIL" in line:
+        if " ILL " in line:
+            ill += 1
+        if " OK " in line or " ILL " in line or " BAD " in line or "FAIL" in line:
             total += 1
         print(line)
-    print(f"\n{ok}/{total} solved to err < 1e-6 (SciPy SuperLU).")
+    print(
+        f"\n{ok}/{total} solved to err < 1e-6 (SciPy SuperLU); "
+        f"{ill} ILL (backward-stable but ill-conditioned)."
+    )
     return 0
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,21 @@ pub enum FeralError {
         required: usize,
         capacity: usize,
     },
+
+    /// An unsymmetric LU basis is numerically singular: pivot column
+    /// `column` had no candidate pivot above `LuParams::zero_pivot_tol`
+    /// and `LuSingularAction::Fail` was specified. Reported so a simplex
+    /// driver can repair the basis instead of receiving a garbage solve.
+    /// See issue #81 and `dev/research/unsymmetric-lu.md`.
+    SingularBasis { column: usize },
+
+    /// A rank-1 LU basis update (column replacement) could not be applied
+    /// within the stability / update-count budget (`LuParams::max_updates`
+    /// or `max_growth`), or a stability monitor tripped. The factorization
+    /// is left unchanged; the caller must call `refactor()` with the
+    /// current basic columns. The recoverable analogue of MUMPS's delayed-
+    /// pivot overflow. See issue #81.
+    NeedsRefactor,
 }
 
 impl std::fmt::Display for FeralError {
@@ -78,6 +93,15 @@ impl std::fmt::Display for FeralError {
                     "delayed-pivot budget exceeded at supernode {}: \
                      required {} delayed columns, capacity {} (issue #55)",
                     supernode, required, capacity
+                )
+            }
+            FeralError::SingularBasis { column } => {
+                write!(f, "LU basis is numerically singular at column {}", column)
+            }
+            FeralError::NeedsRefactor => {
+                write!(
+                    f,
+                    "LU basis update budget exceeded; refactor required (issue #81)"
                 )
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub use io::sidecar::{read_sidecar, KktSidecar, SidecarInertia};
 // Unsymmetric LU basis engine (issue #81). LU operations are methods on the
 // factor structs, so the symmetric crate-root `factor`/`solve` names are
 // unaffected.
+pub use lu::dense_factor::DenseLu;
 pub use lu::dense_matrix::GeneralMatrix;
 pub use lu::{should_use_dense_lu, LuParams, LuScaling, LuSingularAction};
 pub use numeric::condition::{estimate_condition_1norm, estimate_inverse_norm_1, matrix_norm_1};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub use io::sidecar::{read_sidecar, KktSidecar, SidecarInertia};
 // unaffected.
 pub use lu::dense_factor::DenseLu;
 pub use lu::dense_matrix::GeneralMatrix;
+pub use lu::sparse_factor::SparseLu;
+pub use lu::sparse_matrix::SparseColMatrix;
+pub use lu::sparse_symbolic::SparseLuSymbolic;
 pub use lu::{should_use_dense_lu, LuParams, LuScaling, LuSingularAction};
 pub use numeric::condition::{estimate_condition_1norm, estimate_inverse_norm_1, matrix_norm_1};
 pub use numeric::factorize::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod dense;
 pub mod error;
 pub mod inertia;
 pub mod io;
+pub mod lu;
 pub mod numeric;
 pub mod ordering;
 pub mod scaling;
@@ -29,6 +30,11 @@ pub use error::FeralError;
 pub use inertia::Inertia;
 pub use io::mtx::{parse_mtx, read_mtx, MtxMatrix};
 pub use io::sidecar::{read_sidecar, KktSidecar, SidecarInertia};
+// Unsymmetric LU basis engine (issue #81). LU operations are methods on the
+// factor structs, so the symmetric crate-root `factor`/`solve` names are
+// unaffected.
+pub use lu::dense_matrix::GeneralMatrix;
+pub use lu::{should_use_dense_lu, LuParams, LuScaling, LuSingularAction};
 pub use numeric::condition::{estimate_condition_1norm, estimate_inverse_norm_1, matrix_norm_1};
 pub use numeric::factorize::{
     factorize_multifrontal_with_schur, NumericParams, ProfileReport, SchurBlock,

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -11,7 +11,9 @@
 //! The factorization kernel itself works in a packed buffer (the classic
 //! right-looking LAPACK layout) and is split into `L`/`U` at the end.
 
-use super::{LuParams, LuSingularAction};
+use super::scaling::{compute_lu_scale, LuScale};
+use super::sparse_matrix::SparseColMatrix;
+use super::{LuParams, LuScaling, LuSingularAction};
 use crate::error::FeralError;
 
 /// Dense LU factorization of a square basis, with rank-1 update support.
@@ -37,6 +39,8 @@ pub struct DenseLu {
     /// Running growth monitor; tripping `params.max_growth` forces a refactor.
     pub(super) growth: f64,
     pub(super) params: LuParams,
+    /// Two-sided scaling of the factored matrix (identity when unscaled).
+    pub(super) scale: LuScale,
     /// Reusable length-`m` scratch buffer (no per-call allocation in solves).
     pub(super) scratch_a: Vec<f64>,
 }
@@ -45,8 +49,10 @@ impl DenseLu {
     /// Factor the `m`×`m` basis given by its `m` columns (`cols[j]` is column
     /// `j`, length `m`). Computes `P B = L U` with threshold partial pivoting.
     pub fn factor(cols: &[Vec<f64>], m: usize, params: LuParams) -> Result<Self, FeralError> {
+        let (scale, scaled) = compute_scale(cols, m, params.scaling)?;
+        let factor_cols: &[Vec<f64>] = scaled.as_deref().unwrap_or(cols);
         let mut packed = vec![0.0; m * m];
-        copy_columns_into(&mut packed, cols, m)?;
+        copy_columns_into(&mut packed, factor_cols, m)?;
         let mut perm: Vec<usize> = (0..m).collect();
         factorize_packed(&mut packed, &mut perm, m, &params)?;
         let (l, u) = split_packed(&packed, m);
@@ -65,6 +71,7 @@ impl DenseLu {
             updates_since_refactor: 0,
             growth: 1.0,
             params,
+            scale,
             scratch_a: vec![0.0; m],
         })
     }
@@ -72,8 +79,11 @@ impl DenseLu {
     /// Discard all pending updates and re-factor from scratch on fresh columns.
     pub fn refactor(&mut self, cols: &[Vec<f64>]) -> Result<(), FeralError> {
         let m = self.m;
+        let (scale, scaled) = compute_scale(cols, m, self.params.scaling)?;
+        self.scale = scale;
+        let factor_cols: &[Vec<f64>] = scaled.as_deref().unwrap_or(cols);
         let mut packed = vec![0.0; m * m];
-        copy_columns_into(&mut packed, cols, m)?;
+        copy_columns_into(&mut packed, factor_cols, m)?;
         for (k, p) in self.perm.iter_mut().enumerate() {
             *p = k;
         }
@@ -133,6 +143,21 @@ impl DenseLu {
     pub fn u(&self, i: usize, j: usize) -> f64 {
         self.u[i + j * self.m]
     }
+}
+
+/// `(scale, optional scaled columns to factor)`.
+type ScaleResult = Result<(LuScale, Option<Vec<Vec<f64>>>), FeralError>;
+
+/// Compute the scaling for `cols` under `strategy`, returning the scale and
+/// (when non-identity) the scaled columns to factor.
+fn compute_scale(cols: &[Vec<f64>], m: usize, strategy: LuScaling) -> ScaleResult {
+    if strategy == LuScaling::None {
+        return Ok((LuScale::identity(m), None));
+    }
+    let b = SparseColMatrix::from_dense_columns(m, cols)?;
+    let scale = compute_lu_scale(&b, strategy)?;
+    let scaled = scale.scaled_dense_columns(&b);
+    Ok((scale, Some(scaled)))
 }
 
 /// Copy `m` columns (each length `m`) into a packed column-major buffer.

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -1,0 +1,360 @@
+//! Dense unsymmetric LU factorization with threshold partial pivoting.
+//!
+//! Maintains the invariant `P B Q = L U`, where `P` is the row permutation
+//! from partial pivoting, `Q` is a column permutation (identity after a fresh
+//! factorization; a rank-1 update may permute columns), `L` is unit lower
+//! triangular, and `U` is upper triangular. `L` and `U` are stored as separate
+//! dense `m`×`m` column-major buffers so that the rank-1
+//! column-replacement update ([`super::dense_update`]) has a clean home for the
+//! spike column and the Hessenberg bump it eliminates.
+//!
+//! The factorization kernel itself works in a packed buffer (the classic
+//! right-looking LAPACK layout) and is split into `L`/`U` at the end.
+
+use super::{LuParams, LuSingularAction};
+use crate::error::FeralError;
+
+/// Dense LU factorization of a square basis, with rank-1 update support.
+#[derive(Debug, Clone)]
+pub struct DenseLu {
+    pub(super) m: usize,
+    /// Unit lower triangular `L`, column-major `m*m` (explicit unit diagonal).
+    pub(super) l: Vec<f64>,
+    /// Upper triangular `U`, column-major `m*m` (strict lower part is zero).
+    pub(super) u: Vec<f64>,
+    /// Row permutation: `perm[k]` is the original row now in pivot row `k`
+    /// (so `(P a)[k] = a[perm[k]]`).
+    pub(super) perm: Vec<usize>,
+    /// Inverse of `perm`: `perm_inv[orig_row] = pivot_position`.
+    pub(super) perm_inv: Vec<usize>,
+    /// Column permutation: `qcol[k]` is the basis slot in column position `k`
+    /// (so the factorization's column `k` is basis column `qcol[k]`).
+    pub(super) qcol: Vec<usize>,
+    /// Inverse of `qcol`: `qcol_inv[slot] = column_position`.
+    pub(super) qcol_inv: Vec<usize>,
+    /// Updates applied since the last `factor`/`refactor`.
+    pub(super) updates_since_refactor: usize,
+    /// Running growth monitor; tripping `params.max_growth` forces a refactor.
+    pub(super) growth: f64,
+    pub(super) params: LuParams,
+    /// Reusable length-`m` scratch buffer (no per-call allocation in solves).
+    pub(super) scratch_a: Vec<f64>,
+}
+
+impl DenseLu {
+    /// Factor the `m`×`m` basis given by its `m` columns (`cols[j]` is column
+    /// `j`, length `m`). Computes `P B = L U` with threshold partial pivoting.
+    pub fn factor(cols: &[Vec<f64>], m: usize, params: LuParams) -> Result<Self, FeralError> {
+        let mut packed = vec![0.0; m * m];
+        copy_columns_into(&mut packed, cols, m)?;
+        let mut perm: Vec<usize> = (0..m).collect();
+        factorize_packed(&mut packed, &mut perm, m, &params)?;
+        let (l, u) = split_packed(&packed, m);
+        let mut perm_inv = vec![0usize; m];
+        for (k, &p) in perm.iter().enumerate() {
+            perm_inv[p] = k;
+        }
+        Ok(DenseLu {
+            m,
+            l,
+            u,
+            perm,
+            perm_inv,
+            qcol: (0..m).collect(),
+            qcol_inv: (0..m).collect(),
+            updates_since_refactor: 0,
+            growth: 1.0,
+            params,
+            scratch_a: vec![0.0; m],
+        })
+    }
+
+    /// Discard all pending updates and re-factor from scratch on fresh columns.
+    pub fn refactor(&mut self, cols: &[Vec<f64>]) -> Result<(), FeralError> {
+        let m = self.m;
+        let mut packed = vec![0.0; m * m];
+        copy_columns_into(&mut packed, cols, m)?;
+        for (k, p) in self.perm.iter_mut().enumerate() {
+            *p = k;
+        }
+        factorize_packed(&mut packed, &mut self.perm, m, &self.params)?;
+        let (l, u) = split_packed(&packed, m);
+        self.l = l;
+        self.u = u;
+        for (k, &p) in self.perm.iter().enumerate() {
+            self.perm_inv[p] = k;
+        }
+        for (k, (q, qi)) in self
+            .qcol
+            .iter_mut()
+            .zip(self.qcol_inv.iter_mut())
+            .enumerate()
+        {
+            *q = k;
+            *qi = k;
+        }
+        self.updates_since_refactor = 0;
+        self.growth = 1.0;
+        Ok(())
+    }
+
+    /// Basis dimension.
+    #[inline]
+    pub fn dim(&self) -> usize {
+        self.m
+    }
+
+    /// Number of rank-1 updates applied since the last factor/refactor.
+    #[inline]
+    pub fn updates_since_refactor(&self) -> usize {
+        self.updates_since_refactor
+    }
+
+    /// The row permutation `perm` (`perm[k]` = original row in pivot row `k`).
+    #[inline]
+    pub fn perm(&self) -> &[usize] {
+        &self.perm
+    }
+
+    /// The column permutation `qcol` (`qcol[k]` = basis slot in column `k`).
+    #[inline]
+    pub fn qcol(&self) -> &[usize] {
+        &self.qcol
+    }
+
+    /// `L[i,j]`: unit lower triangular.
+    #[inline]
+    pub fn l(&self, i: usize, j: usize) -> f64 {
+        self.l[i + j * self.m]
+    }
+
+    /// `U[i,j]`: upper triangular.
+    #[inline]
+    pub fn u(&self, i: usize, j: usize) -> f64 {
+        self.u[i + j * self.m]
+    }
+}
+
+/// Copy `m` columns (each length `m`) into a packed column-major buffer.
+fn copy_columns_into(buf: &mut [f64], cols: &[Vec<f64>], m: usize) -> Result<(), FeralError> {
+    if cols.len() != m {
+        return Err(FeralError::DimensionMismatch {
+            expected: m,
+            got: cols.len(),
+        });
+    }
+    for (j, col) in cols.iter().enumerate() {
+        if col.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: col.len(),
+            });
+        }
+        buf[j * m..j * m + m].copy_from_slice(col);
+        if col.iter().any(|x| !x.is_finite()) {
+            return Err(FeralError::InvalidInput(
+                "LU basis column contains non-finite entries".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Split a packed LU buffer into explicit `L` (unit lower) and `U` (upper).
+fn split_packed(packed: &[f64], m: usize) -> (Vec<f64>, Vec<f64>) {
+    let mut l = vec![0.0; m * m];
+    let mut u = vec![0.0; m * m];
+    for j in 0..m {
+        for i in 0..m {
+            let v = packed[i + j * m];
+            if i > j {
+                l[i + j * m] = v;
+            } else {
+                u[i + j * m] = v;
+            }
+        }
+        l[j + j * m] = 1.0;
+    }
+    (l, u)
+}
+
+/// Right-looking outer-product LU with threshold partial pivoting, in place on
+/// the packed buffer. `perm` starts as identity and accumulates row swaps.
+fn factorize_packed(
+    packed: &mut [f64],
+    perm: &mut [usize],
+    m: usize,
+    params: &LuParams,
+) -> Result<(), FeralError> {
+    let u = params.pivot_threshold;
+    let ztol = params.zero_pivot_tol;
+    for k in 0..m {
+        // Pivot search: max-magnitude entry in column k over rows k..m.
+        let mut amax = 0.0_f64;
+        let mut argmax = k;
+        for i in k..m {
+            let v = packed[i + k * m].abs();
+            if v > amax {
+                amax = v;
+                argmax = i;
+            }
+        }
+        // Threshold partial pivoting: keep the diagonal if it is within
+        // threshold of the column max (and nonzero), else take the row max.
+        let diag = packed[k + k * m].abs();
+        let pivot_row = if diag >= u * amax && diag > ztol {
+            k
+        } else {
+            argmax
+        };
+
+        if pivot_row != k {
+            swap_rows(packed, k, pivot_row, m);
+            perm.swap(k, pivot_row);
+        }
+
+        // Singularity / perturbation.
+        let mut piv = packed[k + k * m];
+        if piv.abs() <= ztol {
+            match params.on_singular {
+                LuSingularAction::Fail => {
+                    return Err(FeralError::SingularBasis { column: k });
+                }
+                LuSingularAction::PerturbToEps { abs_floor } => {
+                    let s = if piv < 0.0 { -1.0 } else { 1.0 };
+                    piv = s * abs_floor.max(piv.abs());
+                    packed[k + k * m] = piv;
+                }
+            }
+        }
+
+        // Multipliers L(k+1:, k) = A(k+1:, k) / piv.
+        let inv = 1.0 / piv;
+        for i in k + 1..m {
+            packed[i + k * m] *= inv;
+        }
+        // Rank-1 trailing update A(k+1:, k+1:) -= L(k+1:, k) · U(k, k+1:).
+        for j in k + 1..m {
+            let ukj = packed[k + j * m];
+            if ukj != 0.0 {
+                for i in k + 1..m {
+                    packed[i + j * m] -= packed[i + k * m] * ukj;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Swap rows `a` and `b` across all `m` columns of the packed buffer.
+fn swap_rows(buf: &mut [f64], a: usize, b: usize, m: usize) {
+    for c in 0..m {
+        buf.swap(a + c * m, b + c * m);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Columns (column-major) from rows-of-the-matrix, for readable tests.
+    fn cols_from_rows(rows: &[&[f64]]) -> (Vec<Vec<f64>>, usize) {
+        let m = rows.len();
+        let mut cols = vec![vec![0.0; m]; m];
+        for (i, row) in rows.iter().enumerate() {
+            for (j, &v) in row.iter().enumerate() {
+                cols[j][i] = v;
+            }
+        }
+        (cols, m)
+    }
+
+    /// max_{i,j} | (P B)[i,j] - (L U)[i,j] |, the reconstruction residual.
+    /// (Q = I after a fresh factorization.)
+    fn reconstruction_residual(lu: &DenseLu, rows: &[&[f64]]) -> f64 {
+        let m = lu.m;
+        let mut worst = 0.0_f64;
+        for i in 0..m {
+            for j in 0..m {
+                let pb = rows[lu.perm[i]][j];
+                let mut prod = 0.0;
+                for k in 0..m {
+                    prod += lu.l(i, k) * lu.u(k, j);
+                }
+                worst = worst.max((pb - prod).abs());
+            }
+        }
+        worst
+    }
+
+    #[test]
+    fn factor_2x2_swap_exact() {
+        // B = [[0,2],[3,4]]; partial pivoting swaps rows: P=[1,0], L=I,
+        // U=[[3,4],[0,2]]. Hand-computed.
+        let (cols, m) = cols_from_rows(&[&[0.0, 2.0], &[3.0, 4.0]]);
+        let lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        assert_eq!(lu.perm, vec![1, 0]);
+        assert!((lu.u(0, 0) - 3.0).abs() < 1e-14);
+        assert!((lu.u(0, 1) - 4.0).abs() < 1e-14);
+        assert!((lu.u(1, 1) - 2.0).abs() < 1e-14);
+        assert!((lu.l(1, 0) - 0.0).abs() < 1e-14);
+    }
+
+    #[test]
+    fn factor_3x3_reconstruction() {
+        let rows: [&[f64]; 3] = [&[2.0, 1.0, 1.0], &[4.0, 3.0, 3.0], &[8.0, 7.0, 9.0]];
+        let (cols, m) = cols_from_rows(&rows);
+        let lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        assert!(reconstruction_residual(&lu, &rows) < 1e-12);
+    }
+
+    #[test]
+    fn factor_random_reconstruction() {
+        let m = 7;
+        let mut cols = vec![vec![0.0; m]; m];
+        let mut state = 0x1234_5678_u64;
+        for j in 0..m {
+            for i in 0..m {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let r = ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0;
+                cols[j][i] = r;
+            }
+            cols[j][j] += 5.0;
+        }
+        let rows_owned: Vec<Vec<f64>> = (0..m)
+            .map(|i| (0..m).map(|j| cols[j][i]).collect())
+            .collect();
+        let rows: Vec<&[f64]> = rows_owned.iter().map(|r| r.as_slice()).collect();
+        let lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        assert!(reconstruction_residual(&lu, &rows) < 1e-10);
+    }
+
+    #[test]
+    fn factor_singular_repeated_columns_fails() {
+        let (cols, m) = cols_from_rows(&[&[1.0, 1.0], &[2.0, 2.0]]);
+        let err = DenseLu::factor(&cols, m, LuParams::default());
+        assert!(matches!(err, Err(FeralError::SingularBasis { .. })));
+    }
+
+    #[test]
+    fn factor_singular_perturb_succeeds() {
+        let (cols, m) = cols_from_rows(&[&[1.0, 1.0], &[2.0, 2.0]]);
+        let params = LuParams {
+            on_singular: LuSingularAction::PerturbToEps { abs_floor: 1e-10 },
+            ..LuParams::default()
+        };
+        let lu = DenseLu::factor(&cols, m, params).expect("perturbed factor");
+        assert!(lu.u(1, 1).abs() >= 1e-10);
+    }
+
+    #[test]
+    fn refactor_resets_state() {
+        let (cols, m) = cols_from_rows(&[&[2.0, 1.0], &[1.0, 3.0]]);
+        let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        let (cols2, _) = cols_from_rows(&[&[4.0, 0.0], &[1.0, 5.0]]);
+        lu.refactor(&cols2).expect("refactor");
+        assert_eq!(lu.updates_since_refactor(), 0);
+        let rows2: [&[f64]; 2] = [&[4.0, 0.0], &[1.0, 5.0]];
+        assert!(reconstruction_residual(&lu, &rows2) < 1e-12);
+    }
+}

--- a/src/lu/dense_matrix.rs
+++ b/src/lu/dense_matrix.rs
@@ -1,0 +1,134 @@
+//! General (unsymmetric) dense square matrix for the LU basis engine.
+//!
+//! Unlike [`crate::dense::matrix::SymmetricMatrix`], which stores only the
+//! lower triangle of a symmetric matrix, an LU basis is a general square
+//! matrix and every entry is stored. Layout is column-major: entry `(i, j)`
+//! lives at `data[j * m + i]`. The simplex hands us the basic columns, so
+//! [`GeneralMatrix::from_columns`] is the primary constructor.
+
+use crate::error::FeralError;
+
+/// A general `m`×`m` dense matrix in column-major storage.
+#[derive(Debug, Clone)]
+pub struct GeneralMatrix {
+    /// Dimension (the matrix is square).
+    pub m: usize,
+    /// Column-major entries, length `m * m`. Entry `(i, j)` at `data[j*m + i]`.
+    pub data: Vec<f64>,
+}
+
+impl GeneralMatrix {
+    /// All-zeros `m`×`m` matrix.
+    pub fn zeros(m: usize) -> Self {
+        GeneralMatrix {
+            m,
+            data: vec![0.0; m * m],
+        }
+    }
+
+    /// Build from `m` basic columns. `cols[j]` is column `j`, each of length
+    /// `m`. This is the simplex entry point.
+    pub fn from_columns(m: usize, cols: &[Vec<f64>]) -> Result<Self, FeralError> {
+        if cols.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: cols.len(),
+            });
+        }
+        let mut data = vec![0.0; m * m];
+        for (j, col) in cols.iter().enumerate() {
+            if col.len() != m {
+                return Err(FeralError::DimensionMismatch {
+                    expected: m,
+                    got: col.len(),
+                });
+            }
+            data[j * m..j * m + m].copy_from_slice(col);
+        }
+        let mat = GeneralMatrix { m, data };
+        mat.validate()?;
+        Ok(mat)
+    }
+
+    /// Build from a flat column-major buffer of length `m * m`.
+    pub fn from_column_major(m: usize, data: Vec<f64>) -> Result<Self, FeralError> {
+        if data.len() != m * m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m * m,
+                got: data.len(),
+            });
+        }
+        let mat = GeneralMatrix { m, data };
+        mat.validate()?;
+        Ok(mat)
+    }
+
+    /// Read entry `(i, j)`.
+    #[inline]
+    pub fn get(&self, i: usize, j: usize) -> f64 {
+        self.data[j * self.m + i]
+    }
+
+    /// Write entry `(i, j)`.
+    #[inline]
+    pub fn set(&mut self, i: usize, j: usize, v: f64) {
+        self.data[j * self.m + i] = v;
+    }
+
+    /// Column `j` as a slice of length `m`.
+    #[inline]
+    pub fn col(&self, j: usize) -> &[f64] {
+        &self.data[j * self.m..j * self.m + self.m]
+    }
+
+    /// Column `j` as a mutable slice of length `m`.
+    #[inline]
+    pub fn col_mut(&mut self, j: usize) -> &mut [f64] {
+        &mut self.data[j * self.m..j * self.m + self.m]
+    }
+
+    /// Validate dimensions and finiteness.
+    pub fn validate(&self) -> Result<(), FeralError> {
+        if self.data.len() != self.m * self.m {
+            return Err(FeralError::InvalidInput(format!(
+                "GeneralMatrix data length {} != m*m = {}",
+                self.data.len(),
+                self.m * self.m
+            )));
+        }
+        if self.data.iter().any(|x| !x.is_finite()) {
+            return Err(FeralError::InvalidInput(
+                "GeneralMatrix contains non-finite entries".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// `y = A · x`. `x` and `y` must have length `m`.
+    pub fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        for yi in y.iter_mut() {
+            *yi = 0.0;
+        }
+        for (j, &xj) in x.iter().enumerate().take(self.m) {
+            if xj == 0.0 {
+                continue;
+            }
+            let col = self.col(j);
+            for (yi, &cij) in y.iter_mut().zip(col.iter()) {
+                *yi += cij * xj;
+            }
+        }
+    }
+
+    /// `y = Aᵀ · x`. `x` and `y` must have length `m`.
+    pub fn matvec_transpose(&self, x: &[f64], y: &mut [f64]) {
+        for (j, yj) in y.iter_mut().enumerate().take(self.m) {
+            let col = self.col(j);
+            let mut acc = 0.0;
+            for (&cij, &xi) in col.iter().zip(x.iter()) {
+                acc += cij * xi;
+            }
+            *yj = acc;
+        }
+    }
+}

--- a/src/lu/dense_solve.rs
+++ b/src/lu/dense_solve.rs
@@ -12,18 +12,55 @@ use super::dense_matrix::GeneralMatrix;
 use crate::error::FeralError;
 
 impl DenseLu {
-    /// Solve `B x = a`, overwriting `rhs` (= `a`) with `x`.
+    /// Solve `B x = a`, overwriting `rhs` (= `a`) with `x`. Applies scaling
+    /// around the core solve on the scaled matrix `Ã = D_row Π B D_col`:
+    /// `Ã x̃ = D_row Π a`, then `x = D_col x̃`.
     pub fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
+        if self.scale.is_identity() {
+            return self.ftran_core(rhs);
+        }
+        let mut bt = vec![0.0; m];
+        for (i, bi) in bt.iter_mut().enumerate() {
+            *bi = self.scale.d_row[i] * rhs[self.scale.rperm[i]];
+        }
+        self.ftran_core(&mut bt)?;
+        for (j, rj) in rhs.iter_mut().enumerate() {
+            *rj = self.scale.d_col[j] * bt[j];
+        }
+        Ok(())
+    }
+
+    /// Solve `Bᵀ x = a`, overwriting `rhs` (= `a`) with `x`. With scaling:
+    /// `Ãᵀ ỹ = D_col a`, then `x[rperm[i]] = D_row[i] ỹ[i]`.
+    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        if self.scale.is_identity() {
+            return self.btran_core(rhs);
+        }
+        let mut bt = vec![0.0; m];
+        for (j, bj) in bt.iter_mut().enumerate() {
+            *bj = self.scale.d_col[j] * rhs[j];
+        }
+        self.btran_core(&mut bt)?;
+        for (i, &yi) in bt.iter().enumerate() {
+            rhs[self.scale.rperm[i]] = self.scale.d_row[i] * yi;
+        }
+        Ok(())
+    }
+
+    /// Core `ftran` on the (scaled) factored matrix, ignoring outer scaling.
+    pub(super) fn ftran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
         let mut s = std::mem::take(&mut self.scratch_a);
-        // s = P a
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.perm[k]];
         }
         lsolve(&self.l, m, &mut s);
         usolve(&self.u, m, &mut s);
-        // x[qcol[k]] = w[k]
         for (k, &wk) in s.iter().enumerate() {
             rhs[self.qcol[k]] = wk;
         }
@@ -31,18 +68,16 @@ impl DenseLu {
         Ok(())
     }
 
-    /// Solve `Bᵀ x = a`, overwriting `rhs` (= `a`) with `x`.
-    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+    /// Core `btran` on the (scaled) factored matrix, ignoring outer scaling.
+    pub(super) fn btran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
         let mut s = std::mem::take(&mut self.scratch_a);
-        // g = Q⁻¹ a : g[k] = a[qcol[k]]
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.qcol[k]];
         }
         ut_solve(&self.u, m, &mut s); // Uᵀ z = g
         lt_solve(&self.l, m, &mut s); // Lᵀ v = z
-                                      // x[perm[k]] = v[k]
         for (k, &vk) in s.iter().enumerate() {
             rhs[self.perm[k]] = vk;
         }

--- a/src/lu/dense_solve.rs
+++ b/src/lu/dense_solve.rs
@@ -1,0 +1,188 @@
+//! Dense `ftran` / `btran` triangular solves and iterative refinement.
+//!
+//! With `P B Q = L U`, `ftran` solves `B x = a` as `x = Q U⁻¹ L⁻¹ P a`, and
+//! `btran` solves `Bᵀ x = a` via `Bᵀ = Q Uᵀ Lᵀ P` with the transposed triangles
+//! in reverse order.
+//!
+//! `ftran_partial` returns the spike `L⁻¹ P a` (no `U`-solve, no column
+//! permutation), the input the rank-1 update consumes.
+
+use super::dense_factor::DenseLu;
+use super::dense_matrix::GeneralMatrix;
+use crate::error::FeralError;
+
+impl DenseLu {
+    /// Solve `B x = a`, overwriting `rhs` (= `a`) with `x`.
+    pub fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch_a);
+        // s = P a
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.perm[k]];
+        }
+        lsolve(&self.l, m, &mut s);
+        usolve(&self.u, m, &mut s);
+        // x[qcol[k]] = w[k]
+        for (k, &wk) in s.iter().enumerate() {
+            rhs[self.qcol[k]] = wk;
+        }
+        self.scratch_a = s;
+        Ok(())
+    }
+
+    /// Solve `Bᵀ x = a`, overwriting `rhs` (= `a`) with `x`.
+    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch_a);
+        // g = Q⁻¹ a : g[k] = a[qcol[k]]
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.qcol[k]];
+        }
+        ut_solve(&self.u, m, &mut s); // Uᵀ z = g
+        lt_solve(&self.l, m, &mut s); // Lᵀ v = z
+                                      // x[perm[k]] = v[k]
+        for (k, &vk) in s.iter().enumerate() {
+            rhs[self.perm[k]] = vk;
+        }
+        self.scratch_a = s;
+        Ok(())
+    }
+
+    /// Compute the spike `L⁻¹ P a`, overwriting `rhs` (= `a`). This is `ftran`
+    /// stopped before the `U`-solve and column permutation; it is the input to
+    /// [`DenseLu::update`](crate::lu::DenseLu::update).
+    pub fn ftran_partial(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch_a);
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.perm[k]];
+        }
+        lsolve(&self.l, m, &mut s);
+        rhs.copy_from_slice(&s);
+        self.scratch_a = s;
+        Ok(())
+    }
+
+    /// `ftran` with iterative refinement against the original basis `b`.
+    /// Loops `r = a − Bx; Bδ = r; x += δ` up to `params.refine_steps`,
+    /// stopping when `‖r‖ / ‖a‖ < params.refine_tol`.
+    pub fn ftran_refined(&mut self, b: &GeneralMatrix, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let a = rhs.to_vec();
+        self.ftran(rhs)?;
+        refine(self, b, &a, rhs, false)
+    }
+
+    /// `btran` with iterative refinement against the original basis `b`.
+    pub fn btran_refined(&mut self, b: &GeneralMatrix, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let a = rhs.to_vec();
+        self.btran(rhs)?;
+        refine(self, b, &a, rhs, true)
+    }
+}
+
+fn check_len(got: usize, expected: usize) -> Result<(), FeralError> {
+    if got != expected {
+        Err(FeralError::DimensionMismatch { expected, got })
+    } else {
+        Ok(())
+    }
+}
+
+/// Forward solve `L y = s` (unit lower triangular), in place.
+fn lsolve(l: &[f64], m: usize, s: &mut [f64]) {
+    for k in 0..m {
+        let mut acc = s[k];
+        for i in 0..k {
+            acc -= l[k + i * m] * s[i];
+        }
+        s[k] = acc;
+    }
+}
+
+/// Back solve `U w = s` (upper triangular), in place.
+fn usolve(u: &[f64], m: usize, s: &mut [f64]) {
+    for k in (0..m).rev() {
+        let mut acc = s[k];
+        for i in k + 1..m {
+            acc -= u[k + i * m] * s[i];
+        }
+        s[k] = acc / u[k + k * m];
+    }
+}
+
+/// Forward solve `Uᵀ z = s` (`Uᵀ` is lower triangular), in place.
+fn ut_solve(u: &[f64], m: usize, s: &mut [f64]) {
+    for k in 0..m {
+        let mut acc = s[k];
+        for i in 0..k {
+            acc -= u[i + k * m] * s[i]; // Uᵀ[k,i] = U[i,k]
+        }
+        s[k] = acc / u[k + k * m];
+    }
+}
+
+/// Back solve `Lᵀ v = s` (`Lᵀ` is unit upper triangular), in place.
+fn lt_solve(l: &[f64], m: usize, s: &mut [f64]) {
+    for k in (0..m).rev() {
+        let mut acc = s[k];
+        for i in k + 1..m {
+            acc -= l[i + k * m] * s[i]; // Lᵀ[k,i] = L[i,k]
+        }
+        s[k] = acc;
+    }
+}
+
+/// Shared refinement loop. `transpose = true` refines a `btran` solve.
+fn refine(
+    lu: &mut DenseLu,
+    b: &GeneralMatrix,
+    a: &[f64],
+    x: &mut [f64],
+    transpose: bool,
+) -> Result<(), FeralError> {
+    let m = lu.m;
+    let steps = lu.params.refine_steps;
+    let tol = lu.params.refine_tol;
+    if steps == 0 {
+        return Ok(());
+    }
+    let anorm = inf_norm(a);
+    if anorm == 0.0 {
+        return Ok(());
+    }
+    let mut r = vec![0.0; m];
+    for _ in 0..steps {
+        // r = a − (B or Bᵀ) x
+        if transpose {
+            b.matvec_transpose(x, &mut r);
+        } else {
+            b.matvec(x, &mut r);
+        }
+        for (ri, &ai) in r.iter_mut().zip(a.iter()) {
+            *ri = ai - *ri;
+        }
+        if inf_norm(&r) / anorm < tol {
+            break;
+        }
+        if transpose {
+            lu.btran(&mut r)?;
+        } else {
+            lu.ftran(&mut r)?;
+        }
+        for (xi, &dxi) in x.iter_mut().zip(r.iter()) {
+            *xi += dxi;
+        }
+    }
+    Ok(())
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |acc, &x| acc.max(x.abs()))
+}

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -47,8 +47,15 @@ impl DenseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
-        // Spike = L⁻¹ P aₙₑw, in the current factor frame (no factor mutation).
-        let mut spike = entering_col.to_vec();
+        // Scale the entering column into the factored frame Ã, then form the
+        // spike L⁻¹ P ãₙₑw (no factor mutation). With identity scaling this is
+        // just `entering_col`.
+        let mut spike = vec![0.0; m];
+        for (i, si) in spike.iter_mut().enumerate() {
+            *si = self.scale.d_row[i]
+                * entering_col[self.scale.rperm[i]]
+                * self.scale.d_col[leaving_slot];
+        }
         self.ftran_partial(&mut spike)?;
 
         let q = self.qcol_inv[leaving_slot];

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -21,19 +21,19 @@ use super::dense_factor::DenseLu;
 use crate::error::FeralError;
 
 impl DenseLu {
-    /// Replace basis slot `leaving_slot` with the column whose spike is
-    /// `spike = L⁻¹ P aₙₑw` (compute it with [`DenseLu::ftran_partial`] *before*
-    /// calling this). On success the factorization reflects the new basis.
+    /// Replace basis slot `leaving_slot` with `entering_col` (the new basis
+    /// column `aₙₑw`). The spike `L⁻¹ P aₙₑw` is computed internally, then folded
+    /// into the factorization. On success the factors reflect the new basis.
     ///
     /// Returns [`FeralError::NeedsRefactor`] (leaving `self` unchanged) when the
     /// update budget (`max_updates`) or growth budget (`max_growth`) is
     /// exceeded, and [`FeralError::SingularBasis`] when a bump pivot vanishes.
-    pub fn update(&mut self, leaving_slot: usize, spike: &[f64]) -> Result<(), FeralError> {
+    pub fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), FeralError> {
         let m = self.m;
-        if spike.len() != m {
+        if entering_col.len() != m {
             return Err(FeralError::DimensionMismatch {
                 expected: m,
-                got: spike.len(),
+                got: entering_col.len(),
             });
         }
         if leaving_slot >= m {
@@ -46,6 +46,10 @@ impl DenseLu {
         if self.updates_since_refactor + 1 > self.params.max_updates {
             return Err(FeralError::NeedsRefactor);
         }
+
+        // Spike = L⁻¹ P aₙₑw, in the current factor frame (no factor mutation).
+        let mut spike = entering_col.to_vec();
+        self.ftran_partial(&mut spike)?;
 
         let q = self.qcol_inv[leaving_slot];
         let ztol = self.params.zero_pivot_tol;

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -1,0 +1,126 @@
+//! Dense rank-1 column-replacement update (Bartels–Golub).
+//!
+//! Replacing basis slot `leaving_slot` by a new column whose spike is
+//! `s = L⁻¹ P aₙₑw` (from [`DenseLu::ftran_partial`]) maintains the invariant
+//! `P B Q = L U` in three steps.
+//!
+//! Step one overwrites column `q = qcol_inv[leaving_slot]` of `U` with the
+//! spike `s`; `U` is then upper triangular except column `q`, which has a spike
+//! below the diagonal. Step two cyclically shifts columns `q..m-1` of `U` left
+//! by one and moves the spike column to position `m-1` (updating `Q`), turning
+//! `U` into upper-Hessenberg with a single subdiagonal on positions `q..m-2`.
+//! Step three eliminates that subdiagonal with a Gauss sweep (no in-bump
+//! pivoting; the growth monitor and `NeedsRefactor` handle instability): each
+//! elimination is a row operation on `U` and the corresponding column operation
+//! on `L`, so `L` stays unit lower triangular and `U` upper triangular.
+//!
+//! The work is done on clones of `L`, `U`, and `Q`, committed only on success,
+//! so a `NeedsRefactor` return leaves `self` unchanged and recoverable.
+
+use super::dense_factor::DenseLu;
+use crate::error::FeralError;
+
+impl DenseLu {
+    /// Replace basis slot `leaving_slot` with the column whose spike is
+    /// `spike = L⁻¹ P aₙₑw` (compute it with [`DenseLu::ftran_partial`] *before*
+    /// calling this). On success the factorization reflects the new basis.
+    ///
+    /// Returns [`FeralError::NeedsRefactor`] (leaving `self` unchanged) when the
+    /// update budget (`max_updates`) or growth budget (`max_growth`) is
+    /// exceeded, and [`FeralError::SingularBasis`] when a bump pivot vanishes.
+    pub fn update(&mut self, leaving_slot: usize, spike: &[f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        if spike.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: spike.len(),
+            });
+        }
+        if leaving_slot >= m {
+            return Err(FeralError::InvalidInput(format!(
+                "leaving_slot {} out of range for basis dimension {}",
+                leaving_slot, m
+            )));
+        }
+        // Update-count budget (checked before doing any work).
+        if self.updates_since_refactor + 1 > self.params.max_updates {
+            return Err(FeralError::NeedsRefactor);
+        }
+
+        let q = self.qcol_inv[leaving_slot];
+        let ztol = self.params.zero_pivot_tol;
+        let max_growth = self.params.max_growth;
+
+        // Work on clones; commit only on success.
+        let mut u = self.u.clone();
+        let mut l = self.l.clone();
+        let mut qcol = self.qcol.clone();
+
+        // 1. Overwrite column q of U with the spike.
+        for i in 0..m {
+            u[i + q * m] = spike[i];
+        }
+
+        // 2. Cyclic column shift q..m-1: spike column moves to position m-1.
+        cyclic_shift_columns(&mut u, m, q);
+        let leaving = qcol[q];
+        for j in q..m - 1 {
+            qcol[j] = qcol[j + 1];
+        }
+        qcol[m - 1] = leaving;
+
+        // 3. Eliminate the Hessenberg subdiagonal on positions q..m-2.
+        let mut growth = self.growth;
+        for k in q..m.saturating_sub(1) {
+            let piv = u[k + k * m];
+            if piv.abs() <= ztol {
+                return Err(FeralError::NeedsRefactor);
+            }
+            let sub = u[k + 1 + k * m];
+            if sub == 0.0 {
+                continue;
+            }
+            let mult = sub / piv;
+            growth = growth.max(mult.abs());
+            if growth > max_growth {
+                return Err(FeralError::NeedsRefactor);
+            }
+            // Row op on U: row_{k+1} -= mult · row_k, columns k..m-1.
+            for j in k..m {
+                u[k + 1 + j * m] -= mult * u[k + j * m];
+            }
+            u[k + 1 + k * m] = 0.0; // enforce exact zero
+                                    // Column op on L: col_k += mult · col_{k+1} (keeps L unit lower).
+            for i in 0..m {
+                l[i + k * m] += mult * l[i + (k + 1) * m];
+            }
+        }
+
+        // Commit.
+        self.u = u;
+        self.l = l;
+        self.qcol = qcol;
+        for (k, &slot) in self.qcol.iter().enumerate() {
+            self.qcol_inv[slot] = k;
+        }
+        self.growth = growth;
+        self.updates_since_refactor += 1;
+        Ok(())
+    }
+}
+
+/// Cyclically shift columns `q..m-1` of a column-major `m`×`m` buffer left by
+/// one, moving column `q` to position `m-1`.
+fn cyclic_shift_columns(buf: &mut [f64], m: usize, q: usize) {
+    if q + 1 >= m {
+        return;
+    }
+    let mut saved = vec![0.0; m];
+    saved.copy_from_slice(&buf[q * m..q * m + m]);
+    for j in q..m - 1 {
+        let (dst, src) = (j * m, (j + 1) * m);
+        buf.copy_within(src..src + m, dst);
+    }
+    let last = (m - 1) * m;
+    buf[last..last + m].copy_from_slice(&saved);
+}

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -19,6 +19,7 @@ pub mod sparse_factor;
 pub mod sparse_matrix;
 pub mod sparse_solve;
 pub mod sparse_symbolic;
+pub mod sparse_update;
 
 pub use dense_factor::DenseLu;
 pub use dense_matrix::GeneralMatrix;

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -15,6 +15,7 @@ pub mod dense_factor;
 pub mod dense_matrix;
 pub mod dense_solve;
 pub mod dense_update;
+pub mod scaling;
 pub mod sparse_factor;
 pub mod sparse_matrix;
 pub mod sparse_solve;

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -11,8 +11,12 @@
 //! solves, not just one-shot factor/solve. See `dev/research/unsymmetric-lu.md`
 //! and `dev/plans/unsymmetric-lu-epic.md`.
 
+pub mod dense_factor;
 pub mod dense_matrix;
+pub mod dense_solve;
+pub mod dense_update;
 
+pub use dense_factor::DenseLu;
 pub use dense_matrix::GeneralMatrix;
 
 /// What to do when the LU factorization hits a numerically null pivot column.

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -15,9 +15,16 @@ pub mod dense_factor;
 pub mod dense_matrix;
 pub mod dense_solve;
 pub mod dense_update;
+pub mod sparse_factor;
+pub mod sparse_matrix;
+pub mod sparse_solve;
+pub mod sparse_symbolic;
 
 pub use dense_factor::DenseLu;
 pub use dense_matrix::GeneralMatrix;
+pub use sparse_factor::SparseLu;
+pub use sparse_matrix::SparseColMatrix;
+pub use sparse_symbolic::SparseLuSymbolic;
 
 /// What to do when the LU factorization hits a numerically null pivot column.
 ///

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -120,8 +120,10 @@ pub fn should_use_dense_lu(m: usize, nnz: usize, params: &LuParams) -> bool {
         return false;
     }
     // Density gate: dense when at least a quarter of the cells are nonzero.
-    let cells = m * m;
-    nnz * 4 >= cells
+    // Saturating arithmetic so a caller-set large `dense_threshold` (which bounds
+    // `m` above) can't overflow `usize` on `m*m` or `nnz*4`.
+    let cells = m.saturating_mul(m);
+    nnz.saturating_mul(4) >= cells
 }
 
 #[cfg(test)]

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -1,0 +1,138 @@
+//! Unsymmetric LU factorization family for simplex basis factorization
+//! (issue #81).
+//!
+//! This is a **separate** factorization family from feral's symmetric LDLᵀ
+//! solver. An LU basis is unsymmetric and square, factored as `P B Q = L U`
+//! with threshold partial pivoting (row permutation `P`) and, on the sparse
+//! path, a fill-reducing column permutation `Q`. There is no inertia.
+//!
+//! The design target is a revised-simplex basis engine: cheap rank-1
+//! column-replacement updates and warm `ftran` (`B⁻¹a`) / `btran` (`B⁻ᵀa`)
+//! solves, not just one-shot factor/solve. See `dev/research/unsymmetric-lu.md`
+//! and `dev/plans/unsymmetric-lu-epic.md`.
+
+pub mod dense_matrix;
+
+pub use dense_matrix::GeneralMatrix;
+
+/// What to do when the LU factorization hits a numerically null pivot column.
+///
+/// Mirrors [`crate::dense::factor::ZeroPivotAction`] for the symmetric side.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LuSingularAction {
+    /// Return [`FeralError::SingularBasis`](crate::error::FeralError::SingularBasis).
+    Fail,
+    /// Replace the pivot with `sign(d) · max(|d|, abs_floor)` and continue.
+    PerturbToEps {
+        /// Lower bound applied to the perturbed pivot magnitude.
+        abs_floor: f64,
+    },
+}
+
+/// Two-sided scaling strategy for the LU basis (issue #81 robustness layer).
+///
+/// Mirrors the spirit of [`crate::scaling::ScalingStrategy`] but keeps the row
+/// and column scalings separate (the basis is unsymmetric).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LuScaling {
+    /// No scaling.
+    None,
+    /// Two-sided Knight–Ruiz ∞-norm equilibration.
+    InfNorm,
+    /// Unsymmetric MC64 (max-weight bipartite matching) scaling + row
+    /// permutation, with a partial-matching fall back to `InfNorm`.
+    Mc64,
+    /// MC64 first, then ∞-norm equilibration of the matched matrix.
+    Mc64ThenInfNorm,
+}
+
+/// Tuning parameters for the LU factorization and its updates.
+///
+/// Mirrors the shape of [`crate::dense::factor::BunchKaufmanParams`].
+#[derive(Debug, Clone)]
+pub struct LuParams {
+    /// Threshold partial-pivoting parameter `u ∈ (0, 1]`. `1.0` is strict
+    /// partial pivoting (max stability); smaller values permit a sparser /
+    /// closer-to-diagonal pivot when it is within `u·max` of the column max.
+    pub pivot_threshold: f64,
+    /// A pivot column with all candidates `≤ zero_pivot_tol` is singular.
+    pub zero_pivot_tol: f64,
+    /// Action on a singular pivot column.
+    pub on_singular: LuSingularAction,
+    /// `update()` returns `NeedsRefactor` when the growth monitor exceeds this.
+    pub max_growth: f64,
+    /// Hard cap on `updates_since_refactor` before `update()` returns
+    /// `NeedsRefactor`.
+    pub max_updates: usize,
+    /// Bases with `m` at or below this use the dense path unconditionally.
+    pub dense_threshold: usize,
+    /// Scaling strategy applied before factorization.
+    pub scaling: LuScaling,
+    /// Maximum iterative-refinement steps in `ftran_refined`/`btran_refined`.
+    pub refine_steps: usize,
+    /// Stop refinement when `‖r‖/‖a‖ < refine_tol`.
+    pub refine_tol: f64,
+}
+
+impl Default for LuParams {
+    fn default() -> Self {
+        LuParams {
+            pivot_threshold: 1.0,
+            zero_pivot_tol: 1e-13,
+            on_singular: LuSingularAction::Fail,
+            max_growth: 1e8,
+            max_updates: 64,
+            dense_threshold: 128,
+            scaling: LuScaling::None,
+            refine_steps: 0,
+            refine_tol: 1e-12,
+        }
+    }
+}
+
+/// Auto dense/sparse routing for an `m`×`m` basis with `nnz` stored entries.
+///
+/// Mirrors `crate::numeric::factorize::should_use_dense_fast_path`: tiny bases
+/// always go dense; small dense-enough bases (density ≥ 1/4) go dense; the rest
+/// go sparse. `dense_threshold` is the upper `m` bound for the density test.
+pub fn should_use_dense_lu(m: usize, nnz: usize, params: &LuParams) -> bool {
+    const M_TINY: usize = 16;
+    if m == 0 {
+        return false;
+    }
+    if m <= M_TINY {
+        return true;
+    }
+    if m > params.dense_threshold {
+        return false;
+    }
+    // Density gate: dense when at least a quarter of the cells are nonzero.
+    let cells = m * m;
+    nnz * 4 >= cells
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn router_tiny_is_dense() {
+        let p = LuParams::default();
+        assert!(should_use_dense_lu(8, 0, &p));
+        assert!(should_use_dense_lu(16, 0, &p));
+    }
+
+    #[test]
+    fn router_large_is_sparse() {
+        let p = LuParams::default();
+        assert!(!should_use_dense_lu(1000, 1000 * 1000, &p));
+    }
+
+    #[test]
+    fn router_density_gate() {
+        let p = LuParams::default();
+        // 64x64 = 4096 cells; dense iff nnz >= 1024.
+        assert!(!should_use_dense_lu(64, 1023, &p));
+        assert!(should_use_dense_lu(64, 1024, &p));
+    }
+}

--- a/src/lu/scaling.rs
+++ b/src/lu/scaling.rs
@@ -1,0 +1,261 @@
+//! Two-sided scaling for the LU basis (issue #81 robustness layer).
+//!
+//! [`LuScale`] holds a row permutation `Π` and diagonal row/column scalings
+//! `D_row`, `D_col` such that the *scaled* matrix `Ã = D_row · Π · B · D_col`
+//! is well balanced. The factorization factors `Ã`; the solves wrap the scaling
+//! around the core triangular solves (see the `apply_*` helpers).
+//!
+//! Two strategies:
+//!   * [`equilibrate_infnorm`] — Knight–Ruiz two-sided ∞-norm equilibration
+//!     (`Π = I`).
+//!   * [`mc64_unsymmetric`] — a maximum-weight bipartite matching that places
+//!     large entries on the diagonal, reusing feral's `hungarian_match` kernel;
+//!     `D_row`/`D_col` come from the matching duals. Falls back to ∞-norm
+//!     equilibration when the matching is not perfect.
+
+use super::sparse_matrix::SparseColMatrix;
+use super::LuScaling;
+use crate::error::FeralError;
+use crate::scaling::{hungarian_match, CostGraph};
+
+/// Row permutation + two-sided diagonal scaling. With `Ã = D_row Π B D_col`:
+/// `Ã[i,j] = d_row[i] · B[rperm[i], j] · d_col[j]`.
+#[derive(Debug, Clone)]
+pub struct LuScale {
+    /// `rperm[i]` = original row placed at scaled-row position `i`.
+    pub rperm: Vec<usize>,
+    /// Row scaling indexed by scaled-row position.
+    pub d_row: Vec<f64>,
+    /// Column scaling indexed by basis slot.
+    pub d_col: Vec<f64>,
+}
+
+impl LuScale {
+    /// Identity scaling (no row permutation, unit diagonals).
+    pub fn identity(m: usize) -> Self {
+        LuScale {
+            rperm: (0..m).collect(),
+            d_row: vec![1.0; m],
+            d_col: vec![1.0; m],
+        }
+    }
+
+    /// True when this is the identity scaling (cheap fast-path check).
+    pub fn is_identity(&self) -> bool {
+        self.rperm.iter().enumerate().all(|(i, &r)| i == r)
+            && self.d_row.iter().all(|&x| x == 1.0)
+            && self.d_col.iter().all(|&x| x == 1.0)
+    }
+
+    /// Build the scaled, row-permuted dense columns `Ã(:, j)` for factoring.
+    pub fn scaled_dense_columns(&self, b: &SparseColMatrix) -> Vec<Vec<f64>> {
+        let m = b.m;
+        let mut rperm_inv = vec![0usize; m];
+        for (i, &r) in self.rperm.iter().enumerate() {
+            rperm_inv[r] = i;
+        }
+        let mut cols = vec![vec![0.0; m]; m];
+        for (j, colj) in cols.iter_mut().enumerate() {
+            let (rows, vals) = b.column(j);
+            for (&r, &v) in rows.iter().zip(vals.iter()) {
+                let i = rperm_inv[r];
+                colj[i] = self.d_row[i] * v * self.d_col[j];
+            }
+        }
+        cols
+    }
+}
+
+impl LuScale {
+    /// Build the scaled, row-permuted matrix `Ã = D_row Π B D_col` in sparse
+    /// form (preserving sparsity).
+    pub fn apply_sparse(&self, b: &SparseColMatrix) -> Result<SparseColMatrix, FeralError> {
+        let m = b.m;
+        let mut rperm_inv = vec![0usize; m];
+        for (i, &r) in self.rperm.iter().enumerate() {
+            rperm_inv[r] = i;
+        }
+        let mut sparse_cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); m];
+        for (j, colj) in sparse_cols.iter_mut().enumerate() {
+            let (rows, vals) = b.column(j);
+            for (&r, &v) in rows.iter().zip(vals.iter()) {
+                let i = rperm_inv[r];
+                colj.push((i, self.d_row[i] * v * self.d_col[j]));
+            }
+        }
+        SparseColMatrix::from_sparse_columns(m, &sparse_cols)
+    }
+}
+
+/// Compute the scaling for `b` under `strategy`.
+pub fn compute_lu_scale(b: &SparseColMatrix, strategy: LuScaling) -> Result<LuScale, FeralError> {
+    match strategy {
+        LuScaling::None => Ok(LuScale::identity(b.m)),
+        LuScaling::InfNorm => Ok(equilibrate_infnorm(b, 5)),
+        LuScaling::Mc64 => mc64_unsymmetric(b),
+        LuScaling::Mc64ThenInfNorm => {
+            let mc = mc64_unsymmetric(b)?;
+            Ok(compose_with_infnorm(b, mc))
+        }
+    }
+}
+
+/// Knight–Ruiz two-sided ∞-norm equilibration (`Π = I`). Iterates row and
+/// column ∞-norm balancing.
+pub fn equilibrate_infnorm(b: &SparseColMatrix, iters: usize) -> LuScale {
+    let m = b.m;
+    let mut d_row = vec![1.0_f64; m];
+    let mut d_col = vec![1.0_f64; m];
+    for _ in 0..iters {
+        let mut row_max = vec![0.0_f64; m];
+        let mut col_max = vec![0.0_f64; m];
+        for (j, cmj) in col_max.iter_mut().enumerate() {
+            let (rows, vals) = b.column(j);
+            for (&i, &v) in rows.iter().zip(vals.iter()) {
+                let a = (d_row[i] * v * d_col[j]).abs();
+                if a > row_max[i] {
+                    row_max[i] = a;
+                }
+                if a > *cmj {
+                    *cmj = a;
+                }
+            }
+        }
+        for (dr, &rm) in d_row.iter_mut().zip(row_max.iter()) {
+            if rm > 0.0 {
+                *dr /= rm.sqrt();
+            }
+        }
+        for (dc, &cm) in d_col.iter_mut().zip(col_max.iter()) {
+            if cm > 0.0 {
+                *dc /= cm.sqrt();
+            }
+        }
+    }
+    LuScale {
+        rperm: (0..m).collect(),
+        d_row,
+        d_col,
+    }
+}
+
+/// Unsymmetric MC64: maximum-weight bipartite matching placing large entries on
+/// the diagonal, with `D_row`/`D_col` from the matching duals. Falls back to
+/// ∞-norm equilibration when the matching is not perfect.
+pub fn mc64_unsymmetric(b: &SparseColMatrix) -> Result<LuScale, FeralError> {
+    let m = b.m;
+    if m == 0 {
+        return Ok(LuScale::identity(0));
+    }
+    let (graph, cmax) = build_cost_graph(b);
+    let matching = hungarian_match(&graph);
+    if matching.n_matched != m {
+        // Structurally deficient matching → fall back to equilibration.
+        return Ok(equilibrate_infnorm(b, 5));
+    }
+    // rperm[j] = matched row of column j (puts it on the diagonal).
+    let rperm = matching.perm.clone();
+    // Column scaling from the column dual minus the column max.
+    let mut d_col = vec![1.0; m];
+    for (j, dc) in d_col.iter_mut().enumerate() {
+        *dc = clamp_exp(matching.v[j] - cmax[j]).exp();
+    }
+    // Row scaling (indexed by scaled-row position i, whose original row is
+    // rperm[i]) from the row dual.
+    let mut d_row = vec![1.0; m];
+    for (i, dr) in d_row.iter_mut().enumerate() {
+        *dr = clamp_exp(matching.u[rperm[i]]).exp();
+    }
+    Ok(LuScale {
+        rperm,
+        d_row,
+        d_col,
+    })
+}
+
+/// Refine an existing scale by a few ∞-norm equilibration sweeps applied to the
+/// already-scaled matrix (composes the diagonals; keeps the row permutation).
+fn compose_with_infnorm(b: &SparseColMatrix, mut scale: LuScale) -> LuScale {
+    let m = b.m;
+    let mut rperm_inv = vec![0usize; m];
+    for (i, &r) in scale.rperm.iter().enumerate() {
+        rperm_inv[r] = i;
+    }
+    for _ in 0..3 {
+        let mut row_max = vec![0.0_f64; m];
+        let mut col_max = vec![0.0_f64; m];
+        for (j, cmj) in col_max.iter_mut().enumerate() {
+            let (rows, vals) = b.column(j);
+            for (&r, &v) in rows.iter().zip(vals.iter()) {
+                let i = rperm_inv[r];
+                let a = (scale.d_row[i] * v * scale.d_col[j]).abs();
+                if a > row_max[i] {
+                    row_max[i] = a;
+                }
+                if a > *cmj {
+                    *cmj = a;
+                }
+            }
+        }
+        for (dr, &rm) in scale.d_row.iter_mut().zip(row_max.iter()) {
+            if rm > 0.0 {
+                *dr /= rm.sqrt();
+            }
+        }
+        for (dc, &cm) in scale.d_col.iter_mut().zip(col_max.iter()) {
+            if cm > 0.0 {
+                *dc /= cm.sqrt();
+            }
+        }
+    }
+    scale
+}
+
+/// `ln(f64::MAX) ≈ 709.78`; clamp dual sums to keep `exp` finite.
+fn clamp_exp(x: f64) -> f64 {
+    x.clamp(-709.0, 709.0)
+}
+
+/// Build the column-normalized log-cost bipartite graph for `hungarian_match`.
+/// Costs are `cmax[j] − ln|a|` (non-negative), per the MC64 recipe.
+fn build_cost_graph(b: &SparseColMatrix) -> (CostGraph, Vec<f64>) {
+    let m = b.m;
+    let mut col_ptr = Vec::with_capacity(m + 1);
+    let mut row_idx = Vec::new();
+    let mut cost = Vec::new();
+    let mut cmax = vec![f64::NEG_INFINITY; m];
+    col_ptr.push(0);
+    // First pass: cmax per column.
+    for (j, cm) in cmax.iter_mut().enumerate() {
+        let (_rows, vals) = b.column(j);
+        for &v in vals {
+            if v != 0.0 {
+                let c = v.abs().ln();
+                if c > *cm {
+                    *cm = c;
+                }
+            }
+        }
+    }
+    // Second pass: emit non-negative costs.
+    for (j, &cmax_j) in cmax.iter().enumerate() {
+        let (rows, vals) = b.column(j);
+        for (&i, &v) in rows.iter().zip(vals.iter()) {
+            if v != 0.0 {
+                let c = cmax_j - v.abs().ln();
+                row_idx.push(i);
+                cost.push(if c < 0.0 { 0.0 } else { c });
+            }
+        }
+        col_ptr.push(row_idx.len());
+    }
+    (
+        CostGraph {
+            n: m,
+            col_ptr,
+            row_idx,
+            cost,
+        },
+        cmax,
+    )
+}

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -104,6 +104,10 @@ pub struct SparseLu {
     pub(super) params: LuParams,
     /// Two-sided scaling of the factored matrix (identity when unscaled).
     pub(super) scale: LuScale,
+    /// Inverse of `scale.rperm` (original row -> scaled-row position), so the
+    /// sparse FT update can map an entering column's nonzeros into spike space
+    /// without an `O(n)` scan.
+    pub(super) scale_rperm_inv: Vec<usize>,
     pub(super) scratch: Vec<f64>,
     /// Reusable length-`m` boolean marker for the FT update's sparse spike
     /// (tracks touched positions so they can be cleared in `O(touched)`).
@@ -323,6 +327,12 @@ impl SparseLu {
             }
         }
 
+        // Inverse of the scaling row permutation, for sparse-spike seeding.
+        let mut scale_rperm_inv = vec![0usize; m];
+        for (i, &o) in scale.rperm.iter().enumerate() {
+            scale_rperm_inv[o] = i;
+        }
+
         Ok(SparseLu {
             m,
             l_col_ptr,
@@ -339,6 +349,7 @@ impl SparseLu {
             reach_visits,
             params,
             scale,
+            scale_rperm_inv,
             scratch: vec![0.0; m],
             scratch_mark: vec![false; m],
             ft_work: vec![0.0; m],

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -3,14 +3,14 @@
 //! Factors `P A Q = L U` with threshold partial pivoting. `Q` is the
 //! fill-reducing column ordering from [`SparseLuSymbolic`]; `P` is the row
 //! permutation from pivoting. `L` is unit lower triangular (strict-lower stored
-//! CSC, unit diagonal implicit) and `U` is upper triangular (strict-upper
-//! stored CSC plus an explicit diagonal), both in pivot-position coordinates.
+//! CSC, unit diagonal implicit); `U` is upper triangular stored row-wise (CSR,
+//! strict-upper, plus an explicit diagonal) so the Forrest–Tomlin update can do
+//! row operations on it. Both are in pivot-position coordinates.
 //!
 //! Each column `k` (processing original column `qcol[k]`) is computed by a
-//! forward substitution `L w = A(:,qcol[k])` in pivot order; entries landing on
-//! already-pivoted rows form `U(:,k)`, and the largest remaining entry is the
-//! new pivot. This is correct but not yet output-sensitive — the depth-first
-//! symbolic reach that makes it O(flops) is a documented follow-up.
+//! forward substitution `L w = A(:,qcol[k])`, output-sensitive via a
+//! Gilbert–Peierls depth-first reach: the numeric solve runs only over the
+//! pivot positions reachable from the nonzeros of `A(:,qcol[k])`.
 
 use super::scaling::{compute_lu_scale, LuScale};
 use super::sparse_symbolic::SparseLuSymbolic;
@@ -38,9 +38,11 @@ pub struct SparseLu {
     pub(super) l_col_ptr: Vec<usize>,
     pub(super) l_row_idx: Vec<usize>,
     pub(super) l_val: Vec<f64>,
-    // U: strict-upper stored CSC (pivot-position rows) + explicit diagonal.
-    pub(super) u_col_ptr: Vec<usize>,
-    pub(super) u_row_idx: Vec<usize>,
+    // U: strict-upper stored row-wise (CSR, pivot-position rows, ascending
+    // column positions) + explicit diagonal. Row-wise so the Forrest–Tomlin
+    // update can do row operations on U.
+    pub(super) u_row_ptr: Vec<usize>,
+    pub(super) u_col_idx: Vec<usize>,
     pub(super) u_val: Vec<f64>,
     pub(super) u_diag: Vec<f64>,
     /// `perm[k]` = original row in pivot position `k` (`(P a)[k] = a[perm[k]]`).
@@ -247,13 +249,17 @@ impl SparseLu {
         let perm_inv: Vec<usize> = pinv.iter().map(|&p| p as usize).collect();
         remap_and_sort_l(&l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
 
+        // Transpose U from column-wise (built above) to row-wise CSR. Columns
+        // were emitted in increasing order, so each row ends up column-sorted.
+        let (u_row_ptr, u_col_idx, u_val) = transpose_to_csr(&u_col_ptr, &u_row_idx, &u_val, m);
+
         Ok(SparseLu {
             m,
             l_col_ptr,
             l_row_idx,
             l_val,
-            u_col_ptr,
-            u_row_idx,
+            u_row_ptr,
+            u_col_idx,
             u_val,
             u_diag,
             perm,
@@ -328,14 +334,50 @@ impl SparseLu {
         if i == j {
             return self.u_diag[j];
         }
-        let (s, e) = (self.u_col_ptr[j], self.u_col_ptr[j + 1]);
+        if i > j {
+            return 0.0;
+        }
+        let (s, e) = (self.u_row_ptr[i], self.u_row_ptr[i + 1]);
         for idx in s..e {
-            if self.u_row_idx[idx] == i {
+            if self.u_col_idx[idx] == j {
                 return self.u_val[idx];
             }
         }
         0.0
     }
+}
+
+/// Transpose a strict-upper `U` from column-wise CSC (`col_ptr` over columns,
+/// `row_idx` = pivot-row positions) to row-wise CSR. Columns are assumed
+/// emitted in ascending order, so each output row is column-sorted.
+fn transpose_to_csr(
+    col_ptr: &[usize],
+    row_idx: &[usize],
+    val: &[f64],
+    m: usize,
+) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
+    let nnz = val.len();
+    let mut row_cnt = vec![0usize; m];
+    for &r in row_idx.iter() {
+        row_cnt[r] += 1;
+    }
+    let mut row_ptr = vec![0usize; m + 1];
+    for i in 0..m {
+        row_ptr[i + 1] = row_ptr[i] + row_cnt[i];
+    }
+    let mut col_idx = vec![0usize; nnz];
+    let mut out_val = vec![0.0; nnz];
+    let mut next: Vec<usize> = row_ptr[..m].to_vec();
+    for k in 0..m {
+        for idx in col_ptr[k]..col_ptr[k + 1] {
+            let r = row_idx[idx];
+            let dst = next[r];
+            next[r] += 1;
+            col_idx[dst] = k;
+            out_val[dst] = val[idx];
+        }
+    }
+    (row_ptr, col_idx, out_val)
 }
 
 /// Remap L's original row indices to pivot positions and sort each column.

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -18,16 +18,51 @@ use super::{LuParams, LuScaling, LuSingularAction};
 use crate::error::FeralError;
 use crate::lu::sparse_matrix::SparseColMatrix;
 
-/// One product-form update of the `U` factor (issue #81 sparse rank-1 update).
-///
-/// Replacing column `q` of the current factorization by a new column yields
-/// `U' = U·F` with `F = I + (τ − e_q)e_qᵀ`, where `τ` is the transformed spike.
-/// We store `(q, τ)` and apply `F⁻¹` after the `U`-solve in `ftran` (and its
-/// transpose in `btran`). `τ[q]` is the update's pivot / stability monitor.
+/// One elementary operation of a Forrest–Tomlin update's bump elimination,
+/// recorded so it can be replayed on a solve vector (and transposed for btran).
 #[derive(Debug, Clone)]
-pub(super) struct EtaU {
-    pub q: usize,
-    pub tau: Vec<f64>,
+pub(super) enum FtOp {
+    /// Swap two pivot positions (partial-pivot row interchange in the bump).
+    Swap(usize, usize),
+    /// `target_row -= mult · src_row` (Gauss elimination of a sub-diagonal).
+    Axpy {
+        target: usize,
+        src: usize,
+        mult: f64,
+    },
+}
+
+/// One Forrest–Tomlin column-replacement update: the sequence of elementary row
+/// operations (partial-pivot swaps + eliminations) that re-triangularized `U`
+/// after the spike was inserted. The base `L` is never touched; these ops are
+/// replayed on the solve vector between the `L`-solve and the `U`-solve in
+/// `ftran` (transposed, in reverse, between `Uᵀ` and `Lᵀ` in `btran`). Because
+/// the bump is local and sparse, each eta is `O(bump)` — no dense `τ`.
+#[derive(Debug, Clone)]
+pub(super) struct FtEta {
+    pub ops: Vec<FtOp>,
+}
+
+impl FtEta {
+    /// Apply this elimination `E` forward to `y` (`y ← E y`).
+    pub(super) fn apply_forward(&self, y: &mut [f64]) {
+        for op in self.ops.iter() {
+            match *op {
+                FtOp::Swap(a, b) => y.swap(a, b),
+                FtOp::Axpy { target, src, mult } => y[target] -= mult * y[src],
+            }
+        }
+    }
+
+    /// Apply `Eᵀ` to `y` (reverse the ops, transpose each).
+    pub(super) fn apply_transpose(&self, y: &mut [f64]) {
+        for op in self.ops.iter().rev() {
+            match *op {
+                FtOp::Swap(a, b) => y.swap(a, b),
+                FtOp::Axpy { target, src, mult } => y[src] -= mult * y[target],
+            }
+        }
+    }
 }
 
 /// Sparse LU factorization of a square basis.
@@ -49,9 +84,11 @@ pub struct SparseLu {
     pub(super) qcol: Vec<usize>,
     /// Inverse of `qcol`: `qcol_inv[original_col] = column_position`.
     pub(super) qcol_inv: Vec<usize>,
-    /// Product-form `U`-updates applied since the last factor/refactor.
-    pub(super) etas: Vec<EtaU>,
-    /// Running growth monitor (max `1/|τ_q|` over the updates).
+    /// Forrest–Tomlin column-replacement updates applied since the last
+    /// factor/refactor. Each is a replayable bump elimination (`O(bump)`), so
+    /// warm solves stay sparse (no dense eta chain).
+    pub(super) etas: Vec<FtEta>,
+    /// Running growth monitor (max elimination multiplier over the updates).
     pub(super) growth: f64,
     /// Total Gilbert–Peierls reach nodes visited during the factor — a
     /// structural scalability witness (`O(nnz(U))`, not `O(n²)`).

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -53,6 +53,9 @@ pub struct SparseLu {
     pub(super) etas: Vec<EtaU>,
     /// Running growth monitor (max `1/|τ_q|` over the updates).
     pub(super) growth: f64,
+    /// Total Gilbert–Peierls reach nodes visited during the factor — a
+    /// structural scalability witness (`O(nnz(U))`, not `O(n²)`).
+    pub(super) reach_visits: usize,
     pub(super) params: LuParams,
     /// Two-sided scaling of the factored matrix (identity when unscaled).
     pub(super) scale: LuScale,
@@ -103,8 +106,14 @@ impl SparseLu {
         u_col_ptr.push(0);
         let mut u_diag = vec![0.0_f64; m];
 
+        // Gilbert–Peierls symbolic workspace: depth-first reach of each column.
+        let mut reach_mark = vec![false; m];
+        let mut reach: Vec<usize> = Vec::new();
+        let mut dfs_stack: Vec<usize> = Vec::new();
+
         let utol = params.pivot_threshold;
         let ztol = params.zero_pivot_tol;
+        let mut reach_visits = 0usize;
 
         for k in 0..m {
             // Scatter A(:, qcol[k]) into w.
@@ -117,9 +126,39 @@ impl SparseLu {
                 }
             }
 
-            // Forward substitution in pivot order; collect U(:,k) entries.
-            let mut u_entries: Vec<(usize, f64)> = Vec::new();
-            for p in 0..k {
+            // Symbolic: depth-first reach of column k over the graph of L.
+            // A pivot position p < k contributes to column k iff its pivot row
+            // is reachable from the nonzeros of A(:,qcol[k]); edges run from a
+            // column to the pivot positions of its (already-pivoted) rows. All
+            // edges point to strictly larger positions, so ascending position
+            // order is a valid topological order for the numeric solve.
+            reach.clear();
+            for &i in rows.iter() {
+                let pp = pinv[i];
+                if pp >= 0 && !reach_mark[pp as usize] {
+                    reach_mark[pp as usize] = true;
+                    reach.push(pp as usize);
+                    dfs_stack.push(pp as usize);
+                }
+            }
+            while let Some(p) = dfs_stack.pop() {
+                let (ls, le) = (l_col_ptr[p], l_col_ptr[p + 1]);
+                for idx in ls..le {
+                    let pp = pinv[l_row_idx[idx]];
+                    if pp >= 0 && !reach_mark[pp as usize] {
+                        reach_mark[pp as usize] = true;
+                        reach.push(pp as usize);
+                        dfs_stack.push(pp as usize);
+                    }
+                }
+            }
+            reach.sort_unstable();
+            reach_visits += reach.len();
+
+            // Numeric forward substitution over the reach; collect U(:,k).
+            let mut u_entries: Vec<(usize, f64)> = Vec::with_capacity(reach.len());
+            for &p in reach.iter() {
+                reach_mark[p] = false; // clear for the next column
                 let r = perm[p];
                 let xp = w[r];
                 if xp == 0.0 {
@@ -129,8 +168,7 @@ impl SparseLu {
                 let (ls, le) = (l_col_ptr[p], l_col_ptr[p + 1]);
                 for idx in ls..le {
                     let i = l_row_idx[idx];
-                    let before = w[i];
-                    w[i] = before - xp * l_val[idx];
+                    w[i] -= xp * l_val[idx];
                     if !mark[i] {
                         mark[i] = true;
                         touched.push(i);
@@ -223,6 +261,7 @@ impl SparseLu {
             qcol_inv,
             etas: Vec::new(),
             growth: 1.0,
+            reach_visits,
             params,
             scale,
             scratch: vec![0.0; m],
@@ -261,6 +300,13 @@ impl SparseLu {
     /// Total stored nonzeros in `L` and `U` (including the `U` diagonal).
     pub fn factor_nnz(&self) -> usize {
         self.l_val.len() + self.u_val.len() + self.m
+    }
+
+    /// Total Gilbert–Peierls reach nodes visited during the factorization.
+    /// This is `O(nnz(U))` (output-sensitive); it would be `O(n²)` if the
+    /// factor scanned all prior columns. Used by the scalability guard test.
+    pub fn reach_visits(&self) -> usize {
+        self.reach_visits
     }
 
     /// Reconstruct dense entry `(i, j)` of `L` (pivot-position coordinates).

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -17,6 +17,18 @@ use super::{LuParams, LuSingularAction};
 use crate::error::FeralError;
 use crate::lu::sparse_matrix::SparseColMatrix;
 
+/// One product-form update of the `U` factor (issue #81 sparse rank-1 update).
+///
+/// Replacing column `q` of the current factorization by a new column yields
+/// `U' = U·F` with `F = I + (τ − e_q)e_qᵀ`, where `τ` is the transformed spike.
+/// We store `(q, τ)` and apply `F⁻¹` after the `U`-solve in `ftran` (and its
+/// transpose in `btran`). `τ[q]` is the update's pivot / stability monitor.
+#[derive(Debug, Clone)]
+pub(super) struct EtaU {
+    pub q: usize,
+    pub tau: Vec<f64>,
+}
+
 /// Sparse LU factorization of a square basis.
 #[derive(Debug, Clone)]
 pub struct SparseLu {
@@ -34,6 +46,12 @@ pub struct SparseLu {
     pub(super) perm: Vec<usize>,
     /// Column order: factorization column `k` is original column `qcol[k]`.
     pub(super) qcol: Vec<usize>,
+    /// Inverse of `qcol`: `qcol_inv[original_col] = column_position`.
+    pub(super) qcol_inv: Vec<usize>,
+    /// Product-form `U`-updates applied since the last factor/refactor.
+    pub(super) etas: Vec<EtaU>,
+    /// Running growth monitor (max `1/|τ_q|` over the updates).
+    pub(super) growth: f64,
     pub(super) params: LuParams,
     pub(super) scratch: Vec<f64>,
 }
@@ -176,7 +194,6 @@ impl SparseLu {
         // Remap L's stored original rows to pivot positions, then sort columns.
         let perm_inv: Vec<usize> = pinv.iter().map(|&p| p as usize).collect();
         remap_and_sort_l(&l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
-        let _ = qcol_inv; // used by the update path (added with Forrest–Tomlin)
 
         Ok(SparseLu {
             m,
@@ -189,6 +206,9 @@ impl SparseLu {
             u_diag,
             perm,
             qcol,
+            qcol_inv,
+            etas: Vec::new(),
+            growth: 1.0,
             params,
             scratch: vec![0.0; m],
         })

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -1,0 +1,282 @@
+//! Sparse unsymmetric LU factorization (left-looking, Gilbert–Peierls style).
+//!
+//! Factors `P A Q = L U` with threshold partial pivoting. `Q` is the
+//! fill-reducing column ordering from [`SparseLuSymbolic`]; `P` is the row
+//! permutation from pivoting. `L` is unit lower triangular (strict-lower stored
+//! CSC, unit diagonal implicit) and `U` is upper triangular (strict-upper
+//! stored CSC plus an explicit diagonal), both in pivot-position coordinates.
+//!
+//! Each column `k` (processing original column `qcol[k]`) is computed by a
+//! forward substitution `L w = A(:,qcol[k])` in pivot order; entries landing on
+//! already-pivoted rows form `U(:,k)`, and the largest remaining entry is the
+//! new pivot. This is correct but not yet output-sensitive — the depth-first
+//! symbolic reach that makes it O(flops) is a documented follow-up.
+
+use super::sparse_symbolic::SparseLuSymbolic;
+use super::{LuParams, LuSingularAction};
+use crate::error::FeralError;
+use crate::lu::sparse_matrix::SparseColMatrix;
+
+/// Sparse LU factorization of a square basis.
+#[derive(Debug, Clone)]
+pub struct SparseLu {
+    pub(super) m: usize,
+    // L: unit lower triangular, strict-lower stored CSC, pivot-position rows.
+    pub(super) l_col_ptr: Vec<usize>,
+    pub(super) l_row_idx: Vec<usize>,
+    pub(super) l_val: Vec<f64>,
+    // U: strict-upper stored CSC (pivot-position rows) + explicit diagonal.
+    pub(super) u_col_ptr: Vec<usize>,
+    pub(super) u_row_idx: Vec<usize>,
+    pub(super) u_val: Vec<f64>,
+    pub(super) u_diag: Vec<f64>,
+    /// `perm[k]` = original row in pivot position `k` (`(P a)[k] = a[perm[k]]`).
+    pub(super) perm: Vec<usize>,
+    /// Column order: factorization column `k` is original column `qcol[k]`.
+    pub(super) qcol: Vec<usize>,
+    pub(super) params: LuParams,
+    pub(super) scratch: Vec<f64>,
+}
+
+impl SparseLu {
+    /// Factor `a` using the column ordering in `symbolic`.
+    pub fn factor(
+        a: &SparseColMatrix,
+        symbolic: &SparseLuSymbolic,
+        params: LuParams,
+    ) -> Result<Self, FeralError> {
+        let m = a.m;
+        if symbolic.m != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: symbolic.m,
+            });
+        }
+        let qcol = symbolic.qcol.clone();
+        let qcol_inv = symbolic.qcol_inv.clone();
+
+        let mut w = vec![0.0_f64; m];
+        let mut mark = vec![false; m];
+        let mut touched: Vec<usize> = Vec::new();
+        let mut pinv: Vec<isize> = vec![-1; m];
+        let mut perm = vec![0usize; m]; // pivot pos -> orig row
+
+        let mut l_col_ptr = Vec::with_capacity(m + 1);
+        let mut l_row_idx: Vec<usize> = Vec::new(); // original rows, remapped later
+        let mut l_val: Vec<f64> = Vec::new();
+        l_col_ptr.push(0);
+        let mut u_col_ptr = Vec::with_capacity(m + 1);
+        let mut u_row_idx: Vec<usize> = Vec::new();
+        let mut u_val: Vec<f64> = Vec::new();
+        u_col_ptr.push(0);
+        let mut u_diag = vec![0.0_f64; m];
+
+        let utol = params.pivot_threshold;
+        let ztol = params.zero_pivot_tol;
+
+        for k in 0..m {
+            // Scatter A(:, qcol[k]) into w.
+            let (rows, vals) = a.column(qcol[k]);
+            for (&i, &v) in rows.iter().zip(vals.iter()) {
+                w[i] = v;
+                if !mark[i] {
+                    mark[i] = true;
+                    touched.push(i);
+                }
+            }
+
+            // Forward substitution in pivot order; collect U(:,k) entries.
+            let mut u_entries: Vec<(usize, f64)> = Vec::new();
+            for p in 0..k {
+                let r = perm[p];
+                let xp = w[r];
+                if xp == 0.0 {
+                    continue;
+                }
+                u_entries.push((p, xp));
+                let (ls, le) = (l_col_ptr[p], l_col_ptr[p + 1]);
+                for idx in ls..le {
+                    let i = l_row_idx[idx];
+                    let before = w[i];
+                    w[i] = before - xp * l_val[idx];
+                    if !mark[i] {
+                        mark[i] = true;
+                        touched.push(i);
+                    }
+                }
+            }
+
+            // Pivot selection among unpivoted touched rows (partial pivoting).
+            let mut amax = 0.0_f64;
+            let mut ipiv: isize = -1;
+            for &i in touched.iter() {
+                if pinv[i] < 0 {
+                    let av = w[i].abs();
+                    if av > amax {
+                        amax = av;
+                        ipiv = i as isize;
+                    }
+                }
+            }
+
+            let mut piv;
+            let pivot_row: usize;
+            if amax <= ztol {
+                match params.on_singular {
+                    LuSingularAction::Fail => {
+                        return Err(FeralError::SingularBasis { column: k });
+                    }
+                    LuSingularAction::PerturbToEps { abs_floor } => {
+                        // Choose any still-unpivoted row and floor the pivot.
+                        let r = (0..m)
+                            .find(|&i| pinv[i] < 0)
+                            .ok_or(FeralError::SingularBasis { column: k })?;
+                        pivot_row = r;
+                        let s = if w[r] < 0.0 { -1.0 } else { 1.0 };
+                        piv = s * abs_floor.max(w[r].abs());
+                    }
+                }
+            } else {
+                // Threshold partial pivoting: take the max (u=1 default).
+                let _ = utol;
+                pivot_row = ipiv as usize;
+                piv = w[pivot_row];
+                if piv.abs() <= ztol {
+                    piv = if piv < 0.0 { -ztol } else { ztol };
+                }
+            }
+
+            pinv[pivot_row] = k as isize;
+            perm[k] = pivot_row;
+            u_diag[k] = piv;
+            for (p, v) in u_entries.into_iter() {
+                u_row_idx.push(p);
+                u_val.push(v);
+            }
+            u_col_ptr.push(u_row_idx.len());
+
+            // L(:,k): unpivoted touched rows (excluding the pivot) / piv.
+            let inv = 1.0 / piv;
+            for &i in touched.iter() {
+                if pinv[i] < 0 && w[i] != 0.0 {
+                    l_row_idx.push(i); // original row, remapped after the loop
+                    l_val.push(w[i] * inv);
+                }
+            }
+            l_col_ptr.push(l_row_idx.len());
+
+            // Clear w / mark for the next column.
+            for &i in touched.iter() {
+                w[i] = 0.0;
+                mark[i] = false;
+            }
+            touched.clear();
+        }
+
+        // Remap L's stored original rows to pivot positions, then sort columns.
+        let perm_inv: Vec<usize> = pinv.iter().map(|&p| p as usize).collect();
+        remap_and_sort_l(&l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
+        let _ = qcol_inv; // used by the update path (added with Forrest–Tomlin)
+
+        Ok(SparseLu {
+            m,
+            l_col_ptr,
+            l_row_idx,
+            l_val,
+            u_col_ptr,
+            u_row_idx,
+            u_val,
+            u_diag,
+            perm,
+            qcol,
+            params,
+            scratch: vec![0.0; m],
+        })
+    }
+
+    /// Convenience: analyze + factor from dense columns.
+    pub fn factor_dense_columns(
+        m: usize,
+        cols: &[Vec<f64>],
+        params: LuParams,
+    ) -> Result<Self, FeralError> {
+        let a = SparseColMatrix::from_dense_columns(m, cols)?;
+        let symbolic = SparseLuSymbolic::analyze(&a)?;
+        SparseLu::factor(&a, &symbolic, params)
+    }
+
+    /// Basis dimension.
+    #[inline]
+    pub fn dim(&self) -> usize {
+        self.m
+    }
+
+    /// Row permutation: `perm[k]` = original row in pivot position `k`.
+    #[inline]
+    pub fn perm(&self) -> &[usize] {
+        &self.perm
+    }
+
+    /// Column order: `qcol[k]` = original column in position `k`.
+    #[inline]
+    pub fn qcol(&self) -> &[usize] {
+        &self.qcol
+    }
+
+    /// Total stored nonzeros in `L` and `U` (including the `U` diagonal).
+    pub fn factor_nnz(&self) -> usize {
+        self.l_val.len() + self.u_val.len() + self.m
+    }
+
+    /// Reconstruct dense entry `(i, j)` of `L` (pivot-position coordinates).
+    pub fn l_dense(&self, i: usize, j: usize) -> f64 {
+        if i == j {
+            return 1.0;
+        }
+        let (s, e) = (self.l_col_ptr[j], self.l_col_ptr[j + 1]);
+        for idx in s..e {
+            if self.l_row_idx[idx] == i {
+                return self.l_val[idx];
+            }
+        }
+        0.0
+    }
+
+    /// Reconstruct dense entry `(i, j)` of `U` (pivot-position coordinates).
+    pub fn u_dense(&self, i: usize, j: usize) -> f64 {
+        if i == j {
+            return self.u_diag[j];
+        }
+        let (s, e) = (self.u_col_ptr[j], self.u_col_ptr[j + 1]);
+        for idx in s..e {
+            if self.u_row_idx[idx] == i {
+                return self.u_val[idx];
+            }
+        }
+        0.0
+    }
+}
+
+/// Remap L's original row indices to pivot positions and sort each column.
+fn remap_and_sort_l(
+    col_ptr: &[usize],
+    row_idx: &mut [usize],
+    val: &mut [f64],
+    perm_inv: &[usize],
+    m: usize,
+) {
+    for r in row_idx.iter_mut() {
+        *r = perm_inv[*r];
+    }
+    let mut order: Vec<usize> = Vec::new();
+    for j in 0..m {
+        let (s, e) = (col_ptr[j], col_ptr[j + 1]);
+        order.clear();
+        order.extend(s..e);
+        order.sort_by_key(|&idx| row_idx[idx]);
+        let rows: Vec<usize> = order.iter().map(|&idx| row_idx[idx]).collect();
+        let vals: Vec<f64> = order.iter().map(|&idx| val[idx]).collect();
+        row_idx[s..e].copy_from_slice(&rows);
+        val[s..e].copy_from_slice(&vals);
+    }
+}

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -38,13 +38,11 @@ pub struct SparseLu {
     pub(super) l_col_ptr: Vec<usize>,
     pub(super) l_row_idx: Vec<usize>,
     pub(super) l_val: Vec<f64>,
-    // U: strict-upper stored row-wise (CSR, pivot-position rows, ascending
-    // column positions) + explicit diagonal. Row-wise so the Forrest–Tomlin
-    // update can do row operations on U.
-    pub(super) u_row_ptr: Vec<usize>,
-    pub(super) u_col_idx: Vec<usize>,
-    pub(super) u_val: Vec<f64>,
-    pub(super) u_diag: Vec<f64>,
+    // U: upper triangular, one sorted row per pivot position, each row a list
+    // of `(column_position, value)` with column >= row and the diagonal entry
+    // FIRST (column == row). Mutable per-row storage so the Forrest–Tomlin
+    // update can do in-place row operations.
+    pub(super) u_rows: Vec<Vec<(usize, f64)>>,
     /// `perm[k]` = original row in pivot position `k` (`(P a)[k] = a[perm[k]]`).
     pub(super) perm: Vec<usize>,
     /// Column order: factorization column `k` is original column `qcol[k]`.
@@ -249,19 +247,26 @@ impl SparseLu {
         let perm_inv: Vec<usize> = pinv.iter().map(|&p| p as usize).collect();
         remap_and_sort_l(&l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
 
-        // Transpose U from column-wise (built above) to row-wise CSR. Columns
-        // were emitted in increasing order, so each row ends up column-sorted.
+        // Transpose U from column-wise (built above) to row-wise CSR, then into
+        // per-row vectors with the diagonal entry first. Columns were emitted in
+        // increasing order, so each row's strict-upper entries are sorted.
         let (u_row_ptr, u_col_idx, u_val) = transpose_to_csr(&u_col_ptr, &u_row_idx, &u_val, m);
+        let mut u_rows: Vec<Vec<(usize, f64)>> = Vec::with_capacity(m);
+        for i in 0..m {
+            let mut row = Vec::with_capacity(1 + (u_row_ptr[i + 1] - u_row_ptr[i]));
+            row.push((i, u_diag[i])); // diagonal first
+            for idx in u_row_ptr[i]..u_row_ptr[i + 1] {
+                row.push((u_col_idx[idx], u_val[idx]));
+            }
+            u_rows.push(row);
+        }
 
         Ok(SparseLu {
             m,
             l_col_ptr,
             l_row_idx,
             l_val,
-            u_row_ptr,
-            u_col_idx,
-            u_val,
-            u_diag,
+            u_rows,
             perm,
             qcol,
             qcol_inv,
@@ -305,7 +310,7 @@ impl SparseLu {
 
     /// Total stored nonzeros in `L` and `U` (including the `U` diagonal).
     pub fn factor_nnz(&self) -> usize {
-        self.l_val.len() + self.u_val.len() + self.m
+        self.l_val.len() + self.u_rows.iter().map(|r| r.len()).sum::<usize>()
     }
 
     /// Total Gilbert–Peierls reach nodes visited during the factorization.
@@ -331,16 +336,12 @@ impl SparseLu {
 
     /// Reconstruct dense entry `(i, j)` of `U` (pivot-position coordinates).
     pub fn u_dense(&self, i: usize, j: usize) -> f64 {
-        if i == j {
-            return self.u_diag[j];
-        }
         if i > j {
             return 0.0;
         }
-        let (s, e) = (self.u_row_ptr[i], self.u_row_ptr[i + 1]);
-        for idx in s..e {
-            if self.u_col_idx[idx] == j {
-                return self.u_val[idx];
+        for &(c, v) in self.u_rows[i].iter() {
+            if c == j {
+                return v;
             }
         }
         0.0

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -80,10 +80,18 @@ pub struct SparseLu {
     pub(super) u_rows: Vec<Vec<(usize, f64)>>,
     /// `perm[k]` = original row in pivot position `k` (`(P a)[k] = a[perm[k]]`).
     pub(super) perm: Vec<usize>,
+    /// Inverse of `perm`: `perm_inv[orig_row] = pivot_position`. Used to seed the
+    /// sparse spike solve in the Forrest–Tomlin update.
+    pub(super) perm_inv: Vec<usize>,
     /// Column order: factorization column `k` is original column `qcol[k]`.
     pub(super) qcol: Vec<usize>,
     /// Inverse of `qcol`: `qcol_inv[original_col] = column_position`.
     pub(super) qcol_inv: Vec<usize>,
+    /// Column-wise index of `U`'s strict-upper part: `u_above[c]` is the sorted
+    /// list of rows `i < c` with `U[i,c] != 0`. Lets the FT update find column
+    /// `r`'s existing entries (for in-place replacement) without scanning all
+    /// rows. Maintained across updates; not used by the solves.
+    pub(super) u_above: Vec<Vec<usize>>,
     /// Forrest–Tomlin column-replacement updates applied since the last
     /// factor/refactor. Each is a replayable bump elimination (`O(bump)`), so
     /// warm solves stay sparse (no dense eta chain).
@@ -97,6 +105,13 @@ pub struct SparseLu {
     /// Two-sided scaling of the factored matrix (identity when unscaled).
     pub(super) scale: LuScale,
     pub(super) scratch: Vec<f64>,
+    /// Reusable length-`m` boolean marker for the FT update's sparse spike
+    /// (tracks touched positions so they can be cleared in `O(touched)`).
+    pub(super) scratch_mark: Vec<bool>,
+    /// Dedicated length-`m` work buffer for the FT update's sparse spike, kept
+    /// zeroed between updates. Separate from `scratch` (which the solves dirty),
+    /// so `compute_spike`'s sparse scatter can assume a clean buffer.
+    pub(super) ft_work: Vec<f64>,
 }
 
 impl SparseLu {
@@ -297,6 +312,16 @@ impl SparseLu {
             }
             u_rows.push(row);
         }
+        // Column-wise index of U's strict-upper entries (rows added in
+        // increasing order, so each `u_above[c]` is sorted ascending).
+        let mut u_above: Vec<Vec<usize>> = vec![Vec::new(); m];
+        for (i, row) in u_rows.iter().enumerate() {
+            for &(c, _) in row.iter() {
+                if c > i {
+                    u_above[c].push(i);
+                }
+            }
+        }
 
         Ok(SparseLu {
             m,
@@ -305,14 +330,18 @@ impl SparseLu {
             l_val,
             u_rows,
             perm,
+            perm_inv,
             qcol,
             qcol_inv,
+            u_above,
             etas: Vec::new(),
             growth: 1.0,
             reach_visits,
             params,
             scale,
             scratch: vec![0.0; m],
+            scratch_mark: vec![false; m],
+            ft_work: vec![0.0; m],
         })
     }
 

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -12,8 +12,9 @@
 //! new pivot. This is correct but not yet output-sensitive — the depth-first
 //! symbolic reach that makes it O(flops) is a documented follow-up.
 
+use super::scaling::{compute_lu_scale, LuScale};
 use super::sparse_symbolic::SparseLuSymbolic;
-use super::{LuParams, LuSingularAction};
+use super::{LuParams, LuScaling, LuSingularAction};
 use crate::error::FeralError;
 use crate::lu::sparse_matrix::SparseColMatrix;
 
@@ -53,6 +54,8 @@ pub struct SparseLu {
     /// Running growth monitor (max `1/|τ_q|` over the updates).
     pub(super) growth: f64,
     pub(super) params: LuParams,
+    /// Two-sided scaling of the factored matrix (identity when unscaled).
+    pub(super) scale: LuScale,
     pub(super) scratch: Vec<f64>,
 }
 
@@ -70,6 +73,17 @@ impl SparseLu {
                 got: symbolic.m,
             });
         }
+        // Scaling: factor Ã = D_row Π A D_col (pattern is invariant under row
+        // permutation/scaling, so the column ordering `symbolic` still applies).
+        let (scale, scaled) = if params.scaling == LuScaling::None {
+            (LuScale::identity(m), None)
+        } else {
+            let scale = compute_lu_scale(a, params.scaling)?;
+            let mat = scale.apply_sparse(a)?;
+            (scale, Some(mat))
+        };
+        let a: &SparseColMatrix = scaled.as_ref().unwrap_or(a);
+
         let qcol = symbolic.qcol.clone();
         let qcol_inv = symbolic.qcol_inv.clone();
 
@@ -210,6 +224,7 @@ impl SparseLu {
             etas: Vec::new(),
             growth: 1.0,
             params,
+            scale,
             scratch: vec![0.0; m],
         })
     }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -350,6 +350,18 @@ impl SparseLu {
         self.l_val.len() + self.u_rows.iter().map(|r| r.len()).sum::<usize>()
     }
 
+    /// Total elementary operations across all Forrest–Tomlin update etas — the
+    /// work a warm solve replays for the update chain. For bump-local updates
+    /// this stays `O(Σ bump)`, not `O(k·n)` (the structural FT witness).
+    pub fn eta_ops(&self) -> usize {
+        self.etas.iter().map(|e| e.ops.len()).sum()
+    }
+
+    /// Operations in the most recent update's eta (its bump cost).
+    pub fn last_eta_ops(&self) -> usize {
+        self.etas.last().map(|e| e.ops.len()).unwrap_or(0)
+    }
+
     /// Total Gilbert–Peierls reach nodes visited during the factorization.
     /// This is `O(nnz(U))` (output-sensitive); it would be `O(n²)` if the
     /// factor scanned all prior columns. Used by the scalability guard test.

--- a/src/lu/sparse_matrix.rs
+++ b/src/lu/sparse_matrix.rs
@@ -3,8 +3,9 @@
 //! Unlike [`crate::sparse::csc::CscMatrix`], which stores only the lower
 //! triangle of a *symmetric* matrix, an LU basis is general and every entry is
 //! stored. Columns are compressed; row indices within a column are sorted
-//! ascending. This module also builds the patterns the column ordering needs:
-//! the transpose and the `AᵀA` (column-intersection) graph.
+//! ascending. This module also builds the `AᵀA` (column-intersection) graph the
+//! column ordering needs (`ata_pattern`, via an internal row-wise pass — there
+//! is no standalone transpose; `matvec_transpose` applies `Aᵀ` to a vector).
 
 use crate::error::FeralError;
 use crate::sparse::csc::CscPattern;

--- a/src/lu/sparse_matrix.rs
+++ b/src/lu/sparse_matrix.rs
@@ -1,0 +1,240 @@
+//! General (unsymmetric) sparse square matrix in CSC form for the LU basis.
+//!
+//! Unlike [`crate::sparse::csc::CscMatrix`], which stores only the lower
+//! triangle of a *symmetric* matrix, an LU basis is general and every entry is
+//! stored. Columns are compressed; row indices within a column are sorted
+//! ascending. This module also builds the patterns the column ordering needs:
+//! the transpose and the `AᵀA` (column-intersection) graph.
+
+use crate::error::FeralError;
+use crate::sparse::csc::CscPattern;
+
+/// A general `m`×`m` sparse matrix in compressed-sparse-column form.
+#[derive(Debug, Clone)]
+pub struct SparseColMatrix {
+    /// Dimension (square).
+    pub m: usize,
+    /// Column pointers, length `m + 1`.
+    pub col_ptr: Vec<usize>,
+    /// Row indices, length `nnz`, sorted ascending within each column.
+    pub row_idx: Vec<usize>,
+    /// Stored values, length `nnz`.
+    pub values: Vec<f64>,
+}
+
+impl SparseColMatrix {
+    /// Number of stored entries.
+    #[inline]
+    pub fn nnz(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Build from `m` dense columns (compressing out exact zeros). `cols[j]` is
+    /// column `j`, length `m`. The simplex entry point for dense-ish columns.
+    pub fn from_dense_columns(m: usize, cols: &[Vec<f64>]) -> Result<Self, FeralError> {
+        if cols.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: cols.len(),
+            });
+        }
+        let mut col_ptr = Vec::with_capacity(m + 1);
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        col_ptr.push(0);
+        for col in cols.iter() {
+            if col.len() != m {
+                return Err(FeralError::DimensionMismatch {
+                    expected: m,
+                    got: col.len(),
+                });
+            }
+            for (i, &v) in col.iter().enumerate() {
+                if v != 0.0 {
+                    if !v.is_finite() {
+                        return Err(FeralError::InvalidInput(
+                            "LU basis column contains non-finite entries".to_string(),
+                        ));
+                    }
+                    row_idx.push(i);
+                    values.push(v);
+                }
+            }
+            col_ptr.push(row_idx.len());
+        }
+        let mat = SparseColMatrix {
+            m,
+            col_ptr,
+            row_idx,
+            values,
+        };
+        mat.validate()?;
+        Ok(mat)
+    }
+
+    /// Build from explicit sparse columns. `cols[j]` is a list of
+    /// `(row, value)` pairs for column `j` (need not be sorted; duplicates are
+    /// summed).
+    pub fn from_sparse_columns(m: usize, cols: &[Vec<(usize, f64)>]) -> Result<Self, FeralError> {
+        if cols.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: cols.len(),
+            });
+        }
+        let mut col_ptr = Vec::with_capacity(m + 1);
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        col_ptr.push(0);
+        let mut acc = vec![0.0_f64; m];
+        let mut touched = Vec::new();
+        for col in cols.iter() {
+            for &(r, v) in col.iter() {
+                if r >= m {
+                    return Err(FeralError::InvalidInput(format!(
+                        "row index {} out of range for dimension {}",
+                        r, m
+                    )));
+                }
+                if acc[r] == 0.0 {
+                    touched.push(r);
+                }
+                acc[r] += v;
+            }
+            touched.sort_unstable();
+            for &r in touched.iter() {
+                if acc[r] != 0.0 {
+                    row_idx.push(r);
+                    values.push(acc[r]);
+                }
+                acc[r] = 0.0;
+            }
+            touched.clear();
+            col_ptr.push(row_idx.len());
+        }
+        let mat = SparseColMatrix {
+            m,
+            col_ptr,
+            row_idx,
+            values,
+        };
+        mat.validate()?;
+        Ok(mat)
+    }
+
+    /// Validate dimensions, sortedness, and finiteness.
+    pub fn validate(&self) -> Result<(), FeralError> {
+        if self.col_ptr.len() != self.m + 1 {
+            return Err(FeralError::InvalidInput(
+                "col_ptr length != m+1".to_string(),
+            ));
+        }
+        if self.row_idx.len() != self.values.len() {
+            return Err(FeralError::InvalidInput(
+                "row_idx and values length mismatch".to_string(),
+            ));
+        }
+        for j in 0..self.m {
+            let (s, e) = (self.col_ptr[j], self.col_ptr[j + 1]);
+            if e < s || e > self.row_idx.len() {
+                return Err(FeralError::InvalidInput("malformed col_ptr".to_string()));
+            }
+            for k in s..e {
+                if self.row_idx[k] >= self.m {
+                    return Err(FeralError::InvalidInput(
+                        "row index out of range".to_string(),
+                    ));
+                }
+                if k > s && self.row_idx[k] <= self.row_idx[k - 1] {
+                    return Err(FeralError::InvalidInput(
+                        "row indices not strictly ascending".to_string(),
+                    ));
+                }
+            }
+        }
+        if self.values.iter().any(|x| !x.is_finite()) {
+            return Err(FeralError::InvalidInput("non-finite value".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Column `j` as `(row_indices, values)` slices.
+    #[inline]
+    pub fn column(&self, j: usize) -> (&[usize], &[f64]) {
+        let (s, e) = (self.col_ptr[j], self.col_ptr[j + 1]);
+        (&self.row_idx[s..e], &self.values[s..e])
+    }
+
+    /// `y = A · x`.
+    pub fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        for yi in y.iter_mut() {
+            *yi = 0.0;
+        }
+        for (j, &xj) in x.iter().enumerate().take(self.m) {
+            if xj == 0.0 {
+                continue;
+            }
+            let (rows, vals) = self.column(j);
+            for (&i, &v) in rows.iter().zip(vals.iter()) {
+                y[i] += v * xj;
+            }
+        }
+    }
+
+    /// `y = Aᵀ · x`.
+    pub fn matvec_transpose(&self, x: &[f64], y: &mut [f64]) {
+        for (j, yj) in y.iter_mut().enumerate().take(self.m) {
+            let (rows, vals) = self.column(j);
+            let mut acc = 0.0;
+            for (&i, &v) in rows.iter().zip(vals.iter()) {
+                acc += v * x[i];
+            }
+            *yj = acc;
+        }
+    }
+
+    /// The pattern of `AᵀA` as a full-symmetric [`CscPattern`] — the
+    /// column-intersection graph used for fill-reducing column ordering. Two
+    /// columns are adjacent iff they share a nonzero row. The diagonal is
+    /// included.
+    pub fn ata_pattern(&self) -> CscPattern {
+        let m = self.m;
+        // Row-wise lists: for each row, the columns with an entry there.
+        let mut row_cols: Vec<Vec<usize>> = vec![Vec::new(); m];
+        for j in 0..m {
+            let (rows, _) = self.column(j);
+            for &i in rows {
+                row_cols[i].push(j);
+            }
+        }
+        // Adjacency sets (use a marker array to dedup per column).
+        let mut adj: Vec<Vec<usize>> = vec![Vec::new(); m];
+        let mut mark = vec![usize::MAX; m];
+        for j in 0..m {
+            mark[j] = j; // include diagonal
+            adj[j].push(j);
+            let (rows, _) = self.column(j);
+            for &i in rows {
+                for &c in row_cols[i].iter() {
+                    if mark[c] != j {
+                        mark[c] = j;
+                        adj[j].push(c);
+                    }
+                }
+            }
+            adj[j].sort_unstable();
+        }
+        let mut col_ptr = Vec::with_capacity(m + 1);
+        let mut row_idx = Vec::new();
+        col_ptr.push(0);
+        for a in adj.iter() {
+            row_idx.extend_from_slice(a);
+            col_ptr.push(row_idx.len());
+        }
+        CscPattern {
+            n: m,
+            col_ptr,
+            row_idx,
+        }
+    }
+}

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -1,0 +1,190 @@
+//! Sparse `ftran` / `btran` triangular solves and iterative refinement.
+//!
+//! Mirrors the dense path with `P A Q = L U`: `ftran` solves `B x = a`,
+//! `btran` solves `Bᵀ x = a`, and `ftran_partial` returns the spike `L⁻¹ P a`.
+//! All triangular solves operate directly on the CSC factors (no explicit
+//! transpose: `Uᵀ`/`Lᵀ` solves read the same column structure).
+
+use super::sparse_factor::SparseLu;
+use super::sparse_matrix::SparseColMatrix;
+use crate::error::FeralError;
+
+impl SparseLu {
+    /// Solve `B x = a`, overwriting `rhs` with `x`.
+    pub fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch);
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.perm[k]];
+        }
+        self.lsolve(&mut s);
+        self.usolve(&mut s);
+        for (k, &wk) in s.iter().enumerate() {
+            rhs[self.qcol[k]] = wk;
+        }
+        self.scratch = s;
+        Ok(())
+    }
+
+    /// Solve `Bᵀ x = a`, overwriting `rhs` with `x`.
+    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch);
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.qcol[k]];
+        }
+        self.ut_solve(&mut s);
+        self.lt_solve(&mut s);
+        for (k, &vk) in s.iter().enumerate() {
+            rhs[self.perm[k]] = vk;
+        }
+        self.scratch = s;
+        Ok(())
+    }
+
+    /// Compute the spike `L⁻¹ P a`, overwriting `rhs` (input to the FT update).
+    pub fn ftran_partial(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        let mut s = std::mem::take(&mut self.scratch);
+        for (k, sk) in s.iter_mut().enumerate() {
+            *sk = rhs[self.perm[k]];
+        }
+        self.lsolve(&mut s);
+        rhs.copy_from_slice(&s);
+        self.scratch = s;
+        Ok(())
+    }
+
+    /// `ftran` with iterative refinement against the original basis `b`.
+    pub fn ftran_refined(
+        &mut self,
+        b: &SparseColMatrix,
+        rhs: &mut [f64],
+    ) -> Result<(), FeralError> {
+        check_len(rhs.len(), self.m)?;
+        let a = rhs.to_vec();
+        self.ftran(rhs)?;
+        self.refine(b, &a, rhs, false)
+    }
+
+    /// `btran` with iterative refinement against the original basis `b`.
+    pub fn btran_refined(
+        &mut self,
+        b: &SparseColMatrix,
+        rhs: &mut [f64],
+    ) -> Result<(), FeralError> {
+        check_len(rhs.len(), self.m)?;
+        let a = rhs.to_vec();
+        self.btran(rhs)?;
+        self.refine(b, &a, rhs, true)
+    }
+
+    /// Forward solve `L y = s` (unit lower), in place.
+    fn lsolve(&self, s: &mut [f64]) {
+        for k in 0..self.m {
+            let sk = s[k];
+            if sk == 0.0 {
+                continue;
+            }
+            let (lo, hi) = (self.l_col_ptr[k], self.l_col_ptr[k + 1]);
+            for idx in lo..hi {
+                s[self.l_row_idx[idx]] -= self.l_val[idx] * sk;
+            }
+        }
+    }
+
+    /// Back solve `U w = s` (upper), in place.
+    fn usolve(&self, s: &mut [f64]) {
+        for k in (0..self.m).rev() {
+            let sk = s[k] / self.u_diag[k];
+            s[k] = sk;
+            if sk == 0.0 {
+                continue;
+            }
+            let (lo, hi) = (self.u_col_ptr[k], self.u_col_ptr[k + 1]);
+            for idx in lo..hi {
+                s[self.u_row_idx[idx]] -= self.u_val[idx] * sk;
+            }
+        }
+    }
+
+    /// Forward solve `Uᵀ z = s` (`Uᵀ` lower), in place.
+    fn ut_solve(&self, s: &mut [f64]) {
+        for k in 0..self.m {
+            let mut acc = s[k];
+            let (lo, hi) = (self.u_col_ptr[k], self.u_col_ptr[k + 1]);
+            for idx in lo..hi {
+                acc -= self.u_val[idx] * s[self.u_row_idx[idx]];
+            }
+            s[k] = acc / self.u_diag[k];
+        }
+    }
+
+    /// Back solve `Lᵀ v = s` (`Lᵀ` unit upper), in place.
+    fn lt_solve(&self, s: &mut [f64]) {
+        for k in (0..self.m).rev() {
+            let mut acc = s[k];
+            let (lo, hi) = (self.l_col_ptr[k], self.l_col_ptr[k + 1]);
+            for idx in lo..hi {
+                acc -= self.l_val[idx] * s[self.l_row_idx[idx]];
+            }
+            s[k] = acc;
+        }
+    }
+
+    fn refine(
+        &mut self,
+        b: &SparseColMatrix,
+        a: &[f64],
+        x: &mut [f64],
+        transpose: bool,
+    ) -> Result<(), FeralError> {
+        let steps = self.params.refine_steps;
+        let tol = self.params.refine_tol;
+        if steps == 0 {
+            return Ok(());
+        }
+        let anorm = inf_norm(a);
+        if anorm == 0.0 {
+            return Ok(());
+        }
+        let mut r = vec![0.0; self.m];
+        for _ in 0..steps {
+            if transpose {
+                b.matvec_transpose(x, &mut r);
+            } else {
+                b.matvec(x, &mut r);
+            }
+            for (ri, &ai) in r.iter_mut().zip(a.iter()) {
+                *ri = ai - *ri;
+            }
+            if inf_norm(&r) / anorm < tol {
+                break;
+            }
+            if transpose {
+                self.btran(&mut r)?;
+            } else {
+                self.ftran(&mut r)?;
+            }
+            for (xi, &dxi) in x.iter_mut().zip(r.iter()) {
+                *xi += dxi;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn check_len(got: usize, expected: usize) -> Result<(), FeralError> {
+    if got != expected {
+        Err(FeralError::DimensionMismatch { expected, got })
+    } else {
+        Ok(())
+    }
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -1,9 +1,11 @@
 //! Sparse `ftran` / `btran` triangular solves and iterative refinement.
 //!
-//! Mirrors the dense path with `P A Q = L U`: `ftran` solves `B x = a`,
-//! `btran` solves `Bᵀ x = a`, and `ftran_partial` returns the spike `L⁻¹ P a`.
-//! All triangular solves operate directly on the CSC factors (no explicit
-//! transpose: `Uᵀ`/`Lᵀ` solves read the same column structure).
+//! Mirrors the dense path with `P A Q = L U F₁…Fₜ`, where the `Fᵢ` are the
+//! product-form `U`-updates (see [`super::sparse_update`]). `ftran` solves
+//! `B x = a`, `btran` solves `Bᵀ x = a`, and `ftran_partial` returns the spike
+//! `L⁻¹ P a`. Triangular solves operate directly on the CSC factors (no
+//! explicit transpose), and the eta updates are applied after the `U`-solve in
+//! `ftran` (transposed, in reverse, before the `Uᵀ`-solve in `btran`).
 
 use super::sparse_factor::SparseLu;
 use super::sparse_matrix::SparseColMatrix;
@@ -15,11 +17,7 @@ impl SparseLu {
         let m = self.m;
         check_len(rhs.len(), m)?;
         let mut s = std::mem::take(&mut self.scratch);
-        for (k, sk) in s.iter_mut().enumerate() {
-            *sk = rhs[self.perm[k]];
-        }
-        self.lsolve(&mut s);
-        self.usolve(&mut s);
+        self.solve_colspace(rhs, &mut s);
         for (k, &wk) in s.iter().enumerate() {
             rhs[self.qcol[k]] = wk;
         }
@@ -35,6 +33,7 @@ impl SparseLu {
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.qcol[k]];
         }
+        self.apply_etas_transpose_reverse(&mut s);
         self.ut_solve(&mut s);
         self.lt_solve(&mut s);
         for (k, &vk) in s.iter().enumerate() {
@@ -44,7 +43,9 @@ impl SparseLu {
         Ok(())
     }
 
-    /// Compute the spike `L⁻¹ P a`, overwriting `rhs` (input to the FT update).
+    /// Compute the spike `L⁻¹ P a` (base factor only, no eta/`U`), overwriting
+    /// `rhs`. Exposed for inspection; the update computes its own transformed
+    /// spike internally.
     pub fn ftran_partial(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
@@ -80,6 +81,48 @@ impl SparseLu {
         let a = rhs.to_vec();
         self.btran(rhs)?;
         self.refine(b, &a, rhs, true)
+    }
+
+    /// Solve into column-position space: `out = F⁻¹ U⁻¹ L⁻¹ P · rhs` (the
+    /// `ftran` result before the final `Q` scatter). Shared by `ftran` and the
+    /// rank-1 update (which reads `out[qcol_inv[slot]]` as the update pivot).
+    pub(super) fn solve_colspace(&self, rhs: &[f64], out: &mut [f64]) {
+        for (k, ok) in out.iter_mut().enumerate() {
+            *ok = rhs[self.perm[k]];
+        }
+        self.lsolve(out);
+        self.usolve(out);
+        self.apply_etas_forward(out);
+    }
+
+    /// Apply all product-form updates `F₁⁻¹ … Fₜ⁻¹` (chronological order).
+    fn apply_etas_forward(&self, s: &mut [f64]) {
+        for eta in self.etas.iter() {
+            let q = eta.q;
+            let tq = eta.tau[q];
+            let zq = s[q] / tq;
+            for (j, &tj) in eta.tau.iter().enumerate() {
+                if j != q {
+                    s[j] -= tj * zq;
+                }
+            }
+            s[q] = zq;
+        }
+    }
+
+    /// Apply `(F₁⁻¹ … Fₜ⁻¹)ᵀ` in reverse: each `(Fᵢ⁻¹)ᵀ` changes only `s[q]`.
+    fn apply_etas_transpose_reverse(&self, s: &mut [f64]) {
+        for eta in self.etas.iter().rev() {
+            let q = eta.q;
+            let tq = eta.tau[q];
+            let mut dot = 0.0;
+            for (j, &tj) in eta.tau.iter().enumerate() {
+                if j != q {
+                    dot += tj * s[j];
+                }
+            }
+            s[q] = (s[q] - dot) / tq;
+        }
     }
 
     /// Forward solve `L y = s` (unit lower), in place.

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -12,10 +12,45 @@ use super::sparse_matrix::SparseColMatrix;
 use crate::error::FeralError;
 
 impl SparseLu {
-    /// Solve `B x = a`, overwriting `rhs` with `x`.
+    /// Solve `B x = a`, overwriting `rhs` with `x` (scaling applied around the
+    /// core solve on `Ã = D_row Π B D_col`).
     pub fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
+        if self.scale.is_identity() {
+            return self.ftran_core(rhs);
+        }
+        let mut bt = vec![0.0; m];
+        for (i, bi) in bt.iter_mut().enumerate() {
+            *bi = self.scale.d_row[i] * rhs[self.scale.rperm[i]];
+        }
+        self.ftran_core(&mut bt)?;
+        for (j, rj) in rhs.iter_mut().enumerate() {
+            *rj = self.scale.d_col[j] * bt[j];
+        }
+        Ok(())
+    }
+
+    /// Solve `Bᵀ x = a`, overwriting `rhs` with `x`.
+    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        check_len(rhs.len(), m)?;
+        if self.scale.is_identity() {
+            return self.btran_core(rhs);
+        }
+        let mut bt = vec![0.0; m];
+        for (j, bj) in bt.iter_mut().enumerate() {
+            *bj = self.scale.d_col[j] * rhs[j];
+        }
+        self.btran_core(&mut bt)?;
+        for (i, &yi) in bt.iter().enumerate() {
+            rhs[self.scale.rperm[i]] = self.scale.d_row[i] * yi;
+        }
+        Ok(())
+    }
+
+    /// Core `ftran` on the (scaled) factored matrix, ignoring outer scaling.
+    pub(super) fn ftran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let mut s = std::mem::take(&mut self.scratch);
         self.solve_colspace(rhs, &mut s);
         for (k, &wk) in s.iter().enumerate() {
@@ -25,10 +60,8 @@ impl SparseLu {
         Ok(())
     }
 
-    /// Solve `Bᵀ x = a`, overwriting `rhs` with `x`.
-    pub fn btran(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
-        let m = self.m;
-        check_len(rhs.len(), m)?;
+    /// Core `btran` on the (scaled) factored matrix, ignoring outer scaling.
+    pub(super) fn btran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let mut s = std::mem::take(&mut self.scratch);
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.qcol[k]];

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -172,29 +172,30 @@ impl SparseLu {
         }
     }
 
-    /// Back solve `U w = s` (upper, row-wise CSR), in place.
+    /// Back solve `U w = s` (upper; per-row storage, diagonal first), in place.
     fn usolve(&self, s: &mut [f64]) {
         for k in (0..self.m).rev() {
+            let row = &self.u_rows[k];
             let mut acc = s[k];
-            let (lo, hi) = (self.u_row_ptr[k], self.u_row_ptr[k + 1]);
-            for idx in lo..hi {
-                acc -= self.u_val[idx] * s[self.u_col_idx[idx]];
+            // Skip the diagonal (row[0], column == k); the rest are columns > k.
+            for &(c, v) in row[1..].iter() {
+                acc -= v * s[c];
             }
-            s[k] = acc / self.u_diag[k];
+            s[k] = acc / row[0].1;
         }
     }
 
-    /// Forward solve `Uᵀ z = s` (`Uᵀ` lower; scatter form on row-wise U).
+    /// Forward solve `Uᵀ z = s` (`Uᵀ` lower; scatter form on per-row U).
     fn ut_solve(&self, s: &mut [f64]) {
         for i in 0..self.m {
-            let si = s[i] / self.u_diag[i];
+            let row = &self.u_rows[i];
+            let si = s[i] / row[0].1;
             s[i] = si;
             if si == 0.0 {
                 continue;
             }
-            let (lo, hi) = (self.u_row_ptr[i], self.u_row_ptr[i + 1]);
-            for idx in lo..hi {
-                s[self.u_col_idx[idx]] -= self.u_val[idx] * si;
+            for &(c, v) in row[1..].iter() {
+                s[c] -= v * si;
             }
         }
     }

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -52,12 +52,14 @@ impl SparseLu {
     /// Core `ftran` on the (scaled) factored matrix, ignoring outer scaling.
     pub(super) fn ftran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let mut s = std::mem::take(&mut self.scratch);
-        self.solve_colspace(rhs, &mut s);
-        for (k, &wk) in s.iter().enumerate() {
-            rhs[self.qcol[k]] = wk;
+        let res = self.solve_colspace(rhs, &mut s);
+        if res.is_ok() {
+            for (k, &wk) in s.iter().enumerate() {
+                rhs[self.qcol[k]] = wk;
+            }
         }
         self.scratch = s;
-        Ok(())
+        res
     }
 
     /// Core `btran` on the (scaled) factored matrix, ignoring outer scaling.
@@ -68,16 +70,18 @@ impl SparseLu {
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.qcol[k]];
         }
-        self.ut_solve(&mut s);
-        for eta in self.etas.iter().rev() {
-            eta.apply_transpose(&mut s);
-        }
-        self.lt_solve(&mut s);
-        for (k, &vk) in s.iter().enumerate() {
-            rhs[self.perm[k]] = vk;
+        let res = self.ut_solve(&mut s);
+        if res.is_ok() {
+            for eta in self.etas.iter().rev() {
+                eta.apply_transpose(&mut s);
+            }
+            self.lt_solve(&mut s);
+            for (k, &vk) in s.iter().enumerate() {
+                rhs[self.perm[k]] = vk;
+            }
         }
         self.scratch = s;
-        Ok(())
+        res
     }
 
     /// Compute the spike `G⁻¹ L⁻¹ P a` (the `ftran` result in `U`-column space,
@@ -131,9 +135,9 @@ impl SparseLu {
 
     /// Solve into column-position space: `out = U⁻¹ G⁻¹ L⁻¹ P · rhs` (the
     /// `ftran` result before the final `Q` scatter).
-    pub(super) fn solve_colspace(&self, rhs: &[f64], out: &mut [f64]) {
+    pub(super) fn solve_colspace(&self, rhs: &[f64], out: &mut [f64]) -> Result<(), FeralError> {
         self.spike_space(rhs, out);
-        self.usolve(out);
+        self.usolve(out)
     }
 
     /// Forward solve `L y = s` (unit lower), in place.
@@ -151,23 +155,43 @@ impl SparseLu {
     }
 
     /// Back solve `U w = s` (upper; per-row storage, diagonal first), in place.
-    fn usolve(&self, s: &mut [f64]) {
+    ///
+    /// Errors with [`FeralError::SingularBasis`] if a row's stored diagonal is
+    /// absent, zero, or non-finite: after a Forrest–Tomlin update the diagonal
+    /// of `u_rows[k]` is the bump pivot, and dividing by an exact zero would
+    /// otherwise emit a silent `±Inf`. (A fresh factor floors pivots to `±ztol`,
+    /// so this only guards the updated path.)
+    fn usolve(&self, s: &mut [f64]) -> Result<(), FeralError> {
         for k in (0..self.m).rev() {
             let row = &self.u_rows[k];
+            let &(dc, d) = row.first().ok_or(FeralError::SingularBasis { column: k })?;
+            debug_assert_eq!(dc, k, "U row {k} must store its diagonal first");
+            if d == 0.0 || !d.is_finite() {
+                return Err(FeralError::SingularBasis { column: k });
+            }
             let mut acc = s[k];
             // Skip the diagonal (row[0], column == k); the rest are columns > k.
             for &(c, v) in row[1..].iter() {
                 acc -= v * s[c];
             }
-            s[k] = acc / row[0].1;
+            s[k] = acc / d;
         }
+        Ok(())
     }
 
     /// Forward solve `Uᵀ z = s` (`Uᵀ` lower; scatter form on per-row U).
-    fn ut_solve(&self, s: &mut [f64]) {
+    ///
+    /// Errors with [`FeralError::SingularBasis`] on an absent/zero/non-finite
+    /// stored diagonal, for the same reason as [`SparseLu::usolve`].
+    fn ut_solve(&self, s: &mut [f64]) -> Result<(), FeralError> {
         for i in 0..self.m {
             let row = &self.u_rows[i];
-            let si = s[i] / row[0].1;
+            let &(dc, d) = row.first().ok_or(FeralError::SingularBasis { column: i })?;
+            debug_assert_eq!(dc, i, "U row {i} must store its diagonal first");
+            if d == 0.0 || !d.is_finite() {
+                return Err(FeralError::SingularBasis { column: i });
+            }
+            let si = s[i] / d;
             s[i] = si;
             if si == 0.0 {
                 continue;
@@ -176,6 +200,7 @@ impl SparseLu {
                 s[c] -= v * si;
             }
         }
+        Ok(())
     }
 
     /// Back solve `Lᵀ v = s` (`Lᵀ` unit upper), in place.
@@ -242,4 +267,36 @@ fn check_len(got: usize, expected: usize) -> Result<(), FeralError> {
 
 fn inf_norm(v: &[f64]) -> f64 {
     v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lu::LuParams;
+
+    /// A zero `U` diagonal (as a degenerate post-update bump pivot could leave)
+    /// must surface as `SingularBasis`, not a silent `±Inf` out of the divide.
+    #[test]
+    fn zero_u_diagonal_errors_instead_of_inf() {
+        let cols = vec![vec![2.0, 0.0], vec![1.0, 3.0]]; // nonsingular 2x2
+        let mut lu = SparseLu::factor_dense_columns(2, &cols, LuParams::default()).expect("factor");
+        // Sanity: a clean solve has no NaN/Inf.
+        let mut rhs = vec![1.0, 1.0];
+        lu.ftran(&mut rhs).expect("clean ftran");
+        assert!(rhs.iter().all(|x| x.is_finite()));
+
+        // Corrupt the stored diagonal of pivot position 1 to an exact zero.
+        lu.u_rows[1][0].1 = 0.0;
+
+        let mut bad = vec![1.0, 1.0];
+        assert!(matches!(
+            lu.ftran(&mut bad),
+            Err(FeralError::SingularBasis { column: 1 })
+        ));
+        let mut bad_t = vec![1.0, 1.0];
+        assert!(matches!(
+            lu.btran(&mut bad_t),
+            Err(FeralError::SingularBasis { column: 1 })
+        ));
+    }
 }

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -172,30 +172,30 @@ impl SparseLu {
         }
     }
 
-    /// Back solve `U w = s` (upper), in place.
+    /// Back solve `U w = s` (upper, row-wise CSR), in place.
     fn usolve(&self, s: &mut [f64]) {
         for k in (0..self.m).rev() {
-            let sk = s[k] / self.u_diag[k];
-            s[k] = sk;
-            if sk == 0.0 {
-                continue;
-            }
-            let (lo, hi) = (self.u_col_ptr[k], self.u_col_ptr[k + 1]);
+            let mut acc = s[k];
+            let (lo, hi) = (self.u_row_ptr[k], self.u_row_ptr[k + 1]);
             for idx in lo..hi {
-                s[self.u_row_idx[idx]] -= self.u_val[idx] * sk;
+                acc -= self.u_val[idx] * s[self.u_col_idx[idx]];
             }
+            s[k] = acc / self.u_diag[k];
         }
     }
 
-    /// Forward solve `Uᵀ z = s` (`Uᵀ` lower), in place.
+    /// Forward solve `Uᵀ z = s` (`Uᵀ` lower; scatter form on row-wise U).
     fn ut_solve(&self, s: &mut [f64]) {
-        for k in 0..self.m {
-            let mut acc = s[k];
-            let (lo, hi) = (self.u_col_ptr[k], self.u_col_ptr[k + 1]);
-            for idx in lo..hi {
-                acc -= self.u_val[idx] * s[self.u_row_idx[idx]];
+        for i in 0..self.m {
+            let si = s[i] / self.u_diag[i];
+            s[i] = si;
+            if si == 0.0 {
+                continue;
             }
-            s[k] = acc / self.u_diag[k];
+            let (lo, hi) = (self.u_row_ptr[i], self.u_row_ptr[i + 1]);
+            for idx in lo..hi {
+                s[self.u_col_idx[idx]] -= self.u_val[idx] * si;
+            }
         }
     }
 

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -1,11 +1,11 @@
 //! Sparse `ftran` / `btran` triangular solves and iterative refinement.
 //!
-//! Mirrors the dense path with `P A Q = L U F₁…Fₜ`, where the `Fᵢ` are the
-//! product-form `U`-updates (see [`super::sparse_update`]). `ftran` solves
-//! `B x = a`, `btran` solves `Bᵀ x = a`, and `ftran_partial` returns the spike
-//! `L⁻¹ P a`. Triangular solves operate directly on the CSC factors (no
-//! explicit transpose), and the eta updates are applied after the `U`-solve in
-//! `ftran` (transposed, in reverse, before the `Uᵀ`-solve in `btran`).
+//! The factorization is `P A Q = L G U`, where `L` is the base lower factor,
+//! `U` the (Forrest–Tomlin-updated) upper factor, and `G = E₁⁻¹…Eₜ⁻¹` the
+//! product of the update eliminations (see [`super::sparse_update`]). So
+//! `ftran` (`B⁻¹a`) applies `L⁻¹`, then `G⁻¹ = Eₜ…E₁` (the etas forward), then
+//! `U⁻¹`, then `Q`; `btran` does the transpose in reverse. `ftran_partial`
+//! returns the spike `G⁻¹L⁻¹Pa` (the column the update inserts into `U`).
 
 use super::sparse_factor::SparseLu;
 use super::sparse_matrix::SparseColMatrix;
@@ -61,13 +61,17 @@ impl SparseLu {
     }
 
     /// Core `btran` on the (scaled) factored matrix, ignoring outer scaling.
+    /// `Bᵀ⁻¹ = P⁻¹ Lᵀ⁻¹ Gᵀ⁻¹ Uᵀ⁻¹ Q⁻¹`: gather Q, `Uᵀ`-solve, apply the etas
+    /// transposed in reverse, `Lᵀ`-solve, scatter P.
     pub(super) fn btran_core(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let mut s = std::mem::take(&mut self.scratch);
         for (k, sk) in s.iter_mut().enumerate() {
             *sk = rhs[self.qcol[k]];
         }
-        self.apply_etas_transpose_reverse(&mut s);
         self.ut_solve(&mut s);
+        for eta in self.etas.iter().rev() {
+            eta.apply_transpose(&mut s);
+        }
         self.lt_solve(&mut s);
         for (k, &vk) in s.iter().enumerate() {
             rhs[self.perm[k]] = vk;
@@ -76,17 +80,14 @@ impl SparseLu {
         Ok(())
     }
 
-    /// Compute the spike `L⁻¹ P a` (base factor only, no eta/`U`), overwriting
-    /// `rhs`. Exposed for inspection; the update computes its own transformed
-    /// spike internally.
+    /// Compute the spike `G⁻¹ L⁻¹ P a` (the `ftran` result in `U`-column space,
+    /// before the `U`-solve and `Q` scatter), overwriting `rhs`. This is the
+    /// column that the Forrest–Tomlin update inserts into `U`.
     pub fn ftran_partial(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
         let mut s = std::mem::take(&mut self.scratch);
-        for (k, sk) in s.iter_mut().enumerate() {
-            *sk = rhs[self.perm[k]];
-        }
-        self.lsolve(&mut s);
+        self.spike_space(rhs, &mut s);
         rhs.copy_from_slice(&s);
         self.scratch = s;
         Ok(())
@@ -116,46 +117,23 @@ impl SparseLu {
         self.refine(b, &a, rhs, true)
     }
 
-    /// Solve into column-position space: `out = F⁻¹ U⁻¹ L⁻¹ P · rhs` (the
-    /// `ftran` result before the final `Q` scatter). Shared by `ftran` and the
-    /// rank-1 update (which reads `out[qcol_inv[slot]]` as the update pivot).
-    pub(super) fn solve_colspace(&self, rhs: &[f64], out: &mut [f64]) {
+    /// Spike `G⁻¹ L⁻¹ P · rhs` (apply P, `L`-solve, replay the FT etas forward),
+    /// without the `U`-solve. Used to form the column the update inserts into U.
+    pub(super) fn spike_space(&self, rhs: &[f64], out: &mut [f64]) {
         for (k, ok) in out.iter_mut().enumerate() {
             *ok = rhs[self.perm[k]];
         }
         self.lsolve(out);
-        self.usolve(out);
-        self.apply_etas_forward(out);
-    }
-
-    /// Apply all product-form updates `F₁⁻¹ … Fₜ⁻¹` (chronological order).
-    fn apply_etas_forward(&self, s: &mut [f64]) {
         for eta in self.etas.iter() {
-            let q = eta.q;
-            let tq = eta.tau[q];
-            let zq = s[q] / tq;
-            for (j, &tj) in eta.tau.iter().enumerate() {
-                if j != q {
-                    s[j] -= tj * zq;
-                }
-            }
-            s[q] = zq;
+            eta.apply_forward(out);
         }
     }
 
-    /// Apply `(F₁⁻¹ … Fₜ⁻¹)ᵀ` in reverse: each `(Fᵢ⁻¹)ᵀ` changes only `s[q]`.
-    fn apply_etas_transpose_reverse(&self, s: &mut [f64]) {
-        for eta in self.etas.iter().rev() {
-            let q = eta.q;
-            let tq = eta.tau[q];
-            let mut dot = 0.0;
-            for (j, &tj) in eta.tau.iter().enumerate() {
-                if j != q {
-                    dot += tj * s[j];
-                }
-            }
-            s[q] = (s[q] - dot) / tq;
-        }
+    /// Solve into column-position space: `out = U⁻¹ G⁻¹ L⁻¹ P · rhs` (the
+    /// `ftran` result before the final `Q` scatter).
+    pub(super) fn solve_colspace(&self, rhs: &[f64], out: &mut [f64]) {
+        self.spike_space(rhs, out);
+        self.usolve(out);
     }
 
     /// Forward solve `L y = s` (unit lower), in place.

--- a/src/lu/sparse_symbolic.rs
+++ b/src/lu/sparse_symbolic.rs
@@ -1,0 +1,68 @@
+//! Symbolic analysis for the sparse LU: the fill-reducing column ordering `Q`.
+//!
+//! Reuses feral's in-tree AMD (`feral_amd`) on the `AᵀA` (column-intersection)
+//! pattern — a stand-in for COLAMD that needs no new ordering algorithm. The
+//! resulting permutation is the reusable symbolic handle: across numerically
+//! different but structurally identical bases, only the numeric factor is
+//! recomputed.
+
+use super::sparse_matrix::SparseColMatrix;
+use crate::error::FeralError;
+
+/// Reusable symbolic factorization: the column permutation `Q`.
+#[derive(Debug, Clone)]
+pub struct SparseLuSymbolic {
+    /// Dimension.
+    pub m: usize,
+    /// Column order: factorization column position `k` is original column
+    /// `qcol[k]`.
+    pub qcol: Vec<usize>,
+    /// Inverse: `qcol_inv[original_col] = column_position`.
+    pub qcol_inv: Vec<usize>,
+}
+
+impl SparseLuSymbolic {
+    /// Compute the column ordering via AMD on the `AᵀA` pattern.
+    pub fn analyze(a: &SparseColMatrix) -> Result<Self, FeralError> {
+        let m = a.m;
+        if m == 0 {
+            return Ok(SparseLuSymbolic {
+                m,
+                qcol: Vec::new(),
+                qcol_inv: Vec::new(),
+            });
+        }
+        let pat = a.ata_pattern();
+        let col_ptr: Vec<i32> = pat
+            .col_ptr
+            .iter()
+            .map(|&x| i32::try_from(x))
+            .collect::<Result<_, _>>()
+            .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
+        let row_idx: Vec<i32> = pat
+            .row_idx
+            .iter()
+            .map(|&x| i32::try_from(x))
+            .collect::<Result<_, _>>()
+            .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
+        let cpat = feral_ordering_core::CscPattern::new(m, &col_ptr, &row_idx)
+            .ok_or_else(|| FeralError::InvalidInput("malformed AᵀA pattern".to_string()))?;
+        let perm = feral_amd::amd_order(&cpat)
+            .map_err(|e| FeralError::InvalidInput(format!("AMD ordering failed: {:?}", e)))?;
+        let qcol: Vec<usize> = perm.iter().map(|&x| x as usize).collect();
+        let mut qcol_inv = vec![0usize; m];
+        for (k, &q) in qcol.iter().enumerate() {
+            qcol_inv[q] = k;
+        }
+        Ok(SparseLuSymbolic { m, qcol, qcol_inv })
+    }
+
+    /// Identity column ordering (natural order) — for testing and as a fallback.
+    pub fn natural(m: usize) -> Self {
+        SparseLuSymbolic {
+            m,
+            qcol: (0..m).collect(),
+            qcol_inv: (0..m).collect(),
+        }
+    }
+}

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -2,17 +2,18 @@
 //!
 //! Replacing basis slot `leaving_slot` (column position `r`) by a new column
 //! folds the spike `ρ = G⁻¹ L⁻¹ P aₙₑw` into `U`'s column `r`, then
-//! re-triangularizes the resulting *bump* (`U` is upper-triangular except a
-//! spike in column `r`) by **sparse Gaussian elimination with partial
-//! pivoting**. Partial pivoting is what makes this correct on a sparse `U`: the
-//! diagonal pivot of the spiked column may be zero, but a sub-diagonal spike
-//! entry provides a nonzero pivot via a row interchange.
+//! re-triangularizes the resulting *bump* by sparse Gaussian elimination with
+//! partial pivoting (partial pivoting is what makes this correct on a sparse
+//! `U`: a zero diagonal pivot is replaced by a nonzero sub-diagonal spike entry
+//! via a row interchange; the swap goes into the eta so the base `L` is never
+//! permuted).
 //!
-//! The elimination's elementary operations (swaps + `row -= mult·row`) are
-//! recorded as a [`FtEta`](super::sparse_factor::FtEta) and replayed on the
-//! solve vector (between the `L`-solve and `U`-solve in `ftran`), so the base
-//! `L` is never touched and the eta is `O(bump)` — no dense `τ`, no `O(k·n)`
-//! warm-solve growth. `U` itself is updated in place.
+//! The work is **bump-local**: the spike is computed by a Gilbert–Peierls
+//! depth-first reach (only the reachable `L`-columns are touched, not all `n`),
+//! column `r` is located via the `u_above` index (no full-row scan), and the
+//! "unchanged on failure" guarantee is provided by saving/restoring only the
+//! changed rows (no `O(nnz)` clone of `U`). Apart from one `O(n)` read of the
+//! dense entering column, the cost is `O(bump)`.
 
 use super::sparse_factor::{FtEta, FtOp, SparseLu};
 use super::sparse_symbolic::SparseLuSymbolic;
@@ -49,81 +50,69 @@ impl SparseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
-        // Spike ρ = G⁻¹ L⁻¹ P (scaled entering column), in U-column space.
-        let mut scaled = vec![0.0_f64; m];
-        for (i, si) in scaled.iter_mut().enumerate() {
-            *si = self.scale.d_row[i]
-                * entering_col[self.scale.rperm[i]]
-                * self.scale.d_col[leaving_slot];
-        }
-        let mut rho = vec![0.0_f64; m];
-        self.spike_space(&scaled, &mut rho);
+        // --- Sparse spike ρ = G⁻¹ L⁻¹ P (scaled aₙₑw) via Gilbert–Peierls reach ---
+        let mut w = std::mem::take(&mut self.ft_work); // dedicated buffer, zero on entry
+        let mut touched: Vec<usize> = Vec::new(); // positions made nonzero in w
+        self.compute_spike(entering_col, leaving_slot, &mut w, &mut touched);
 
         let r = self.qcol_inv[leaving_slot];
-        // Bump high-water mark: the highest row of the spike at/below the
-        // diagonal. No entry at rows >= r means column r has no pivot.
-        let h = match (r..m).rev().find(|&i| rho[i] != 0.0) {
-            Some(h) => h,
-            None => return Err(FeralError::SingularBasis { column: r }),
+        let mut supp: Vec<usize> = touched.iter().copied().filter(|&k| w[k] != 0.0).collect();
+        supp.sort_unstable();
+        supp.dedup();
+        let h = match supp.last().copied() {
+            Some(h) if h >= r => h,
+            _ => {
+                clear(&mut w, &touched);
+                self.ft_work = w;
+                return Err(FeralError::SingularBasis { column: r });
+            }
         };
 
-        let ztol = self.params.zero_pivot_tol;
-        let max_growth = self.params.max_growth;
+        // --- Rows whose U content will change (all <= h): bump + spike support
+        // + old column-r entries (above-diagonal rows from u_above, plus r). ---
+        let mut changed: Vec<usize> = (r..=h).collect();
+        changed.extend(supp.iter().copied());
+        changed.extend(self.u_above[r].iter().copied());
+        changed.push(r);
+        changed.sort_unstable();
+        changed.dedup();
 
-        // Work on a clone of U so a failure leaves `self` unchanged.
-        let mut u = self.u_rows.clone();
-        set_column(&mut u, m, r, &rho);
+        // Save the changed rows so a mid-elimination failure can roll back.
+        let saved: Vec<(usize, Vec<(usize, f64)>)> = changed
+            .iter()
+            .map(|&i| (i, self.u_rows[i].clone()))
+            .collect();
 
-        let mut ops: Vec<FtOp> = Vec::new();
-        let mut growth = self.growth;
+        // Overwrite column r of U with the spike ρ (= w).
+        self.set_column_r(r, &w, &supp);
 
-        for k in r..=h {
-            // Partial pivot: among rows [k, h] with a column-k entry, take the
-            // largest in magnitude.
-            let mut pivot_row = k;
-            let mut pivot_abs = 0.0_f64;
-            for (i, urow) in u.iter().enumerate().take(h + 1).skip(k) {
-                if let Some(v) = get_col(urow, k) {
-                    if v.abs() > pivot_abs {
-                        pivot_abs = v.abs();
-                        pivot_row = i;
-                    }
+        // Re-triangularize the bump [r, h] with partial pivoting.
+        let result = self.eliminate_bump(r, h);
+
+        clear(&mut w, &touched);
+        self.ft_work = w;
+
+        match result {
+            Ok((ops, growth)) => {
+                // Commit: refresh the u_above index for every changed row.
+                for (i, old_row) in saved.iter() {
+                    self.unindex_above(*i, old_row);
+                    let new_row = std::mem::take(&mut self.u_rows[*i]);
+                    self.index_above(*i, &new_row);
+                    self.u_rows[*i] = new_row;
                 }
+                self.etas.push(FtEta { ops });
+                self.growth = growth;
+                Ok(())
             }
-            if pivot_abs <= ztol {
-                return Err(FeralError::SingularBasis { column: k });
-            }
-            if pivot_row != k {
-                u.swap(k, pivot_row);
-                ops.push(FtOp::Swap(k, pivot_row));
-            }
-            let pivot_data = u[k].clone();
-            let pivot = get_col(&pivot_data, k).unwrap_or(0.0);
-
-            // Eliminate the column-k entry from every lower bump row that has one.
-            #[allow(clippy::needless_range_loop)]
-            for i in k + 1..=h {
-                if let Some(vik) = get_col(&u[i], k) {
-                    let mult = vik / pivot;
-                    growth = growth.max(mult.abs());
-                    if growth > max_growth {
-                        return Err(FeralError::NeedsRefactor);
-                    }
-                    u[i] = row_sub(&u[i], &pivot_data, mult, k);
-                    ops.push(FtOp::Axpy {
-                        target: i,
-                        src: k,
-                        mult,
-                    });
+            Err(e) => {
+                // Roll back the changed rows (u_above was not yet modified).
+                for (i, row) in saved {
+                    self.u_rows[i] = row;
                 }
+                Err(e)
             }
         }
-
-        // Commit.
-        self.u_rows = u;
-        self.etas.push(FtEta { ops });
-        self.growth = growth;
-        Ok(())
     }
 
     /// Discard all pending updates and re-factor from scratch on `a`, reusing
@@ -136,6 +125,196 @@ impl SparseLu {
         *self = SparseLu::factor(a, symbolic, self.params.clone())?;
         Ok(())
     }
+
+    /// Compute the spike `ρ = G⁻¹ L⁻¹ P (D_row Π aₙₑw D_col[slot])` into the dense
+    /// work vector `w`, recording every touched position in `touched`. Uses a
+    /// Gilbert–Peierls depth-first reach so only the reachable `L`-columns are
+    /// visited, then replays the FT etas forward.
+    fn compute_spike(
+        &mut self,
+        entering_col: &[f64],
+        leaving_slot: usize,
+        w: &mut [f64],
+        touched: &mut Vec<usize>,
+    ) {
+        let m = w.len();
+        let dcol = self.scale.d_col[leaving_slot];
+        let mut mark = std::mem::take(&mut self.scratch_mark);
+        let mut stack: Vec<usize> = Vec::new();
+
+        // Scatter the scaled entering column into w (pivot-position space) and
+        // seed the reach. scaled[i] = d_row[i]·entering_col[rperm[i]]·dcol lands
+        // at pivot position perm_inv[i].
+        for i in 0..m {
+            let e = entering_col[self.scale.rperm[i]];
+            if e == 0.0 {
+                continue;
+            }
+            let v = self.scale.d_row[i] * e * dcol;
+            if v == 0.0 {
+                continue;
+            }
+            let k = self.perm_inv[i];
+            w[k] = v;
+            if !mark[k] {
+                mark[k] = true;
+                touched.push(k);
+                stack.push(k);
+            }
+        }
+
+        // Depth-first reach over the graph of L (column k -> its rows).
+        let mut reach: Vec<usize> = touched.clone();
+        while let Some(k) = stack.pop() {
+            let (lo, hi) = (self.l_col_ptr[k], self.l_col_ptr[k + 1]);
+            for idx in lo..hi {
+                let i = self.l_row_idx[idx];
+                if !mark[i] {
+                    mark[i] = true;
+                    touched.push(i);
+                    reach.push(i);
+                    stack.push(i);
+                }
+            }
+        }
+        reach.sort_unstable(); // ascending = valid topological order for L
+
+        // Sparse forward solve L y = w over the reach.
+        for &k in reach.iter() {
+            let yk = w[k];
+            if yk == 0.0 {
+                continue;
+            }
+            let (lo, hi) = (self.l_col_ptr[k], self.l_col_ptr[k + 1]);
+            for idx in lo..hi {
+                w[self.l_row_idx[idx]] -= self.l_val[idx] * yk;
+            }
+        }
+
+        // Replay the FT etas forward (G⁻¹), tracking newly touched positions.
+        for eta in self.etas.iter() {
+            for op in eta.ops.iter() {
+                match *op {
+                    FtOp::Swap(a, b) => {
+                        w.swap(a, b);
+                        for x in [a, b] {
+                            if w[x] != 0.0 && !mark[x] {
+                                mark[x] = true;
+                                touched.push(x);
+                            }
+                        }
+                    }
+                    FtOp::Axpy { target, src, mult } => {
+                        w[target] -= mult * w[src];
+                        if w[target] != 0.0 && !mark[target] {
+                            mark[target] = true;
+                            touched.push(target);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Clear the marker for the touched set and hand the buffer back.
+        for &k in touched.iter() {
+            mark[k] = false;
+        }
+        self.scratch_mark = mark;
+    }
+
+    /// Overwrite column `r` of `U` with the spike (`w` at positions `supp`),
+    /// removing any old column-`r` entries. Old above-diagonal rows are located
+    /// via `u_above[r]` (read only — `u_above` is refreshed wholesale in the
+    /// commit phase via unindex/reindex of the changed rows).
+    fn set_column_r(&mut self, r: usize, w: &[f64], supp: &[usize]) {
+        let old_above = self.u_above[r].clone();
+        for &i in old_above.iter() {
+            remove_col(&mut self.u_rows[i], r);
+        }
+        remove_col(&mut self.u_rows[r], r); // old diagonal
+        for &i in supp.iter() {
+            insert_or_set(&mut self.u_rows[i], r, w[i]);
+        }
+    }
+
+    /// Eliminate the bump `[r, h]` of `U` with partial pivoting, returning the
+    /// recorded eta ops and the updated growth monitor. Operates in place on
+    /// `self.u_rows`; the caller is responsible for rollback on `Err`.
+    fn eliminate_bump(&mut self, r: usize, h: usize) -> Result<(Vec<FtOp>, f64), FeralError> {
+        let ztol = self.params.zero_pivot_tol;
+        let max_growth = self.params.max_growth;
+        let mut ops: Vec<FtOp> = Vec::new();
+        let mut growth = self.growth;
+
+        for k in r..=h {
+            // Partial pivot among rows [k, h] with a column-k entry.
+            let mut pivot_row = k;
+            let mut pivot_abs = 0.0_f64;
+            for i in k..=h {
+                if let Some(v) = get_col(&self.u_rows[i], k) {
+                    if v.abs() > pivot_abs {
+                        pivot_abs = v.abs();
+                        pivot_row = i;
+                    }
+                }
+            }
+            if pivot_abs <= ztol {
+                return Err(FeralError::SingularBasis { column: k });
+            }
+            if pivot_row != k {
+                self.u_rows.swap(k, pivot_row);
+                ops.push(FtOp::Swap(k, pivot_row));
+            }
+            let pivot_data = self.u_rows[k].clone();
+            let pivot = get_col(&pivot_data, k).unwrap_or(0.0);
+
+            for i in k + 1..=h {
+                if let Some(vik) = get_col(&self.u_rows[i], k) {
+                    let mult = vik / pivot;
+                    growth = growth.max(mult.abs());
+                    if growth > max_growth {
+                        return Err(FeralError::NeedsRefactor);
+                    }
+                    self.u_rows[i] = row_sub(&self.u_rows[i], &pivot_data, mult, k);
+                    ops.push(FtOp::Axpy {
+                        target: i,
+                        src: k,
+                        mult,
+                    });
+                }
+            }
+        }
+        Ok((ops, growth))
+    }
+
+    /// Remove row `i`'s strict-upper entries from the `u_above` column index
+    /// (using its pre-update content `old_row`).
+    fn unindex_above(&mut self, i: usize, old_row: &[(usize, f64)]) {
+        for &(c, _) in old_row.iter() {
+            if c > i {
+                if let Ok(pos) = self.u_above[c].binary_search(&i) {
+                    self.u_above[c].remove(pos);
+                }
+            }
+        }
+    }
+
+    /// Add row `i`'s strict-upper entries to the `u_above` column index.
+    fn index_above(&mut self, i: usize, new_row: &[(usize, f64)]) {
+        for &(c, _) in new_row.iter() {
+            if c > i {
+                if let Err(pos) = self.u_above[c].binary_search(&i) {
+                    self.u_above[c].insert(pos, i);
+                }
+            }
+        }
+    }
+}
+
+fn clear(w: &mut [f64], touched: &[usize]) {
+    for &k in touched.iter() {
+        w[k] = 0.0;
+    }
 }
 
 /// Look up the value at column `c` in a column-sorted sparse row.
@@ -145,22 +324,27 @@ fn get_col(row: &[(usize, f64)], c: usize) -> Option<f64> {
         .map(|pos| row[pos].1)
 }
 
-/// Overwrite column `r` of `U` (per-row storage) with the dense spike `rho`.
-fn set_column(u: &mut [Vec<(usize, f64)>], m: usize, r: usize, rho: &[f64]) {
-    for (i, row) in u.iter_mut().enumerate().take(m) {
-        let v = rho[i];
-        match row.binary_search_by_key(&r, |&(col, _)| col) {
-            Ok(pos) => {
-                if v != 0.0 {
-                    row[pos].1 = v;
-                } else {
-                    row.remove(pos);
-                }
+/// Remove column `c` from a column-sorted sparse row, if present.
+fn remove_col(row: &mut Vec<(usize, f64)>, c: usize) {
+    if let Ok(pos) = row.binary_search_by_key(&c, |&(col, _)| col) {
+        row.remove(pos);
+    }
+}
+
+/// Set column `c` of a column-sorted sparse row to `v` (insert/replace; remove
+/// if `v == 0`).
+fn insert_or_set(row: &mut Vec<(usize, f64)>, c: usize, v: f64) {
+    match row.binary_search_by_key(&c, |&(col, _)| col) {
+        Ok(pos) => {
+            if v != 0.0 {
+                row[pos].1 = v;
+            } else {
+                row.remove(pos);
             }
-            Err(pos) => {
-                if v != 0.0 {
-                    row.insert(pos, (r, v));
-                }
+        }
+        Err(pos) => {
+            if v != 0.0 {
+                row.insert(pos, (c, v));
             }
         }
     }

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -1,18 +1,20 @@
-//! Sparse rank-1 column-replacement update (product-form update of `U`).
+//! Sparse rank-1 column-replacement update — Forrest–Tomlin / Bartels–Golub–Reid.
 //!
-//! Replacing basis slot `leaving_slot` (at column position `q`) by a new column
-//! `aₙₑw` yields `U' = U·F` with `F = I + (τ − e_q)e_qᵀ`, where
-//! `τ = F_{prev}⁻¹ U⁻¹ L⁻¹ P aₙₑw` is the transformed spike — exactly the
-//! `ftran` solve of `aₙₑw` in column-position space. Then `U'⁻¹ = F⁻¹ U⁻¹`, so
-//! the update is recorded as the eta `(q, τ)` and applied after the `U`-solve
-//! in `ftran` (transposed in `btran`). `τ[q]` is the update pivot: if it
-//! vanishes the new basis is singular.
+//! Replacing basis slot `leaving_slot` (column position `r`) by a new column
+//! folds the spike `ρ = G⁻¹ L⁻¹ P aₙₑw` into `U`'s column `r`, then
+//! re-triangularizes the resulting *bump* (`U` is upper-triangular except a
+//! spike in column `r`) by **sparse Gaussian elimination with partial
+//! pivoting**. Partial pivoting is what makes this correct on a sparse `U`: the
+//! diagonal pivot of the spiked column may be zero, but a sub-diagonal spike
+//! entry provides a nonzero pivot via a row interchange.
 //!
-//! This is a correct, genuinely sparse first-class rank-1 update with a refactor
-//! budget. The full Forrest–Tomlin row-eta refinement (which keeps the eta
-//! sparser than the dense `τ` stored here) is a documented optimization.
+//! The elimination's elementary operations (swaps + `row -= mult·row`) are
+//! recorded as a [`FtEta`](super::sparse_factor::FtEta) and replayed on the
+//! solve vector (between the `L`-solve and `U`-solve in `ftran`), so the base
+//! `L` is never touched and the eta is `O(bump)` — no dense `τ`, no `O(k·n)`
+//! warm-solve growth. `U` itself is updated in place.
 
-use super::sparse_factor::{EtaU, SparseLu};
+use super::sparse_factor::{FtEta, FtOp, SparseLu};
 use super::sparse_symbolic::SparseLuSymbolic;
 use crate::error::FeralError;
 use crate::lu::sparse_matrix::SparseColMatrix;
@@ -28,7 +30,7 @@ impl SparseLu {
     ///
     /// Returns [`FeralError::NeedsRefactor`] (leaving `self` unchanged) when the
     /// update or growth budget is exceeded, and [`FeralError::SingularBasis`]
-    /// when the update pivot `τ[q]` vanishes.
+    /// when the bump has no acceptable pivot (the new basis is singular).
     pub fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), FeralError> {
         let m = self.m;
         if entering_col.len() != m {
@@ -47,30 +49,80 @@ impl SparseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
-        // Scale the entering column into the factored frame Ã, then solve into
-        // column-position space: τ = F⁻¹ U⁻¹ L⁻¹ P ãₙₑw. Identity scaling leaves
-        // `entering_col` unchanged.
+        // Spike ρ = G⁻¹ L⁻¹ P (scaled entering column), in U-column space.
         let mut scaled = vec![0.0_f64; m];
         for (i, si) in scaled.iter_mut().enumerate() {
             *si = self.scale.d_row[i]
                 * entering_col[self.scale.rperm[i]]
                 * self.scale.d_col[leaving_slot];
         }
-        let mut tau = vec![0.0_f64; m];
-        self.solve_colspace(&scaled, &mut tau);
+        let mut rho = vec![0.0_f64; m];
+        self.spike_space(&scaled, &mut rho);
 
-        let q = self.qcol_inv[leaving_slot];
-        let tq = tau[q];
-        if tq.abs() <= self.params.zero_pivot_tol {
-            return Err(FeralError::SingularBasis { column: q });
-        }
-        let new_growth = self.growth.max(1.0 / tq.abs());
-        if new_growth > self.params.max_growth {
-            return Err(FeralError::NeedsRefactor);
+        let r = self.qcol_inv[leaving_slot];
+        // Bump high-water mark: the highest row of the spike at/below the
+        // diagonal. No entry at rows >= r means column r has no pivot.
+        let h = match (r..m).rev().find(|&i| rho[i] != 0.0) {
+            Some(h) => h,
+            None => return Err(FeralError::SingularBasis { column: r }),
+        };
+
+        let ztol = self.params.zero_pivot_tol;
+        let max_growth = self.params.max_growth;
+
+        // Work on a clone of U so a failure leaves `self` unchanged.
+        let mut u = self.u_rows.clone();
+        set_column(&mut u, m, r, &rho);
+
+        let mut ops: Vec<FtOp> = Vec::new();
+        let mut growth = self.growth;
+
+        for k in r..=h {
+            // Partial pivot: among rows [k, h] with a column-k entry, take the
+            // largest in magnitude.
+            let mut pivot_row = k;
+            let mut pivot_abs = 0.0_f64;
+            for (i, urow) in u.iter().enumerate().take(h + 1).skip(k) {
+                if let Some(v) = get_col(urow, k) {
+                    if v.abs() > pivot_abs {
+                        pivot_abs = v.abs();
+                        pivot_row = i;
+                    }
+                }
+            }
+            if pivot_abs <= ztol {
+                return Err(FeralError::SingularBasis { column: k });
+            }
+            if pivot_row != k {
+                u.swap(k, pivot_row);
+                ops.push(FtOp::Swap(k, pivot_row));
+            }
+            let pivot_data = u[k].clone();
+            let pivot = get_col(&pivot_data, k).unwrap_or(0.0);
+
+            // Eliminate the column-k entry from every lower bump row that has one.
+            #[allow(clippy::needless_range_loop)]
+            for i in k + 1..=h {
+                if let Some(vik) = get_col(&u[i], k) {
+                    let mult = vik / pivot;
+                    growth = growth.max(mult.abs());
+                    if growth > max_growth {
+                        return Err(FeralError::NeedsRefactor);
+                    }
+                    u[i] = row_sub(&u[i], &pivot_data, mult, k);
+                    ops.push(FtOp::Axpy {
+                        target: i,
+                        src: k,
+                        mult,
+                    });
+                }
+            }
         }
 
-        self.etas.push(EtaU { q, tau });
-        self.growth = new_growth;
+        // Commit.
+        self.u_rows = u;
+        self.etas.push(FtEta { ops });
+        self.growth = growth;
         Ok(())
     }
 
@@ -84,4 +136,83 @@ impl SparseLu {
         *self = SparseLu::factor(a, symbolic, self.params.clone())?;
         Ok(())
     }
+}
+
+/// Look up the value at column `c` in a column-sorted sparse row.
+fn get_col(row: &[(usize, f64)], c: usize) -> Option<f64> {
+    row.binary_search_by_key(&c, |&(col, _)| col)
+        .ok()
+        .map(|pos| row[pos].1)
+}
+
+/// Overwrite column `r` of `U` (per-row storage) with the dense spike `rho`.
+fn set_column(u: &mut [Vec<(usize, f64)>], m: usize, r: usize, rho: &[f64]) {
+    for (i, row) in u.iter_mut().enumerate().take(m) {
+        let v = rho[i];
+        match row.binary_search_by_key(&r, |&(col, _)| col) {
+            Ok(pos) => {
+                if v != 0.0 {
+                    row[pos].1 = v;
+                } else {
+                    row.remove(pos);
+                }
+            }
+            Err(pos) => {
+                if v != 0.0 {
+                    row.insert(pos, (r, v));
+                }
+            }
+        }
+    }
+}
+
+/// `dst − mult·src` over two column-sorted sparse rows, dropping the eliminated
+/// column `drop_col` and any exact zeros. Result stays column-sorted.
+fn row_sub(
+    dst: &[(usize, f64)],
+    src: &[(usize, f64)],
+    mult: f64,
+    drop_col: usize,
+) -> Vec<(usize, f64)> {
+    let mut out = Vec::with_capacity(dst.len() + src.len());
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < dst.len() && j < src.len() {
+        let (dc, dv) = dst[i];
+        let (sc, sv) = src[j];
+        if dc < sc {
+            if dc != drop_col {
+                out.push((dc, dv));
+            }
+            i += 1;
+        } else if dc > sc {
+            let v = -mult * sv;
+            if sc != drop_col && v != 0.0 {
+                out.push((sc, v));
+            }
+            j += 1;
+        } else {
+            let v = dv - mult * sv;
+            if dc != drop_col && v != 0.0 {
+                out.push((dc, v));
+            }
+            i += 1;
+            j += 1;
+        }
+    }
+    while i < dst.len() {
+        let (dc, dv) = dst[i];
+        if dc != drop_col {
+            out.push((dc, dv));
+        }
+        i += 1;
+    }
+    while j < src.len() {
+        let (sc, sv) = src[j];
+        let v = -mult * sv;
+        if sc != drop_col && v != 0.0 {
+            out.push((sc, v));
+        }
+        j += 1;
+    }
+    out
 }

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -1,0 +1,79 @@
+//! Sparse rank-1 column-replacement update (product-form update of `U`).
+//!
+//! Replacing basis slot `leaving_slot` (at column position `q`) by a new column
+//! `aₙₑw` yields `U' = U·F` with `F = I + (τ − e_q)e_qᵀ`, where
+//! `τ = F_{prev}⁻¹ U⁻¹ L⁻¹ P aₙₑw` is the transformed spike — exactly the
+//! `ftran` solve of `aₙₑw` in column-position space. Then `U'⁻¹ = F⁻¹ U⁻¹`, so
+//! the update is recorded as the eta `(q, τ)` and applied after the `U`-solve
+//! in `ftran` (transposed in `btran`). `τ[q]` is the update pivot: if it
+//! vanishes the new basis is singular.
+//!
+//! This is a correct, genuinely sparse first-class rank-1 update with a refactor
+//! budget. The full Forrest–Tomlin row-eta refinement (which keeps the eta
+//! sparser than the dense `τ` stored here) is a documented optimization.
+
+use super::sparse_factor::{EtaU, SparseLu};
+use super::sparse_symbolic::SparseLuSymbolic;
+use crate::error::FeralError;
+use crate::lu::sparse_matrix::SparseColMatrix;
+
+impl SparseLu {
+    /// Number of rank-1 updates applied since the last factor/refactor.
+    #[inline]
+    pub fn updates_since_refactor(&self) -> usize {
+        self.etas.len()
+    }
+
+    /// Replace basis slot `leaving_slot` with `entering_col` (`aₙₑw`).
+    ///
+    /// Returns [`FeralError::NeedsRefactor`] (leaving `self` unchanged) when the
+    /// update or growth budget is exceeded, and [`FeralError::SingularBasis`]
+    /// when the update pivot `τ[q]` vanishes.
+    pub fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), FeralError> {
+        let m = self.m;
+        if entering_col.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: entering_col.len(),
+            });
+        }
+        if leaving_slot >= m {
+            return Err(FeralError::InvalidInput(format!(
+                "leaving_slot {} out of range for basis dimension {}",
+                leaving_slot, m
+            )));
+        }
+        if self.updates_since_refactor() + 1 > self.params.max_updates {
+            return Err(FeralError::NeedsRefactor);
+        }
+
+        // τ = ftran of the entering column in column-position space.
+        let mut tau = vec![0.0_f64; m];
+        self.solve_colspace(entering_col, &mut tau);
+
+        let q = self.qcol_inv[leaving_slot];
+        let tq = tau[q];
+        if tq.abs() <= self.params.zero_pivot_tol {
+            return Err(FeralError::SingularBasis { column: q });
+        }
+        let new_growth = self.growth.max(1.0 / tq.abs());
+        if new_growth > self.params.max_growth {
+            return Err(FeralError::NeedsRefactor);
+        }
+
+        self.etas.push(EtaU { q, tau });
+        self.growth = new_growth;
+        Ok(())
+    }
+
+    /// Discard all pending updates and re-factor from scratch on `a`, reusing
+    /// the column ordering in `symbolic`.
+    pub fn refactor(
+        &mut self,
+        a: &SparseColMatrix,
+        symbolic: &SparseLuSymbolic,
+    ) -> Result<(), FeralError> {
+        *self = SparseLu::factor(a, symbolic, self.params.clone())?;
+        Ok(())
+    }
+}

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -27,24 +27,57 @@ impl SparseLu {
         self.etas.len()
     }
 
-    /// Replace basis slot `leaving_slot` with `entering_col` (`aₙₑw`).
+    /// Replace basis slot `leaving_slot` with the dense entering column `aₙₑw`.
+    ///
+    /// Convenience wrapper over [`SparseLu::update_sparse`]: it scans `aₙₑw`
+    /// once (`O(n)`) for its nonzeros, then delegates. Callers that already hold
+    /// the sparse entering column should call `update_sparse` directly to avoid
+    /// the scan.
     ///
     /// Returns [`FeralError::NeedsRefactor`] (leaving `self` unchanged) when the
     /// update or growth budget is exceeded, and [`FeralError::SingularBasis`]
     /// when the bump has no acceptable pivot (the new basis is singular).
     pub fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), FeralError> {
-        let m = self.m;
-        if entering_col.len() != m {
+        if entering_col.len() != self.m {
             return Err(FeralError::DimensionMismatch {
-                expected: m,
+                expected: self.m,
                 got: entering_col.len(),
             });
         }
+        let sparse: Vec<(usize, f64)> = entering_col
+            .iter()
+            .enumerate()
+            .filter(|&(_, &v)| v != 0.0)
+            .map(|(i, &v)| (i, v))
+            .collect();
+        self.update_sparse(leaving_slot, &sparse)
+    }
+
+    /// Replace basis slot `leaving_slot` with the entering column given by its
+    /// nonzeros `(row, value)` (rows need not be sorted; duplicates are summed).
+    /// Fully bump-local: cost is `O(bump + nnz(aₙₑw))`, with no `O(n)` term.
+    ///
+    /// Returns [`FeralError::NeedsRefactor`] / [`FeralError::SingularBasis`] as
+    /// for [`SparseLu::update`].
+    pub fn update_sparse(
+        &mut self,
+        leaving_slot: usize,
+        entering: &[(usize, f64)],
+    ) -> Result<(), FeralError> {
+        let m = self.m;
         if leaving_slot >= m {
             return Err(FeralError::InvalidInput(format!(
                 "leaving_slot {} out of range for basis dimension {}",
                 leaving_slot, m
             )));
+        }
+        for &(row, _) in entering.iter() {
+            if row >= m {
+                return Err(FeralError::InvalidInput(format!(
+                    "entering-column row {} out of range for dimension {}",
+                    row, m
+                )));
+            }
         }
         if self.updates_since_refactor() + 1 > self.params.max_updates {
             return Err(FeralError::NeedsRefactor);
@@ -53,7 +86,7 @@ impl SparseLu {
         // --- Sparse spike ρ = G⁻¹ L⁻¹ P (scaled aₙₑw) via Gilbert–Peierls reach ---
         let mut w = std::mem::take(&mut self.ft_work); // dedicated buffer, zero on entry
         let mut touched: Vec<usize> = Vec::new(); // positions made nonzero in w
-        self.compute_spike(entering_col, leaving_slot, &mut w, &mut touched);
+        self.compute_spike(entering, leaving_slot, &mut w, &mut touched);
 
         let r = self.qcol_inv[leaving_slot];
         let mut supp: Vec<usize> = touched.iter().copied().filter(|&k| w[k] != 0.0).collect();
@@ -127,35 +160,33 @@ impl SparseLu {
     }
 
     /// Compute the spike `ρ = G⁻¹ L⁻¹ P (D_row Π aₙₑw D_col[slot])` into the dense
-    /// work vector `w`, recording every touched position in `touched`. Uses a
+    /// work vector `w`, recording every touched position in `touched`. Seeds
+    /// directly from the sparse entering column (no `O(n)` scan), then uses a
     /// Gilbert–Peierls depth-first reach so only the reachable `L`-columns are
-    /// visited, then replays the FT etas forward.
+    /// visited, and finally replays the FT etas forward.
     fn compute_spike(
         &mut self,
-        entering_col: &[f64],
+        entering: &[(usize, f64)],
         leaving_slot: usize,
         w: &mut [f64],
         touched: &mut Vec<usize>,
     ) {
-        let m = w.len();
         let dcol = self.scale.d_col[leaving_slot];
         let mut mark = std::mem::take(&mut self.scratch_mark);
         let mut stack: Vec<usize> = Vec::new();
 
         // Scatter the scaled entering column into w (pivot-position space) and
-        // seed the reach. scaled[i] = d_row[i]·entering_col[rperm[i]]·dcol lands
-        // at pivot position perm_inv[i].
-        for i in 0..m {
-            let e = entering_col[self.scale.rperm[i]];
-            if e == 0.0 {
-                continue;
-            }
-            let v = self.scale.d_row[i] * e * dcol;
+        // seed the reach. An original-row entry `o` scales to scaled row
+        // `i = rperm_inv[o]` (factor `d_row[i]·dcol`) and lands at pivot position
+        // `perm_inv[i]`. Duplicates accumulate (`+=`).
+        for &(o, val) in entering.iter() {
+            let i = self.scale_rperm_inv[o];
+            let v = self.scale.d_row[i] * val * dcol;
             if v == 0.0 {
                 continue;
             }
             let k = self.perm_inv[i];
-            w[k] = v;
+            w[k] += v;
             if !mark[k] {
                 mark[k] = true;
                 touched.push(k);

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -47,9 +47,17 @@ impl SparseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
-        // τ = ftran of the entering column in column-position space.
+        // Scale the entering column into the factored frame Ã, then solve into
+        // column-position space: τ = F⁻¹ U⁻¹ L⁻¹ P ãₙₑw. Identity scaling leaves
+        // `entering_col` unchanged.
+        let mut scaled = vec![0.0_f64; m];
+        for (i, si) in scaled.iter_mut().enumerate() {
+            *si = self.scale.d_row[i]
+                * entering_col[self.scale.rperm[i]]
+                * self.scale.d_col[leaving_slot];
+        }
         let mut tau = vec![0.0_f64; m];
-        self.solve_colspace(entering_col, &mut tau);
+        self.solve_colspace(&scaled, &mut tau);
 
         let q = self.qcol_inv[leaving_slot];
         let tq = tau[q];

--- a/tests/lu_dense.rs
+++ b/tests/lu_dense.rs
@@ -1,0 +1,298 @@
+//! Integration tests for the dense unsymmetric LU basis engine (issue #81).
+//!
+//! Oracles: hand-worked exact factor/solve values (external) and equation-
+//! residual property checks `‖Bx−a‖` (oracle-free — they verify the equation,
+//! not a self-computed truth), on plain, adversarial, and ill-conditioned
+//! bases.
+#![allow(clippy::needless_range_loop)]
+
+use feral::lu::dense_matrix::GeneralMatrix;
+use feral::lu::{DenseLu, LuParams};
+use feral::FeralError;
+
+/// Column-major columns from rows-of-the-matrix.
+fn cols_from_rows(rows: &[&[f64]]) -> (Vec<Vec<f64>>, usize) {
+    let m = rows.len();
+    let mut cols = vec![vec![0.0; m]; m];
+    for (i, row) in rows.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            cols[j][i] = v;
+        }
+    }
+    (cols, m)
+}
+
+fn general_from_cols(cols: &[Vec<f64>], m: usize) -> GeneralMatrix {
+    GeneralMatrix::from_columns(m, cols).expect("general matrix")
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+/// Relative residual of `B x − a` after `ftran`.
+fn ftran_rel_residual(b: &GeneralMatrix, lu: &mut DenseLu, a: &[f64]) -> f64 {
+    let mut x = a.to_vec();
+    lu.ftran(&mut x).expect("ftran");
+    let mut bx = vec![0.0; a.len()];
+    b.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+/// Relative residual of `Bᵀ x − a` after `btran`.
+fn btran_rel_residual(b: &GeneralMatrix, lu: &mut DenseLu, a: &[f64]) -> f64 {
+    let mut x = a.to_vec();
+    lu.btran(&mut x).expect("btran");
+    let mut bx = vec![0.0; a.len()];
+    b.matvec_transpose(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+/// Deterministic pseudo-random diagonally-dominant basis (well-conditioned).
+fn random_basis(m: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut cols = vec![vec![0.0; m]; m];
+    let mut state = seed;
+    for j in 0..m {
+        for i in 0..m {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            cols[j][i] = ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0;
+        }
+        cols[j][j] += 5.0;
+    }
+    cols
+}
+
+// ───────────────────────── hand-worked exact ─────────────────────────
+
+#[test]
+fn ftran_2x2_swap_exact_solution() {
+    // B = [[0,2],[3,4]] forces a pivot swap (P = [1,0]); verify the solve via
+    // the equation residual ‖Bx − a‖ rather than a hand-computed x.
+    let (cols, m) = cols_from_rows(&[&[0.0, 2.0], &[3.0, 4.0]]);
+    let b = general_from_cols(&cols, m);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    let a = vec![2.0, 11.0];
+    assert!(ftran_rel_residual(&b, &mut lu, &a) < 1e-12);
+}
+
+#[test]
+fn ftran_partial_equals_handbuilt_spike() {
+    // B = [[0,2],[3,4]] → perm = [1,0], L = I. Spike of a = [5,11] is
+    // L⁻¹ P a = P a = [a[1], a[0]] = [11, 5].
+    let (cols, m) = cols_from_rows(&[&[0.0, 2.0], &[3.0, 4.0]]);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    let mut spike = vec![5.0, 11.0];
+    lu.ftran_partial(&mut spike).expect("ftran_partial");
+    assert!((spike[0] - 11.0).abs() < 1e-12);
+    assert!((spike[1] - 5.0).abs() < 1e-12);
+}
+
+// ───────────────────── equation-residual properties ──────────────────
+
+#[test]
+fn ftran_btran_residual_random() {
+    for seed in [0x1111u64, 0x2222, 0xBEEF] {
+        let m = 9;
+        let cols = random_basis(m, seed);
+        let b = general_from_cols(&cols, m);
+        let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+        let a: Vec<f64> = (0..m).map(|i| (i as f64) - 4.0).collect();
+        assert!(
+            ftran_rel_residual(&b, &mut lu, &a) < 1e-10,
+            "ftran seed {seed:x}"
+        );
+        assert!(
+            btran_rel_residual(&b, &mut lu, &a) < 1e-10,
+            "btran seed {seed:x}"
+        );
+    }
+}
+
+#[test]
+fn ftran_btran_roundtrip() {
+    // x then Bᵀ(B x): btran(ftran(a)) is NOT identity, but ftran then a fresh
+    // solve must reproduce a via matvec — covered above. Here check that
+    // solving and multiplying back is consistent for several RHS.
+    let m = 6;
+    let cols = random_basis(m, 0x5151);
+    let b = general_from_cols(&cols, m);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    for k in 0..m {
+        let mut a = vec![0.0; m];
+        a[k] = 1.0;
+        assert!(ftran_rel_residual(&b, &mut lu, &a) < 1e-10);
+    }
+}
+
+// ───────────────────────── rank-1 update ─────────────────────────────
+
+/// Build the matrix that results from replacing column `slot` of `cols` with
+/// `new_col`, and run one update, returning the post-update relative residual.
+fn do_update_residual(
+    cols: &[Vec<f64>],
+    m: usize,
+    slot: usize,
+    new_col: Vec<f64>,
+    a: &[f64],
+) -> f64 {
+    let mut lu = DenseLu::factor(cols, m, LuParams::default()).expect("factor");
+    // spike = L⁻¹ P new_col
+    let mut spike = new_col.clone();
+    lu.ftran_partial(&mut spike).expect("ftran_partial");
+    lu.update(slot, &spike).expect("update");
+    // B_new
+    let mut new_cols = cols.to_vec();
+    new_cols[slot] = new_col;
+    let b_new = general_from_cols(&new_cols, m);
+    ftran_rel_residual(&b_new, &mut lu, a)
+}
+
+#[test]
+fn update_single_column_residual() {
+    let cols = random_basis(7, 0xABCD);
+    let m = 7;
+    let a: Vec<f64> = (0..m).map(|i| 1.0 + i as f64).collect();
+    let new_col: Vec<f64> = (0..m).map(|i| 2.0 - 0.3 * i as f64).collect();
+    for slot in [0usize, 3, 6] {
+        let res = do_update_residual(&cols, m, slot, new_col.clone(), &a);
+        assert!(res < 1e-8, "update slot {slot}: residual {res:e}");
+    }
+}
+
+#[test]
+fn update_with_row_swap_residual() {
+    // A basis whose factorization pivots (P ≠ I), stressing perm composition.
+    let (cols, m) = cols_from_rows(&[&[0.0, 2.0, 1.0], &[3.0, 4.0, 0.0], &[1.0, 1.0, 5.0]]);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    assert_ne!(lu.perm(), &[0usize, 1, 2], "expected a pivot");
+    let new_col = vec![2.0, 1.0, 3.0];
+    let mut spike = new_col.clone();
+    lu.ftran_partial(&mut spike).expect("ftran_partial");
+    lu.update(1, &spike).expect("update");
+    let mut new_cols = cols.clone();
+    new_cols[1] = new_col;
+    let b_new = general_from_cols(&new_cols, m);
+    let a = vec![1.0, -2.0, 0.5];
+    assert!(ftran_rel_residual(&b_new, &mut lu, &a) < 1e-9);
+}
+
+#[test]
+fn update_sequence_five_residual() {
+    let m = 8;
+    let mut cols = random_basis(m, 0x0707);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    let a: Vec<f64> = (0..m).map(|i| (i as f64 * 0.7) - 1.0).collect();
+    for (step, slot) in [1usize, 4, 0, 6, 2].into_iter().enumerate() {
+        let new_col: Vec<f64> = (0..m)
+            .map(|i| 1.0 + ((step * 31 + i * 7) % 11) as f64 * 0.1)
+            .collect();
+        let mut spike = new_col.clone();
+        lu.ftran_partial(&mut spike).expect("ftran_partial");
+        lu.update(slot, &spike).expect("update");
+        cols[slot] = new_col;
+        let b_new = general_from_cols(&cols, m);
+        let res = ftran_rel_residual(&b_new, &mut lu, &a);
+        assert!(res < 1e-7, "after update {step} (slot {slot}): {res:e}");
+    }
+    assert_eq!(lu.updates_since_refactor(), 5);
+}
+
+#[test]
+fn refactor_matches_updated_factor() {
+    let m = 6;
+    let mut cols = random_basis(m, 0x9090);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
+    // Two updates.
+    for slot in [2usize, 5] {
+        let new_col: Vec<f64> = (0..m).map(|i| 0.5 + slot as f64 - i as f64 * 0.2).collect();
+        let mut spike = new_col.clone();
+        lu.ftran_partial(&mut spike).expect("ftran_partial");
+        lu.update(slot, &spike).expect("update");
+        cols[slot] = new_col;
+    }
+    let a: Vec<f64> = (0..m).map(|i| 3.0 - i as f64).collect();
+    let mut x_updated = a.clone();
+    lu.ftran(&mut x_updated).expect("ftran updated");
+    // A fresh factorization of the same basis must give the same solve.
+    let mut lu2 = DenseLu::factor(&cols, m, LuParams::default()).expect("refactor");
+    let mut x_fresh = a.clone();
+    lu2.ftran(&mut x_fresh).expect("ftran fresh");
+    let diff: f64 = x_updated
+        .iter()
+        .zip(&x_fresh)
+        .map(|(&u, &f)| (u - f).abs())
+        .fold(0.0, f64::max);
+    assert!(diff < 1e-9, "updated vs refactored solve diff {diff:e}");
+}
+
+#[test]
+fn update_budget_returns_needs_refactor() {
+    let m = 5;
+    let cols = random_basis(m, 0x1234);
+    let params = LuParams {
+        max_updates: 2,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(&cols, m, params).expect("factor");
+    let new_col = vec![1.0, 2.0, 1.0, 0.5, 3.0];
+    // Two successful updates.
+    for slot in [0usize, 1] {
+        let mut spike = new_col.clone();
+        lu.ftran_partial(&mut spike).expect("ftran_partial");
+        lu.update(slot, &spike).expect("update");
+    }
+    // Third trips the budget; self must be unchanged.
+    let before = {
+        let mut a = vec![1.0, 1.0, 1.0, 1.0, 1.0];
+        lu.ftran(&mut a).expect("ftran");
+        a
+    };
+    let mut spike = new_col.clone();
+    lu.ftran_partial(&mut spike).expect("ftran_partial");
+    let err = lu.update(2, &spike);
+    assert!(matches!(err, Err(FeralError::NeedsRefactor)));
+    assert_eq!(lu.updates_since_refactor(), 2);
+    let after = {
+        let mut a = vec![1.0, 1.0, 1.0, 1.0, 1.0];
+        lu.ftran(&mut a).expect("ftran");
+        a
+    };
+    let diff: f64 = before
+        .iter()
+        .zip(&after)
+        .map(|(&x, &y)| (x - y).abs())
+        .fold(0.0, f64::max);
+    assert!(diff < 1e-14, "self changed after NeedsRefactor: {diff:e}");
+}
+
+// ───────────────────── adversarial / refinement ──────────────────────
+
+#[test]
+fn singular_repeated_columns_fails() {
+    let (cols, m) = cols_from_rows(&[&[1.0, 2.0], &[2.0, 4.0]]);
+    let err = DenseLu::factor(&cols, m, LuParams::default());
+    assert!(matches!(err, Err(FeralError::SingularBasis { .. })));
+}
+
+#[test]
+fn ill_conditioned_refinement_helps() {
+    // A moderately ill-conditioned basis: refinement should not worsen the
+    // residual and should keep it small.
+    let (cols, m) = cols_from_rows(&[&[1.0, 1.0, 1.0], &[1.0, 1.0001, 1.0], &[1.0, 1.0, 1.0002]]);
+    let b = general_from_cols(&cols, m);
+    let params = LuParams {
+        refine_steps: 3,
+        refine_tol: 1e-14,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(&cols, m, params).expect("factor");
+    let a = vec![3.0, 3.0001, 3.0002];
+    let mut x = a.clone();
+    lu.ftran_refined(&b, &mut x).expect("ftran_refined");
+    let mut bx = vec![0.0; m];
+    b.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(&a).map(|(&p, &ai)| p - ai).collect();
+    assert!(inf_norm(&r) / inf_norm(&a) < 1e-12);
+}

--- a/tests/lu_dense.rs
+++ b/tests/lu_dense.rs
@@ -138,10 +138,7 @@ fn do_update_residual(
     a: &[f64],
 ) -> f64 {
     let mut lu = DenseLu::factor(cols, m, LuParams::default()).expect("factor");
-    // spike = L⁻¹ P new_col
-    let mut spike = new_col.clone();
-    lu.ftran_partial(&mut spike).expect("ftran_partial");
-    lu.update(slot, &spike).expect("update");
+    lu.update(slot, &new_col).expect("update");
     // B_new
     let mut new_cols = cols.to_vec();
     new_cols[slot] = new_col;
@@ -168,9 +165,7 @@ fn update_with_row_swap_residual() {
     let mut lu = DenseLu::factor(&cols, m, LuParams::default()).expect("factor");
     assert_ne!(lu.perm(), &[0usize, 1, 2], "expected a pivot");
     let new_col = vec![2.0, 1.0, 3.0];
-    let mut spike = new_col.clone();
-    lu.ftran_partial(&mut spike).expect("ftran_partial");
-    lu.update(1, &spike).expect("update");
+    lu.update(1, &new_col).expect("update");
     let mut new_cols = cols.clone();
     new_cols[1] = new_col;
     let b_new = general_from_cols(&new_cols, m);
@@ -188,9 +183,7 @@ fn update_sequence_five_residual() {
         let new_col: Vec<f64> = (0..m)
             .map(|i| 1.0 + ((step * 31 + i * 7) % 11) as f64 * 0.1)
             .collect();
-        let mut spike = new_col.clone();
-        lu.ftran_partial(&mut spike).expect("ftran_partial");
-        lu.update(slot, &spike).expect("update");
+        lu.update(slot, &new_col).expect("update");
         cols[slot] = new_col;
         let b_new = general_from_cols(&cols, m);
         let res = ftran_rel_residual(&b_new, &mut lu, &a);
@@ -207,9 +200,7 @@ fn refactor_matches_updated_factor() {
     // Two updates.
     for slot in [2usize, 5] {
         let new_col: Vec<f64> = (0..m).map(|i| 0.5 + slot as f64 - i as f64 * 0.2).collect();
-        let mut spike = new_col.clone();
-        lu.ftran_partial(&mut spike).expect("ftran_partial");
-        lu.update(slot, &spike).expect("update");
+        lu.update(slot, &new_col).expect("update");
         cols[slot] = new_col;
     }
     let a: Vec<f64> = (0..m).map(|i| 3.0 - i as f64).collect();
@@ -239,9 +230,7 @@ fn update_budget_returns_needs_refactor() {
     let new_col = vec![1.0, 2.0, 1.0, 0.5, 3.0];
     // Two successful updates.
     for slot in [0usize, 1] {
-        let mut spike = new_col.clone();
-        lu.ftran_partial(&mut spike).expect("ftran_partial");
-        lu.update(slot, &spike).expect("update");
+        lu.update(slot, &new_col).expect("update");
     }
     // Third trips the budget; self must be unchanged.
     let before = {
@@ -249,9 +238,7 @@ fn update_budget_returns_needs_refactor() {
         lu.ftran(&mut a).expect("ftran");
         a
     };
-    let mut spike = new_col.clone();
-    lu.ftran_partial(&mut spike).expect("ftran_partial");
-    let err = lu.update(2, &spike);
+    let err = lu.update(2, &new_col);
     assert!(matches!(err, Err(FeralError::NeedsRefactor)));
     assert_eq!(lu.updates_since_refactor(), 2);
     let after = {

--- a/tests/lu_scaling.rs
+++ b/tests/lu_scaling.rs
@@ -1,0 +1,166 @@
+//! Scaling-layer tests for the LU basis engine (issue #81): ∞-norm
+//! equilibration and unsymmetric MC64. Oracles are equation residuals
+//! `‖Bx−a‖` (scaling must preserve correctness) plus a direct balance check on
+//! the equilibrated matrix.
+#![allow(clippy::needless_range_loop)]
+
+use feral::lu::scaling::{compute_lu_scale, equilibrate_infnorm};
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{DenseLu, LuParams, LuScaling, SparseLu, SparseLuSymbolic};
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+/// A badly row/column-scaled but nonsingular basis.
+fn ill_scaled(m: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut state = seed;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0
+    };
+    // Row scales spanning ~16 orders of magnitude, column scales too.
+    let row_scale: Vec<f64> = (0..m).map(|i| 10f64.powi((i as i32 % 8) - 4)).collect();
+    let col_scale: Vec<f64> = (0..m).map(|j| 10f64.powi(3 - (j as i32 % 7))).collect();
+    let mut cols = vec![vec![0.0; m]; m];
+    for j in 0..m {
+        for i in 0..m {
+            let base = if i == j {
+                3.0 + rng().abs()
+            } else if i.abs_diff(j) <= 1 {
+                rng()
+            } else {
+                0.0
+            };
+            cols[j][i] = base * row_scale[i] * col_scale[j];
+        }
+    }
+    cols
+}
+
+fn ftran_residual_dense(cols: &[Vec<f64>], m: usize, scaling: LuScaling, a: &[f64]) -> f64 {
+    let params = LuParams {
+        scaling,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(cols, m, params).expect("dense factor");
+    let b = feral::lu::dense_matrix::GeneralMatrix::from_columns(m, cols).expect("gen");
+    let mut x = a.to_vec();
+    lu.ftran(&mut x).expect("ftran");
+    let mut bx = vec![0.0; m];
+    b.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+fn ftran_residual_sparse(cols: &[Vec<f64>], m: usize, scaling: LuScaling, a: &[f64]) -> f64 {
+    let bmat = SparseColMatrix::from_dense_columns(m, cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&bmat).expect("analyze");
+    let params = LuParams {
+        scaling,
+        ..LuParams::default()
+    };
+    let mut lu = SparseLu::factor(&bmat, &symbolic, params).expect("sparse factor");
+    let mut x = a.to_vec();
+    lu.ftran(&mut x).expect("ftran");
+    let mut bx = vec![0.0; m];
+    bmat.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+#[test]
+fn dense_scaling_preserves_correctness() {
+    let m = 10;
+    let cols = ill_scaled(m, 0x1234);
+    let a: Vec<f64> = (0..m).map(|i| 1.0 + i as f64).collect();
+    for scaling in [
+        LuScaling::InfNorm,
+        LuScaling::Mc64,
+        LuScaling::Mc64ThenInfNorm,
+    ] {
+        let res = ftran_residual_dense(&cols, m, scaling, &a);
+        assert!(res < 1e-8, "{scaling:?}: residual {res:e}");
+    }
+}
+
+#[test]
+fn sparse_scaling_preserves_correctness() {
+    let m = 10;
+    let cols = ill_scaled(m, 0x9999);
+    let a: Vec<f64> = (0..m).map(|i| 2.0 - i as f64 * 0.1).collect();
+    for scaling in [
+        LuScaling::InfNorm,
+        LuScaling::Mc64,
+        LuScaling::Mc64ThenInfNorm,
+    ] {
+        let res = ftran_residual_sparse(&cols, m, scaling, &a);
+        assert!(res < 1e-8, "{scaling:?}: residual {res:e}");
+    }
+}
+
+#[test]
+fn dense_sparse_agreement_under_mc64() {
+    let m = 9;
+    let cols = ill_scaled(m, 0x5151);
+    let a: Vec<f64> = (0..m).map(|i| 1.0 + (i % 3) as f64).collect();
+    let dr = ftran_residual_dense(&cols, m, LuScaling::Mc64, &a);
+    let sr = ftran_residual_sparse(&cols, m, LuScaling::Mc64, &a);
+    assert!(dr < 1e-8 && sr < 1e-8, "dense {dr:e}, sparse {sr:e}");
+}
+
+#[test]
+fn equilibration_balances_the_matrix() {
+    // After ∞-norm equilibration every row and column ∞-norm should be ≈ 1.
+    let m = 12;
+    let cols = ill_scaled(m, 0xABCD);
+    let b = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let scale = equilibrate_infnorm(&b, 8);
+    let mut row_max = vec![0.0_f64; m];
+    let mut col_max = vec![0.0_f64; m];
+    for j in 0..m {
+        let (rows, vals) = b.column(j);
+        for (&i, &v) in rows.iter().zip(vals) {
+            let a = (scale.d_row[i] * v * scale.d_col[j]).abs();
+            row_max[i] = row_max[i].max(a);
+            col_max[j] = col_max[j].max(a);
+        }
+    }
+    for (i, &rm) in row_max.iter().enumerate() {
+        assert!(
+            (0.1..=10.0).contains(&rm),
+            "row {i} max {rm:e} not balanced"
+        );
+    }
+    for (j, &cm) in col_max.iter().enumerate() {
+        assert!(
+            (0.1..=10.0).contains(&cm),
+            "col {j} max {cm:e} not balanced"
+        );
+    }
+}
+
+#[test]
+fn mc64_places_large_entries_on_diagonal() {
+    // After MC64 scaling + row permutation, the diagonal entries of Ã should be
+    // the dominant entries (magnitude ≈ 1 by construction of the matching).
+    let m = 8;
+    let cols = ill_scaled(m, 0x2468);
+    let b = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let scale = compute_lu_scale(&b, LuScaling::Mc64).expect("mc64");
+    let scaled = scale.apply_sparse(&b).expect("apply");
+    // Each diagonal entry should be present and of order 1.
+    for j in 0..m {
+        let (rows, vals) = scaled.column(j);
+        let diag = rows
+            .iter()
+            .zip(vals)
+            .find(|(&i, _)| i == j)
+            .map(|(_, &v)| v.abs())
+            .unwrap_or(0.0);
+        assert!(
+            diag > 1e-3,
+            "col {j} diagonal {diag:e} too small after MC64"
+        );
+    }
+}

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -222,6 +222,50 @@ fn sparse_update_single_residual() {
 }
 
 #[test]
+fn sparse_ft_long_chain_residual() {
+    // A long Forrest–Tomlin update chain on a sparse basis: every warm solve
+    // must stay correct (residual small) as the chain grows — and the etas are
+    // bump-local, so this also exercises partial pivoting in the bump.
+    let m = 30;
+    let mut cols = banded_basis(m, 0xFEED);
+    let params = LuParams {
+        max_updates: 1000,
+        ..LuParams::default()
+    };
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
+    let rhs: Vec<f64> = (0..m).map(|i| 1.0 + (i % 5) as f64 * 0.5).collect();
+
+    let mut state = 0xC0FFEEu64;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0
+    };
+    for step in 0..25 {
+        let slot = (step * 7 + 3) % m;
+        // Diagonally-dominant replacement column keeps the basis nonsingular.
+        let mut nc = vec![0.0; m];
+        nc[slot] = 5.0 + rng().abs();
+        if slot > 0 {
+            nc[slot - 1] = rng();
+        }
+        if slot + 1 < m {
+            nc[slot + 1] = rng();
+        }
+        lu.update(slot, &nc).expect("ft update");
+        cols[slot] = nc;
+        let b_new = SparseColMatrix::from_dense_columns(m, &cols).expect("b_new");
+        let res = ftran_rel_residual(&b_new, &mut lu, &rhs);
+        assert!(res < 1e-7, "after FT update {step} (slot {slot}): {res:e}");
+        // btran must also stay correct.
+        let bres = btran_rel_residual(&b_new, &mut lu, &rhs);
+        assert!(bres < 1e-7, "btran after FT update {step}: {bres:e}");
+    }
+    assert_eq!(lu.updates_since_refactor(), 25);
+}
+
+#[test]
 fn sparse_update_budget_and_refactor() {
     let m = 8;
     let cols = banded_basis(m, 0x55);

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -270,6 +270,48 @@ fn sparse_update_matches_dense() {
     assert!(diff < 1e-9, "post-update dense vs sparse diff {diff:e}");
 }
 
+/// Build a diagonally-dominant tridiagonal `n`×`n` basis (≈3n nonzeros).
+fn tridiagonal(n: usize) -> SparseColMatrix {
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for (j, col) in cols.iter_mut().enumerate() {
+        if j > 0 {
+            col.push((j - 1, -1.0));
+        }
+        col.push((j, 4.0));
+        if j + 1 < n {
+            col.push((j + 1, -1.0));
+        }
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("tridiagonal")
+}
+
+#[test]
+fn factor_traversal_is_subquadratic() {
+    // Deterministic (timing-free) scalability guard: on a no-fill tridiagonal
+    // basis the Gilbert–Peierls reach work is O(nnz) = O(n). Doubling n must
+    // (well) less than quadruple the reach work; the pre-reach O(n²) scan would
+    // have quadrupled it. We allow a 3× margin (linear ≈ 2×).
+    let work = |n: usize| -> usize {
+        let a = tridiagonal(n);
+        let sym = SparseLuSymbolic::natural(n);
+        let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+        // Sanity: tridiagonal has no fill.
+        assert_eq!(lu.factor_nnz(), a.nnz());
+        lu.reach_visits()
+    };
+    let w1 = work(2000);
+    let w2 = work(4000);
+    let w3 = work(8000);
+    assert!(
+        w2 < 3 * w1,
+        "2000→4000 reach work {w1} → {w2} not sub-quadratic"
+    );
+    assert!(
+        w3 < 3 * w2,
+        "4000→8000 reach work {w2} → {w3} not sub-quadratic"
+    );
+}
+
 #[test]
 fn sparse_refinement_converges() {
     let m = 11;

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -221,6 +221,64 @@ fn sparse_update_single_residual() {
     assert_eq!(lu.updates_since_refactor(), 4);
 }
 
+/// Identical diagonally-dominant blocks of size `bs` down the diagonal.
+fn block_diag_fixed(nblocks: usize, bs: usize) -> SparseColMatrix {
+    let n = nblocks * bs;
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for b in 0..nblocks {
+        let base = b * bs;
+        for cc in 0..bs {
+            for rr in 0..bs {
+                let v = if rr == cc {
+                    5.0
+                } else if (rr + 2 * cc) % 4 == 0 {
+                    0.5
+                } else {
+                    0.0
+                };
+                if v != 0.0 {
+                    cols[base + cc].push((base + rr, v));
+                }
+            }
+        }
+    }
+    SparseColMatrix::from_sparse_columns(n, &cols).expect("block_diag")
+}
+
+#[test]
+fn ft_update_is_bump_local() {
+    // The FT eta replays the bump elimination; for a within-block update the
+    // bump is confined to that block, so the eta size is the SAME regardless of
+    // how many other blocks exist — i.e., independent of n (the win over the
+    // product-form's always-O(n) dense τ).
+    let bs = 8;
+    let do_block0_update = |nblocks: usize| -> usize {
+        let n = nblocks * bs;
+        let a = block_diag_fixed(nblocks, bs);
+        let sym = SparseLuSymbolic::natural(n);
+        let mut lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+        // Replace column 0 (in block 0) with a fixed within-block-0 column.
+        let mut col = vec![0.0; n];
+        col[0] = 6.0;
+        col[1] = 1.0;
+        col[2] = -0.5;
+        lu.update(0, &col).expect("update");
+        lu.last_eta_ops()
+    };
+    let ops_small = do_block0_update(3); // n = 24
+    let ops_big = do_block0_update(50); // n = 400
+    assert_eq!(
+        ops_small, ops_big,
+        "FT eta size must be independent of n for a block-local update"
+    );
+    // And bounded by the block, far below n.
+    assert!(
+        ops_big <= bs * bs,
+        "eta ops {ops_big} exceed block bound {}",
+        bs * bs
+    );
+}
+
 #[test]
 fn sparse_ft_long_chain_residual() {
     // A long Forrest–Tomlin update chain on a sparse basis: every warm solve

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -1,0 +1,208 @@
+//! Integration tests for the sparse unsymmetric LU basis engine (issue #81).
+//!
+//! Oracles: reconstruction `‖PAQ − LU‖` and equation-residual `‖Bx−a‖` (both
+//! oracle-free identities), plus dense↔sparse agreement (consistency check).
+#![allow(clippy::needless_range_loop)]
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{DenseLu, LuParams, LuSingularAction, SparseLu, SparseLuSymbolic};
+use feral::FeralError;
+
+fn cols_from_rows(rows: &[&[f64]]) -> (Vec<Vec<f64>>, usize) {
+    let m = rows.len();
+    let mut cols = vec![vec![0.0; m]; m];
+    for (i, row) in rows.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            cols[j][i] = v;
+        }
+    }
+    (cols, m)
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+/// Deterministic sparse-ish basis: a tridiagonal-plus-noise matrix.
+fn banded_basis(m: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut cols = vec![vec![0.0; m]; m];
+    let mut state = seed;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((state >> 33) as f64) / (1u64 << 31) as f64 - 1.0
+    };
+    for j in 0..m {
+        cols[j][j] = 4.0 + rng();
+        if j > 0 {
+            cols[j][j - 1] = rng();
+        }
+        if j + 1 < m {
+            cols[j][j + 1] = rng();
+        }
+        // a couple of off-band entries for fill
+        if j >= 2 {
+            cols[j][j - 2] = 0.5 * rng();
+        }
+    }
+    cols
+}
+
+/// max | (P A Q)[i,j] − (L U)[i,j] | over the dense reconstruction.
+fn reconstruction_residual(a: &SparseColMatrix, lu: &SparseLu) -> f64 {
+    let m = a.m;
+    // Dense A for convenience.
+    let mut dense = vec![0.0; m * m];
+    for j in 0..m {
+        let (rows, vals) = a.column(j);
+        for (&i, &v) in rows.iter().zip(vals) {
+            dense[i + j * m] = v;
+        }
+    }
+    let perm = lu.perm();
+    let qcol = lu.qcol();
+    let mut worst = 0.0_f64;
+    for i in 0..m {
+        for j in 0..m {
+            let paq = dense[perm[i] + qcol[j] * m];
+            let mut prod = 0.0;
+            for k in 0..m {
+                prod += lu.l_dense(i, k) * lu.u_dense(k, j);
+            }
+            worst = worst.max((paq - prod).abs());
+        }
+    }
+    worst
+}
+
+fn ftran_rel_residual(b: &SparseColMatrix, lu: &mut SparseLu, a: &[f64]) -> f64 {
+    let mut x = a.to_vec();
+    lu.ftran(&mut x).expect("ftran");
+    let mut bx = vec![0.0; a.len()];
+    b.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+fn btran_rel_residual(b: &SparseColMatrix, lu: &mut SparseLu, a: &[f64]) -> f64 {
+    let mut x = a.to_vec();
+    lu.btran(&mut x).expect("btran");
+    let mut bx = vec![0.0; a.len()];
+    b.matvec_transpose(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(a).map(|(&p, &ai)| p - ai).collect();
+    inf_norm(&r) / inf_norm(a).max(1e-300)
+}
+
+#[test]
+fn sparse_factor_reconstruction() {
+    for seed in [0x11u64, 0xA5, 0xF0] {
+        let m = 12;
+        let cols = banded_basis(m, seed);
+        let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+        let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+        let lu = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+        let res = reconstruction_residual(&a, &lu);
+        assert!(res < 1e-10, "seed {seed:x}: ‖PAQ−LU‖ = {res:e}");
+    }
+}
+
+#[test]
+fn sparse_ftran_btran_residual() {
+    let m = 14;
+    let cols = banded_basis(m, 0x99);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let mut lu = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+    let rhs: Vec<f64> = (0..m).map(|i| 1.0 + i as f64).collect();
+    assert!(ftran_rel_residual(&a, &mut lu, &rhs) < 1e-10);
+    assert!(btran_rel_residual(&a, &mut lu, &rhs) < 1e-10);
+}
+
+#[test]
+fn sparse_natural_ordering_works() {
+    let m = 10;
+    let cols = banded_basis(m, 0x42);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::natural(m);
+    let mut lu = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+    assert!(reconstruction_residual(&a, &lu) < 1e-10);
+    let rhs: Vec<f64> = (0..m).map(|i| 2.0 - i as f64 * 0.3).collect();
+    assert!(ftran_rel_residual(&a, &mut lu, &rhs) < 1e-10);
+}
+
+#[test]
+fn dense_sparse_agreement() {
+    // The same basis solved through both paths must agree.
+    let m = 9;
+    let cols = banded_basis(m, 0x7777);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let mut sparse = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("sparse");
+    let mut dense = DenseLu::factor(&cols, m, LuParams::default()).expect("dense");
+
+    let rhs: Vec<f64> = (0..m).map(|i| (i as f64 * 1.3) - 2.0).collect();
+    let mut xs = rhs.clone();
+    let mut xd = rhs.clone();
+    sparse.ftran(&mut xs).expect("sparse ftran");
+    dense.ftran(&mut xd).expect("dense ftran");
+    let diff: f64 = xs
+        .iter()
+        .zip(&xd)
+        .map(|(&s, &d)| (s - d).abs())
+        .fold(0.0, f64::max);
+    assert!(diff < 1e-9, "ftran dense vs sparse diff {diff:e}");
+
+    let mut ys = rhs.clone();
+    let mut yd = rhs.clone();
+    sparse.btran(&mut ys).expect("sparse btran");
+    dense.btran(&mut yd).expect("dense btran");
+    let diffb: f64 = ys
+        .iter()
+        .zip(&yd)
+        .map(|(&s, &d)| (s - d).abs())
+        .fold(0.0, f64::max);
+    assert!(diffb < 1e-9, "btran dense vs sparse diff {diffb:e}");
+}
+
+#[test]
+fn sparse_singular_fails() {
+    // Two identical columns → structurally singular.
+    let (cols, m) = cols_from_rows(&[&[1.0, 1.0, 0.0], &[2.0, 2.0, 0.0], &[0.0, 0.0, 3.0]]);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::natural(m);
+    let err = SparseLu::factor(&a, &symbolic, LuParams::default());
+    assert!(matches!(err, Err(FeralError::SingularBasis { .. })));
+}
+
+#[test]
+fn sparse_perturb_succeeds() {
+    let (cols, m) = cols_from_rows(&[&[1.0, 1.0, 0.0], &[2.0, 2.0, 0.0], &[0.0, 0.0, 3.0]]);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::natural(m);
+    let params = LuParams {
+        on_singular: LuSingularAction::PerturbToEps { abs_floor: 1e-10 },
+        ..LuParams::default()
+    };
+    let lu = SparseLu::factor(&a, &symbolic, params);
+    assert!(lu.is_ok());
+}
+
+#[test]
+fn sparse_refinement_converges() {
+    let m = 11;
+    let cols = banded_basis(m, 0xABCDEF);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let params = LuParams {
+        refine_steps: 2,
+        refine_tol: 1e-14,
+        ..LuParams::default()
+    };
+    let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
+    let rhs: Vec<f64> = (0..m).map(|i| 1.0 + (i % 3) as f64).collect();
+    let mut x = rhs.clone();
+    lu.ftran_refined(&a, &mut x).expect("ftran_refined");
+    let mut bx = vec![0.0; m];
+    a.matvec(&x, &mut bx);
+    let r: Vec<f64> = bx.iter().zip(&rhs).map(|(&p, &ai)| p - ai).collect();
+    assert!(inf_norm(&r) / inf_norm(&rhs) < 1e-12);
+}

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -246,6 +246,49 @@ fn block_diag_fixed(nblocks: usize, bs: usize) -> SparseColMatrix {
 }
 
 #[test]
+fn sparse_update_api_matches_dense_update() {
+    // update_sparse(&[(row,val)]) must produce the same factorization as the
+    // dense update() given the same column.
+    let m = 14;
+    let cols = banded_basis(m, 0x2024);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let lu0 = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+
+    // A genuinely sparse entering column.
+    let dense_col: Vec<f64> = {
+        let mut c = vec![0.0; m];
+        c[6] = 4.0;
+        c[7] = -1.0;
+        c[9] = 0.5;
+        c
+    };
+    let sparse_col = vec![(6usize, 4.0), (9usize, 0.5), (7usize, -1.0)]; // unsorted on purpose
+
+    let mut lu_dense = lu0.clone();
+    lu_dense.update(8, &dense_col).expect("dense update");
+    let mut lu_sparse = lu0.clone();
+    lu_sparse
+        .update_sparse(8, &sparse_col)
+        .expect("sparse update");
+
+    // Both factorizations must give identical solves.
+    for rhs_seed in 0..m {
+        let rhs: Vec<f64> = (0..m).map(|i| 1.0 + ((i + rhs_seed) % 5) as f64).collect();
+        let mut xd = rhs.clone();
+        let mut xs = rhs.clone();
+        lu_dense.ftran(&mut xd).expect("ftran d");
+        lu_sparse.ftran(&mut xs).expect("ftran s");
+        let diff: f64 = xd
+            .iter()
+            .zip(&xs)
+            .map(|(&d, &s)| (d - s).abs())
+            .fold(0.0, f64::max);
+        assert!(diff < 1e-14, "dense vs sparse update solve diff {diff:e}");
+    }
+}
+
+#[test]
 fn ft_update_is_bump_local() {
     // The FT eta replays the bump elimination; for a within-block update the
     // bump is confined to that block, so the eta size is the SAME regardless of

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -187,6 +187,90 @@ fn sparse_perturb_succeeds() {
 }
 
 #[test]
+fn sparse_update_single_residual() {
+    let m = 12;
+    let mut cols = banded_basis(m, 0x33);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let mut lu = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("factor");
+    let rhs: Vec<f64> = (0..m).map(|i| 1.0 + (i as f64) * 0.4).collect();
+    let new_col: Vec<f64> = (0..m).map(|i| 0.5 + ((i * 3) % 5) as f64).collect();
+    for &slot in &[0usize, 5, 11] {
+        let mut lu_k = lu.clone();
+        lu_k.update(slot, &new_col).expect("update");
+        let mut new_cols = cols.clone();
+        new_cols[slot] = new_col.clone();
+        let b_new = SparseColMatrix::from_dense_columns(m, &new_cols).expect("b_new");
+        assert!(
+            ftran_rel_residual(&b_new, &mut lu_k, &rhs) < 1e-8,
+            "slot {slot}"
+        );
+    }
+    // Chain of updates on the live factor.
+    let a0 = rhs.clone();
+    for (step, &slot) in [2usize, 7, 4, 9].iter().enumerate() {
+        let nc: Vec<f64> = (0..m)
+            .map(|i| 1.0 + ((step + i) % 6) as f64 * 0.3)
+            .collect();
+        lu.update(slot, &nc).expect("chain update");
+        cols[slot] = nc;
+        let b_new = SparseColMatrix::from_dense_columns(m, &cols).expect("b_new");
+        let res = ftran_rel_residual(&b_new, &mut lu, &a0);
+        assert!(res < 1e-7, "chain step {step}: {res:e}");
+    }
+    assert_eq!(lu.updates_since_refactor(), 4);
+}
+
+#[test]
+fn sparse_update_budget_and_refactor() {
+    let m = 8;
+    let cols = banded_basis(m, 0x55);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let params = LuParams {
+        max_updates: 2,
+        ..LuParams::default()
+    };
+    let mut lu = SparseLu::factor(&a, &symbolic, params).expect("factor");
+    let nc0: Vec<f64> = (0..m).map(|i| 1.0 + (i % 3) as f64).collect();
+    let nc1: Vec<f64> = (0..m).map(|i| 2.0 - (i % 4) as f64 * 0.5).collect();
+    let nc2: Vec<f64> = (0..m).map(|i| 0.5 + (i % 5) as f64 * 0.3).collect();
+    lu.update(0, &nc0).expect("u1");
+    lu.update(1, &nc1).expect("u2");
+    let err = lu.update(2, &nc2);
+    assert!(matches!(err, Err(FeralError::NeedsRefactor)));
+    assert_eq!(lu.updates_since_refactor(), 2);
+    // Refactor clears the eta chain.
+    lu.refactor(&a, &symbolic).expect("refactor");
+    assert_eq!(lu.updates_since_refactor(), 0);
+}
+
+#[test]
+fn sparse_update_matches_dense() {
+    // The same update through both engines must agree.
+    let m = 9;
+    let cols = banded_basis(m, 0xDD);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+    let symbolic = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let mut sparse = SparseLu::factor(&a, &symbolic, LuParams::default()).expect("sparse");
+    let mut dense = DenseLu::factor(&cols, m, LuParams::default()).expect("dense");
+    let new_col: Vec<f64> = (0..m).map(|i| 2.0 - 0.25 * i as f64).collect();
+    sparse.update(3, &new_col).expect("sparse update");
+    dense.update(3, &new_col).expect("dense update");
+    let rhs: Vec<f64> = (0..m).map(|i| 1.0 + i as f64).collect();
+    let mut xs = rhs.clone();
+    let mut xd = rhs.clone();
+    sparse.ftran(&mut xs).expect("sparse ftran");
+    dense.ftran(&mut xd).expect("dense ftran");
+    let diff: f64 = xs
+        .iter()
+        .zip(&xd)
+        .map(|(&s, &d)| (s - d).abs())
+        .fold(0.0, f64::max);
+    assert!(diff < 1e-9, "post-update dense vs sparse diff {diff:e}");
+}
+
+#[test]
 fn sparse_refinement_converges() {
     let m = 11;
     let cols = banded_basis(m, 0xABCDEF);


### PR DESCRIPTION
## Summary

This PR adds a new, separate factorization family to feral: **unsymmetric LU** (`feral::lu`) designed as a revised-simplex basis engine. The symmetric LDLᵀ solver and all its code paths remain untouched (additive change). LU has no inertia and is built for cheap rank-1 column-replacement updates and warm `ftran`/`btran` solves.

## Key Changes

### Core Factorization
- **Dense path** (`src/lu/dense_*`): Right-looking LU with threshold partial pivoting, maintaining `P B Q = L U` with explicit `L`/`U` storage and column permutation `Q`. Bartels–Golub rank-1 update with in-place column replacement and cyclic shift elimination.
- **Sparse path** (`src/lu/sparse_*`): Left-looking Gilbert–Peierls LU with output-sensitive depth-first reach, storing `L` as CSC (strict-lower, unit diagonal implicit) and `U` as CSR (row-wise, diagonal first). Forrest–Tomlin rank-1 update with bump-local eta elimination (no dense `τ`).

### Solves and Updates
- `ftran` / `btran`: Forward and backward triangular solves with scaling applied around the core solve.
- `ftran_partial`: Returns the spike for the rank-1 update (no `U`-solve, no column permutation).
- `update` / `update_sparse`: Dense and sparse rank-1 column-replacement with growth monitoring and `NeedsRefactor` on instability or budget exceeded.

### Robustness Layer
- **Scaling** (`src/lu/scaling.rs`): Two-sided diagonal scaling via Knight–Ruiz ∞-norm equilibration and unsymmetric MC64 (reusing feral's `hungarian_match` kernel). Scaling is applied around the core solve; the factorization factors the scaled matrix.
- **Iterative refinement**: `ftran_refined` / `btran_refined` with residual-based correction (deferred to later phase per epic plan).

### Symbolic Analysis
- **Column ordering** (`src/lu/sparse_symbolic.rs`): Reuses feral's in-tree AMD on the `AᵀA` (column-intersection) pattern as a stand-in for COLAMD. Reusable across numerically different but structurally identical bases.

### Matrix Representations
- **Dense** (`src/lu/dense_matrix.rs`): `GeneralMatrix` — general square matrix in column-major storage.
- **Sparse** (`src/lu/sparse_matrix.rs`): `SparseColMatrix` — CSC form with sorted row indices per column. Builds transpose and `AᵀA` patterns for ordering.

## Tests and Validation

- **Dense tests** (`tests/lu_dense.rs`): Hand-worked exact factor/solve values and equation-residual property checks on plain, adversarial, and ill-conditioned bases.
- **Sparse tests** (`tests/lu_sparse.rs`): Reconstruction residual `‖PAQ − LU‖`, equation residuals `‖Bx−a‖`, and dense↔sparse agreement.
- **Scaling tests** (`tests/lu_scaling.rs`): Equilibration and MC64 correctness via equation residuals and balance checks.
- **Benchmarks** (`benches/lu.rs`): Factor + warm-solve baselines, rank-1 update cost, and update vs. refactor crossover.

## Diagnostics and Reference

- **Validation harness** (`crates/feral-diagnostics/src/bin/lu_reference.rs`): Reads square Matrix Market files, validates sparse LU against known-x oracle, and exercises rank-1 updates.
- **Scaling probes** (`crates/feral-diagnostics/src/bin/lu_scale_probe.rs`, `lu_update_probe.rs`): Demonstrate scalability on tridiagonal and block-diagonal bases.
- **SciPy cross-check** (`scripts/lu

https://claude.ai/code/session_01JEvT1SNr58v2vmrEoP5WKj