### PR TITLE
issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — sparse LU update: O(m³) → O(m²) `u_above` reindex on filled bumps (issue #89)
+
+`SparseLu::update` re-indexed the `u_above` column index for *every* changed row
+on commit (`unindex_above` + `index_above` over each row), an
+`O(bump · rowlen · shift)` ≈ `O(m³)` sorted-`Vec` memmove churn on dense/filled
+bumps. Profiling a single update on a dense-inverse (set-covering) basis showed
+this commit step was **99% of the update time** (m=2048: 537 ms of 545 ms), while
+the actual elimination arithmetic was ~3 ms. The reindex is now incremental: only
+column `r` (whose holders are exactly the spike support) and row `r` (the only
+rebuilt row) change — every other "changed" row only gains/loses its single
+column-`r` entry, already captured by column `r`'s holder list, so it is no longer
+re-indexed. This drops the commit to `O(m²)` = the elimination's own order.
+
+Measured on the `ft_dense_bump` reproducer (release): **13–62× faster** per update
+(m=256: 1.46 ms → 0.11 ms; m=2048: 350 ms → 5.6 ms), and the per-update scaling
+falls from ~m^2.7 to ~m² — a constant 2.6 ns per counted multiply-add at every
+size, i.e. the update now sits on the `Θ(factor_nnz)` arithmetic floor. Validated
+by the `lu-ft-invariant-check` feature (rebuilds expected `u_above` from `U` and
+asserts exact equality after every update): all `lu` tests pass with it enabled.
+No public API or numerical change.
+
 ### Added — true per-update cost counter for refactorization scheduling (issue #89)
 
 `SparseLu` now exposes `last_update_work()` (scalar multiply-adds of the most
@@ -14,11 +35,12 @@ factor/refactor), and the advisory `should_refactor()` predicate
 *solve-replay* ops (O(1) each) and is the right witness for warm-solve cost — the
 new counter is proportional to the factor fill and grows O(factor_nnz) per update
 on dense-inverse (set-covering) bases. On those bases a single Forrest–Tomlin
-update is intrinsically O(factor_nnz) — the spike `B⁻¹aₙₑw` is itself dense, so
-the small entering-column nnz does not bound the work, and there is no
-asymptotically cheaper FT path; the correct response is to refactor aggressively,
-which `should_refactor()` now lets callers schedule on the true cost instead of
-the undercounting `eta_ops()`. No change to `update()`'s behaviour; `eta_ops()`
+update is intrinsically Ω(factor_nnz) — the spike `B⁻¹aₙₑw` is itself dense, so
+the small entering-column nnz does not bound the work (for a genuinely *dense
+factor* that floor is Θ(m²); for the sparse-factor/dense-inverse bases in the
+issue it is Θ(factor_nnz) ≪ Θ(m²)). Past that floor the correct response is to
+refactor aggressively, which `should_refactor()` now lets callers schedule on the
+true cost instead of the undercounting `eta_ops()`. No change to `update()`'s behaviour; `eta_ops()`
 is retained unchanged. See `dev/research/ft-dense-bump-cost-2026-06-27.md` and the
 standalone reproducer `examples/ft_dense_bump.rs`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — true per-update cost counter for refactorization scheduling (issue #89)
+
+`SparseLu` now exposes `last_update_work()` (scalar multiply-adds of the most
+recent committed column-replacement update: the spike solve plus the
+row-elimination scatters), `update_work()` (cumulative since the last
+factor/refactor), and the advisory `should_refactor()` predicate
+(`update_work() >= factor_nnz()`). Unlike `eta_ops()` — which counts
+*solve-replay* ops (O(1) each) and is the right witness for warm-solve cost — the
+new counter is proportional to the factor fill and grows O(factor_nnz) per update
+on dense-inverse (set-covering) bases. On those bases a single Forrest–Tomlin
+update is intrinsically O(factor_nnz) — the spike `B⁻¹aₙₑw` is itself dense, so
+the small entering-column nnz does not bound the work, and there is no
+asymptotically cheaper FT path; the correct response is to refactor aggressively,
+which `should_refactor()` now lets callers schedule on the true cost instead of
+the undercounting `eta_ops()`. No change to `update()`'s behaviour; `eta_ops()`
+is retained unchanged. See `dev/research/ft-dense-bump-cost-2026-06-27.md` and the
+standalone reproducer `examples/ft_dense_bump.rs`.
+
 ### Performance — sparse LU Forrest–Tomlin update: O(bump²) → O(bump) on wide spikes
 
 `SparseLu::update` now performs a true **Forrest–Tomlin** update instead of a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,5 +114,8 @@ harness = false
 name = "lu_update_trace"
 harness = false
 
+[[example]]
+name = "ft_dense_bump"
+
 [profile.release]
 debug = true

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,124 +1,112 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-21T15:43:20Z
+Generated: 2026-06-27T22:16:46Z
 
 ## Latest Session
-File: dev/sessions/2026-06-19-01.md
+File: dev/sessions/2026-06-21-01.md
 ```
-# Session 2026-06-19-01
+# Session 2026-06-21-01
 
 ## Goal
 
-Two pieces of work:
-
-1. Cut release **v0.11.1** (patch) for the sparse LU Forrest–Tomlin
-   bump-elimination perf already on `main`.
-2. Answer "is there any reason to think memory allocation would speed up
-   performance anywhere?" — and, since the answer was yes, act on it under a
-   measure-then-pool gate.
+Issue #87: eliminate the residual **O(bump²)** Forrest–Tomlin row-elimination on
+wide (dense-spike) McCormick simplex bases — the Step-2 follow-up of discopt#229
+that was parked as a research spike. The user asked for the **most robust and
+performant** solution, chosen after digging into the code and the literature, and
+verified with before/after timing + scaling experiments.
 
 ## Accomplished
 
-### v0.11.1 release
+### Diagnosis (the key insight)
 
-- Bumped all six version strings via `scripts/release-checklist.sh bump 0.11.1`;
-  cut `CHANGELOG [0.11.1] - 2026-06-19` from `[Unreleased]`.
-- Committed (`e5587b3`), tagged `v0.11.1`, pushed, created the GitHub release.
-- `release.yml` (crates.io) and `python-wheels.yml` (PyPI) both green; verified
-  crates.io `feral` max_version = 0.11.1 and PyPI `feral-solver` = 0.11.1.
+The current `SparseLu::update`/`eliminate_bump` is **not** a Forrest–Tomlin update
+— it sets the spike into `U`'s column `r` and runs a full partial-pivoting bump
+re-triangularization in fixed pivot order. It eliminates the dense spike
+**column**, touching `O(bump)` rows with cascading fill, so both the work **and**
+the recorded eta are `O(bump²)` on a dense spike. True FT eliminates the single
+pivotal **row** after a symmetric permutation (the permuted diagonal pivots are
+the old nonzero `U` diagonals — dodging the zero-superdiagonal landmine that
+reverted the 2026-06-08 column-shift attempt), which is `O(bump)` for sparse `U`.
 
-### LU-update allocation pooling (the allocation question)
+### Route chosen: logical-permutation Forrest–Tomlin
 
-Investigation found the multifrontal **factor** path is already
-allocation-optimized (FactorWorkspace etc.; two further pooling attempts were
-falsified there), but the **LU basis-update** path (`src/lu/sparse_update.rs`)
-— the code v0.11.1 touched — pooled nothing, unlike its sibling
-`sparse_solve.rs`.
+Carry one evolving `uperm` (pivot-position ↔ triangular rank), applied once per
+solve; never relabel `U`'s indices or prior etas. Rejected the column-ordering
+lever (no asymptotic change) and physical permutation (stales prior etas →
+`O(k²·bump)`; cyclic shift as per-eta swaps → `O(k·bump)` solve blow-up).
+Clean-room from Forrest–Tomlin 1972, Reid 1982, Schork–Gondzio ERGO-17-002
+(`BASICLU` is GPL — paper only). Docs: `dev/research/ft-row-elimination-design-2026-06-21.md`,
+`dev/plans/ft-row-elimination-2026-06-21.md`, `dev/decisions.md`.
 
-**Phase 0 (measure):** new `tests/lu_update_alloc_probe.rs` (counting
-`#[global_allocator]`) on the casctanks wide-bump trace (discopt#229, in-tree
-fixture m=2169, 144 updates): **~1804 allocs + 176 reallocs per update** against
-an **85.8 µs/update** budget (`lu_update_trace` bench 12.351 ms / 144). Gate
-passed; the bench delta was the arbiter (pooling has been falsified here before
-when bookkeeping > malloc saved).
+### Implementation (P1+P2)
 
-**Phase 1 Step 1 — bump-loop pools** (`9cf5a96`): `pivot_scratch`,
-`targets_scratch`, `row_pool` (+`row_sub`→`row_sub_into`), `col_rows_pool`.
-allocs/update 1804 → 636 (−65%); bench 12.351 → 9.955 ms (**−19.0%**, p<0.05).
+- **P1** (`a676aaf`): `uperm`/`uperm_inv`; `usolve`/`ut_solve` walk `U` in rank
+  order (identity at factor ⇒ byte-identical).
+- **P2** (`ebaeca6`): rewrote `sparse_update.rs` — `set_column_r` (spike into
+  other rows), `shift_uperm` (symmetric cyclic shift, `O(bump)`),
+  `eliminate_pivot_row` (single-row sparse forward sweep via a rank min-heap, one
+  `FtOp::Axpy` per sub-diagonal). Widened `u_above` to all off-diagonal holders;
+  diagonal-first-aware row helpers; removed `FtOp::Swap`.
+- **Bug fixed during bring-up**: the eliminated pivot column's FP residual
+  `vrc − mult·piv ≠ 0` re-enqueued the column forever (infinite loop / OOM, exit
+  137). Fixed by clearing `rw[c]` exactly and skipping the pivot's own diagonal.
 
-**Phase 1 Step 2 — saved-row snapshot pool** (`edf1f0f`): `saved_scratch` +
-`saved_pool`. allocs/update 636 → 82.5 (−95% vs baseline); bench 9.955 →
-8.545 ms (**−14.8%**). Hardened the probe into a regression guard (<250
-allocs/update).
+### Evidence (before → after, release, this host)
 
-**Cumulative:** 1804 → 82.5 allocs/update (−95%); **12.351 → 8.545 ms = −30.8%**
-on the casctanks replay. Numerics **bit-identical** at every step
-(`worst_true_residual=9.095e-13`, `worst_sparse_vs_dense=0.000e0`; `FtOp` eta
-sequence and pivot choices unchanged). Full suite green; `cargo fmt` +
+| probe | metric | BEFORE | AFTER |
+|---|---|---:|---:|
 ```
 
 ## Git Status
 ```
+a9cea82 issue #87: Forrest–Tomlin row-elimination LU update (O(bump²) → O(bump)) (#88)
+380459c issue #87: gate FT invariant self-check behind off-by-default feature (CI: alloc probe)
+47a3d66 issue #87: fix duplicate-column bug in FT row gather (CI: casctanks drift)
+1808467 issue #87 P5: checkpoint — FT row-elimination session docs
 ebaeca6 issue #87 P2: Forrest-Tomlin row-elimination update (O(bump²) → O(bump))
-a676aaf issue #87 P1: add uperm_inv logical-permutation order, route U-solves through it
-a34367e issue #87: diagnose O(bump²) FT update, choose logical-permutation FT, add baseline probe
-75b0322 release: feral v0.11.2
-2ed962d docs(session): 2026-06-19-01 checkpoint — LU-update allocation pooling
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
-test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
-test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
-test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 371 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.43s
+test result: ok. 373 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.56s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-19-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-21-01.md)
 
 
-lu_update_trace (casctanks FT-update chain, 144 updates, m=2169):
-  baseline (v0.11.1):  12.351 ms
-  after Step 1:         9.955 ms   (-19.0%)
-  after Step 2:         8.545 ms   (-14.8%; -30.8% cumulative)
+cargo run --bin bench --release  (symmetric indefinite gate — unaffected)
+  Residual pass: 2/2 (100.0%)   Worst residual: 1.26e-16
+  Dense/Sparse failure analysis: no failures
 
-alloc probe (allocs / reallocs / bytes per update):
-  baseline:  1804.2 / 176.3 / 128610
-  Step 1:     636.5 /  68.7 /  63428
-  Step 2:      82.5 /  80.7 /  23560
+casctanks_ft_update/chain_144_updates_m2169
+  BEFORE: 16.770–17.036 ms   AFTER: 1.6413–1.6748 ms   (10.2×)
 
-`cargo run --bin bench --release` (full KKT corpus; factorization path,
-unaffected by the LU-update pooling — confirms no regression):
-
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.09     <= 3.0     PASS
-
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.48     <= 2.0     PASS
-medium (<500)            153560     1.48     <= 3.0     PASS
-
-Top worst factor-ratio vs MUMPS unchanged (KIRBY2_0007 9.95, CRESC132 6.69, …).
+lu_wide_bump_probe (dense-spike tridiagonal, AFTER):
+   m    us/update   us/update/m   eta_ops/upd
+  250     102.11       0.41           52
+ 1000     675.41       0.68          116
+ 4000   69415.61      17.35         ~120
 
 ```
 
@@ -236,8 +224,8 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering.rs
 tests/column_renumbering_parity.rs
+tests/column_renumbering.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -250,10 +238,6 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs
@@ -262,6 +246,10 @@ tests/issue_38_static_pivot.rs
 tests/issue_46_saddle_kkt_cascade.rs
 tests/issue_55_delay_budget.rs
 tests/issue_55_n_tiny_counter.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
@@ -285,8 +273,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue.rs
 tests/rook_rescue_kkt.rs
+tests/rook_rescue.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/journal/2026-06-27-01.org
+++ b/dev/journal/2026-06-27-01.org
@@ -44,3 +44,44 @@ column adds nnz(row)>=1 to work but 1 to eta. Both pass; full lib suite 375 pass
 clippy clean, fmt clean.
 
 Research note: `dev/research/ft-dense-bump-cost-2026-06-27.md`.
+
+* 19:20 :issue-89:ft-update:perf:u_above:profiling:
+Followed up on "is there room for improvement" by PROFILING instead of
+speculating (had guessed wrong twice on the theory). Added temp per-phase
+timers (atomics) around compute_spike / set_column_r / eliminate_pivot_row /
+commit. Dense reproducer, m=2048, per update:
+
+  spike=1.3ms  setcol=1.8ms  elim=2.8ms  commit=537ms
+
+i.e. the u_above reindex on commit was 99% of the time and scaled 1.7->13.6->76
+->537ms over m=256..2048 (~m^2.7, toward O(m^3)), while the real elimination
+arithmetic stayed at ~Theta(factor_nnz). This was a GENUINE BUG, not the
+fundamental dense cost I'd claimed.
+
+Root cause: commit re-indexed EVERY changed row wholesale (unindex_above +
+index_above over the full row), O(bump*rowlen*shift) ~ O(m^3) of sorted-Vec
+memmoves, almost all for entries that didn't change. Of the O(m) changed rows,
+only row r is rebuilt; the rest just gained/lost their single column-r entry.
+
+Fix: incremental u_above maintenance. set_column_r only rewrites column r (its
+holders = spike support exactly), eliminate_pivot_row only rebuilds row r, no
+other row's column membership changes (the FT win). So commit does just:
+  (a) u_above[r] = supp \ {r}   (clear+extend, O(|supp|))
+  (b) unindex/index row r alone against its old/new column set
+Drops commit O(m^3) -> O(m^2) = arithmetic order. Rollback unchanged (u_above
+still only mutated in the Ok branch, so failures stay consistent).
+
+Oracle: lu-ft-invariant-check rebuilds expected u_above from U and asserts exact
+equality after every update. All 28 lu tests pass with the feature on => the
+incremental index is byte-identical to a full rebuild.
+
+Measured (release, dense reproducer): 13-62x faster per update (m=256 1.46ms->
+0.11ms; m=2048 350ms->5.6ms). Scaling ~m^2.7 -> ~m^2; constant 2.6 ns per
+counted multiply-add at every m => update now sits on the Theta(factor_nnz)
+floor. Full lib suite 375 pass, fmt clean.
+
+Also corrected the over-stated "no asymptotically cheaper FT path" claim in the
+research note + CHANGELOG: dense INVERSE != dense FACTOR. The real sc bases have
+sparse factors (factor_nnz/m=2-39), update is Theta(factor_nnz) << Theta(m^2),
+linear in fill (matches the issue's own 0.01->0.72ms table). Only a genuinely
+dense FACTOR has the Theta(m^2) floor.

--- a/dev/journal/2026-06-27-01.org
+++ b/dev/journal/2026-06-27-01.org
@@ -1,0 +1,46 @@
+* 18:41 :issue-89:ft-update:cost-counter:
+Investigated and confirmed issue #89: `SparseLu::update()` cost scales with the
+factor fill, not the entering-column nnz, on dense-inverse (set-covering) bases.
+
+Built standalone reproducer B (`examples/ft_dense_bump.rs`, autoexamples=false so
+added an `[[example]]` entry). Covering columns (~8 nnz, random values ⇒ dense
+inverse) over m=256..2048, 50 updates each, release:
+
+| m    | factor_nnz/m | update_avg (us) | avg_last_eta_ops | us/eta-op |
+|------|--------------|-----------------|------------------|-----------|
+|  256 |        146   |          1461   |             210  |    7.0    |
+|  512 |        292   |          9647   |             414  |   23.3    |
+| 1024 |        548   |         49620   |             765  |   65.0    |
+| 2048 |       1115   |        349883   |            1516  |  230.8    |
+
+Entering nnz fixed at 8. update_avg ~ m^2.6 ~ factor_nnz^1.3; eta_ops only ~O(m).
+So us-per-recorded-eta-op grows ~m ⇒ `eta_ops()` undercounts true build cost by
+exactly the row density. Both claims in the issue confirmed.
+
+Root cause (fundamental, not a bug): `eliminate_pivot_row` is a single-row sparse
+forward sweep; per eliminated sub-diagonal column c it scatters
+`row_r -= mult·u_rows[c]`, cost nnz(u_rows[c]). On a dense U that is O(m) per
+column over O(m) columns ⇒ O(m²)=O(factor_nnz). The spike B⁻¹aₙₑw is itself dense,
+so even computing it is O(factor_nnz). There is no cheaper FT path on a dense
+bump (answer to issue Q1: refactor aggressively).
+
+Fix (answer to Q2): added a true per-update *build*-cost counter. Threaded a
+`&mut usize work` accumulator through `compute_spike` (L-solve flops + eta-replay
+flops) and `eliminate_pivot_row` (row_r seed len + Σ nnz(u_rows[c]) over
+eliminated c). Folded into new fields on commit: `last_update_work`,
+`update_work_total`. Exposed `last_update_work()`, `update_work()`,
+`should_refactor()` (advisory: update_work() >= factor_nnz()). `eta_ops()` left
+unchanged (correct solve-replay witness; used by the scalability guard test).
+
+Re-ran the reproducer with the counter: avg_last_update_work ≈ factor_nnz per
+update (42380 vs 37478 at m=256; 2.12M vs 2.28M at m=2048) and work/eta climbs
+202→1398 — captures exactly the density factor eta_ops misses.
+
+Tests: `update_work_accumulates_and_resets` (zero after factor; cumulative =
+running sum; refactor resets) and `update_work_exceeds_eta_ops_on_dense_bump`
+(invariant last_update_work >= last_eta_ops always, with >=2× gap on the
+tridiagonal-base wide bump). External oracle = FT structure: each eliminated
+column adds nnz(row)>=1 to work but 1 to eta. Both pass; full lib suite 375 pass,
+clippy clean, fmt clean.
+
+Research note: `dev/research/ft-dense-bump-cost-2026-06-27.md`.

--- a/dev/research/ft-dense-bump-cost-2026-06-27.md
+++ b/dev/research/ft-dense-bump-cost-2026-06-27.md
@@ -1,0 +1,81 @@
+# FT update cost on dense-inverse bases — confirmation + fix (issue #89)
+
+Date: 2026-06-27
+Refs: issue #89, #87 (the prior FT row-elimination fix, `a9cea82`),
+`dev/research/ft-row-elimination-design-2026-06-21.md`.
+
+## Claim under test
+
+On `main` after the #87 fix, `SparseLu::update()` cost scales with the **factor
+fill** (`factor_nnz`), not with the bump / entering-column nnz. On set-covering
+LP bases (sparse columns, ~6 nnz, but a *dense inverse*) a single column
+replacement costs ~O(factor_nnz) → the update dominates a revised-simplex solve.
+Second claim: `eta_ops()` undercounts the true per-update cost, so a caller's
+"refactor when work is large" heuristic never fires in time.
+
+## Confirmation (reproducer B, `examples/ft_dense_bump.rs`, release, this host)
+
+Entering column fixed at 8 nonzeros throughout:
+
+```
+m=  256  factor_nnz/m= 146.4  update_avg=    1460.8 us/upd  avg_last_eta_ops= 210
+m=  512  factor_nnz/m= 291.7  update_avg=    9647.1 us/upd  avg_last_eta_ops= 414
+m= 1024  factor_nnz/m= 548.3  update_avg=   49620.5 us/upd  avg_last_eta_ops= 765
+m= 2048  factor_nnz/m=1115.3  update_avg=  349883.3 us/upd  avg_last_eta_ops=1516
+```
+
+- `factor_nnz` ~ m² (the inverse is dense). `update_avg` grows ~ m^2.6, i.e.
+  ~ `factor_nnz^1.3` — confirms cost ∝ fill, NOT the fixed entering nnz.
+- `avg_last_eta_ops` grows only ~ O(m), so **µs per recorded eta-op** is
+  7 → 23 → 65 → 231 as m doubles — i.e. the per-op build cost grows ~m. The
+  recorded eta op-count undercounts true build work by exactly the row density.
+
+Both claims confirmed.
+
+## Root cause (why this is fundamental, not a bug)
+
+`eliminate_pivot_row` (`src/lu/sparse_update.rs`) is a single-row sparse forward
+sweep: for each eliminated sub-diagonal column `c` of the pivotal row it scatters
+`row_r -= mult · u_rows[c]`, costing `nnz(u_rows[c])`. On a dense-inverse basis
+`U` is dense, so each `u_rows[c]` is O(m) and the bump spans O(m) ranks ⇒
+O(m²) = O(factor_nnz) per update. This is the irreducible cost of triangularizing
+one row against a dense `U`; there is **no asymptotically cheaper Forrest–Tomlin
+path** when the bump is dense. Worse, the spike ρ = B⁻¹·aₙₑw is itself dense on
+these bases, so even *computing* it (`compute_spike`: forward L-solve + eta
+replay) is already O(factor_nnz) — the 8-nnz entering column does not bound
+anything once the inverse is dense.
+
+Answer to issue Q1: no cheaper FT path; the caller must refactor aggressively.
+Answer to issue Q2 (the actionable fix): `eta_ops()` measures *solve-replay*
+cost (one O(1) axpy per op) — correct for warm solves but the wrong signal for
+scheduling refactorization. We need a counter that reflects the true per-update
+**build** cost.
+
+## Fix
+
+1. Add an accurate per-update work counter `last_update_work` (and cumulative
+   `update_work` since the last factor/refactor) measuring the actual scalar
+   multiply-add operations the update performs:
+   - the spike solve in `compute_spike` (L forward-solve flops + eta-replay
+     flops), and
+   - the row-elimination scatters in `eliminate_pivot_row`.
+   These are the dominant, fill-proportional terms. Exposed via
+   `last_update_work()` / `update_work()`.
+2. `should_refactor()` — advisory predicate (does not change `update()`'s
+   behaviour): true once cumulative `update_work()` since refactor reaches
+   `factor_nnz()`, i.e. the update chain has cost about one refactorization.
+   Callers (e.g. discopt's simplex driver) drive refactor scheduling off this
+   instead of `eta_ops()`.
+3. Document the dense-bump reality at the `update_sparse` doc-comment.
+
+`eta_ops()` is retained unchanged — it is the correct *solve* cost witness used
+by the scalability guard test. The new counters are the *update* cost witness.
+
+## Oracle for the new counter (external, hand calculation)
+
+A 3×3 hand-built bump with a known elimination: replacing a column so the spike
+forces exactly one sub-diagonal elimination against a known-length upper row lets
+the elimination scatter count be hand-derived, independent of the counter's own
+bookkeeping. The dense-scaling test asserts the *qualitative* invariant the
+counter exists to expose — `last_update_work ≫ last_eta_ops` and grows with
+`factor_nnz` — which the pre-fix `eta_ops` cannot satisfy.

--- a/dev/research/ft-dense-bump-cost-2026-06-27.md
+++ b/dev/research/ft-dense-bump-cost-2026-06-27.md
@@ -34,22 +34,89 @@ Both claims confirmed.
 
 ## Root cause (why this is fundamental, not a bug)
 
-`eliminate_pivot_row` (`src/lu/sparse_update.rs`) is a single-row sparse forward
-sweep: for each eliminated sub-diagonal column `c` of the pivotal row it scatters
-`row_r -= mult · u_rows[c]`, costing `nnz(u_rows[c])`. On a dense-inverse basis
-`U` is dense, so each `u_rows[c]` is O(m) and the bump spans O(m) ranks ⇒
-O(m²) = O(factor_nnz) per update. This is the irreducible cost of triangularizing
-one row against a dense `U`; there is **no asymptotically cheaper Forrest–Tomlin
-path** when the bump is dense. Worse, the spike ρ = B⁻¹·aₙₑw is itself dense on
-these bases, so even *computing* it (`compute_spike`: forward L-solve + eta
-replay) is already O(factor_nnz) — the 8-nnz entering column does not bound
-anything once the inverse is dense.
+The *arithmetic* lower bound is real: the spike ρ = B⁻¹·aₙₑw is dense on these
+bases, so even computing it (`compute_spike`: forward L-solve + eta replay) is
+Ω(factor_nnz) — the 8-nnz entering column does not bound anything once the inverse
+is dense. And `eliminate_pivot_row` triangularizes one row against `U` at
+O(factor_nnz). For a genuinely **dense factor** (`factor_nnz/m ≈ m/2`) that is
+Θ(m²) and unbeatable by any FT variant — you must form the dense spike.
 
-Answer to issue Q1: no cheaper FT path; the caller must refactor aggressively.
-Answer to issue Q2 (the actionable fix): `eta_ops()` measures *solve-replay*
-cost (one O(1) axpy per op) — correct for warm solves but the wrong signal for
-scheduling refactorization. We need a counter that reflects the true per-update
-**build** cost.
+**BUT the first version of this note over-generalized** that to "no asymptotically
+cheaper FT path, period." Two corrections:
+
+1. **"Dense inverse" ≠ "dense factor."** The real `sc2000x800` bases have a dense
+   inverse but *sparse factors* (`factor_nnz/m` = 2–39). There the update is
+   Θ(factor_nnz) ≈ Θ(fill·m), **not** Θ(m²); the issue's own table (0.01→0.72 ms
+   as fill 2→39) is *linear in fill*. So "O(m²) is fundamental" is the wrong
+   framing for the bases that actually hurt.
+
+2. **The dominant cost was not the arithmetic at all — it was `u_above` index
+   churn**, and that part was a genuine, fixable bug (see below).
+
+## The real bottleneck: `u_above` reindex was O(m³) (profiled)
+
+Per-phase timing of one update on the dense reproducer (m=2048, ns→µs/update):
+
+```
+spike (FTRAN)        1.3 ms
+set_column_r         1.8 ms
+eliminate_pivot_row  2.8 ms   <- the actual Θ(factor_nnz) arithmetic
+commit (u_above)   537   ms   <- 99% of the time
+```
+
+`commit` scaled 1.7→13.6→76→537 ms over m=256..2048 — **~m^2.7, toward O(m³)**,
+while the arithmetic stayed at ~Θ(factor_nnz). Root cause: the commit block
+re-indexed *every* changed row wholesale —
+
+```rust
+for (i, old_row) in saved.iter() {       // O(bump) ≈ O(m) changed rows
+    self.unindex_above(i, old_row);      // O(rowlen) binary-search + Vec::remove
+    self.index_above(i, new_row);        // O(rowlen) binary-search + Vec::insert
+}                                         //   each shift O(|u_above[c]|)
+```
+
+On a dense bump that is O(bump · rowlen · shift) ≈ O(m·m·m) = **O(m³)** of
+sorted-`Vec` memmove traffic, for entries that did not change: of the O(m) changed
+rows, all but row `r` only gained/lost their single column-`r` entry.
+
+## Fix (this is the performance fix, beyond the counter)
+
+`set_column_r` only rewrites column `r`; `eliminate_pivot_row` only rebuilds row
+`r`. No other row's column membership changes (the FT win). So the commit needs
+only:
+
+- **(a)** `u_above[r] = supp \ {r}` — column `r`'s holders are exactly the spike
+  support (one clear+extend, O(|supp|)); and
+- **(b)** unindex/index **row `r` alone** against its old/new column set.
+
+This drops commit from O(m³) to O(m²) = the arithmetic order. Validated by the
+`lu-ft-invariant-check` feature (rebuilds expected `u_above` from `U`, asserts
+exact equality after every update): all 28 `lu` tests pass with it on.
+
+**Measured (dense reproducer, release):**
+
+```
+m      update_avg before → after      speedup   time/work after
+256        1461 → 112 µs                13×       2.6 ns/work-unit
+512        9647 → 394 µs                24×       2.6
+1024      49620 → 1300 µs               38×       2.6
+2048     349883 → 5612 µs               62×       2.6
+```
+
+Scaling after the fix is ~m² (constant 2.6 ns per counted multiply-add at every
+m) — the update now sits on the Θ(factor_nnz) arithmetic floor.
+
+## Answers to the issue questions (revised)
+
+- **Q1 (cheaper FT path):** For a *dense factor*, no — Θ(factor_nnz)=Θ(m²) is the
+  floor. For the *sparse-factor/dense-inverse* bases in the issue, the per-update
+  cost is Θ(factor_nnz) ≪ Θ(m²) and now near-optimal after removing the O(m³)
+  index churn. A *product-form* FT (fixed U₀ + row etas, never mutating U) could
+  further avoid fill compounding across a chain, trading into a growing eta chain
+  — a larger redesign, not pursued here.
+- **Q2 (true cost signal):** `eta_ops()` measures *solve-replay* cost (O(1)/op),
+  the wrong signal for refactor scheduling. Added `last_update_work` /
+  `update_work` (true build flops) and `should_refactor()`.
 
 ## Fix
 

--- a/examples/ft_dense_bump.rs
+++ b/examples/ft_dense_bump.rs
@@ -1,0 +1,97 @@
+//! Issue #89 reproducer B (standalone, feral-only): Forrest–Tomlin `update()`
+//! cost on dense-inverse (set-covering) bases.
+//!
+//! The entering column always has a fixed, small nnz, yet `update()` cost grows
+//! with the factor fill. This also prints `eta_ops()` / `last_eta_ops()` so the
+//! mismatch between the recorded eta op-count and the true per-update build cost
+//! is visible: an O(bump/nnz) update would be ~flat in time but the time tracks
+//! `factor_nnz`, and the recorded eta op-count badly undercounts the real work.
+
+use feral::{LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use std::time::Instant;
+
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0 >> 11
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() as usize) % n
+    }
+    fn unit(&mut self) -> f64 {
+        (self.next() as f64) / ((1u64 << 53) as f64) * 2.0 - 1.0
+    }
+}
+
+// per_col entries at random rows with random values (=> dense inverse, the
+// covering regime) plus a unit diagonal so the basis is nonsingular.
+fn covering_col(diag: usize, m: usize, per_col: usize, rng: &mut Lcg) -> Vec<(usize, f64)> {
+    let mut rows = vec![diag];
+    while rows.len() < per_col {
+        let r = rng.below(m);
+        if !rows.contains(&r) {
+            rows.push(r);
+        }
+    }
+    rows.into_iter()
+        .map(|r| (r, if r == diag { 1.0 } else { 0.5 * rng.unit() }))
+        .collect()
+}
+
+fn factor(m: usize, cols: &[Vec<(usize, f64)>], p: LuParams) -> SparseLu {
+    let a = SparseColMatrix::from_sparse_columns(m, cols).unwrap();
+    let sym = SparseLuSymbolic::analyze(&a).unwrap();
+    SparseLu::factor(&a, &sym, p).unwrap()
+}
+
+fn run(m: usize, per_col: usize) {
+    let p = LuParams::default(); // max_updates = 64
+    let mut rng = Lcg(0x9E37_79B9_7F4A_7C15 ^ (m as u64).wrapping_mul(2654435761));
+    let basis: Vec<_> = (0..m)
+        .map(|t| covering_col(t, m, per_col, &mut rng))
+        .collect();
+    let mut lu = factor(m, &basis, p.clone());
+    let nnz0 = lu.factor_nnz();
+    let mut dense = vec![0.0f64; m];
+    let mut times = Vec::new();
+    let mut last_etas = Vec::new();
+    let mut last_work = Vec::new();
+    for t in 0..50usize.min(m - 1) {
+        let s = covering_col(t, m, per_col, &mut rng);
+        for v in dense.iter_mut() {
+            *v = 0.0;
+        }
+        for &(r, v) in &s {
+            dense[r] = v;
+        }
+        let t0 = Instant::now();
+        if lu.update(t, &dense).is_ok() {
+            times.push(t0.elapsed().as_secs_f64() * 1e6);
+            last_etas.push(lu.last_eta_ops());
+            last_work.push(lu.last_update_work());
+        }
+    }
+    let n = times.len().max(1);
+    let avg = times.iter().sum::<f64>() / n as f64;
+    let avg_eta = last_etas.iter().sum::<usize>() as f64 / n as f64;
+    let avg_work = last_work.iter().sum::<usize>() as f64 / n as f64;
+    println!(
+        "m={m:>5}  factor_nnz/m={:>7.1}  update_avg={:>12.1} us/upd  \
+         avg_last_eta_ops={:>7.0}  avg_last_update_work={:>9.0}  (entering nnz = {per_col})",
+        nnz0 as f64 / m as f64,
+        avg,
+        avg_eta,
+        avg_work,
+    );
+}
+
+fn main() {
+    println!("# entering column always has 8 nonzeros; an O(bump/nnz) update should be ~flat");
+    for &m in &[256usize, 512, 1024, 2048] {
+        run(m, 8);
+    }
+}

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -164,6 +164,18 @@ pub struct SparseLu {
     /// rebuilds the whole `SparseLu` (pools included), so no leak accumulates.
     pub(super) saved_scratch: Vec<(usize, Vec<(usize, f64)>)>,
     pub(super) saved_pool: Vec<Vec<(usize, f64)>>,
+    /// True per-update **build** cost (scalar multiply-adds) of the most recent
+    /// committed column-replacement update: the spike solve (`compute_spike`)
+    /// plus the row-elimination scatters (`eliminate_pivot_row`). Unlike
+    /// [`Self::last_eta_ops`] (a *solve-replay* op count, O(1) per op), this
+    /// tracks the work proportional to the factor fill — the cost that grows
+    /// O(factor_nnz) on dense-inverse bases (issue #89). Zero after factor.
+    pub(super) last_update_work: usize,
+    /// Cumulative [`Self::last_update_work`] across all updates since the last
+    /// factor/refactor. The signal callers use to schedule refactorization
+    /// (`update_work() >= factor_nnz()` ⇒ the update chain has cost about one
+    /// refactor; see [`Self::should_refactor`]). Reset to zero by factor.
+    pub(super) update_work_total: usize,
 }
 
 impl SparseLu {
@@ -487,6 +499,8 @@ impl SparseLu {
             row_pool: Vec::new(),
             saved_scratch: Vec::new(),
             saved_pool: Vec::new(),
+            last_update_work: 0,
+            update_work_total: 0,
         })
     }
 
@@ -534,6 +548,37 @@ impl SparseLu {
     /// Operations in the most recent update's eta (its bump cost).
     pub fn last_eta_ops(&self) -> usize {
         self.etas.last().map(|e| e.ops.len()).unwrap_or(0)
+    }
+
+    /// True **build** cost (scalar multiply-adds) of the most recent committed
+    /// column-replacement update: the spike solve plus the row-elimination
+    /// scatters. Unlike [`Self::last_eta_ops`] (the O(1)-per-op *solve-replay*
+    /// count), this is proportional to the factor fill and grows O(factor_nnz)
+    /// on dense-inverse bases — the cost the warm `update()` path actually pays
+    /// (issue #89). Zero immediately after a factor/refactor.
+    pub fn last_update_work(&self) -> usize {
+        self.last_update_work
+    }
+
+    /// Cumulative [`Self::last_update_work`] over all updates since the last
+    /// factor/refactor. This — not [`Self::eta_ops`] — is the signal for
+    /// scheduling refactorization: it tracks the real work the update chain has
+    /// spent, which on dense-inverse bases climbs far faster than the eta op
+    /// count. See [`Self::should_refactor`].
+    pub fn update_work(&self) -> usize {
+        self.update_work_total
+    }
+
+    /// Advisory: has the update chain since the last factor/refactor cost about
+    /// as much as a fresh factorization? True once cumulative
+    /// [`Self::update_work`] reaches [`Self::factor_nnz`] — the point past which
+    /// continuing to update is no cheaper than refactoring (and keeps getting
+    /// more expensive as the bumps fill). Purely advisory: it does **not** change
+    /// [`SparseLu::update`]'s behaviour; callers decide when to call
+    /// [`SparseLu::refactor`]. On sparse bases (where updates stay cheap) this
+    /// stays `false` for many updates; on dense-inverse bases it trips quickly.
+    pub fn should_refactor(&self) -> bool {
+        self.update_work_total >= self.factor_nnz()
     }
 
     /// Total Gilbert–Peierls reach nodes visited during the factorization.

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -94,10 +94,15 @@ impl SparseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
+        // True per-update build cost (scalar multiply-adds): the spike solve plus
+        // the row-elimination scatters. Folded into the public `last_update_work`
+        // / `update_work` counters only on commit (issue #89).
+        let mut work: usize = 0;
+
         // --- Sparse spike ρ = G⁻¹ L⁻¹ P (scaled aₙₑw) via Gilbert–Peierls reach ---
         let mut w = std::mem::take(&mut self.ft_work); // dedicated buffer, zero on entry
         let mut touched: Vec<usize> = Vec::new(); // positions made nonzero in w
-        self.compute_spike(entering, leaving_slot, &mut w, &mut touched);
+        self.compute_spike(entering, leaving_slot, &mut w, &mut touched, &mut work);
 
         let r = self.qcol_inv[leaving_slot];
         let r_rank = self.uperm[r];
@@ -152,7 +157,7 @@ impl SparseLu {
         self.shift_uperm(r, r_rank, h_rank);
 
         // Eliminate the single pivotal row `r` (now at rank `h_rank`).
-        let result = self.eliminate_pivot_row(r, h_rank, w[r]);
+        let result = self.eliminate_pivot_row(r, h_rank, w[r], &mut work);
 
         clear(&mut w, &touched);
         self.ft_work = w;
@@ -185,6 +190,8 @@ impl SparseLu {
                 self.saved_scratch = saved;
                 self.etas.push(FtEta { ops });
                 self.growth = growth;
+                self.last_update_work = work;
+                self.update_work_total += work;
                 #[cfg(feature = "lu-ft-invariant-check")]
                 self.debug_check_invariants();
                 Ok(())
@@ -238,6 +245,7 @@ impl SparseLu {
         leaving_slot: usize,
         w: &mut [f64],
         touched: &mut Vec<usize>,
+        work: &mut usize,
     ) {
         let dcol = self.scale.d_col[leaving_slot];
         let mut mark = std::mem::take(&mut self.scratch_mark);
@@ -285,6 +293,7 @@ impl SparseLu {
                 continue;
             }
             let (lo, hi) = (self.l_col_ptr[k], self.l_col_ptr[k + 1]);
+            *work += hi - lo;
             for idx in lo..hi {
                 w[self.l_row_idx[idx]] -= self.l_val[idx] * yk;
             }
@@ -292,6 +301,7 @@ impl SparseLu {
 
         // Replay the FT etas forward (G⁻¹), tracking newly touched positions.
         for eta in self.etas.iter() {
+            *work += eta.ops.len();
             for op in eta.ops.iter() {
                 match *op {
                     FtOp::Axpy { target, src, mult } => {
@@ -360,6 +370,7 @@ impl SparseLu {
         r: usize,
         h_rank: usize,
         diag0: f64,
+        work: &mut usize,
     ) -> Result<Vec<FtOp>, FeralError> {
         let ztol = self.params.zero_pivot_tol * self.u_max0;
         let mut ops: Vec<FtOp> = Vec::new();
@@ -373,6 +384,7 @@ impl SparseLu {
         // Seed: row r off-diagonals (column `r` excluded — its value is `diag0`),
         // pushing the sub-diagonal columns onto the heap.
         let row_r = std::mem::take(&mut self.u_rows[r]);
+        *work += row_r.len();
         for &(c, v) in row_r.iter() {
             if c == r {
                 continue; // old diagonal discarded; replaced by the spike value
@@ -428,6 +440,10 @@ impl SparseLu {
             // skip the pivot's own diagonal in the scatter accordingly. Fill at
             // strictly higher ranks may enqueue further sub-diagonal columns.
             rw[c] = 0.0;
+            // One scatter per off-diagonal of the eliminated row — the
+            // fill-proportional term that makes the update O(factor_nnz) on a
+            // dense bump (issue #89).
+            *work += self.u_rows[c].len();
             for &(cc, v) in self.u_rows[c].iter() {
                 if cc == c {
                     continue;
@@ -649,6 +665,8 @@ fn insert_offdiag(row: &mut Vec<(usize, f64)>, c: usize, v: f64) {
 #[cfg(test)]
 mod tests {
     use crate::lu::sparse_factor::SparseLu;
+    use crate::lu::sparse_matrix::SparseColMatrix;
+    use crate::lu::sparse_symbolic::SparseLuSymbolic;
     use crate::lu::LuParams;
 
     /// L5 (dev/research/repo-review-2026-06-09.md): the sparse growth monitor
@@ -763,6 +781,114 @@ mod tests {
                 assert_eq!(lu.uperm[lu.uperm_inv[k]], k);
             }
         }
+    }
+
+    /// `last_update_work`/`update_work` accounting (issue #89): zero after factor,
+    /// strictly positive and equal to `last_update_work` after the first commit,
+    /// accumulating across updates, and reset by `refactor`. Oracle is the
+    /// definitional bookkeeping (no external solver needed): the cumulative
+    /// counter is the running sum of the per-update counter.
+    #[test]
+    fn update_work_accumulates_and_resets() {
+        let cols = vec![
+            vec![4.0, 1.0, 0.0, 0.0],
+            vec![1.0, 3.0, 1.0, 0.0],
+            vec![0.0, 1.0, 2.0, 1.0],
+            vec![0.0, 0.0, 1.0, 5.0],
+        ];
+        let m = 4;
+        let params = LuParams {
+            max_updates: 20,
+            max_growth: 1e12,
+            ..LuParams::default()
+        };
+        let mut lu = SparseLu::factor_dense_columns(m, &cols, params).expect("factor");
+        assert_eq!(lu.last_update_work(), 0, "no work before any update");
+        assert_eq!(lu.update_work(), 0);
+        assert!(!lu.should_refactor(), "fresh factor never needs refactor");
+
+        let mut running = 0usize;
+        for (slot, col) in [
+            (1usize, vec![0.5, 6.0, 0.5, 0.0]),
+            (2usize, vec![0.0, 0.5, 4.0, 0.5]),
+        ] {
+            lu.update(slot, &col).expect("update commits");
+            let w = lu.last_update_work();
+            assert!(w > 0, "a committed update must record positive work");
+            running += w;
+            assert_eq!(lu.update_work(), running, "cumulative = running sum");
+        }
+
+        // Rebuild from the *current* basis columns; refactor must zero the work.
+        let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+        let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+        lu.refactor(&a, &sym).expect("refactor");
+        assert_eq!(lu.last_update_work(), 0, "refactor resets per-update work");
+        assert_eq!(lu.update_work(), 0, "refactor resets cumulative work");
+    }
+
+    /// The new counter must reflect the *fill-proportional build* cost that
+    /// `eta_ops` (a solve-replay op count) cannot. External oracle (FT structure,
+    /// not the counter's own bookkeeping): each eliminated sub-diagonal column `c`
+    /// of the pivotal row contributes `nnz(U row c) >= 1` to the build work but
+    /// exactly 1 to the eta op-count, so `last_update_work >= last_eta_ops` always
+    /// — and on a dense bump (tridiagonal base ⇒ dense spike, the issue #87/#89
+    /// regime) the U rows are long, so the gap is wide. A counter that merely
+    /// re-counted eta ops could not satisfy the strict inequality.
+    #[test]
+    fn update_work_exceeds_eta_ops_on_dense_bump() {
+        let m = 12;
+        let mut cols: Vec<Vec<f64>> = vec![vec![0.0; m]; m];
+        for (j, col) in cols.iter_mut().enumerate() {
+            col[j] = 4.0;
+            if j > 0 {
+                col[j - 1] = -1.0;
+            }
+            if j + 1 < m {
+                col[j + 1] = -1.0;
+            }
+        }
+        let params = LuParams {
+            max_updates: 1000,
+            max_growth: 1e30,
+            ..LuParams::default()
+        };
+        let mut lu = SparseLu::factor_dense_columns(m, &cols, params).expect("factor");
+
+        let mut saw_wide_bump = false;
+        for s in 0..15usize {
+            let slot = s % 4;
+            let mut col = vec![0.0; m];
+            for (i, ci) in col.iter_mut().enumerate() {
+                *ci = 0.5 + ((i * 5 + s * 3) % 7) as f64 * 0.25;
+            }
+            col[slot] = 40.0 + s as f64;
+            if lu.update(slot, &col).is_err() {
+                continue;
+            }
+            // General invariant: build work never undercounts the eta op-count.
+            assert!(
+                lu.last_update_work() >= lu.last_eta_ops(),
+                "update {s}: build work {} must be >= eta ops {}",
+                lu.last_update_work(),
+                lu.last_eta_ops()
+            );
+            // On a genuine wide bump the gap is large — the density factor the old
+            // `eta_ops` signal misses.
+            if lu.last_eta_ops() >= 3 {
+                saw_wide_bump = true;
+                assert!(
+                    lu.last_update_work() >= 2 * lu.last_eta_ops(),
+                    "update {s}: dense bump build work {} should dwarf eta ops {}",
+                    lu.last_update_work(),
+                    lu.last_eta_ops()
+                );
+            }
+        }
+        assert!(
+            saw_wide_bump,
+            "test must exercise at least one wide (dense) bump"
+        );
     }
 
     /// The diagonal-first row helpers must round-trip a value at the diagonal

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -177,13 +177,37 @@ impl SparseLu {
                     self.rollback(saved, &saved_uperm_inv, r_rank);
                     return Err(FeralError::NeedsRefactor);
                 }
-                // Commit: refresh the u_above index for every changed row.
-                for (i, old_row) in saved.iter() {
-                    self.unindex_above(*i, old_row);
-                    let new_row = std::mem::take(&mut self.u_rows[*i]);
-                    self.index_above(*i, &new_row);
-                    self.u_rows[*i] = new_row;
-                }
+                // Commit: refresh the `u_above` column index *incrementally*. Only
+                // two things changed structurally (issue #89): `set_column_r`
+                // rewrote column `r` (its holders are now exactly the spike
+                // support), and `eliminate_pivot_row` rebuilt row `r`. Every other
+                // "changed" row only gained or lost its single column-`r` entry —
+                // already captured by column `r`'s holder list — so its membership
+                // in *other* columns is untouched and must NOT be re-indexed. The
+                // old code re-indexed every changed row wholesale, an
+                // `O(bump · rowlen · shift)` (≈ `O(m³)` on a dense bump) churn that
+                // dwarfed the elimination's `O(factor_nnz)` arithmetic.
+                //
+                // (a) Column `r`'s holders = spike support minus `r`. `supp` is
+                //     already sorted+deduped and `p != r` preserves order, so the
+                //     list stays sorted.
+                self.u_above[r].clear();
+                self.u_above[r].extend(supp.iter().copied().filter(|&p| p != r));
+                // (b) Row `r` changed its column set: drop `r` from its old
+                //     columns' holder lists and add it to the new ones. (Both skip
+                //     column `r` itself — that is the diagonal, not a `u_above`
+                //     entry — so this never touches the list rebuilt in (a).)
+                //     `saved` is a local moved out of `self`, so borrowing the
+                //     snapshot while mutating `self` is sound (no clone needed).
+                let old_row_r: &[(usize, f64)] = saved
+                    .iter()
+                    .find(|(i, _)| *i == r)
+                    .map(|(_, b)| b.as_slice())
+                    .unwrap_or(&[]);
+                self.unindex_above(r, old_row_r);
+                let new_row_r = std::mem::take(&mut self.u_rows[r]);
+                self.index_above(r, &new_row_r);
+                self.u_rows[r] = new_row_r;
                 for (_, buf) in saved.drain(..) {
                     self.saved_pool.push(buf);
                 }


### PR DESCRIPTION
## Summary

Closes #89 (feral-side; the residual is caller-side — see "Scope"). Two feral-side changes plus a corrected analysis:

1. **`u_above` reindex: O(m³) → O(m²) on filled bumps** (`35ece1c`). The Forrest–Tomlin `update()` re-indexed the `u_above` column index for *every* changed row on commit — an `O(bump·rowlen·shift)` ≈ `O(m³)` sorted-`Vec` memmove churn on dense bumps, almost all of it redundant. Profiling one update on a dense-inverse basis (m=2048) attributed **99% of the update time (537 ms of 545 ms)** to this step; the actual elimination arithmetic was ~3 ms. Now incremental: only column `r` (holders = spike support) and row `r` (the only rebuilt row) change membership, so only those are reindexed.

2. **True per-update cost counter** (`c5757da`). `last_update_work()` / `update_work()` / `should_refactor()` report the real build cost (spike solve + elimination scatters), proportional to the factor fill. `eta_ops()` measures *solve-replay* cost (O(1)/op) — the right witness for warm solves but the wrong signal for scheduling refactorization, which is exactly #89's Q2.

## Evidence

**Correctness:** the `lu-ft-invariant-check` feature rebuilds expected `u_above` from `U` and asserts exact equality after every update — all 28 `lu` tests pass with it enabled, so the incremental index is identical to a full rebuild. Full lib suite 375 pass; clippy `-D warnings` clean; fmt clean.

**Performance (synthetic `examples/ft_dense_bump`, fully-dense factors, release):**

| m | update before | after | speedup |
|---|---|---|---|
| 256 | 1.46 ms | 0.11 ms | 13× |
| 512 | 9.6 ms | 0.39 ms | 24× |
| 1024 | 49.6 ms | 1.3 ms | 38× |
| 2048 | 350 ms | 5.6 ms | 62× |

Per-update scaling falls from ~m^2.7 to ~m² — a constant 2.6 ns per counted multiply-add at every size, i.e. the update now sits on the `Θ(factor_nnz)` arithmetic floor.

## Scope — what this closes, and what it doesn't

Validated against the issue's authoritative reproducer (real `sc` bases) and the end-to-end root-LP solve:

- On the **real `sc2000x800` / `sc4000x1500` bases** the factors are sparse (`factor_nnz/m` ≤ 39), so the O(m³) reindex was never the bottleneck — the fix is a **no-op there** (update stays ~0.05–0.15 ms).
- **End-to-end `sc2000x800` root LP solve: 3.784 s → 3.775 s** (noise). Unchanged, because the caller already refactorizes every ~48 pivots, so bases never reach the density where the fix matters.

This resolves #89's two questions and removes a real feral-internal bug, so it **closes the feral issue**. It does not (and cannot, feral-side) move the end-to-end solve: that residual is **caller-side** — refactor cadence, and discopt's work-gate reading `eta_ops()` instead of the new `update_work()`. That belongs in a discopt issue, not here. Details on #89.

The asymptotic wording in an earlier draft ("no asymptotically cheaper FT path") is corrected: dense *inverse* ≠ dense *factor*; only a genuinely dense factor carries the `Θ(m²)` floor.

## Notes

No public API removed; no numerical change. Research note: `dev/research/ft-dense-bump-cost-2026-06-27.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
