### PR TITLE
chore(release): bump ordering crates 0.2.0 -> 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to FERAL will be documented in this file.
 
 ## [0.11.0] - 2026-06-11
 
+### Packaging — ordering crates bumped to 0.2.1
+
+The six fill-reducing ordering crates (`feral-ordering-core`, `feral-amd`,
+`feral-amf`, `feral-metis`, `feral-scotch`, `feral-kahip`) are bumped from
+`0.2.0` to `0.2.1` so the published crates.io artifacts pick up the
+API-compatible fixes, perf work, and refactors accumulated since `0.2.0` was
+first published — notably the `feral-metis` (real SHEM coarsening, true GGP
+gain in initial bisection), `feral-kahip` (vertex-weight flow balancing,
+`n_components`), `feral-scotch` (vertex-separator FM past imbalance-rejected
+heads), and `feral-ordering-core` (sorted-rows invariant) changes from the
+repo-review campaign. They had been left at `0.2.0` across the `0.3.0`–`0.10.0`
+feral releases, so `cargo publish` silently skipped them (the version already
+existed) and consumers linked stale ordering code. The changes are
+semver-compatible (the ordering-crate API contract is fixed; see
+`dev/decisions.md` 2026-04-17), so `feral`'s `version = "0.2"` requirement is
+unchanged and resolves to `0.2.1`.
+
 ### Documentation
 
 - The mdBook Python chapter (`book/src/python.md`) now documents the new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,14 +213,14 @@ dependencies = [
 
 [[package]]
 name = "feral-amd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-ordering-core",
 ]
 
 [[package]]
 name = "feral-amf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "feral-kahip"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "feral-metis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -261,11 +261,11 @@ dependencies = [
 
 [[package]]
 name = "feral-ordering-core"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "feral-scotch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/feral-amd/Cargo.toml
+++ b/crates/feral-amd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-amd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Approximate Minimum Degree (AMD) fill-reducing ordering, quotient-graph algorithm (Amestoy, Davis & Duff 1996, 2004). Pure Rust, standalone."

--- a/crates/feral-amf/Cargo.toml
+++ b/crates/feral-amf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-amf"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Approximate Minimum Fill (AMF / HAMF4) fill-reducing ordering, quotient-graph algorithm (Amestoy 1999). Pure Rust, standalone."

--- a/crates/feral-kahip/Cargo.toml
+++ b/crates/feral-kahip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-kahip"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "KaHIP-style flow-based nested-dissection fill-reducing ordering (Sanders & Schulz 2011; data reduction per Ost, Schulz & Strash 2021). Pure Rust, clean-room, standalone. Implements the FERAL ordering-crate contract."

--- a/crates/feral-metis/Cargo.toml
+++ b/crates/feral-metis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-metis"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Multilevel nested-dissection fill-reducing ordering (Karypis & Kumar 1998). Pure Rust, clean-room, standalone. Implements the FERAL ordering-crate contract."

--- a/crates/feral-ordering-core/Cargo.toml
+++ b/crates/feral-ordering-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-ordering-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Shared input/output types for FERAL's fill-reducing ordering crates (feral-amd, feral-metis, feral-scotch, feral-kahip). Defines the locked contract surface — CscPattern, OrderingStats, OrderingError."

--- a/crates/feral-scotch/Cargo.toml
+++ b/crates/feral-scotch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feral-scotch"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "SCOTCH-style nested-dissection fill-reducing ordering (Pellegrini 1996). Pure Rust, clean-room, standalone. Implements the FERAL ordering-crate contract."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -75,21 +75,21 @@ dependencies = [
 
 [[package]]
 name = "feral-amd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-ordering-core",
 ]
 
 [[package]]
 name = "feral-amf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-ordering-core",
 ]
 
 [[package]]
 name = "feral-kahip"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "feral-metis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "feral-ordering-core"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "feral-python"
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "feral-scotch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "feral-amd",
  "feral-metis",


### PR DESCRIPTION
## Bump ordering crates 0.2.0 → 0.2.1 (release blocker for 0.11.0)

Found while auditing publish-readiness for `v0.11.0`: the six fill-reducing
ordering crates are **published on crates.io at `0.2.0`** but have accumulated
API-compatible changes since that version was first published (2026-05-12),
across the `0.3.0`–`0.10.0` feral releases. Because `release.yml` treats
"already exists on crates.io" as success, `cargo publish` has been **silently
skipping** them — so crates.io consumers of `feral` link **stale ordering
code**. This is the same version-drift failure mode that shipped the v0.5.0
Python trio at 0.4.0.

### What
- Bump all six in lockstep `0.2.0 → 0.2.1`: `feral-ordering-core`, `feral-amd`,
  `feral-amf`, `feral-metis`, `feral-scotch`, `feral-kahip`.
- Refresh both `Cargo.lock` files (root + the separate `python/` workspace);
  the lockfile diff is exclusively the six version lines.

### Why a patch bump, and why `feral` is untouched
The changes are semver-compatible — the ordering-crate API contract is fixed
(`dev/decisions.md` 2026-04-17: one free function per crate, `i32` indices, no
etree across the boundary). So `0.2.1` is a patch, `feral`'s
`version = "0.2"` requirement is unchanged and resolves to `0.2.1`, and the
backends' `feral-ordering-core = "0.2"` deps likewise resolve untouched.

The skipped work includes real fixes: `feral-metis` (real SHEM coarsening,
true GGP gain in initial bisection), `feral-kahip` (vertex-weight flow
balancing, `n_components`), `feral-scotch` (separator-FM past
imbalance-rejected heads), `feral-ordering-core` (sorted-rows invariant).

### Verification
- All six `[package]` versions now `0.2.1`; dep strings unchanged.
- `cargo update --workspace` on both manifests bumped only the six crates.
- `cargo test` (root workspace): 0 failures across all targets.
- crates.io currently reports `0.2.0` as `max_version` for all six; `0.2.1`
  is new and will **publish** (not skip) on the `v0.11.0` release.

### Sequencing
Merge this **before** tagging `v0.11.0`. The single `v0.11.0` GitHub release
then publishes the ordering crates at `0.2.1` (in dependency order) followed by
`feral 0.11.0`, which resolves to the freshly-published `0.2.1`.

### Follow-up (not in this PR)
`scripts/release-checklist.sh` only checks `feral` + the Python trio — it has
no guard against ordering-crate staleness, which is the root cause. Worth
adding a check that flags any ordering crate whose tree changed since the last
tag while its version still equals the crates.io `max_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
