### PR TITLE
issue #94: one-norm condition estimate for the unsymmetric LU factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — one-norm condition estimate for the unsymmetric LU basis (issue #94)
+
+`SparseLu::condition_estimate_1(&mut self, b: &SparseColMatrix)` and
+`DenseLu::condition_estimate_1(&mut self, b: &GeneralMatrix)` return a
+Hager–Higham one-norm condition estimate `κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁` for the LU basis,
+running the estimator's inverse-norm solves through the factor's own
+`ftran`/`btran` (the LU is unsymmetric, so each iteration is one `ftran` for
+`B⁻¹` and one `btran` for `B⁻ᵀ`, dropping the symmetric `A⁻ᵀ = A⁻¹` shortcut).
+`b` is the original basis (supplies `‖B‖₁` as the max absolute column sum;
+the factor does not retain it, mirroring `ftran_refined`); the result is a lower
+bound on the true `κ₁`. This is the LP-engine enabler for deciding
+"ill-conditioned node → iteratively refine / re-solve with perturbation" inside
+one solver instead of swapping engines (discopt#364).
+
+The Hager–Higham iteration is now factored into a shared driver
+`numeric::condition::hager_higham_inverse_norm_1` over a new
+`HagerHighamOperator` trait (both re-exported at the crate root); the symmetric
+LDLᵀ path (`estimate_inverse_norm_1`) and the new LU path share the estimator
+loop, differing only in the solve callback. The symmetric path is numerically
+unchanged (same pooled `SolveWorkspace`, bit-identical arithmetic). Also adds
+`SparseColMatrix::one_norm` / `GeneralMatrix::one_norm` (max absolute column sum).
+
 ## [0.11.3] - 2026-06-28
 
 ### Performance — sparse LU update: O(m³) → O(m²) `u_above` reindex on filled bumps (issue #89)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-06-27T22:16:46Z
+Generated: 2026-07-01T01:13:24Z
 
 ## Latest Session
 File: dev/sessions/2026-06-21-01.md
@@ -59,34 +59,34 @@ Clean-room from Forrest–Tomlin 1972, Reid 1982, Schork–Gondzio ERGO-17-002
 
 ## Git Status
 ```
+7b4669b issue #94: LU-basis one-norm condition estimate via ftran/btran
+01a1527 issue #94: extract shared Hager–Higham driver + HagerHighamOperator trait
+f037285 release: feral v0.11.3
+a5c789f issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter (#90)
 a9cea82 issue #87: Forrest–Tomlin row-elimination LU update (O(bump²) → O(bump)) (#88)
-380459c issue #87: gate FT invariant self-check behind off-by-default feature (CI: alloc probe)
-47a3d66 issue #87: fix duplicate-column bug in FT row gather (CI: casctanks drift)
-1808467 issue #87 P5: checkpoint — FT row-elimination session docs
-ebaeca6 issue #87 P2: Forrest-Tomlin row-elimination update (O(bump²) → O(bump))
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 373 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.56s
+test result: ok. 381 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.90s
 
 ```
 
@@ -182,6 +182,7 @@ src/io/mod.rs
 src/io/mtx.rs
 src/io/sidecar.rs
 src/lib.rs
+src/lu/condition.rs
 src/lu/dense_factor.rs
 src/lu/dense_matrix.rs
 src/lu/dense_solve.rs
@@ -224,8 +225,8 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -238,6 +239,10 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs
@@ -246,10 +251,6 @@ tests/issue_38_static_pivot.rs
 tests/issue_46_saddle_kkt_cascade.rs
 tests/issue_55_delay_budget.rs
 tests/issue_55_n_tiny_counter.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
@@ -273,8 +274,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/journal/2026-07-01-01.org
+++ b/dev/journal/2026-07-01-01.org
@@ -1,0 +1,43 @@
+#+TITLE: FERAL Journal — 2026-07-01-01
+
+* 09:00 :issue-94:condition:lu:orient:
+Goal: issue #94 — one-norm condition estimate (rcond/κ₁) for the unsymmetric LU
+factor. Existing Hager–Higham estimator (=src/numeric/condition.rs=) is bound to
+the symmetric =SparseFactors= and drives solves through =numeric::solve=,
+exploiting =A⁻ᵀ = A⁻¹= (1 solve/iter). Unreachable for an LU basis. Journal
+sub-agent confirmed: greenfield, no prior attempts, no plan/tried-and-rejected
+entry. Wrote =dev/research/lu-condition-estimate.md=.
+
+* 09:30 :issue-94:refactor:
+Factored the Hager loop out of =estimate_inverse_norm_1= into a shared driver
+=hager_higham_inverse_norm_1<O: HagerHighamOperator>= (trait: =dim=,
+=apply_inverse=, =apply_inverse_transpose=). Symmetric path now builds a
+=SymmetricHager= adapter (pools one =SolveWorkspace= + one in-buffer;
+=apply_inverse_transpose= delegates to =apply_inverse=) and calls the driver.
+The driver operates in-place on =rhs=; the symmetric adapter copies rhs→inbuf
+then uses the out-of-place =solve_sparse_into_ws=. Math is bit-identical (same
+op order). Evidence: all 9 pre-existing =numeric::condition= tests pass,
+including =estimate_pools_one_solve_workspace_across_internal_solves= (N5:
+exactly ONE SolveWorkspace build) — the pooling contract is preserved.
+
+* 09:50 :issue-94:lu:implement:
+New =src/lu/condition.rs=: =SparseLuHager=/=DenseLuHager= adapters wire
+=ftran=/=btran= into the driver; =SparseLu::condition_estimate_1(&b)= /
+=DenseLu::condition_estimate_1(&b)= multiply the driver result by =b.one_norm()=
+(=‖B‖₁= = max absolute column sum, new method on both matrix types). Deviated
+from issue's sketched =-> f64= to =-> Result<f64, FeralError>= (solves are
+fallible; crate forbids unwrap/expect in src). Dim-mismatch guarded before any
+solve.
+
+* 10:10 :issue-94:test:evidence:
+8 new unit tests, all external hand-calc oracles:
+- =one_norm= hand values (6 for [[1,2],[3,4]]; abs handling → 5).
+- identity I₅ → κ ≈ 1; diag(1,1e3,1e6) → κ₁ = 1e6 (within 2×).
+- =B=[[1,2],[3,4]]=: det −2, B⁻¹=[[−2,1],[1.5,−0.5]], ‖B‖₁=6, ‖B⁻¹‖₁=3.5,
+  κ₁=21 (hand). Estimate is a lower bound → assert κ_est ∈ [10.5, 21·(1+1e-6)].
+  Both dense and sparse paths hit it.
+- dense/sparse parity on a well-conditioned 3×3 (rel < 1e-6).
+- dim-mismatch → Err on both paths.
+Result: =cargo test= 381 lib passed (was 373; +8), 0 failed. fmt + clippy
+(-D warnings) clean. Re-exported =hager_higham_inverse_norm_1= +
+=HagerHighamOperator= at crate root.

--- a/dev/research/lu-condition-estimate.md
+++ b/dev/research/lu-condition-estimate.md
@@ -1,0 +1,77 @@
+# LU-path condition estimate (issue #94)
+
+## Problem
+
+`src/numeric/condition.rs` has a Hager–Higham 1-norm condition estimator
+(`κ₁ = ‖A‖₁·‖A⁻¹‖₁`, Hager 1984 + Higham 1988, DLACON-style, ≤5 iters). Its
+`estimate_inverse_norm_1` is bound to the **symmetric** `SparseFactors` and drives
+each Hager iteration through `numeric::solve` (the symmetric solver), exploiting
+the specialization `A⁻ᵀ = A⁻¹` so one iteration = one solve. It cannot see an LU
+basis: there is no `rcond()`/`condition_estimate()` on `SparseLu`/`DenseLu`.
+
+Downstream (discopt#364) wants a trustworthy κ estimate on the *unsymmetric LU
+basis* the simplex factors, so a B&B node can decide "ill-conditioned → refine /
+re-solve with perturbation" inside one engine instead of swapping solvers.
+
+## Algorithm (unchanged math, new solve callback)
+
+Hager–Higham estimates `‖B⁻¹‖₁` by a power iteration on the cube
+`{x : ‖x‖₁ ≤ 1}`:
+
+```
+x₀ = (1/n,…,1/n)
+repeat (≤ MAX_ITER):
+    y  = B⁻¹ x           ;  est = ‖y‖₁
+    if est stopped growing → break
+    ξ  = sign(y)         (sign(0)=+1, LAPACK)
+    z  = B⁻ᵀ ξ
+    if ‖z‖∞ ≤ zᵀx → break         (local max on the cube)
+    x  = e_j, j = argmax|z|;  cycle-guard on repeated j
+refine (Higham): b_i = (-1)^i (1 + i/(n-1)); est = max(est, 2‖B⁻¹ b‖₁/(3n))
+```
+
+For a **symmetric** factor `B⁻ᵀ = B⁻¹`, so the `z`-solve reuses the same solver
+(1 solve/iter). For the **unsymmetric LU** the two differ: `y = B⁻¹x` is `ftran`
+and `z = B⁻ᵀξ` is `btran` (~2 solves/iter). Both are O(1) factorizations; the
+factor is reused.
+
+`‖B‖₁ = max_j Σ_i |B_ij|` is the max absolute **column** sum — for a general
+(unsymmetric) matrix this is a straight column-sum, no symmetry doubling (unlike
+`matrix_norm_1`, which reflects the stored lower triangle).
+
+## Design: factor out the shared driver
+
+Introduce in `condition.rs`:
+
+- `trait HagerHighamOperator { dim(); apply_inverse(&mut [f64]); apply_inverse_transpose(&mut [f64]); }`
+  — the two in-place solves `B⁻¹·rhs` / `B⁻ᵀ·rhs`.
+- `hager_higham_inverse_norm_1<O: HagerHighamOperator>(op) -> Result<f64>` — the
+  driver loop above, verbatim from the current `estimate_inverse_norm_1`.
+
+Then:
+- `estimate_inverse_norm_1(&SparseFactors)` builds a `SymmetricHager` adapter
+  (holds the pooled `SolveWorkspace` + one in-buffer, `apply_inverse_transpose`
+  delegates to `apply_inverse`) and calls the driver. **Math is bit-identical**:
+  same operation order, same pooled `ws` (the N5 one-build test still holds).
+- `SparseLu::condition_estimate_1(&mut self, b: &SparseColMatrix)` and
+  `DenseLu::condition_estimate_1(&mut self, b: &GeneralMatrix)` build an adapter
+  over `ftran`/`btran` and multiply the driver result by `b.one_norm()`.
+
+Signature note: issue #94 sketches `-> f64`, but the LU solves and the dimension
+check are fallible and the crate forbids `unwrap`/`expect` in `src/`, so the
+methods return `Result<f64, FeralError>`, matching `estimate_condition_1norm`.
+
+## Oracles (external, hand-computed)
+
+- Identity `n×n`: κ₁ = 1 (both paths).
+- Diagonal `diag(1, 1e3, 1e6)`: κ₁ = 1e6 exactly (Hager on a diagonal is exact).
+- `B = [[1,2],[3,4]]`: `B⁻¹ = [[-2,1],[1.5,-0.5]]`, `‖B‖₁ = 6`, `‖B⁻¹‖₁ = 3.5`,
+  κ₁ = 21 (hand). Estimate is a lower bound on `‖B⁻¹‖₁`, so assert
+  `κ_est ∈ [κ_true/2, κ_true·(1+ε)]`.
+- Dense/sparse parity on the same basis (estimates agree bit-for-bit).
+- Dimension-mismatch (`b.m ≠ self.m`) → `Err`.
+
+## Scope
+
+Additive: shared driver + trait in `condition.rs`, two `condition_estimate_1`
+methods, two `one_norm` matrix helpers. Reuses the existing, tested Hager loop.

--- a/dev/sessions/2026-07-01-01.md
+++ b/dev/sessions/2026-07-01-01.md
@@ -1,0 +1,85 @@
+# Session 2026-07-01-01
+
+## Goal
+
+Issue #94: provide a one-norm condition estimate (`rcond`/κ₁) for the
+**unsymmetric LU** factor (`SparseLu`/`DenseLu`). The crate's Hager–Higham
+1-norm estimator existed but was hard-wired to the symmetric LDLᵀ path
+(`estimate_inverse_norm_1(&SparseFactors)`, driving `numeric::solve` and
+exploiting `A⁻ᵀ = A⁻¹`), so it was unreachable for the LU basis a simplex uses.
+
+## Accomplished
+
+### Shared driver refactor (commit `01a1527`)
+
+Factored the Hager–Higham inverse-norm loop out of `estimate_inverse_norm_1`
+into `numeric::condition::hager_higham_inverse_norm_1<O: HagerHighamOperator>`.
+The new `HagerHighamOperator` trait exposes the two in-place solves the
+iteration needs: `apply_inverse` (`A⁻¹·rhs`) and `apply_inverse_transpose`
+(`A⁻ᵀ·rhs`). The symmetric path is now a `SymmetricHager` adapter that delegates
+transpose→inverse (`A⁻ᵀ = A⁻¹`) and pools one `SolveWorkspace` + one input
+buffer across every internal solve.
+
+- Behavior-preserving: all 9 pre-existing `numeric::condition` tests pass,
+  including the N5 one-build guard (exactly ONE `SolveWorkspace` construction).
+  Bit-identical arithmetic (same operation order).
+
+### LU condition estimate (commit `7b4669b`)
+
+New `src/lu/condition.rs`: `SparseLuHager`/`DenseLuHager` adapters wire
+`ftran`/`btran` into the shared driver; `SparseLu::condition_estimate_1(&b)` and
+`DenseLu::condition_estimate_1(&b)` return κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁. The LU is
+unsymmetric, so each iteration does one `ftran` (`B⁻¹`) and one `btran`
+(`B⁻ᵀ`) — the symmetric single-solve shortcut is dropped. `‖B‖₁` is the max
+absolute column sum of the supplied basis (new `one_norm` on `SparseColMatrix`
+and `GeneralMatrix`; the factor does not retain `B`, mirroring `ftran_refined`).
+Re-exported the driver + trait at the crate root.
+
+- Signature: returns `Result<f64, FeralError>`, not the issue's sketched
+  `-> f64` — the LU solves and the dimension check are fallible and `src/`
+  forbids `unwrap`/`expect`.
+- 8 new unit tests, all external hand-calc oracles:
+  - `one_norm` hand values (6; abs-handling → 5).
+  - identity I₅ → κ ≈ 1; diag(1, 1e3, 1e6) → κ₁ = 1e6 (within 2×).
+  - `B = [[1,2],[3,4]]`: `B⁻¹ = [[−2,1],[1.5,−0.5]]`, ‖B‖₁ = 6, ‖B⁻¹‖₁ = 3.5,
+    κ₁ = 21 (hand); estimate is a lower bound → κ_est ∈ [10.5, 21] on both
+    dense and sparse paths.
+  - dense/sparse parity on a 3×3 (rel < 1e-6); dim-mismatch → `Err`.
+
+### Evidence
+
+- `cargo test`: **381 lib passed** (was 373; +8 new), 0 failed, 6 ignored;
+  all integration suites green.
+- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`: clean.
+- `cargo run --bin bench --release`: symmetric indefinite residual gate
+  unaffected — 2/2 pass, worst residual 1.26e-16 (this feature is additive to
+  the LU family and does not touch the symmetric solver).
+
+## Benchmark Results
+
+```
+cargo run --bin bench --release  (symmetric indefinite gate — unaffected)
+  Residual pass: 2/2 (100.0%)   Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+  Dense/Sparse failure analysis: no failures
+```
+
+## Decisions Made
+
+- Public LU condition API returns `Result<f64, FeralError>` (fallible solves +
+  dim check; `src/` no-unwrap rule) rather than the issue's sketched `-> f64`.
+- The Hager–Higham loop is now shared via a trait/driver in `condition.rs`; the
+  symmetric and LU paths differ only in the solve callback (1 vs 2 solves/iter).
+
+## Abandoned Approaches
+
+None — greenfield (journal search confirmed no prior attempt at LU condition
+estimation).
+
+## Next Session Should
+
+- (Optional) Expose `condition_estimate_1` through any higher-level LP/simplex
+  engine wrapper if/when one lands, and feed κ into a refine-vs-refactor policy
+  (the discopt#364 motivation).
+- (Housekeeping, noted by the journal agent) `condition.rs` module docs still
+  say "3–5 solves" — the true bound is up to `2·MAX_ITER+1 = 11`; correct when
+  next touching that file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,10 @@ pub use lu::sparse_factor::SparseLu;
 pub use lu::sparse_matrix::SparseColMatrix;
 pub use lu::sparse_symbolic::SparseLuSymbolic;
 pub use lu::{should_use_dense_lu, LuParams, LuScaling, LuSingularAction};
-pub use numeric::condition::{estimate_condition_1norm, estimate_inverse_norm_1, matrix_norm_1};
+pub use numeric::condition::{
+    estimate_condition_1norm, estimate_inverse_norm_1, hager_higham_inverse_norm_1, matrix_norm_1,
+    HagerHighamOperator,
+};
 pub use numeric::factorize::{
     factorize_multifrontal_with_schur, LdltExport, NumericParams, ProfileReport, SchurBlock,
 };

--- a/src/lu/condition.rs
+++ b/src/lu/condition.rs
@@ -1,0 +1,249 @@
+//! One-norm condition estimate (`κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁`) for the unsymmetric LU
+//! basis (issue #94).
+//!
+//! The crate's Hager–Higham 1-norm estimator lives in
+//! [`crate::numeric::condition`], where the shared driver
+//! [`hager_higham_inverse_norm_1`](crate::numeric::condition::hager_higham_inverse_norm_1)
+//! runs the power iteration through a
+//! [`HagerHighamOperator`](crate::numeric::condition::HagerHighamOperator).
+//! The symmetric LDLᵀ path exploits `B⁻ᵀ = B⁻¹` (one solve per iteration); the
+//! LU basis is unsymmetric, so each iteration needs one `ftran` (`B⁻¹`) and one
+//! `btran` (`B⁻ᵀ`) — the two adapters below wire those solves into the driver.
+//!
+//! `‖B‖₁` is the maximum absolute column sum of the *supplied* basis `b` (the
+//! factor does not retain it, mirroring `ftran_refined`).
+
+use super::dense_factor::DenseLu;
+use super::dense_matrix::GeneralMatrix;
+use super::sparse_factor::SparseLu;
+use super::sparse_matrix::SparseColMatrix;
+use crate::error::FeralError;
+use crate::numeric::condition::{hager_higham_inverse_norm_1, HagerHighamOperator};
+
+/// Driver adapter over `SparseLu`: `apply_inverse` is `ftran` (`B⁻¹`),
+/// `apply_inverse_transpose` is `btran` (`B⁻ᵀ`).
+struct SparseLuHager<'a> {
+    lu: &'a mut SparseLu,
+}
+
+impl HagerHighamOperator for SparseLuHager<'_> {
+    fn dim(&self) -> usize {
+        self.lu.dim()
+    }
+    fn apply_inverse(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        self.lu.ftran(rhs)
+    }
+    fn apply_inverse_transpose(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        self.lu.btran(rhs)
+    }
+}
+
+/// Driver adapter over `DenseLu`.
+struct DenseLuHager<'a> {
+    lu: &'a mut DenseLu,
+}
+
+impl HagerHighamOperator for DenseLuHager<'_> {
+    fn dim(&self) -> usize {
+        self.lu.dim()
+    }
+    fn apply_inverse(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        self.lu.ftran(rhs)
+    }
+    fn apply_inverse_transpose(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        self.lu.btran(rhs)
+    }
+}
+
+impl SparseLu {
+    /// One-norm condition estimate `κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁` via Hager–Higham, using
+    /// this factor's `ftran`/`btran` for the `‖B⁻¹‖₁` solves.
+    ///
+    /// `b` is the original basis this factor was produced from (the factor does
+    /// not retain it, mirroring [`SparseLu::ftran_refined`]); its maximum
+    /// absolute column sum supplies `‖B‖₁`. The estimate is a lower bound on the
+    /// true `κ₁` (Hager returns a lower bound on `‖B⁻¹‖₁`).
+    ///
+    /// Cost: `‖B‖₁` is one O(nnz) pass; the inverse-norm estimate is ≤ `2·5+1`
+    /// ftran/btran solves against the stored factor. Returns
+    /// `Err(DimensionMismatch)` if `b.m ≠ self.m`, and propagates a solve error
+    /// (e.g. `SingularBasis`) from the underlying ftran/btran.
+    pub fn condition_estimate_1(&mut self, b: &SparseColMatrix) -> Result<f64, FeralError> {
+        if b.m != self.dim() {
+            return Err(FeralError::DimensionMismatch {
+                expected: self.dim(),
+                got: b.m,
+            });
+        }
+        if self.dim() == 0 {
+            return Ok(0.0);
+        }
+        let bnorm = b.one_norm();
+        let mut op = SparseLuHager { lu: self };
+        let inv_norm = hager_higham_inverse_norm_1(&mut op)?;
+        Ok(bnorm * inv_norm)
+    }
+}
+
+impl DenseLu {
+    /// One-norm condition estimate `κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁` via Hager–Higham, using
+    /// this factor's `ftran`/`btran` for the `‖B⁻¹‖₁` solves.
+    ///
+    /// See [`SparseLu::condition_estimate_1`] for the contract; `b` is the
+    /// original dense basis (supplies `‖B‖₁`), and the estimate is a lower bound
+    /// on the true `κ₁`.
+    pub fn condition_estimate_1(&mut self, b: &GeneralMatrix) -> Result<f64, FeralError> {
+        if b.m != self.dim() {
+            return Err(FeralError::DimensionMismatch {
+                expected: self.dim(),
+                got: b.m,
+            });
+        }
+        if self.dim() == 0 {
+            return Ok(0.0);
+        }
+        let bnorm = b.one_norm();
+        let mut op = DenseLuHager { lu: self };
+        let inv_norm = hager_higham_inverse_norm_1(&mut op)?;
+        Ok(bnorm * inv_norm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lu::LuParams;
+
+    // ---- `one_norm` (max absolute column sum). Oracle: hand computation. ----
+
+    #[test]
+    fn sparse_one_norm_hand() {
+        // B = [[1, 2], [3, 4]]  (col0 = [1,3], col1 = [2,4]).
+        // Column sums: |1|+|3| = 4, |2|+|4| = 6.  ‖B‖₁ = 6.
+        let cols = vec![vec![1.0, 3.0], vec![2.0, 4.0]];
+        let b = SparseColMatrix::from_dense_columns(2, &cols).expect("matrix");
+        assert!((b.one_norm() - 6.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn dense_one_norm_uses_absolute_value() {
+        // B = [[-1, 0], [0, -5]].  Column sums: 1 and 5.  ‖B‖₁ = 5.
+        let cols = vec![vec![-1.0, 0.0], vec![0.0, -5.0]];
+        let b = GeneralMatrix::from_columns(2, &cols).expect("matrix");
+        assert!((b.one_norm() - 5.0).abs() < 1e-15);
+    }
+
+    // ---- Condition estimate. Oracle: hand-computed κ₁ = ‖B‖₁·‖B⁻¹‖₁. ----
+
+    /// Identity `I₅`: `B⁻¹ = I`, so κ₁ = 1 exactly. The estimator is a lower
+    /// bound, so require `≥ 1 − √eps`; a sane upper cap guards against blow-up.
+    #[test]
+    fn sparse_condition_identity_is_one() {
+        let m = 5;
+        let cols: Vec<Vec<f64>> = (0..m)
+            .map(|j| (0..m).map(|i| if i == j { 1.0 } else { 0.0 }).collect())
+            .collect();
+        let b = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
+        let mut lu = SparseLu::factor_dense_columns(m, &cols, LuParams::default()).expect("factor");
+        let kappa = lu.condition_estimate_1(&b).expect("estimate");
+        assert!(kappa >= 1.0 - 1e-8, "identity κ {kappa} below 1");
+        assert!(kappa <= 2.0, "identity κ {kappa} unexpectedly large");
+    }
+
+    /// Diagonal `diag(1, 1e3, 1e6)`: `‖B‖₁ = 1e6`, `B⁻¹ = diag(1, 1e-3, 1e-6)`
+    /// so `‖B⁻¹‖₁ = 1`, giving true κ₁ = 1e6. Hager on a diagonal is exact, so
+    /// require the estimate within 2× (matching the symmetric diagonal test).
+    #[test]
+    fn sparse_condition_diagonal_spectrum() {
+        let cols = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1e3, 0.0],
+            vec![0.0, 0.0, 1e6],
+        ];
+        let b = SparseColMatrix::from_dense_columns(3, &cols).expect("matrix");
+        let mut lu = SparseLu::factor_dense_columns(3, &cols, LuParams::default()).expect("factor");
+        let kappa = lu.condition_estimate_1(&b).expect("estimate");
+        assert!(
+            (0.5e6..=2.0e6).contains(&kappa),
+            "diagonal κ {kappa} not within 2× of 1e6"
+        );
+    }
+
+    /// `B = [[1, 2], [3, 4]]`: `det = −2`, `B⁻¹ = [[−2, 1], [1.5, −0.5]]`,
+    /// `‖B‖₁ = 6`, `‖B⁻¹‖₁ = 3.5`, so true κ₁ = 21 (hand). The estimate is a
+    /// lower bound on `‖B⁻¹‖₁`, so require `κ_est ∈ [κ_true/2, κ_true·(1+ε)]`.
+    #[test]
+    fn sparse_condition_2x2_hand_oracle() {
+        let cols = vec![vec![1.0, 3.0], vec![2.0, 4.0]];
+        let b = SparseColMatrix::from_dense_columns(2, &cols).expect("matrix");
+        let mut lu = SparseLu::factor_dense_columns(2, &cols, LuParams::default()).expect("factor");
+        let kappa = lu.condition_estimate_1(&b).expect("estimate");
+        assert!(
+            (10.5..=21.0 * (1.0 + 1e-6)).contains(&kappa),
+            "2×2 κ {kappa} outside [10.5, 21] (true 21)"
+        );
+    }
+
+    /// Same `B = [[1, 2], [3, 4]]` through the dense path, hand oracle κ₁ = 21.
+    #[test]
+    fn dense_condition_2x2_hand_oracle() {
+        let cols = vec![vec![1.0, 3.0], vec![2.0, 4.0]];
+        let b = GeneralMatrix::from_columns(2, &cols).expect("matrix");
+        let mut lu = DenseLu::factor(&cols, 2, LuParams::default()).expect("factor");
+        let kappa = lu.condition_estimate_1(&b).expect("estimate");
+        assert!(
+            (10.5..=21.0 * (1.0 + 1e-6)).contains(&kappa),
+            "dense 2×2 κ {kappa} outside [10.5, 21] (true 21)"
+        );
+    }
+
+    /// The dense and sparse paths estimate the same κ on the same well-
+    /// conditioned basis (both exercise ftran/btran; the estimate must not
+    /// depend on the storage path beyond floating-point rounding).
+    #[test]
+    fn dense_sparse_parity_on_same_basis() {
+        let cols = vec![
+            vec![10.0, 1.0, 0.0],
+            vec![1.0, 8.0, 2.0],
+            vec![0.0, 1.0, 5.0],
+        ];
+        let sb = SparseColMatrix::from_dense_columns(3, &cols).expect("sparse matrix");
+        let db = GeneralMatrix::from_columns(3, &cols).expect("dense matrix");
+        let mut slu =
+            SparseLu::factor_dense_columns(3, &cols, LuParams::default()).expect("sparse factor");
+        let mut dlu = DenseLu::factor(&cols, 3, LuParams::default()).expect("dense factor");
+        let sk = slu.condition_estimate_1(&sb).expect("sparse estimate");
+        let dk = dlu.condition_estimate_1(&db).expect("dense estimate");
+        let rel = (sk - dk).abs() / sk.max(dk).max(1.0);
+        assert!(
+            rel < 1e-6,
+            "dense/sparse κ parity: sparse {sk}, dense {dk} (rel {rel})"
+        );
+    }
+
+    /// `b.m ≠ self.dim()` is rejected before any solve, on both paths.
+    #[test]
+    fn condition_dimension_mismatch_rejected() {
+        let cols2 = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+        let cols3 = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ];
+
+        let sb3 = SparseColMatrix::from_dense_columns(3, &cols3).expect("matrix");
+        let mut slu =
+            SparseLu::factor_dense_columns(2, &cols2, LuParams::default()).expect("factor");
+        assert!(matches!(
+            slu.condition_estimate_1(&sb3),
+            Err(FeralError::DimensionMismatch { .. })
+        ));
+
+        let db3 = GeneralMatrix::from_columns(3, &cols3).expect("matrix");
+        let mut dlu = DenseLu::factor(&cols2, 2, LuParams::default()).expect("factor");
+        assert!(matches!(
+            dlu.condition_estimate_1(&db3),
+            Err(FeralError::DimensionMismatch { .. })
+        ));
+    }
+}

--- a/src/lu/dense_matrix.rs
+++ b/src/lu/dense_matrix.rs
@@ -104,6 +104,18 @@ impl GeneralMatrix {
         Ok(())
     }
 
+    /// `‖A‖₁ = max_j Σ_i |A_ij|`, the maximum absolute column sum.
+    pub fn one_norm(&self) -> f64 {
+        let mut best = 0.0f64;
+        for j in 0..self.m {
+            let s: f64 = self.col(j).iter().map(|v| v.abs()).sum();
+            if s > best {
+                best = s;
+            }
+        }
+        best
+    }
+
     /// `y = A · x`. `x` and `y` must have length `m`.
     pub fn matvec(&self, x: &[f64], y: &mut [f64]) {
         for yi in y.iter_mut() {

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -11,6 +11,7 @@
 //! solves, not just one-shot factor/solve. See `dev/research/unsymmetric-lu.md`
 //! and `dev/plans/unsymmetric-lu-epic.md`.
 
+pub mod condition;
 pub mod dense_factor;
 pub mod dense_matrix;
 pub mod dense_solve;

--- a/src/lu/sparse_matrix.rs
+++ b/src/lu/sparse_matrix.rs
@@ -166,6 +166,22 @@ impl SparseColMatrix {
         (&self.row_idx[s..e], &self.values[s..e])
     }
 
+    /// `‖A‖₁ = max_j Σ_i |A_ij|`, the maximum absolute column sum. For a
+    /// general (unsymmetric) matrix this is a straight per-column sum — unlike
+    /// [`crate::numeric::condition::matrix_norm_1`], which doubles off-diagonal
+    /// contributions to reflect symmetric lower-triangular storage.
+    pub fn one_norm(&self) -> f64 {
+        let mut best = 0.0f64;
+        for j in 0..self.m {
+            let (_, vals) = self.column(j);
+            let s: f64 = vals.iter().map(|v| v.abs()).sum();
+            if s > best {
+                best = s;
+            }
+        }
+        best
+    }
+
     /// `y = A · x`.
     pub fn matvec(&self, x: &[f64], y: &mut [f64]) {
         for yi in y.iter_mut() {

--- a/src/numeric/condition.rs
+++ b/src/numeric/condition.rs
@@ -50,31 +50,45 @@ pub fn matrix_norm_1(matrix: &CscMatrix) -> f64 {
     col_sums.into_iter().fold(0.0f64, f64::max)
 }
 
-/// Hager-Higham estimate of `||A^{-1}||_1` given a factor of `A`.
+/// A factored operator exposing the two solves the Hager–Higham iteration
+/// needs: `apply_inverse` (`A⁻¹·rhs`) and `apply_inverse_transpose`
+/// (`A⁻ᵀ·rhs`), each overwriting `rhs` in place.
 ///
-/// Uses the symmetric specialization `A^{-T} = A^{-1}`, so each iteration
-/// performs one solve (not two as in the general nonsymmetric case).
+/// For a **symmetric** factor `A⁻ᵀ = A⁻¹`, so both methods are the same solve
+/// and one Hager iteration costs one solve. For an **unsymmetric** LU basis the
+/// two differ — `apply_inverse` is `ftran`, `apply_inverse_transpose` is
+/// `btran` — so each iteration costs ~2 solves (still O(1) factorizations).
+pub trait HagerHighamOperator {
+    /// Dimension `n` of the operator (`rhs` slices must have this length).
+    fn dim(&self) -> usize;
+    /// Overwrite `rhs` with `A⁻¹·rhs`.
+    fn apply_inverse(&mut self, rhs: &mut [f64]) -> Result<(), FeralError>;
+    /// Overwrite `rhs` with `A⁻ᵀ·rhs`.
+    fn apply_inverse_transpose(&mut self, rhs: &mut [f64]) -> Result<(), FeralError>;
+}
+
+/// Hager–Higham estimate of `‖A⁻¹‖₁`, driving the iteration through `op`'s
+/// `apply_inverse` / `apply_inverse_transpose` solves.
 ///
-/// Returns `Ok(0.0)` for `n == 0`. Returns `Err(DimensionMismatch)` if
-/// the factor's `n` is inconsistent with itself (should not happen in
-/// well-formed factors).
-pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralError> {
-    let n = factors.n;
+/// This is the shared estimator loop: Hager's 1984 power iteration on the cube
+/// `{x : ‖x‖₁ ≤ 1}`, Higham's 1988 alternating-sign refinement, LAPACK DLACON
+/// conventions (`sign(0)=+1`, `MAX_ITER` cap, cycle guard). The symmetric factor
+/// path (`estimate_inverse_norm_1`) and the unsymmetric LU path
+/// (`SparseLu`/`DenseLu::condition_estimate_1`) both call it, differing only in
+/// the two solve callbacks — one solve per iteration in the symmetric case, two
+/// in the unsymmetric case.
+///
+/// Returns `Ok(0.0)` for `n == 0`.
+pub fn hager_higham_inverse_norm_1<O: HagerHighamOperator>(op: &mut O) -> Result<f64, FeralError> {
+    let n = op.dim();
     if n == 0 {
         return Ok(0.0);
     }
 
-    // N5 (`dev/research/repo-review-2026-06-09.md`): pool one solve
-    // workspace and one output buffer across the up-to 2·MAX_ITER + 1
-    // internal solves. `solve_sparse` allocates a fresh `SolveWorkspace`
-    // (three vecs) plus a result vec per call, and this estimator calls it
-    // ~11× — the cited allocation churn. Reuse is safe: `solve_sparse_into_ws`
-    // fully overwrites both its output (`sol`) and its scratch on every call
-    // (see solve.rs), and `sol` (the "y" output) is fully consumed into `xi`
-    // before it is overwritten by the "z" solve. The arithmetic is
-    // bit-identical to the old per-call `solve_sparse`.
-    let mut ws = SolveWorkspace::for_factors(factors);
-    let mut sol = vec![0.0f64; n];
+    // `y` holds `A⁻¹x` (the "y" solve), then is reused for `A⁻ᵀξ` (the "z"
+    // solve): the "y" values are folded into `xi` before the "z" solve
+    // overwrites them, so the reuse is safe.
+    let mut y = vec![0.0f64; n];
     let mut xi = vec![0.0f64; n];
 
     // x_0 = (1/n, ..., 1/n)
@@ -86,9 +100,10 @@ pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralErro
     let mut prev_j: Option<usize> = None;
 
     for _iter in 0..MAX_ITER {
-        // y = A^{-1} x  (written into `sol`)
-        solve_sparse_into_ws(factors, &x, &mut sol, &mut ws)?;
-        est = sol.iter().map(|v| v.abs()).sum();
+        // y = A^{-1} x
+        y.copy_from_slice(&x);
+        op.apply_inverse(&mut y)?;
+        est = y.iter().map(|v| v.abs()).sum();
 
         // Termination: estimate stopped growing.
         if _iter > 0 && est <= est_old {
@@ -97,18 +112,19 @@ pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralErro
         }
 
         // xi = sign(y), with sign(0) = +1 (LAPACK convention).
-        for (slot, &v) in xi.iter_mut().zip(sol.iter()) {
+        for (slot, &v) in xi.iter_mut().zip(y.iter()) {
             *slot = if v >= 0.0 { 1.0 } else { -1.0 };
         }
 
-        // z = A^{-T} xi = A^{-1} xi (symmetry), reusing `sol` — the "y"
-        // values are already folded into `xi` above, so overwriting is safe.
-        solve_sparse_into_ws(factors, &xi, &mut sol, &mut ws)?;
+        // z = A^{-T} xi, reusing `y` — the "y" values are already folded into
+        // `xi` above, so overwriting is safe.
+        y.copy_from_slice(&xi);
+        op.apply_inverse_transpose(&mut y)?;
 
         // Termination: ||z||_inf <= z . x  =>  current estimate is
         // a local maximum on the cube {x: ||x||_1 <= 1}.
-        let zx: f64 = sol.iter().zip(x.iter()).map(|(zi, xv)| zi * xv).sum();
-        let z_inf = sol.iter().map(|v| v.abs()).fold(0.0f64, f64::max);
+        let zx: f64 = y.iter().zip(x.iter()).map(|(zi, xv)| zi * xv).sum();
+        let z_inf = y.iter().map(|v| v.abs()).fold(0.0f64, f64::max);
         if z_inf <= zx {
             break;
         }
@@ -116,7 +132,7 @@ pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralErro
         // x = e_j with j = argmax |z_i|.
         let mut j = 0usize;
         let mut zmax = 0.0f64;
-        for (i, &zi) in sol.iter().enumerate() {
+        for (i, &zi) in y.iter().enumerate() {
             let zabs = zi.abs();
             if zabs > zmax {
                 zmax = zabs;
@@ -151,14 +167,65 @@ pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralErro
             *slot = sign * mag;
         }
     }
-    solve_sparse_into_ws(factors, &b, &mut sol, &mut ws)?;
-    let yb_l1: f64 = sol.iter().map(|v| v.abs()).sum();
+    op.apply_inverse(&mut b)?;
+    let yb_l1: f64 = b.iter().map(|v| v.abs()).sum();
     let refined = 2.0 * yb_l1 / (3.0 * n as f64);
     if refined > est {
         est = refined;
     }
 
     Ok(est)
+}
+
+/// Symmetric-factor adapter for [`hager_higham_inverse_norm_1`]. Exploits
+/// `A⁻ᵀ = A⁻¹`, so `apply_inverse_transpose` delegates to `apply_inverse`, and
+/// pools one [`SolveWorkspace`] plus one input buffer across every internal
+/// solve (N5, `dev/research/repo-review-2026-06-09.md`).
+struct SymmetricHager<'a> {
+    factors: &'a SparseFactors,
+    ws: SolveWorkspace,
+    /// `solve_sparse_into_ws` is out-of-place (`rhs` in, `x_out` out); this
+    /// pooled buffer holds the input copy so the driver's in-place contract is
+    /// met without a per-solve allocation.
+    inbuf: Vec<f64>,
+}
+
+impl HagerHighamOperator for SymmetricHager<'_> {
+    fn dim(&self) -> usize {
+        self.factors.n
+    }
+
+    fn apply_inverse(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        self.inbuf.copy_from_slice(rhs);
+        solve_sparse_into_ws(self.factors, &self.inbuf, rhs, &mut self.ws)
+    }
+
+    fn apply_inverse_transpose(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
+        // Symmetric factor: A^{-T} = A^{-1}.
+        self.apply_inverse(rhs)
+    }
+}
+
+/// Hager-Higham estimate of `||A^{-1}||_1` given a symmetric factor of `A`.
+///
+/// Uses the symmetric specialization `A^{-T} = A^{-1}`, so each iteration
+/// performs one solve (not two as in the general nonsymmetric case). Delegates
+/// to the shared [`hager_higham_inverse_norm_1`] driver via [`SymmetricHager`].
+///
+/// Returns `Ok(0.0)` for `n == 0`.
+pub fn estimate_inverse_norm_1(factors: &SparseFactors) -> Result<f64, FeralError> {
+    let n = factors.n;
+    if n == 0 {
+        return Ok(0.0);
+    }
+    // One pooled `SolveWorkspace` (N5): the driver reuses `op` across every
+    // internal solve, so the workspace is built exactly once.
+    let mut op = SymmetricHager {
+        factors,
+        ws: SolveWorkspace::for_factors(factors),
+        inbuf: vec![0.0f64; n],
+    };
+    hager_higham_inverse_norm_1(&mut op)
 }
 
 /// Estimate `kappa_1(A) = ||A||_1 * ||A^{-1}||_1`.


### PR DESCRIPTION
Closes #94.

## Summary

Adds a Hager–Higham one-norm condition estimate `κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁` for the
**unsymmetric LU** basis. The crate already had a Hager–Higham estimator, but it
was hard-wired to the symmetric LDLᵀ path and could not see an LU basis. It now
runs its inverse-norm solves through the LU factor's own `ftran`/`btran`.

## What changed

**Shared driver refactor** (`src/numeric/condition.rs`)
- Factored the Hager–Higham inverse-norm loop out of the symmetric
  `estimate_inverse_norm_1` into `hager_higham_inverse_norm_1<O: HagerHighamOperator>`.
- New `HagerHighamOperator` trait exposes the two in-place solves the iteration
  needs: `apply_inverse` (`A⁻¹·rhs`) and `apply_inverse_transpose` (`A⁻ᵀ·rhs`).
- The symmetric path is now a `SymmetricHager` adapter that delegates
  transpose→inverse (`A⁻ᵀ = A⁻¹`) and keeps its pooled `SolveWorkspace`.
- Behavior-preserving: bit-identical arithmetic, same one-build workspace pooling.

**LU condition estimate** (`src/lu/condition.rs`)
- `SparseLu::condition_estimate_1(&mut self, b: &SparseColMatrix)` and
  `DenseLu::condition_estimate_1(&mut self, b: &GeneralMatrix)`.
- `SparseLuHager`/`DenseLuHager` adapters wire `ftran` (`B⁻¹`) and `btran`
  (`B⁻ᵀ`) into the shared driver — the LU is unsymmetric, so each iteration is
  ~2 solves, no `A⁻ᵀ = A⁻¹` shortcut, still O(1) factorizations.
- `‖B‖₁` is the max absolute column sum of the supplied basis (new `one_norm` on
  `SparseColMatrix` and `GeneralMatrix`; the factor does not retain `B`,
  mirroring `ftran_refined`).
- Driver + trait re-exported at the crate root.

## API note

The methods return `Result<f64, FeralError>` rather than the issue's sketched
`-> f64`: the LU solves and the dimension check are fallible, and `src/` forbids
`unwrap`/`expect`. This matches the existing `estimate_condition_1norm`.

## Testing

8 new unit tests, all external hand-calc oracles:
- `one_norm` hand values (`6`; abs-handling → `5`).
- identity I₅ → κ ≈ 1; `diag(1, 1e3, 1e6)` → κ₁ = 1e6 (within 2×).
- `B = [[1,2],[3,4]]`: `B⁻¹ = [[−2,1],[1.5,−0.5]]`, ‖B‖₁ = 6, ‖B⁻¹‖₁ = 3.5,
  κ₁ = 21 (hand); estimate is a lower bound → κ_est ∈ [10.5, 21] on both dense
  and sparse paths.
- dense/sparse parity on a 3×3 (rel < 1e-6); dimension-mismatch → `Err`.

Evidence:
- `cargo test`: **381 lib passed** (was 373; +8), 0 failed; all integration suites green.
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo run --bin bench --release`: symmetric residual gate unaffected (2/2, worst 1.26e-16) — additive to the LU family.

## Motivation (downstream)

Enables an LP engine to decide "ill-conditioned node → iteratively refine /
re-solve with perturbation" inside one solver instead of swapping engines
(jkitchin/discopt#364).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAMM4bTrYrNNw3aug6H8QG)_