### PR TITLE
docs: session checkpoint 2026-07-01-03 (issue #91 dense-kernel follow-up)

### DIFF
--- a/dev/sessions/2026-07-01-03.md
+++ b/dev/sessions/2026-07-01-03.md
@@ -1,0 +1,76 @@
+# Session 2026-07-01-03
+
+## Goal
+Follow up the issue #91 ordering fix: profile the fixed qap15 conic-KKT factor,
+find and (if byte-exact) close the residual ~3.5× gap to faer, and file a
+tracking issue for whatever remains. (Spans 2026-06-30 evening → 2026-07-01;
+the ordering fix itself is checkpointed in `2026-06-30-01.md`.)
+
+## Accomplished
+- **Merged PR #92** — the `OrderingPreprocess::Auto` verified-fill fix (**20×**
+  on qap15, byte-exact, corpus-green) plus the dense-kernel work below.
+- **Profiled the fixed factor** (`examples/profile_qap15.rs`): the residual gap
+  is 100% dense-kernel throughput on ~36 large fronts; a single 2955×2955
+  indefinite root is 42% of the sequential loop. FMA would be +23–32% (identical
+  inertia) but changes bit patterns.
+- **Ruled out cheap levers by measurement** (recorded in
+  `dev/tried-and-rejected.md`): source-panel packing (net −13…−22%), larger
+  `block_size` (no change, `MAX_N_ELIM=128` cap), finer intra-front chunks (no
+  gain).
+- **Diagnosed parallel scaling**: tree-level parallelism ≈ useless (work is in a
+  few big fronts); intra-front parallelism carries everything but scales ~2× on
+  10 cores.
+- **Step-1 phase split refuted the look-ahead premise** (`profile_qap15
+  phase_split`): serial Bunch–Kaufman panel factor is only **41 ms / 2%**;
+  trailing update (schur) is **75%**, assembly **10%**. So Lever A (look-ahead)
+  was NOT built — the measurement caught the wrong premise before implementation.
+- **Landed Lever B** (`INTRAFRONT_MIN_AREA` 256²→256×128): the original ramp-down
+  floor left large-front trailing-update tails and whole medium fronts serial.
+  **+17%** on qap15, byte-exact (parallel_parity 8/8, lib green, corpus bench
+  PASS). A/B: lower (≤16384) regresses, higher regresses — 256×128 is the sweet
+  spot. `FERAL_INTRAFRONT_MIN_AREA` env override retained.
+- **Filed tracking issue #99** for the rest (finish schur scaling, assembly
+  parallelism, per-core FMA, Lever D static/SQD) with all measured data +
+  projections.
+- Reviewed/merged sibling PRs this session: #96 (issue #93), #98 (issue #94),
+  #97 (issue #95) — including bookkeeping-conflict resolution.
+
+## Benchmark Results
+qap15 conic KKT (n=50880, nnz=168105), 10 perf cores, `bench_qap15`:
+```
+before (this whole arc):  ~15,400 ms   nnz_L 40.9M   (Auto-preproc misfire)
+after ordering fix (#92):    ~770 ms   nnz_L 9.25M   inertia (+22275,-28605,0)
+after + Lever B:             ~650 ms   (+17% over the fix)   byte-exact
+faer reference:              ~220 ms
+```
+Corpus bench (`cargo run --bin bench --release`) after Lever B: dense p90
+small-frontal 1.35 (≤2.0 PASS), medium 1.77 (≤3.0 PASS); sparse 1.54/1.54 PASS.
+
+Phase split (sequential): panelfactor 41 ms (2%), schur 1426 ms (75%), assembly
+194 ms (10%), scalartail 28 ms. Serial fraction ≈ 0.25 → Amdahl ceiling ~3.1×.
+
+## Decisions Made
+- `OrderingPreprocess::Auto` resolves by verified fill race (2× catastrophe
+  ceiling), not structural prediction — see `dev/decisions.md` (2026-06-30).
+- Lever B: lower `INTRAFRONT_MIN_AREA` to 256×128 (byte-exact scheduling; a
+  global-constant recalibration, validated by the corpus bench).
+
+## Abandoned Approaches
+- B-1a source-panel packing (net slowdown — root is DST-bandwidth/compute bound,
+  not source-panel bound).
+- Auto-preprocess "smaller-fill-wins" race (regressed inertia on twirism1/sawpath
+  — replaced by the 2× catastrophe threshold).
+- Lever A look-ahead pipelining — **not built**: measured serial panel factor is
+  only 2%, so overlapping it buys ~nothing.
+All in `dev/tried-and-rejected.md`.
+
+## Next Session Should
+- Pick up issue #99. Byte-exact first: finish schur scaling (adaptive
+  `INTRAFRONT_MIN_AREA` / residual sub-linear scaling) + parallelize the 10%
+  assembly → ~1.8× byte-exact ceiling (~0.42 s).
+- Then a policy call: opt-in FMA-on-large (per-core throughput) and/or Lever D
+  (static/SQD large-front factorization → faer-class, but perturbs → inertia of
+  `A+Δ` + iterative refinement).
+- Research notes: `dev/research/issue-91-parallel-dense-front-2026-06-30.md`,
+  `issue-91-dense-kernel-profile-2026-06-30.md`,
+  `issue-91-preprocess-misfire.md`.


### PR DESCRIPTION
Adds the session checkpoint for the issue #91 dense-kernel follow-up work (profiling the fixed qap15 factor, ruling out cheap levers, refuting the look-ahead premise, landing Lever B, and filing tracking issue #99).

Docs only.
