### PR TITLE
issue #93: expose the LU element-growth factor via public getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — public getters for the LU element-growth monitor (issue #93)
+
+`SparseLu` and `DenseLu` now expose the ‖U‖∞ element-growth monitor they already
+track internally:
+
+- `growth() -> f64` — current element-growth high-water ratio since the last
+  factorize (`1.0` on a fresh factor); the continuous conditioning signal that,
+  when it trips `params.max_growth`, forces `update()` to return `NeedsRefactor`.
+- `u_max0() -> f64` — the reference `max|U|` captured at factorize time (the
+  denominator of `growth()`).
+
+Purely additive — the fields already existed as `pub(super)`; this only widens
+their visibility so downstream callers can threshold on a continuous conditioning
+signal rather than the binary refactor-or-not verdict. No algorithm or behavior
+change.
+
 ## [0.11.3] - 2026-06-28
 
 ### Performance — sparse LU update: O(m³) → O(m²) `u_above` reindex on filled bumps (issue #89)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,112 +1,109 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-27T22:16:46Z
+Generated: 2026-07-01T01:00:54Z
 
 ## Latest Session
-File: dev/sessions/2026-06-21-01.md
+File: dev/sessions/2026-07-01-01.md
 ```
-# Session 2026-06-21-01
+# Session 2026-07-01-01
 
 ## Goal
-
-Issue #87: eliminate the residual **O(bump²)** Forrest–Tomlin row-elimination on
-wide (dense-spike) McCormick simplex bases — the Step-2 follow-up of discopt#229
-that was parked as a research spike. The user asked for the **most robust and
-performant** solution, chosen after digging into the code and the literature, and
-verified with before/after timing + scaling experiments.
+Issue #93: expose the LU element-growth factor via public getters on both
+`SparseLu` and `DenseLu`, so downstream callers (discopt's spatial B&B
+"NumericFocus"-style escalation) can threshold on a continuous conditioning
+signal instead of the binary `NeedsRefactor` verdict.
 
 ## Accomplished
+- Added `pub fn growth(&self) -> f64` and `pub fn u_max0(&self) -> f64` to:
+  - `SparseLu` (`src/lu/sparse_factor.rs`, after `reach_visits()`)
+  - `DenseLu` (`src/lu/dense_factor.rs`, after `updates_since_refactor()`)
+  Purely additive — the `growth`/`u_max0` fields already existed as
+  `pub(super)`; this only widens their visibility. No field, algorithm, or
+  behavior change.
+- Added a getter test on each side
+  (`growth_getters_expose_internal_fields`): fresh factor reports
+  `growth() == 1.0`; getters equal the internal fields before and after a
+  committed update; `u_max0() > 0` (floored away from zero). Oracle is the
+  existing internal field, itself already pinned to an independent
+  element-growth recomputation by
+  `growth_monitor_tracks_compounded_element_growth` — so no new numerical
+  oracle was authored this session (satisfies the same-session oracle rule).
+- Updated `CHANGELOG.md` Unreleased with the additive-getters entry.
 
-### Diagnosis (the key insight)
+Evidence:
+- `cargo test --lib growth_getters` → 2 passed, 0 failed.
+- `cargo test --lib lu::` → 30 passed, 0 failed.
+- `cargo clippy --all-targets -- -D warnings` → clean.
+- `cargo fmt` reformatted the two test files (long assert lines only).
 
-The current `SparseLu::update`/`eliminate_bump` is **not** a Forrest–Tomlin update
-— it sets the spike into `U`'s column `r` and runs a full partial-pivoting bump
-re-triangularization in fixed pivot order. It eliminates the dense spike
-**column**, touching `O(bump)` rows with cascading fill, so both the work **and**
-the recorded eta are `O(bump²)` on a dense spike. True FT eliminates the single
-pivotal **row** after a symmetric permutation (the permuted diagonal pivots are
-the old nonzero `U` diagonals — dodging the zero-superdiagonal landmine that
-reverted the 2026-06-08 column-shift attempt), which is `O(bump)` for sparse `U`.
+## Benchmark Results
+```
+--- Dense solver validation ---
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+```
+(No perf regression possible — no code path changed; getters are field reads.)
 
-### Route chosen: logical-permutation Forrest–Tomlin
+## Decisions Made
+- None. Additive API only.
 
-Carry one evolving `uperm` (pivot-position ↔ triangular rank), applied once per
-solve; never relabel `U`'s indices or prior etas. Rejected the column-ordering
-lever (no asymptotic change) and physical permutation (stales prior etas →
-`O(k²·bump)`; cyclic shift as per-eta swaps → `O(k·bump)` solve blow-up).
-Clean-room from Forrest–Tomlin 1972, Reid 1982, Schork–Gondzio ERGO-17-002
-(`BASICLU` is GPL — paper only). Docs: `dev/research/ft-row-elimination-design-2026-06-21.md`,
-`dev/plans/ft-row-elimination-2026-06-21.md`, `dev/decisions.md`.
-
-### Implementation (P1+P2)
-
-- **P1** (`a676aaf`): `uperm`/`uperm_inv`; `usolve`/`ut_solve` walk `U` in rank
-  order (identity at factor ⇒ byte-identical).
-- **P2** (`ebaeca6`): rewrote `sparse_update.rs` — `set_column_r` (spike into
-  other rows), `shift_uperm` (symmetric cyclic shift, `O(bump)`),
-  `eliminate_pivot_row` (single-row sparse forward sweep via a rank min-heap, one
-  `FtOp::Axpy` per sub-diagonal). Widened `u_above` to all off-diagonal holders;
-  diagonal-first-aware row helpers; removed `FtOp::Swap`.
-- **Bug fixed during bring-up**: the eliminated pivot column's FP residual
-  `vrc − mult·piv ≠ 0` re-enqueued the column forever (infinite loop / OOM, exit
-  137). Fixed by clearing `rw[c]` exactly and skipping the pivot's own diagonal.
-
-### Evidence (before → after, release, this host)
-
-| probe | metric | BEFORE | AFTER |
-|---|---|---:|---:|
+## Abandoned Approaches
+- None.
 ```
 
 ## Git Status
 ```
+f037285 release: feral v0.11.3
+a5c789f issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter (#90)
 a9cea82 issue #87: Forrest–Tomlin row-elimination LU update (O(bump²) → O(bump)) (#88)
 380459c issue #87: gate FT invariant self-check behind off-by-default feature (CI: alloc probe)
 47a3d66 issue #87: fix duplicate-column bug in FT row gather (CI: casctanks drift)
-1808467 issue #87 P5: checkpoint — FT row-elimination session docs
-ebaeca6 issue #87 P2: Forrest-Tomlin row-elimination update (O(bump²) → O(bump))
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 373 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.56s
+test result: ok. 375 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.16s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-06-21-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-01-01.md)
 
-
-cargo run --bin bench --release  (symmetric indefinite gate — unaffected)
-  Residual pass: 2/2 (100.0%)   Worst residual: 1.26e-16
-  Dense/Sparse failure analysis: no failures
-
-casctanks_ft_update/chain_144_updates_m2169
-  BEFORE: 16.770–17.036 ms   AFTER: 1.6413–1.6748 ms   (10.2×)
-
-lu_wide_bump_probe (dense-spike tridiagonal, AFTER):
-   m    us/update   us/update/m   eta_ops/upd
-  250     102.11       0.41           52
- 1000     675.41       0.68          116
- 4000   69415.61      17.35         ~120
+--- Dense solver validation ---
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+(No perf regression possible — no code path changed; getters are field reads.)
 
 ```
 
@@ -224,8 +221,8 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -238,6 +235,10 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs
@@ -246,10 +247,6 @@ tests/issue_38_static_pivot.rs
 tests/issue_46_saddle_kkt_cascade.rs
 tests/issue_55_delay_budget.rs
 tests/issue_55_n_tiny_counter.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
@@ -273,8 +270,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/journal/2026-07-01-01.org
+++ b/dev/journal/2026-07-01-01.org
@@ -1,0 +1,21 @@
+* 10:00 :issue-93:lu:api:
+Issue #93: expose the LU element-growth factor via public getters.
+Both LU factor types already track a running ‖U‖∞ element-growth high-water
+ratio (largest max|U| over updates ÷ u_max0) as pub(super) fields —
+src/lu/sparse_factor.rs:115-118 and src/lu/dense_factor.rs:43-46 — updated on
+every commit (sparse_update.rs:216, dense_update.rs:143). Only observable
+downstream indirectly as the binary NeedsRefactor when it trips max_growth.
+Added `growth(&self) -> f64` and `u_max0(&self) -> f64` on both SparseLu
+(after reach_visits()) and DenseLu (after updates_since_refactor()). Purely
+additive, no field/algorithm change — just widened visibility.
+
+Added a getter test on each side (growth_getters_expose_internal_fields):
+fresh factor → growth() == 1.0; getters == the internal fields before and
+after a committed update; u_max0() > 0 (floored). Oracle is the existing
+internal field (already pinned to the independent element-growth recomputation
+by growth_monitor_tracks_compounded_element_growth), so no new numerical
+oracle written this session.
+
+Evidence: `cargo test --lib growth_getters` → 2 passed. Full `cargo test
+--lib lu::` → 30 passed, 0 failed. `cargo clippy --all-targets -- -D
+warnings` clean. cargo fmt reformatted the two test files (long assert lines).

--- a/dev/sessions/2026-07-01-01.md
+++ b/dev/sessions/2026-07-01-01.md
@@ -1,0 +1,54 @@
+# Session 2026-07-01-01
+
+## Goal
+Issue #93: expose the LU element-growth factor via public getters on both
+`SparseLu` and `DenseLu`, so downstream callers (discopt's spatial B&B
+"NumericFocus"-style escalation) can threshold on a continuous conditioning
+signal instead of the binary `NeedsRefactor` verdict.
+
+## Accomplished
+- Added `pub fn growth(&self) -> f64` and `pub fn u_max0(&self) -> f64` to:
+  - `SparseLu` (`src/lu/sparse_factor.rs`, after `reach_visits()`)
+  - `DenseLu` (`src/lu/dense_factor.rs`, after `updates_since_refactor()`)
+  Purely additive — the `growth`/`u_max0` fields already existed as
+  `pub(super)`; this only widens their visibility. No field, algorithm, or
+  behavior change.
+- Added a getter test on each side
+  (`growth_getters_expose_internal_fields`): fresh factor reports
+  `growth() == 1.0`; getters equal the internal fields before and after a
+  committed update; `u_max0() > 0` (floored away from zero). Oracle is the
+  existing internal field, itself already pinned to an independent
+  element-growth recomputation by
+  `growth_monitor_tracks_compounded_element_growth` — so no new numerical
+  oracle was authored this session (satisfies the same-session oracle rule).
+- Updated `CHANGELOG.md` Unreleased with the additive-getters entry.
+
+Evidence:
+- `cargo test --lib growth_getters` → 2 passed, 0 failed.
+- `cargo test --lib lu::` → 30 passed, 0 failed.
+- `cargo clippy --all-targets -- -D warnings` → clean.
+- `cargo fmt` reformatted the two test files (long assert lines only).
+
+## Benchmark Results
+```
+--- Dense solver validation ---
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+```
+(No perf regression possible — no code path changed; getters are field reads.)
+
+## Decisions Made
+- None. Additive API only.
+
+## Abandoned Approaches
+- None.
+
+## Next Session Should
+- Ship the getters in a patch release (e.g. 0.11.4) if discopt needs them
+  promptly, or batch with other additive API work.

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -143,6 +143,23 @@ impl DenseLu {
         self.updates_since_refactor
     }
 
+    /// Current ‖U‖∞ element-growth high-water ratio since the last factorize:
+    /// the largest `max|U|` seen across all updates divided by [`Self::u_max0`].
+    /// A continuous conditioning signal (`1.0` on a fresh factor); tripping
+    /// `params.max_growth` is what forces [`DenseLu::update`] to return
+    /// `NeedsRefactor`.
+    #[inline]
+    pub fn growth(&self) -> f64 {
+        self.growth
+    }
+
+    /// Reference `max|U|` captured immediately after the last factor/refactor —
+    /// the denominator of [`Self::growth`]. Floored away from zero.
+    #[inline]
+    pub fn u_max0(&self) -> f64 {
+        self.u_max0
+    }
+
     /// The row permutation `perm` (`perm[k]` = original row in pivot row `k`).
     #[inline]
     pub fn perm(&self) -> &[usize] {

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -252,4 +252,34 @@ mod tests {
         }
         assert!(hw > 1.0, "test must exercise genuine element growth");
     }
+
+    /// Issue #93: the public `growth`/`u_max0` getters must expose exactly the
+    /// internal fields (no divergence). Fresh factor reports `growth == 1.0`;
+    /// after a committed update the getter tracks the internal high-water field.
+    #[test]
+    fn growth_getters_expose_internal_fields() {
+        let cols = vec![vec![4.0, 1.0], vec![1.0, 3.0]];
+        let params = LuParams {
+            max_updates: 20,
+            max_growth: 1e12,
+            ..LuParams::default()
+        };
+        let mut lu = DenseLu::factor(&cols, 2, params).expect("factor");
+
+        assert_eq!(lu.growth(), 1.0, "fresh factor growth is 1.0");
+        assert_eq!(lu.growth(), lu.growth, "getter mirrors internal field");
+        assert_eq!(lu.u_max0(), lu.u_max0, "getter mirrors internal field");
+        assert!(
+            lu.u_max0() > 0.0,
+            "reference max|U| is floored away from zero"
+        );
+
+        lu.update(1, &[0.0, 40.0]).expect("update commits");
+        assert_eq!(
+            lu.growth(),
+            lu.growth,
+            "getter mirrors internal after update"
+        );
+        assert_eq!(lu.u_max0(), lu.u_max0, "u_max0 unchanged by update");
+    }
 }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -588,6 +588,21 @@ impl SparseLu {
         self.reach_visits
     }
 
+    /// Current ‖U‖∞ element-growth high-water ratio since the last factorize:
+    /// the largest `max|U|` seen across all updates divided by [`Self::u_max0`].
+    /// A continuous conditioning signal (`1.0` on a fresh factor); tripping
+    /// `params.max_growth` is what forces [`SparseLu::update`] to return
+    /// `NeedsRefactor`.
+    pub fn growth(&self) -> f64 {
+        self.growth
+    }
+
+    /// Reference `max|U|` captured immediately after the last factor/refactor —
+    /// the denominator of [`Self::growth`]. Floored away from zero.
+    pub fn u_max0(&self) -> f64 {
+        self.u_max0
+    }
+
     /// Reconstruct dense entry `(i, j)` of `L` (pivot-position coordinates).
     pub fn l_dense(&self, i: usize, j: usize) -> f64 {
         if i == j {

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -750,6 +750,43 @@ mod tests {
         assert!(hw > 1.0, "test must exercise genuine element growth");
     }
 
+    /// Issue #93: the public `growth`/`u_max0` getters must expose exactly the
+    /// internal fields. Fresh factor reports `growth == 1.0`; after a committed
+    /// update the getter tracks the internal high-water field.
+    #[test]
+    fn growth_getters_expose_internal_fields() {
+        let cols = vec![
+            vec![4.0, 1.0, 0.0, 0.0],
+            vec![1.0, 3.0, 1.0, 0.0],
+            vec![0.0, 1.0, 2.0, 1.0],
+            vec![0.0, 0.0, 1.0, 5.0],
+        ];
+        let m = 4;
+        let params = LuParams {
+            max_updates: 20,
+            max_growth: 1e12,
+            ..LuParams::default()
+        };
+        let mut lu = SparseLu::factor_dense_columns(m, &cols, params).expect("factor");
+
+        assert_eq!(lu.growth(), 1.0, "fresh factor growth is 1.0");
+        assert_eq!(lu.growth(), lu.growth, "getter mirrors internal field");
+        assert_eq!(lu.u_max0(), lu.u_max0, "getter mirrors internal field");
+        assert!(
+            lu.u_max0() > 0.0,
+            "reference max|U| is floored away from zero"
+        );
+
+        lu.update(3, &[0.0, 0.0, 1.0, 60.0])
+            .expect("update commits");
+        assert_eq!(
+            lu.growth(),
+            lu.growth,
+            "getter mirrors internal after update"
+        );
+        assert_eq!(lu.u_max0(), lu.u_max0, "u_max0 unchanged by update");
+    }
+
     /// After a chain of wide-bump dense-column updates, `U` must stay upper
     /// triangular *in `uperm` order* (every off-diagonal entry's column outranks
     /// its row) and diagonal-first — the structural invariant the row-ordered


### PR DESCRIPTION
## Summary

Closes #93. Adds public getters exposing the ‖U‖∞ element-growth monitor that both LU factor types already track internally:

```rust
/// Current ‖U‖∞ element-growth high-water ratio since the last factorize.
pub fn growth(&self) -> f64;
/// Reference max|U| captured at factorize time (denominator of `growth`).
pub fn u_max0(&self) -> f64;
```

- `SparseLu` — `src/lu/sparse_factor.rs`, after `reach_visits()`
- `DenseLu` — `src/lu/dense_factor.rs`, after `updates_since_refactor()`

Purely additive: the `growth`/`u_max0` fields already existed as `pub(super)`; this only widens their visibility. No algorithm, field, or behavior change — the getters just return the existing fields.

## Motivation

Until now the growth monitor was only observable indirectly, as the binary `NeedsRefactor` returned by `update()` when it trips `params.max_growth`. discopt's spatial B&B wants a **continuous** conditioning signal to drive a "NumericFocus"-style escalation policy (tighten tolerance / switch primal↔dual / refine before falling back or branching); a boolean refactor-or-not is too coarse. Growth is the cheapest such signal feral already has.

## Testing

Added `growth_getters_expose_internal_fields` on each side:
- fresh factor reports `growth() == 1.0`
- getters equal the internal fields before and after a committed update
- `u_max0() > 0` (floored away from zero)

The oracle is the internal field, itself already pinned to an independent element-growth recomputation by the existing `growth_monitor_tracks_compounded_element_growth` test — so no new numerical oracle was authored.

- `cargo test --lib lu::` → 30 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` → clean
- `bench --release` → dense worst residual 1.14e-15, sparse inertia 2/2 vs MUMPS, worst residual 1.26e-16, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjPY7SvqSBSkFQxcXscvB8)_