### PR TITLE
issue #91: verify fill for OrderingPreprocess::Auto (20× on qap15 conic KKT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — opt-in per-front FMA size gate for large dense fronts (issue #99)
+
+`Solver::with_fma_large_fronts(min_area)` and the underlying
+`BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) route a
+dense front to the single-rounding FMA trailing-Schur kernels when its
+trailing-update area `nrow * ncol >= min_area`, **while leaving smaller fronts on
+the bit-exact `*_nofma` path**. Unlike the existing all-or-nothing
+`with_fma`/`NumericParams::fma`, this lets one factorization run the fast kernel
+on its throughput-dominant roots while sensitive small KKT fronts — where FMA
+rounding can perturb Bunch-Kaufman pivot classification (`dev/tried-and-rejected.md`
+2026-04-14) — keep the reference kernels. `None` is a strict no-op, so the
+default cross-arch bit-exactness contract is unchanged; enabling the gate
+changes cross-arch bit patterns only on the gated large fronts.
+
+Measured on a synthetic 2955×2955 indefinite root (the qap15 root size) on a
+4-core x86_64 box via the new `examples/bench_dense_front` harness: FMA is
+**1.66× faster per-core** (25.6 s → 15.4 s serial) and **1.67×** inside the
+intra-front-parallel path (8.6 s → 5.1 s), with **identical inertia**
+`(+1478, −1477, 0)` across all four nofma/FMA × serial/intrafront variants.
+This is issue #99's Lever 3 (per-core kernel throughput) delivered as an opt-in;
+reaching faer-class GFLOP/s additionally needs the 2-D tiled BLAS-3 GEMM
+(`dev/plans/dense-kernel-blas3.md`). See
+`dev/research/issue-99-dense-front-fma-gate.md`.
+
 ### Added — one-norm condition estimate for the unsymmetric LU basis (issue #94)
 
 `SparseLu::condition_estimate_1(&mut self, b: &SparseColMatrix)` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,48 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
-### Added — opt-in per-front FMA size gate for large dense fronts (issue #99)
+### Performance — shape-aware intra-front parallel gate for tall, thin fronts (issue #99, Lever 1, byte-exact)
 
-`Solver::with_fma_large_fronts(min_area)` and the underlying
-`BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) route a
-dense front to the single-rounding FMA trailing-Schur kernels when its
-trailing-update area `nrow * ncol >= min_area`, **while leaving smaller fronts on
-the bit-exact `*_nofma` path**. Unlike the existing all-or-nothing
-`with_fma`/`NumericParams::fma`, this lets one factorization run the fast kernel
-on its throughput-dominant roots while sensitive small KKT fronts — where FMA
-rounding can perturb Bunch-Kaufman pivot classification (`dev/tried-and-rejected.md`
-2026-04-14) — keep the reference kernels. `None` is a strict no-op, so the
-default cross-arch bit-exactness contract is unchanged; enabling the gate
-changes cross-arch bit patterns only on the gated large fronts.
+The intra-front parallel Schur update fired only when a front's
+`(nrow - j_start) * n_elim` **area** cleared `INTRAFRONT_MIN_AREA`. That area
+metric is blind to *tall, thin* fronts — large trailing width, small elimination
+depth — whose parallelizable work is `~n_elim * trailing_cols²` (large) even
+though their area is small. On real conic KKTs these dominate: the synthetic
+qap15 stand-in factors its dense border as ~117 fronts of `2000 × 16` (area
+31 744, just under the 32 768 floor), so intra-front parallelism never fired and
+99.9 % of the schur loop ran serially even on the parallel driver.
 
-Measured on a synthetic 2955×2955 indefinite root (the qap15 root size) on a
-4-core x86_64 box via the new `examples/bench_dense_front` harness: FMA is
-**1.66× faster per-core** (25.6 s → 15.4 s serial) and **1.67×** inside the
-intra-front-parallel path (8.6 s → 5.1 s), with **identical inertia**
-`(+1478, −1477, 0)` across all four nofma/FMA × serial/intrafront variants.
-This is issue #99's Lever 3 (per-core kernel throughput) delivered as an opt-in;
-reaching faer-class GFLOP/s additionally needs the 2-D tiled BLAS-3 GEMM
+A new **shape-aware trigger** additionally fires when a front is wide enough to
+split (`trailing_cols >= INTRAFRONT_TALL_MIN_COLS = 512`) AND deep enough to
+amortize the fork (`n_elim >= INTRAFRONT_TALL_MIN_ELIM = 8`), **OR-ed** with the
+area gate so no front that parallelized before regresses. Pure scheduling —
+**byte-exact** (each trailing column is still reduced on a single thread;
+`parallel_parity` holds). Measured on the synthetic KKT (32000², 4-core x86_64):
+end-to-end factor **9.25 s → 3.46 s (2.68×)**, inertia `(+30000, −2000, 0)`
+unchanged. See `dev/research/issue-99-dense-front-fma-gate.md`.
+
+### Added — opt-in per-front FMA gate for tall dense fronts (issue #99, Lever 3)
+
+`Solver::with_fma_large_fronts(min_rows)` and the underlying
+`BunchKaufmanParams::fma_min_front_rows: Option<usize>` (default `None`) route a
+dense front to the single-rounding FMA trailing-Schur kernels when it has at
+least `min_rows` rows (`nrow >= min_rows`), **while leaving smaller fronts on the
+bit-exact `*_nofma` path**. The gate is on **rows**, not `nrow * ncol` area,
+because the throughput-dominant fronts on real conic KKTs are tall and thin (an
+area gate silently misses them — the same blindness fixed in the intra-front gate
+above). Unlike the all-or-nothing `with_fma`/`NumericParams::fma`, this lets one
+factorization run the fast kernel on its dominant fronts while sensitive small
+KKT fronts — where FMA rounding can perturb Bunch-Kaufman pivot classification
+(`dev/tried-and-rejected.md` 2026-04-14) — keep the reference kernels. `None` is
+a strict no-op, so the default cross-arch bit-exactness contract is unchanged;
+enabling the gate changes cross-arch bit patterns only on the gated fronts.
+
+Measured (4-core x86_64): **1.66× per-core** on a synthetic 2955×2955 indefinite
+root (`examples/bench_dense_front`), and **1.47× on top of the byte-exact
+intra-front win** end-to-end on the synthetic qap15 stand-in (`bench_qap15`:
+3.46 s → 2.35 s, `with_fma_large_fronts(256)` matching global FMA), inertia
+identical throughout. Issue #99 Lever 3, opt-in; reaching faer-class per-core
+GFLOP/s additionally needs the 2-D tiled BLAS-3 GEMM
 (`dev/plans/dense-kernel-blas3.md`). See
 `dev/research/issue-99-dense-front-fma-gate.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,18 @@ runs ~22–26× faster in isolation (`examples/bench_schur_micro`), giving **10.
 on a dense-1500 front's schur phase and **8.0×** on a 2955 front (0.34 → 2.69
 GFLOP/s, nofma). Default on; `FERAL_PACKED_SCHUR=0` restores the strided path.
 
-Reached for **all-1×1-pivot panels** (the `apply_blocked_schur` fast path), so
-definite / quasi-definite (SQD, regularized KKT) / SPD fronts get the full win;
-strongly-indefinite fronts whose panels carry 2×2 pivots fall to the un-packed
-fallback (packing that path is future work). Combined with the shape-aware
-intra-front gate, the synthetic qap15 stand-in factors **9.25 s → 2.03 s (4.56×),
-byte-exact**, inertia `(+30000, −2000, 0)` unchanged. Correctness: the full
-byte-exact factor-parity suite green with packed default, plus a dedicated
-`packed_matches_scalar_reference_bit_for_bit` unit test. See
-`dev/research/issue-99-dense-front-fma-gate.md`.
+The packed path handles a **mixed 1×1 / 2×2 / zero-d pivot stream** (Phase B-2):
+each element walks the stream in `q` order, emitting `mul → sub` for a 1×1 pivot
+and the fused `dl0·L_q + dl1·L_{q+1}` add-then-sub (or two chained FMAs) for a 2×2
+pivot — byte-exact with the scalar `do_1x1_update` / `do_2x2_update` and the
+strided `axpy`/`axpy2` fallback. So **strongly-indefinite fronts** now get the
+packed win too, not only definite / quasi-definite (SQD, regularized KKT) / SPD
+fronts. Combined with the shape-aware intra-front gate, the synthetic qap15
+stand-in factors **9.25 s → 2.03 s (4.56×), byte-exact**, inertia
+`(+30000, −2000, 0)` unchanged. Correctness: the full byte-exact factor-parity
+suite (incl. indefinite/2×2 KKT suites) green with packed default, plus a
+`packed_matches_scalar_reference_bit_for_bit` unit test covering 1×1/2×2/zero-d
+streams in both `fma` modes. See `dev/research/issue-99-dense-front-fma-gate.md`.
 
 ### Performance — shape-aware intra-front parallel gate for tall, thin fronts (issue #99, Lever 1, byte-exact)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — packed BLAS-3 dense trailing update, byte-exact ~8–10× on dense fronts (issue #99)
+
+The dense trailing Schur update (~94 % of a dense factor) ran at only
+~0.35 GFLOP/s — ~10× below scalar peak on an AVX2/FMA CPU — because the strided
+per-column kernels re-read the eliminated panel at column-stride `nrow` every
+elimination step, thrashing cache. A new packed, register-tiled (`MR=8 × NR=4`)
+trailing update (`apply_schur_panel_range_packed`) packs the panel into
+`q`-contiguous micro-panels so the inner loop is L1-resident. It is **byte-exact**
+with the strided kernels (each `A[i,j]`, `i≥j`, reduced over ascending `q` with
+the identical `mul → sub` / `mul_add`; packing changes only memory layout) and
+runs ~22–26× faster in isolation (`examples/bench_schur_micro`), giving **10.2×**
+on a dense-1500 front's schur phase and **8.0×** on a 2955 front (0.34 → 2.69
+GFLOP/s, nofma). Default on; `FERAL_PACKED_SCHUR=0` restores the strided path.
+
+Reached for **all-1×1-pivot panels** (the `apply_blocked_schur` fast path), so
+definite / quasi-definite (SQD, regularized KKT) / SPD fronts get the full win;
+strongly-indefinite fronts whose panels carry 2×2 pivots fall to the un-packed
+fallback (packing that path is future work). Combined with the shape-aware
+intra-front gate, the synthetic qap15 stand-in factors **9.25 s → 2.03 s (4.56×),
+byte-exact**, inertia `(+30000, −2000, 0)` unchanged. Correctness: the full
+byte-exact factor-parity suite green with packed default, plus a dedicated
+`packed_matches_scalar_reference_bit_for_bit` unit test. See
+`dev/research/issue-99-dense-front-fma-gate.md`.
+
 ### Performance — shape-aware intra-front parallel gate for tall, thin fronts (issue #99, Lever 1, byte-exact)
 
 The intra-front parallel Schur update fired only when a front's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — `OrderingPreprocess::Auto` no longer inflates fill on conic KKTs (issue #91)
+
+feral factorized a 50,880×50,880 quasi-definite conic KKT (the qap15 QAP
+LP-relaxation system from POUNCE's convex IPM) in ~15 s, vs faer's ~0.22 s.
+The cause was a single mis-firing ordering heuristic: `pick_ordering_preprocess`
+turns on MC64 `LdltCompress` whenever ≥30 % of columns have ≤2 nonzeros — a
+property a regularized quasi-definite IPM KKT has in abundance (its diagonal
+regularization rows). On qap15 that compression *inflated* fill 6.3× (simplicial
+nnz_L 7.16M → 45.4M) and factor time ~20× (0.77 s → 15.4 s). feral's AMD ordering
+itself is excellent here (7.16M, below faer's 13.4M); the blowup was entirely the
+preprocessing trigger — not AMD quality, amalgamation, or delayed pivots (nnz_L is
+identical across pivot strategies, inertia clean).
+
+`OrderingPreprocess::Auto` now **verifies** rather than predicts: when the
+predicate recommends `LdltCompress`, the symbolic pipeline is run both ways and
+`LdltCompress` is kept only if it does not inflate fill past 2× the `None`
+baseline. This catches the qap15 misfire (→ **0.77 s, 20×**) while preserving
+`LdltCompress`'s genuine wins, including the near-singular KKTs (twirism1, sawpath)
+where its MC64-matched 2×2 pivots are needed for the oracle-correct inertia.
+Default-on; no public API change. Inertia unchanged across the corpus suite.
+See `dev/research/issue-91-preprocess-misfire.md`.
+
 ## [0.11.3] - 2026-06-28
 
 ### Performance — sparse LU update: O(m³) → O(m²) `u_above` reindex on filled bumps (issue #89)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,9 @@ name = "ft_dense_bump"
 name = "bench_dense_front"
 
 [[example]]
+name = "bench_schur_micro"
+
+[[example]]
 name = "bench_qap15"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,5 +120,8 @@ name = "ft_dense_bump"
 [[example]]
 name = "bench_qap15"
 
+[[example]]
+name = "profile_qap15"
+
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,5 +117,8 @@ harness = false
 [[example]]
 name = "ft_dense_bump"
 
+[[example]]
+name = "bench_qap15"
+
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,5 +117,8 @@ harness = false
 [[example]]
 name = "ft_dense_bump"
 
+[[example]]
+name = "bench_dense_front"
+
 [profile.release]
 debug = true

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-01T11:25:52Z
+Generated: 2026-07-01T11:51:27Z
 
 ## Latest Session
 File: dev/sessions/2026-07-01-03.md
@@ -59,11 +59,11 @@ unilateral default flips, no unvalidatable parallel retunes.
 
 ## Git Status
 ```
+efb205b issue #99: packed BLAS-3 dense trailing update — byte-exact ~8-10x on dense fronts
+45777c0 issue #99: checkpoint update — PR #92 merge + byte-exact intra-front win
 ad70b5b issue #99: shape-aware intra-front gate (Lever 1, byte-exact 2.68x) + FMA row gate
 c1d00a2 Merge PR #92 (issue #91) into issue-99 branch: qap15 ordering fix + harness + Lever B
 1286297 issue #99: session 2026-07-01-03 checkpoint (FMA size gate)
-b25f3f8 issue #99: opt-in per-front FMA size gate for large dense fronts (Lever 3)
-9f80362 Merge current main into issue #91 branch (resolve decisions.md conflict)
 ```
 
 ## Test Status
@@ -86,7 +86,7 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.22s
+test result: ok. 392 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.33s
 
 ```
 
@@ -111,58 +111,58 @@ examples/bench_dense_front 2955 5 (the new issue-99 harness):
 ```
 
 ## Recent Decisions
-large-work fronts, so it cannot regress the area gate's measured calibration.
-Pure scheduling ⇒ byte-exact (each trailing column reduced on one thread).
+register-tiled kernel then autovectorizes to 9–10.5 GFLOP/s (22–26× isolated).
 
-**Decision 2 (opt-in, Lever 3).** The FMA gate had the identical area blind spot
-(`nrow*ncol`); rename `BunchKaufmanParams::fma_min_front_area` →
-`fma_min_front_rows` and gate on `nrow >= t` (front rows = trailing-update size).
-`Solver::with_fma_large_fronts(min_rows)` accordingly. Same opt-in / default-None
-policy as before.
+**Supersedes** the 2026-06-30 `tried-and-rejected` "DST-bandwidth-bound"
+conclusion for this hardware: that came from packing the source into the *same
+strided kernel* (which kept the strided `q`-access and only shrank the stride).
+A proper packed micro-kernel with a contiguous `q`-loop is a different design and
+wins decisively. Recorded there, not overwriting the prior entry.
 
-**Why rows/shape, not area.** On real conic KKTs the time is in tall-thin fronts
-(large `nrow`, small `ncol`), created when regularization leaves break supernode
-amalgamation of a dense block. An area gate silently misses them; a
-rows/width-based gate catches them while still protecting genuinely small fronts.
+**Byte-exactness.** Each `A[i,j]` (i≥j) is reduced over ascending `q` with the
+identical `mul → sub` (nofma) / `mul_add` (fma) as the reference — packing changes
+only memory layout, not arithmetic order. A zero alpha gives `acc − round(0·L) =
+acc` for finite `L`, matching the strided zero-skip. Validated: full byte-exact
+factor-parity suite green with packed default + `packed_matches_scalar_reference_
+bit_for_bit` unit test.
 
-**Evidence (synthetic KKT, 32000², 2000×16 fronts, 4-core x86_64, `bench_qap15`).**
-Original default 9.25 s → **3.46 s (2.68×) byte-exact** with the shape-aware
-intra-front gate → **2.35 s (3.94× total)** adding opt-in FMA. Inertia
-`(+30000, −2000, 0)` identical across every config. Confirmed the intra-front
-diagnosis first via `FERAL_INTRAFRONT_MIN_AREA=16384` (9.25 → 4.35 s byte-exact).
-Full suite **735 passed / 0 failed** — `parallel_parity` (parallel==sequential
-bit-for-bit) green, so the intra-front change is byte-exact as claimed. clippy
-`-D warnings` clean.
+**Scope.** Reached only for all-1×1-pivot panels (the `apply_blocked_schur` W-2
+fast path). 2×2-pivot panels fall to the un-packed `axpy2` fallback, so strongly
+indefinite fronts — and the `fma` path, whose rounding drifts more pivots to 2×2 —
+benefit less. Definite / quasi-definite (SQD, regularized KKT) / SPD fronts get
+the full win. Packing the 2×2 fallback (Phase B-2) is the next step.
 
-**Note.** The largest lever on this workload was **byte-exact** (the shape-aware
-gate), not the rule-breaking FMA. The maintainer authorized breaking
-bit-exactness/inertia to explore; the exploration instead surfaced a byte-exact
-scheduling bug affecting *both* gates. The synthetic fixture is a stand-in — the
-real qap15 KKT needs POUNCE (unavailable here); the tall-thin-front phenomenon and
-its 10-core behavior should be re-validated on the real matrix before promoting
-the thresholds to a hard default. See `dev/research/issue-99-dense-front-fma-gate.md`.
+**Evidence.** dense-1500 schur 3165→309 ms (10.2×); dense-2955 nofma serial
+25586→3202 ms (8.0×, 0.34→2.69 GFLOP/s); synth qap15 stand-in end-to-end
+3379→2029 ms; full byte-exact stack (intra-front + packed) 9247→2029 ms (4.56×),
+inertia `(+30000,−2000,0)` unchanged. Suite 736 passed / 0 failed; clippy clean.
+
+**Caveat.** Absolute GFLOP/s (packed ~10, vs a fully-tuned BLAS-3 core ~30–50) is
+partly this 4-core container; the tile (8×4) and the lack of L2 cache-blocking /
+FMA-in-packed leave headroom. Re-tune on target hardware. The `fma` packed path
+exists (bit-matches the fma reference) but is not the default.
 
 ## Recent Tried-and-Rejected
-stride `span`), gated to large fronts (`nrow>128`). Byte-exact by construction.
-
-**Rejected — net slowdown on qap15.** Byte-exact parity held (blocked_ldlt
-21/21, inertia/nnz_L unchanged) but it was *slower* everywhere: sequential
-factor loop 1747 → 1976 ms (+13%), the 2955×2955 root front 736 → 818 ms
-(+11%), parallel default 771 → 945 ms (+22%).
-
-**Why.** The root's early panels have `span ≈ nrow`, so packing does not reduce
-the K-stride — it just adds an alloc + copy. More fundamentally, profiling of
-the root shows it is **DST-bandwidth-bound, not panel-bound**: the ~70 MB
-trailing block (2955×2955 f64) is streamed ~46 times (once per rank-64 panel),
-which dwarfs the ~1.5 MB panel (already L2-resident). Packing the *source* panel
-optimizes the wrong operand.
-
-**Implication for the plan.** The effective lever is reducing DST traffic:
-cache-blocked / recursive dense-root factorization (Phase C — reuse a
-cache-sized trailing tile across many panels) or a larger panel width (more
-flops per DST stream). A source-side pack (B-1a) is off the table. FMA remains a
 +23% option but is a reproducibility-policy change (kept opt-in), not a
 bit-exact win.
+
+## 2026-07-01 — UPDATE: packed micro-kernel succeeds where B-1a source-pack failed (issue #99)
+
+The 2026-06-30 "B-1a panel packing" entry above rejected source-panel packing as a
+net slowdown and concluded the root front is DST-bandwidth-bound. That conclusion
+was **specific to the variant tried** — packing the source into a tighter stride
+but *feeding the same strided kernels*, which keep the per-`q` `as_simd` + strided
+access. It does **not** generalize to a proper packed micro-kernel.
+
+A different design — pack the panel into `q`-contiguous MR=8×NR=4 micro-panels and
+run a register-tiled kernel with a **contiguous inner `q`-loop**
+(`apply_schur_panel_range_packed`) — is **22–26× faster in isolation and
+byte-exact** (`examples/bench_schur_micro`), and gives 8–10× on real dense fronts.
+So the bottleneck was strided-`q` cache latency, not DST bandwidth, on this
+hardware. Not a rejection — a correction of scope. See
+`dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
+2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
+rejected; the packed micro-kernel is the shipped design.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-01T10:55:37Z
+Generated: 2026-07-01T11:25:52Z
 
 ## Latest Session
 File: dev/sessions/2026-07-01-03.md
@@ -59,11 +59,11 @@ unilateral default flips, no unvalidatable parallel retunes.
 
 ## Git Status
 ```
+ad70b5b issue #99: shape-aware intra-front gate (Lever 1, byte-exact 2.68x) + FMA row gate
+c1d00a2 Merge PR #92 (issue #91) into issue-99 branch: qap15 ordering fix + harness + Lever B
+1286297 issue #99: session 2026-07-01-03 checkpoint (FMA size gate)
 b25f3f8 issue #99: opt-in per-front FMA size gate for large dense fronts (Lever 3)
-a17fb7a issue #95: richer update() instability signal + growth-aware/dense-parity refactor recommendations (#97)
-f9398fd issue #94: one-norm condition estimate for the unsymmetric LU factor (#98)
-f114b5d issue #93: expose the LU element-growth factor via public getters (#96)
-f037285 release: feral v0.11.3
+9f80362 Merge current main into issue #91 branch (resolve decisions.md conflict)
 ```
 
 ## Test Status
@@ -86,7 +86,7 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.38s
+test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.22s
 
 ```
 
@@ -111,58 +111,58 @@ examples/bench_dense_front 2955 5 (the new issue-99 harness):
 ```
 
 ## Recent Decisions
-small-front pivot-drift KKTs (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851)
-need nofma to keep their Bunch-Kaufman pivot classification. The existing `fma`
-flag is all-or-nothing, so it cannot serve both. A front-size gate does: fast
-kernel on the roots, reference kernel on the sensitive small fronts.
+large-work fronts, so it cannot regress the area gate's measured calibration.
+Pure scheduling ⇒ byte-exact (each trailing column reduced on one thread).
 
-**Why opt-in / default `None`.** Enabling FMA changes cross-arch bit patterns
-(single vs double rounding) on the gated fronts — the reproducibility policy the
-owner deliberately kept opt-in (`dev/tried-and-rejected.md` 2026-04-14). This
-session had no authorization to flip a default (the interactive policy question
-could not be delivered — harness permission-stream failure), so the lever is
-shipped as a knob with measured evidence, leaving the default-on decision to the
-owner.
+**Decision 2 (opt-in, Lever 3).** The FMA gate had the identical area blind spot
+(`nrow*ncol`); rename `BunchKaufmanParams::fma_min_front_area` →
+`fma_min_front_rows` and gate on `nrow >= t` (front rows = trailing-update size).
+`Solver::with_fma_large_fronts(min_rows)` accordingly. Same opt-in / default-None
+policy as before.
 
-**Evidence.** `examples/bench_dense_front 2955 5` (4-core x86_64): FMA 1.66×
-per-core serial (25.6 s → 15.4 s), 1.67× inside intrafront (8.6 s → 5.1 s),
-inertia `(+1478,−1477,0)` identical across all four nofma/FMA × serial/intrafront
-variants. `tests/issue99_fma_front_gate.rs` (4 tests): gate above threshold is
-bit-identical to `fma=true`, below threshold bit-identical to nofma default,
-inertia preserved, threshold is exactly `nrow*ncol` with `>=`. Full suite 734
-passed / 0 failed; fmt + clippy `-D warnings` clean; bench residual gate
-unchanged (default path byte-for-byte identical). Note:
-`dev/research/issue-99-dense-front-fma-gate.md`.
+**Why rows/shape, not area.** On real conic KKTs the time is in tall-thin fronts
+(large `nrow`, small `ncol`), created when regularization leaves break supernode
+amalgamation of a dense block. An area gate silently misses them; a
+rows/width-based gate catches them while still protecting genuinely small fronts.
 
-**Not closed.** This does not reach faer-class throughput — the best variant is
-1.67 GFLOP/s vs ~50–100 for a tuned BLAS-3 core. The structural gap is feral's
-memory-bandwidth-bound rank-panel update vs a 2-D register-tiled GEMM
-(`dev/plans/dense-kernel-blas3.md`), a multi-session rewrite. Levers 1 (adaptive
-`INTRAFRONT_MIN_AREA`) and 2 (assembly parallelism) are parallel-scaling levers
-that need the bench corpus + a representative core count to validate no-regression
-— not possible on this 4-core box without the (unmerged-PR-#92) qap15 fixtures.
+**Evidence (synthetic KKT, 32000², 2000×16 fronts, 4-core x86_64, `bench_qap15`).**
+Original default 9.25 s → **3.46 s (2.68×) byte-exact** with the shape-aware
+intra-front gate → **2.35 s (3.94× total)** adding opt-in FMA. Inertia
+`(+30000, −2000, 0)` identical across every config. Confirmed the intra-front
+diagnosis first via `FERAL_INTRAFRONT_MIN_AREA=16384` (9.25 → 4.35 s byte-exact).
+Full suite **735 passed / 0 failed** — `parallel_parity` (parallel==sequential
+bit-for-bit) green, so the intra-front change is byte-exact as claimed. clippy
+`-D warnings` clean.
+
+**Note.** The largest lever on this workload was **byte-exact** (the shape-aware
+gate), not the rule-breaking FMA. The maintainer authorized breaking
+bit-exactness/inertia to explore; the exploration instead surfaced a byte-exact
+scheduling bug affecting *both* gates. The synthetic fixture is a stand-in — the
+real qap15 KKT needs POUNCE (unavailable here); the tall-thin-front phenomenon and
+its 10-core behavior should be re-validated on the real matrix before promoting
+the thresholds to a hard default. See `dev/research/issue-99-dense-front-fma-gate.md`.
 
 ## Recent Tried-and-Rejected
-more work.** Step 2's premise (dense-spike bump, contiguous SAXPY) does not hold
-for this workload; implementing it would **regress** casctanks, not speed it up.
+stride `span`), gated to large fronts (`nrow>128`). Byte-exact by construction.
 
-This also explains Step 1's 15.8×: the old O(bump²) **scan** probed ~731²/2 ≈ 267k
-cells per update to find the ~24 that needed work. Removing the scan (Step 1) was
-the correct and sufficient fix for the sparse-wide-bump regime; the residual
-elimination work is already near-minimal.
+**Rejected — net slowdown on qap15.** Byte-exact parity held (blocked_ldlt
+21/21, inertia/nnz_L unchanged) but it was *slower* everywhere: sequential
+factor loop 1747 → 1976 ms (+13%), the 2955×2955 root front 736 → 818 ms
+(+11%), parallel default 771 → 945 ms (+22%).
 
-**Not generally rejected.** A dense path could still help a genuinely *dense*-spike
-basis (the journal's 2026-06-08 tridiagonal/`L⁻¹`-dense worst case). If such a
-workload appears, Step 2 should be width-AND-density gated (dense path only when
-block density exceeds a threshold), never width-only. For the McCormick LP regime
-that motivated discopt#229, Step 1 stands alone.
+**Why.** The root's early panels have `span ≈ nrow`, so packing does not reduce
+the K-stride — it just adds an alloc + copy. More fundamentally, profiling of
+the root shows it is **DST-bandwidth-bound, not panel-bound**: the ~70 MB
+trailing block (2955×2955 f64) is streamed ~46 times (once per rank-64 panel),
+which dwarfs the ~1.5 MB panel (already L2-resident). Packing the *source* panel
+optimizes the wrong operand.
 
-**Evidence.** `FERAL_BUMP_STATS` aggregate over
-`FERAL_LU_TRACE=.../casctanks_trace.txt` (full trace): avg_width=731.3,
-max_width=2157, avg_density=0.1346 (all bumps) / 0.0023 (width>500),
-avg_axpy=23.9, avg_merge_work=233.4. Step 1 end-to-end: casctanks LP solve
-82.4 s → 5.2 s debug (15.8×), optimum −167.751 unchanged. Journal:
-dev/journal/2026-06-18-01.org.
+**Implication for the plan.** The effective lever is reducing DST traffic:
+cache-blocked / recursive dense-root factorization (Phase C — reuse a
+cache-sized trailing tile across many panels) or a larger panel width (more
+flops per DST stream). A source-side pack (B-1a) is off the table. FMA remains a
++23% option but is a reproducibility-policy change (kept opt-in), not a
+bit-exact win.
 
 ## Source Files
 ```
@@ -243,6 +243,7 @@ tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-01T01:38:26Z
+Generated: 2026-07-01T10:55:37Z
 
 ## Latest Session
-File: dev/sessions/2026-07-01-02.md
+File: dev/sessions/2026-07-01-03.md
 ```
-# Session 2026-07-01-02
+# Session 2026-07-01-03
 
 ## Goal
 
-Issue #95: enrich the LU rank-1 `update()` failure signal so a caller can tell an
-ill-conditioning failure (refine and retry) from a bookkeeping-budget trip (just
-refactor), and close the `should_refactor()` sparse/dense parity gap. discopt#364
-needs the *why* behind a `NeedsRefactor`, and discopt forces the dense LU for
-small bases (`m ≤ 256`).
+Issue #99: "loop over all levers until faer-level performance" on the dense-front
+factorization throughput gap (~3.5× to faer on the qap15 conic KKT, dominated by
+a 2955×2955 indefinite root).
+
+## Reality check (reported up-front, per protocol)
+
+The issue's premises are **not reproducible on this branch**, and I established
+this before writing code:
+
+- **PR #92 is open/unmerged.** It (issue #91) contains the `OrderingPreprocess::Auto`
+  fill-verification fix that made qap15 tractable *and* the qap15 fixture
+  generator + `bench_qap15` harness. This branch is cut from current `main` and
+  lacks all of it — `INTRAFRONT_MIN_AREA` is still `256*256`, not #92's `256*128`.
+- **The qap15 fixture, its generator, `examples/{profile,bench}_qap15.rs`, and the
+  two research notes the issue cites for "the full diagnosis" exist on no remote
+  branch** (unpushed/lost work). The end-to-end qap15 number that defines the
+  target cannot be reproduced here.
+- **This container has 4 cores; the issue's numbers are 10-core.** The
+  parallel-scaling levers (1 assembly, 2 schur scaling) cannot be validated
+  against the issue's targets here.
+- The issue itself states **no byte-exact lever closes 3.5×**; faer-class needs a
+  policy decision (default-on FMA / static-SQD) the owner deliberately deferred.
+
+I attempted to ask the owner the fixture-strategy and policy questions via
+`AskUserQuestion`; the harness failed to deliver it (permission-stream error).
+Told to continue, I proceeded autonomously with the **defensible subset**:
+additive, default-off, byte-exact-preserving, measurable-here work only — no
+unilateral default flips, no unvalidatable parallel retunes.
 
 ## Accomplished
 
-Chose the issue's **preferred additive (non-breaking)** design: keep the
-payload-free `Err(NeedsRefactor)`, record cause + magnitude alongside.
+**Issue #99 Lever 3 (per-core kernel throughput) — delivered as an opt-in knob.**
 
-- New public enum `RefactorCause { Growth, UpdateBudget, TinyPivot, Singular }`
-  (`src/lu/mod.rs`, re-exported from the crate root via `src/lib.rs`).
-- `last_refactor() -> Option<(RefactorCause, f64)>` on both `SparseLu` and
-  `DenseLu`. Set on **every** `NeedsRefactor` return path (update-count budget,
-  singular/empty-support, growth, tiny/zero/non-finite pivot). `None` after a
-  fresh factor/refactor; untouched by a successful update (read only after `Err`).
-- `growth()` getter on both (exposes the element-growth high-water monitor).
-- `should_refactor_growth()` on both: growth-aware recommendation firing once
-  `growth >= sqrt(max_growth)` (finite, > 1) — the geometric midpoint in log
-  space — so a caller can pre-empt a growth trip.
-- `should_refactor()` parity on `DenseLu` (cost-based: `updates_since_refactor >= m`;
-  dense update is O(m²), fresh factor O(m³)), mirroring the sparse cost-based
-  `should_refactor()`. `updates_since_refactor()` already existed on both.
-- Docs: `src/error.rs` `NeedsRefactor` variant now points at the accessor;
-  `CHANGELOG.md` Unreleased; design note `dev/research/refactor-signal-2026-07-01.md`.
-
-**Magnitude semantics** — Growth: the growth ratio that tripped (> max_growth);
-UpdateBudget: the update count that hit the cap (= max_updates); TinyPivot:
-|offending pivot| (≤ zero_pivot_tol·u_max0); Singular: 0.0.
-
-**Dense/sparse asymmetry (inherent, documented):** the dense path has no distinct
-`Singular` branch — a linearly dependent replacement drives the final `U` diagonal
-to ~0 and reports `TinyPivot`. Only the sparse path can cheaply detect the
-empty-support case (`h_rank < r_rank`) *before* eliminating, so `Singular` is
-sparse-only.
-
-### Evidence
-
-- 9 new unit tests (5 sparse, 4 dense): each cause reached via a deterministically
-  constructed input, plus the two recommendation getters. Assertions are
-  behavioral (which cause) and self-consistent (the magnitude relation the path
-  itself guarantees) — no external numerical oracle required.
-  - Note: the naive identity-basis update `update(0, e0/[1,1])` trips a
-    `TinyPivot` (after the cyclic shift `u[0,0]` = the identity's off-diagonal 0),
-    *not* a clean commit — so the budget/recommendation tests use the tridiagonal
+- New `examples/bench_dense_front.rs`: self-contained synthetic indefinite front
+  (no external fixture), factored through the real `factor_frontal_blocked` path,
+  timing nofma/FMA × serial/intrafront with an inertia-equality gate. Fills the
+  measurement-harness hole the issue's (missing) `bench_qap15` left.
+- New `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) +
+  `effective_front_fma(params, nrow, ncol)` helper. Gated at the single dense
+  front-factor entry `factor_frontal_blocked_in_place_with_scratch` by shadowing
+  `params` with an fma-flipped clone **only when the gate fires** (unarmed path
+  pays nothing). Both multifrontal drivers funnel through this entry, so one
+  insertion covers all.
+- New `Solver::with_fma_large_fronts(min_area)` — writes straight to
+  `numeric_params.bk` (no `NumericParams` field / funnel needed; low churn).
+- `None` default ⇒ strict no-op: the production cross-arch bit-exact contract is
 ```
 
 ## Git Status
 ```
-daa058f issue #95: richer update() instability signal + refactor recommendations
+b25f3f8 issue #99: opt-in per-front FMA size gate for large dense fronts (Lever 3)
+a17fb7a issue #95: richer update() instability signal + growth-aware/dense-parity refactor recommendations (#97)
 f9398fd issue #94: one-norm condition estimate for the unsymmetric LU factor (#98)
 f114b5d issue #93: expose the LU element-growth factor via public getters (#96)
 f037285 release: feral v0.11.3
-a5c789f issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter (#90)
 ```
 
 ## Test Status
@@ -86,58 +86,61 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.40s
+test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.38s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-01-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-01-03.md)
 
 
-Residual pass: 2/2 (100.0%)
-Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
+cargo run --bin bench --release  →  Sparse failure analysis: no failures
 Dense ∩ Sparse failure overlap: 0 / 0 / 0
 (no oracle timings loaded in this environment; perf partitions N/A)
+Default path unchanged (gate defaults None) → residual gate identical to the
+2026-07-01-02 baseline (2/2, worst residual 1.26e-16).
 
-Purely additive API + metadata on the error path (a single `Option` write only on
-a `NeedsRefactor` return); no factorization or solve arithmetic changed.
+examples/bench_dense_front 2955 5 (the new issue-99 harness):
+  nofma serial     25586.15 ms  0.34 GFLOP/s  1.00×
+  nofma intrafront  8631.85 ms  1.00 GFLOP/s  2.96×
+  fma   serial     15422.96 ms  0.56 GFLOP/s  1.66×
+  fma   intrafront  5142.82 ms  1.67 GFLOP/s  4.98×
+  inertia (+1478,−1477,0) identical across all four variants ✓
 
 ```
 
 ## Recent Decisions
-accessor, not a breaking error-variant change. `SparseLu::update`/`DenseLu::update`
-keep returning the payload-free `Err(FeralError::NeedsRefactor)`; the cause +
-magnitude are recorded on `self` and read back via
-`last_refactor() -> Option<(RefactorCause, f64)>`. New public enum
-`RefactorCause { Growth, UpdateBudget, TinyPivot, Singular }`.
+small-front pivot-drift KKTs (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851)
+need nofma to keep their Bunch-Kaufman pivot classification. The existing `fma`
+flag is all-or-nothing, so it cannot serve both. A front-size gate does: fast
+kernel on the roots, reference kernel on the sensitive small fronts.
 
-**Why.** discopt#364 needs to distinguish an ill-conditioning failure
-(Growth/TinyPivot/Singular → refine-and-retry) from a mere update-count budget
-trip (UpdateBudget → refactor). The additive route (the issue's stated
-preference) leaves every existing caller compiling unchanged.
+**Why opt-in / default `None`.** Enabling FMA changes cross-arch bit patterns
+(single vs double rounding) on the gated fronts — the reproducibility policy the
+owner deliberately kept opt-in (`dev/tried-and-rejected.md` 2026-04-14). This
+session had no authorization to flip a default (the interactive policy question
+could not be delivered — harness permission-stream failure), so the lever is
+shipped as a knob with measured evidence, leaving the default-on decision to the
+owner.
 
-**Magnitude semantics.** Growth = growth ratio that tripped; UpdateBudget =
-update count that hit the cap (= max_updates); TinyPivot = |offending pivot|;
-Singular = 0.0. `last_refactor()` is `None` after factor/refactor, untouched by a
-successful update.
+**Evidence.** `examples/bench_dense_front 2955 5` (4-core x86_64): FMA 1.66×
+per-core serial (25.6 s → 15.4 s), 1.67× inside intrafront (8.6 s → 5.1 s),
+inertia `(+1478,−1477,0)` identical across all four nofma/FMA × serial/intrafront
+variants. `tests/issue99_fma_front_gate.rs` (4 tests): gate above threshold is
+bit-identical to `fma=true`, below threshold bit-identical to nofma default,
+inertia preserved, threshold is exactly `nrow*ncol` with `>=`. Full suite 734
+passed / 0 failed; fmt + clippy `-D warnings` clean; bench residual gate
+unchanged (default path byte-for-byte identical). Note:
+`dev/research/issue-99-dense-front-fma-gate.md`.
 
-**Dense/sparse asymmetry (accepted, not a gap).** The dense path has no distinct
-`Singular` cause — a dependent replacement drives the final `U` diagonal to ~0 and
-reports `TinyPivot`. Only the sparse path detects the empty-support case
-(`h_rank < r_rank`) before eliminating, so `Singular` is sparse-only.
-
-**Refactor recommendations.** `should_refactor_growth()` (both types) fires at
-`growth >= sqrt(max_growth)` — the log-space midpoint between the floor 1 and the
-cap — to pre-empt a growth trip. Dense `should_refactor()` (cost-based parity) =
-`updates_since_refactor() >= m` (O(m²) update vs O(m³) factor), the dense analogue
-of sparse's `update_work_total >= factor_nnz()`.
-
-**Evidence.** +9 unit tests (each cause + both recommendation getters), 381 lib
-tests green, fmt/clippy clean, no numerical change (bench: no failures). Design
-note: `dev/research/refactor-signal-2026-07-01.md`.
+**Not closed.** This does not reach faer-class throughput — the best variant is
+1.67 GFLOP/s vs ~50–100 for a tuned BLAS-3 core. The structural gap is feral's
+memory-bandwidth-bound rank-panel update vs a 2-D register-tiled GEMM
+(`dev/plans/dense-kernel-blas3.md`), a multi-session rewrite. Levers 1 (adaptive
+`INTRAFRONT_MIN_AREA`) and 2 (assembly parallelism) are parallel-scaling levers
+that need the bench corpus + a representative core count to validate no-regression
+— not possible on this 4-core box without the (unmerged-PR-#92) qap15 fixtures.
 
 ## Recent Tried-and-Rejected
 more work.** Step 2's premise (dense-spike bump, contiguous SAXPY) does not hold
@@ -240,6 +243,7 @@ tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
+tests/issue99_fma_front_gate.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-01T11:51:27Z
+Generated: 2026-07-01T12:08:47Z
 
 ## Latest Session
 File: dev/sessions/2026-07-01-03.md
@@ -59,11 +59,11 @@ unilateral default flips, no unvalidatable parallel retunes.
 
 ## Git Status
 ```
+f35f22f issue #99: Phase B-2 — packed trailing update handles mixed 1x1/2x2/zero-d streams
+99fe666 issue #99: checkpoint — packed BLAS-3 trailing update (byte-exact ~8-10x)
 efb205b issue #99: packed BLAS-3 dense trailing update — byte-exact ~8-10x on dense fronts
 45777c0 issue #99: checkpoint update — PR #92 merge + byte-exact intra-front win
 ad70b5b issue #99: shape-aware intra-front gate (Lever 1, byte-exact 2.68x) + FMA row gate
-c1d00a2 Merge PR #92 (issue #91) into issue-99 branch: qap15 ordering fix + harness + Lever B
-1286297 issue #99: session 2026-07-01-03 checkpoint (FMA size gate)
 ```
 
 ## Test Status
@@ -86,7 +86,7 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 392 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.33s
+test result: ok. 392 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.34s
 
 ```
 
@@ -111,36 +111,36 @@ examples/bench_dense_front 2955 5 (the new issue-99 harness):
 ```
 
 ## Recent Decisions
-register-tiled kernel then autovectorizes to 9–10.5 GFLOP/s (22–26× isolated).
+**Decision.** Extend `apply_schur_panel_range_packed` to handle a mixed
+1×1/2×2/zero-d pivot stream, and route **every** panel through the packed path
+when packing is enabled (previously only all-1×1 panels; 2×2 panels used the
+un-packed `axpy2` fallback). `subdiag` is threaded
+`apply_blocked_schur → apply_blocked_schur_panel → apply_schur_panel_range → packed`.
 
-**Supersedes** the 2026-06-30 `tried-and-rejected` "DST-bandwidth-bound"
-conclusion for this hardware: that came from packing the source into the *same
-strided kernel* (which kept the strided `q`-access and only shrank the stride).
-A proper packed micro-kernel with a contiguous `q`-loop is a different design and
-wins decisively. Recorded there, not overwriting the prior entry.
+**Why.** The B-1 packed kernel gave ~8–10× on all-1×1 panels but strongly
+indefinite fronts (and the fma path, whose rounding drifts more pivots to 2×2)
+fell to the slow strided fallback for their 2×2 panels. B-2 closes that gap.
 
-**Byte-exactness.** Each `A[i,j]` (i≥j) is reduced over ascending `q` with the
-identical `mul → sub` (nofma) / `mul_add` (fma) as the reference — packing changes
-only memory layout, not arithmetic order. A zero alpha gives `acc − round(0·L) =
-acc` for finite `L`, matching the strided zero-skip. Validated: full byte-exact
-factor-parity suite green with packed default + `packed_matches_scalar_reference_
-bit_for_bit` unit test.
+**Byte-exactness.** Each element walks the stream in `q` order: 1×1 →
+`acc -= (L[j,q]·d_q)·L[i,q]` (`mul→sub` / `mul_add`), skipping `d_q==0` as the
+fallback does; 2×2 → the fused `acc -= dl0·L[i,q] + dl1·L[i,q+1]` (add-then-sub
+nofma / two chained FMAs) with `dl0=d11·L[j,q]+d21·L[j,q+1]`,
+`dl1=d21·L[j,q]+d22·L[j,q+1]`. This matches `do_1x1_update`/`do_2x2_update` and
+`axpy`/`axpy2_minus_unroll4*` exactly. Validated: full suite 736/0 incl. the
+indefinite/2×2 KKT parity gates green with packed default, plus the
+`packed_matches_scalar_reference_bit_for_bit` unit test sweeping 1×1/2×2/zero-d
+in both fma modes.
 
-**Scope.** Reached only for all-1×1-pivot panels (the `apply_blocked_schur` W-2
-fast path). 2×2-pivot panels fall to the un-packed `axpy2` fallback, so strongly
-indefinite fronts — and the `fma` path, whose rounding drifts more pivots to 2×2 —
-benefit less. Definite / quasi-definite (SQD, regularized KKT) / SPD fronts get
-the full win. Packing the 2×2 fallback (Phase B-2) is the next step.
+**Evidence.** Indefinite 2955 front nofma serial 25586 → 2780 ms (9.2×, 0.34 →
+3.09 GFLOP/s). Note: on the degenerate ±n-diagonal `bench_dense_front` synthetic,
+the fma factorization is ~5× slower than nofma at equal inertia — a matrix-specific
+BK pivoting interaction (fma rounding shifts 1×1-vs-2×2 choices), *not* a kernel
+effect (both use packed). Reinforces keeping FMA opt-in.
 
-**Evidence.** dense-1500 schur 3165→309 ms (10.2×); dense-2955 nofma serial
-25586→3202 ms (8.0×, 0.34→2.69 GFLOP/s); synth qap15 stand-in end-to-end
-3379→2029 ms; full byte-exact stack (intra-front + packed) 9247→2029 ms (4.56×),
-inertia `(+30000,−2000,0)` unchanged. Suite 736 passed / 0 failed; clippy clean.
-
-**Caveat.** Absolute GFLOP/s (packed ~10, vs a fully-tuned BLAS-3 core ~30–50) is
-partly this 4-core container; the tile (8×4) and the lack of L2 cache-blocking /
-FMA-in-packed leave headroom. Re-tune on target hardware. The `fma` packed path
-exists (bit-matches the fma reference) but is not the default.
+**Remaining headroom (not done).** Absolute packed throughput (~3–10 GFLOP/s) is
+still below a fully-tuned BLAS-3 core; the 8×4 tile, L2 cache-blocking, an
+explicit-SIMD (pulp) packed kernel, and FMA-in-packed are untuned, and this is a
+4-core container. Re-tune on target hardware.
 
 ## Recent Tried-and-Rejected
 +23% option but is a reproducibility-policy change (kept opt-in), not a

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5585,3 +5585,48 @@ of sparse's `update_work_total >= factor_nnz()`.
 **Evidence.** +9 unit tests (each cause + both recommendation getters), 381 lib
 tests green, fmt/clippy clean, no numerical change (bench: no failures). Design
 note: `dev/research/refactor-signal-2026-07-01.md`.
+
+## 2026-07-01 — Opt-in per-front FMA size gate (issue #99, Lever 3)
+
+**Decision.** Add `BunchKaufmanParams::fma_min_front_area: Option<usize>`
+(default `None`) and `Solver::with_fma_large_fronts(min_area)`. When armed, a
+dense front whose trailing-update area `nrow * ncol >= min_area` uses the FMA
+trailing-Schur kernels even when the global `fma` flag is off; smaller fronts
+keep the bit-exact `*_nofma` kernels. The gate lives on `BunchKaufmanParams`
+(read directly by the dense front factor) and is set straight into
+`numeric_params.bk` by the builder — no new `NumericParams` field and no funnel,
+so the change is low-churn (every `..Default::default()` site is unaffected) and
+`None` is a strict no-op.
+
+**Why.** Issue #99's Lever 3: the trailing-update kernel is nofma (bit-exact) and
+~1.3–2× below FMA peak; large indefinite roots dominate the factor loop but the 4
+small-front pivot-drift KKTs (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851)
+need nofma to keep their Bunch-Kaufman pivot classification. The existing `fma`
+flag is all-or-nothing, so it cannot serve both. A front-size gate does: fast
+kernel on the roots, reference kernel on the sensitive small fronts.
+
+**Why opt-in / default `None`.** Enabling FMA changes cross-arch bit patterns
+(single vs double rounding) on the gated fronts — the reproducibility policy the
+owner deliberately kept opt-in (`dev/tried-and-rejected.md` 2026-04-14). This
+session had no authorization to flip a default (the interactive policy question
+could not be delivered — harness permission-stream failure), so the lever is
+shipped as a knob with measured evidence, leaving the default-on decision to the
+owner.
+
+**Evidence.** `examples/bench_dense_front 2955 5` (4-core x86_64): FMA 1.66×
+per-core serial (25.6 s → 15.4 s), 1.67× inside intrafront (8.6 s → 5.1 s),
+inertia `(+1478,−1477,0)` identical across all four nofma/FMA × serial/intrafront
+variants. `tests/issue99_fma_front_gate.rs` (4 tests): gate above threshold is
+bit-identical to `fma=true`, below threshold bit-identical to nofma default,
+inertia preserved, threshold is exactly `nrow*ncol` with `>=`. Full suite 734
+passed / 0 failed; fmt + clippy `-D warnings` clean; bench residual gate
+unchanged (default path byte-for-byte identical). Note:
+`dev/research/issue-99-dense-front-fma-gate.md`.
+
+**Not closed.** This does not reach faer-class throughput — the best variant is
+1.67 GFLOP/s vs ~50–100 for a tuned BLAS-3 core. The structural gap is feral's
+memory-bandwidth-bound rank-panel update vs a 2-D register-tiled GEMM
+(`dev/plans/dense-kernel-blas3.md`), a multi-session rewrite. Levers 1 (adaptive
+`INTRAFRONT_MIN_AREA`) and 2 (assembly parallelism) are parallel-scaling levers
+that need the bench corpus + a representative core count to validate no-regression
+— not possible on this 4-core box without the (unmerged-PR-#92) qap15 fixtures.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5763,3 +5763,36 @@ inertia `(+30000,−2000,0)` unchanged. Suite 736 passed / 0 failed; clippy clea
 partly this 4-core container; the tile (8×4) and the lack of L2 cache-blocking /
 FMA-in-packed leave headroom. Re-tune on target hardware. The `fma` packed path
 exists (bit-matches the fma reference) but is not the default.
+
+## 2026-07-01 — Packed trailing update: Phase B-2 mixed 1×1/2×2 streams (issue #99, byte-exact)
+
+**Decision.** Extend `apply_schur_panel_range_packed` to handle a mixed
+1×1/2×2/zero-d pivot stream, and route **every** panel through the packed path
+when packing is enabled (previously only all-1×1 panels; 2×2 panels used the
+un-packed `axpy2` fallback). `subdiag` is threaded
+`apply_blocked_schur → apply_blocked_schur_panel → apply_schur_panel_range → packed`.
+
+**Why.** The B-1 packed kernel gave ~8–10× on all-1×1 panels but strongly
+indefinite fronts (and the fma path, whose rounding drifts more pivots to 2×2)
+fell to the slow strided fallback for their 2×2 panels. B-2 closes that gap.
+
+**Byte-exactness.** Each element walks the stream in `q` order: 1×1 →
+`acc -= (L[j,q]·d_q)·L[i,q]` (`mul→sub` / `mul_add`), skipping `d_q==0` as the
+fallback does; 2×2 → the fused `acc -= dl0·L[i,q] + dl1·L[i,q+1]` (add-then-sub
+nofma / two chained FMAs) with `dl0=d11·L[j,q]+d21·L[j,q+1]`,
+`dl1=d21·L[j,q]+d22·L[j,q+1]`. This matches `do_1x1_update`/`do_2x2_update` and
+`axpy`/`axpy2_minus_unroll4*` exactly. Validated: full suite 736/0 incl. the
+indefinite/2×2 KKT parity gates green with packed default, plus the
+`packed_matches_scalar_reference_bit_for_bit` unit test sweeping 1×1/2×2/zero-d
+in both fma modes.
+
+**Evidence.** Indefinite 2955 front nofma serial 25586 → 2780 ms (9.2×, 0.34 →
+3.09 GFLOP/s). Note: on the degenerate ±n-diagonal `bench_dense_front` synthetic,
+the fma factorization is ~5× slower than nofma at equal inertia — a matrix-specific
+BK pivoting interaction (fma rounding shifts 1×1-vs-2×2 choices), *not* a kernel
+effect (both use packed). Reinforces keeping FMA opt-in.
+
+**Remaining headroom (not done).** Absolute packed throughput (~3–10 GFLOP/s) is
+still below a fully-tuned BLAS-3 core; the 8×4 tile, L2 cache-blocking, an
+explicit-SIMD (pulp) packed kernel, and FMA-in-packed are untuned, and this is a
+4-core container. Re-tune on target hardware.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5551,3 +5551,47 @@ not required for correctness.
 144-chain: 16.88 ms → 1.66 ms (10.2×). Localized-spike (`lu_update_probe`) and
 the full suite unchanged/green. Clean-room from Forrest–Tomlin 1972, Reid 1982,
 Schork–Gondzio ERGO-17-002 (`BASICLU` is GPL — paper only).
+
+## 2026-06-30 — `OrderingPreprocess::Auto` resolves by verified fill race, not structural prediction (issue #91)
+
+**Decision.** When `OrderingPreprocess::Auto` is selected (the default),
+resolve it by *verifying* fill rather than trusting `pick_ordering_preprocess`
+alone. If the structural predicate recommends `LdltCompress`, run the symbolic
+pipeline both ways and keep `LdltCompress` only if its `factor_nnz_estimate`
+does not exceed `PREPROCESS_FILL_INFLATION_LIMIT = 2.0×` the `None` baseline;
+otherwise fall back to `None`. If the predicate declines, use `None` directly
+(no race). Implemented in `symbolic_factorize_preprocess_auto`
+(`src/symbolic/mod.rs`).
+
+**Why.** `pick_ordering_preprocess` fires `LdltCompress` when ≥30 % of columns
+have ≤2 nonzeros — a property regularized quasi-definite IPM KKTs have in
+abundance (their diagonal regularization rows). On the qap15 conic KKT
+(n=50880) MC64 compression *inflated* simplicial fill 6.3× (7.16M → 45.4M) and
+factor time ~20× (0.77 s → 15.4 s). The predicate is a one-way structural proxy
+and cannot know whether compression actually helps; verifying fill makes `Auto`
+robust to this and any future misfire.
+
+**Why a 2× threshold, not "smaller fill wins".** An initial pure-fill race
+(keep `LdltCompress` only on ties/improvements) regressed inertia on
+near-singular corpus KKTs: twirism1's `LdltCompress` ordering is +15 % fill but
+its MC64-matched 2×2 pivots produce the **oracle-correct** inertia (432,313,0),
+where the leaner `None` ordering misclassifies two near-zero pivots
+(434,311,0); sawpath similarly. `LdltCompress` (MUMPS ICNTL(12)=2 for SYM=2)
+carries a numerical benefit that symbolic fill does not capture, so the guard
+must only fire on a *catastrophic* inflation. 2× sits well above the normal
+~1.1–1.2× compression overhead and well below qap15's 6.3×.
+
+**Alternatives rejected.**
+- *Blanket-disable `LdltCompress`*: kills its inertia benefit on twirism1/sawpath
+  and any other SYM=2 case it exists to serve.
+- *Fix the predicate's threshold*: still a one-way proxy; would need re-tuning per
+  pathology and cannot account for the numerical benefit.
+- *Smaller-fill-wins race*: regresses the `issue65_mc64_fallback` inertia gate
+  (above).
+
+**Evidence.** qap15 default factor 15.4 s → 0.77 s (20×), nnz_L 40.9M → 9.25M,
+inertia (+22275,−28605,0) unchanged. Full corpus suite green (no inertia
+regression). Regression guard: `tests/issue91_preprocess_misfire.rs` (gitignored
+fixture `tests/data/large/qap15_kkt.mtx`, regen via
+`dev/scripts/regen_qap15_kkt.sh`). Research note:
+`dev/research/issue-91-preprocess-misfire.md`.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5673,3 +5673,49 @@ memory-bandwidth-bound rank-panel update vs a 2-D register-tiled GEMM
 `INTRAFRONT_MIN_AREA`) and 2 (assembly parallelism) are parallel-scaling levers
 that need the bench corpus + a representative core count to validate no-regression
 — not possible on this 4-core box without the (unmerged-PR-#92) qap15 fixtures.
+
+## 2026-07-01 — Shape-aware intra-front gate + FMA row gate (issue #99, Levers 1 & 3)
+
+**Context.** After merging PR #92 (issue #91 ordering fix + qap15 harness) onto
+this branch at the maintainer's request, profiling the synthetic qap15 stand-in
+(`dev/scripts/gen_synth_kkt.py`) exposed that the dense border factors as ~117
+*tall, thin* fronts of `2000 × 16` carrying 99.9% of the schur loop — not one
+wide root. Both per-front gates key on **area** and miss exactly this shape.
+
+**Decision 1 (byte-exact, Lever 1).** Add a shape-aware intra-front trigger
+`intrafront_tall_gate(trailing_cols, n_elim) = trailing_cols >=
+INTRAFRONT_TALL_MIN_COLS(512) && n_elim >= INTRAFRONT_TALL_MIN_ELIM(8)`, OR-ed
+with the existing `(nrow-j_start)*n_elim >= INTRAFRONT_MIN_AREA` gate. The area
+metric under-counts tall-thin fronts whose parallelizable work is
+`~n_elim * trailing_cols²`; `2000×16` has area 31744, just under the 32768 floor,
+so intra-front parallelism never fired. OR-ing can only *add* parallelism to
+large-work fronts, so it cannot regress the area gate's measured calibration.
+Pure scheduling ⇒ byte-exact (each trailing column reduced on one thread).
+
+**Decision 2 (opt-in, Lever 3).** The FMA gate had the identical area blind spot
+(`nrow*ncol`); rename `BunchKaufmanParams::fma_min_front_area` →
+`fma_min_front_rows` and gate on `nrow >= t` (front rows = trailing-update size).
+`Solver::with_fma_large_fronts(min_rows)` accordingly. Same opt-in / default-None
+policy as before.
+
+**Why rows/shape, not area.** On real conic KKTs the time is in tall-thin fronts
+(large `nrow`, small `ncol`), created when regularization leaves break supernode
+amalgamation of a dense block. An area gate silently misses them; a
+rows/width-based gate catches them while still protecting genuinely small fronts.
+
+**Evidence (synthetic KKT, 32000², 2000×16 fronts, 4-core x86_64, `bench_qap15`).**
+Original default 9.25 s → **3.46 s (2.68×) byte-exact** with the shape-aware
+intra-front gate → **2.35 s (3.94× total)** adding opt-in FMA. Inertia
+`(+30000, −2000, 0)` identical across every config. Confirmed the intra-front
+diagnosis first via `FERAL_INTRAFRONT_MIN_AREA=16384` (9.25 → 4.35 s byte-exact).
+Full suite **735 passed / 0 failed** — `parallel_parity` (parallel==sequential
+bit-for-bit) green, so the intra-front change is byte-exact as claimed. clippy
+`-D warnings` clean.
+
+**Note.** The largest lever on this workload was **byte-exact** (the shape-aware
+gate), not the rule-breaking FMA. The maintainer authorized breaking
+bit-exactness/inertia to explore; the exploration instead surfaced a byte-exact
+scheduling bug affecting *both* gates. The synthetic fixture is a stand-in — the
+real qap15 KKT needs POUNCE (unavailable here); the tall-thin-front phenomenon and
+its 10-core behavior should be re-validated on the real matrix before promoting
+the thresholds to a hard default. See `dev/research/issue-99-dense-front-fma-gate.md`.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5719,3 +5719,47 @@ scheduling bug affecting *both* gates. The synthetic fixture is a stand-in — t
 real qap15 KKT needs POUNCE (unavailable here); the tall-thin-front phenomenon and
 its 10-core behavior should be re-validated on the real matrix before promoting
 the thresholds to a hard default. See `dev/research/issue-99-dense-front-fma-gate.md`.
+
+## 2026-07-01 — Packed BLAS-3 dense trailing update (issue #99, byte-exact)
+
+**Decision.** Add `apply_schur_panel_range_packed` — a packed, register-tiled
+(MR=8×NR=4) implementation of the dense rank-`n_elim` trailing Schur update — and
+make it the default (env `FERAL_PACKED_SCHUR=0` restores the strided kernels).
+Byte-exact with the strided path.
+
+**Why.** The trailing update is ~94% of a dense factor yet ran at ~0.35 GFLOP/s
+(~10× below scalar peak on an AVX2/FMA CPU). An isolated microbench
+(`examples/bench_schur_micro`) showed the strided per-column kernels re-read the
+eliminated panel at column-stride `nrow` every `q`, touching `n_elim` scattered
+cache lines — cache latency, not compute or DST bandwidth. Packing the panel into
+`q`-contiguous MR/NR micro-panels makes the inner loop L1-resident; a plain
+register-tiled kernel then autovectorizes to 9–10.5 GFLOP/s (22–26× isolated).
+
+**Supersedes** the 2026-06-30 `tried-and-rejected` "DST-bandwidth-bound"
+conclusion for this hardware: that came from packing the source into the *same
+strided kernel* (which kept the strided `q`-access and only shrank the stride).
+A proper packed micro-kernel with a contiguous `q`-loop is a different design and
+wins decisively. Recorded there, not overwriting the prior entry.
+
+**Byte-exactness.** Each `A[i,j]` (i≥j) is reduced over ascending `q` with the
+identical `mul → sub` (nofma) / `mul_add` (fma) as the reference — packing changes
+only memory layout, not arithmetic order. A zero alpha gives `acc − round(0·L) =
+acc` for finite `L`, matching the strided zero-skip. Validated: full byte-exact
+factor-parity suite green with packed default + `packed_matches_scalar_reference_
+bit_for_bit` unit test.
+
+**Scope.** Reached only for all-1×1-pivot panels (the `apply_blocked_schur` W-2
+fast path). 2×2-pivot panels fall to the un-packed `axpy2` fallback, so strongly
+indefinite fronts — and the `fma` path, whose rounding drifts more pivots to 2×2 —
+benefit less. Definite / quasi-definite (SQD, regularized KKT) / SPD fronts get
+the full win. Packing the 2×2 fallback (Phase B-2) is the next step.
+
+**Evidence.** dense-1500 schur 3165→309 ms (10.2×); dense-2955 nofma serial
+25586→3202 ms (8.0×, 0.34→2.69 GFLOP/s); synth qap15 stand-in end-to-end
+3379→2029 ms; full byte-exact stack (intra-front + packed) 9247→2029 ms (4.56×),
+inertia `(+30000,−2000,0)` unchanged. Suite 736 passed / 0 failed; clippy clean.
+
+**Caveat.** Absolute GFLOP/s (packed ~10, vs a fully-tuned BLAS-3 core ~30–50) is
+partly this 4-core container; the tile (8×4) and the lack of L2 cache-blocking /
+FMA-in-packed leave headroom. Re-tune on target hardware. The `fma` packed path
+exists (bit-matches the fma reference) but is not the default.

--- a/dev/journal/2026-06-30-01.org
+++ b/dev/journal/2026-06-30-01.org
@@ -1,0 +1,91 @@
+#+TITLE: Session journal 2026-06-30-01
+#+STARTUP: showall
+
+* 18:30 :issue-91:ordering:preprocess:qap15:perf:
+Investigating issue #91 ("catastrophic factorization slowdown on a QAP-style
+KKT vs faer, 12s -> 0.2s"). Reproduced the exact matrix and root-caused it.
+
+** Reproduction
+Generated the real qap15 conic KKT via pounce-convex: parsed
+~/projects/pounce/benchmarks/lpopt/mps/qap15.mps.bz2 with HiGHS, rebuilt the
+LP as (A,b,G,h,lb,ub), ran pounce.qp.solve_qp with POUNCE_DBG_KKT_DUMP set
+(env hook in pounce-linsol/src/t_sym_solver.rs). Dump matches the issue
+*exactly*: dim=50880, nnz=168105. 1-based lower triangle. Converted to
+symmetric .mtx. Diagonal sign structure: 22275 positive (all ~1e-10), 28605
+negative (down to -1.0), 0 zero -> quasi-definite with *tiny* primal
+regularization (delta ~ 1e-10).
+
+** Numbers (feral, release, example bench_qap15)
+| config                | factor time | nnz_L  | inertia            |
+| default (Auto prep)   | 15,400 ms   | 40.9M  | (+22275,-28605,0)  |
+| default + fma         | 13,300 ms   | 40.9M  | same               |
+| static_pivot(1e-8)    | 14,300 ms   | 40.9M  | same               |
+| sqd_mode              | TRIPS col 0 | --     | SqdContractViolated{pivot:1e-10} |
+| preprocess=None       |    771 ms   | 9.25M  | (+22275,-28605,0)  |
+| preprocess=None + fma |    671 ms   | 9.25M  | same               |
+| faer AMD (issue)      | ~220 ms     | 13.4M (symbolic) | -- |
+
+** Root cause: OrderingPreprocess::Auto mis-fires LdltCompress
+Symbolic-only fill (col_counts sum, amalgamation-independent):
+- AMD + Auto preprocessing : 45,376,046  <-- the bug
+- AMD + preprocess=None    :  7,155,773  <-- BETTER than faer's 13.4M
+nemin / amalgamation_strategy change *nothing* in simplicial fill. AMF+None
+= 7.64M, MetisND+None = 19.0M. So feral-amd ordering is excellent; the whole
+3-4x "fill gap" and the 20x time blowup come from
+`pick_ordering_preprocess` (src/symbolic/mod.rs:485) firing
+`OrderingPreprocess::LdltCompress` whenever >=30% of columns have <=2
+nonzeros. A regularized quasi-definite IPM KKT is *full* of degree-<=2
+columns (the diagonal regularization rows), so the heuristic fires exactly
+where MC64 symmetric-matching compression destroys the elimination order.
+
+Disabling preprocessing: 15.4s -> 0.77s (20x), nnz_L 40.9M -> 9.25M,
+inertia unchanged and correct. FMA on top: -> 0.67s. Residual vs faer
+(~0.22s) is dense-kernel throughput (FMA/GEMM), the secondary lever.
+
+** Hypotheses refuted along the way
+- "delayed pivots inflate fill" : NO. nnz_L identical (40.9M) across
+  default / +fma / static_pivot. Inertia clean, no cascade.
+- "supernode amalgamation padding" : NO. nemin=1 vs 16 -> identical
+  simplicial fill; amalgamated_est tracks simplicial.
+- "feral-amd worse than faer-amd" : NO. AMD+None = 7.16M < faer 13.4M.
+- "needs SQD fast-path" : the existing SQD mode is unusable here anyway --
+  trips SqdContractViolated at col 0 because the legit pivot is 1e-10 <
+  zero_tol. (Separate robustness issue, not the perf cause.)
+
+** Proposed fix (robust, future-proof)
+Make OrderingPreprocess::Auto *verify* rather than *predict*: cheaply race
+None vs LdltCompress on symbolic factor_nnz_estimate and pick the smaller
+fill (mirrors existing OrderingMethod::AutoRace). Guarantees Auto never
+produces worse fill than None on qap15 or any future pattern, while keeping
+LdltCompress wins where it genuinely helps. Must verify no corpus
+regression (LdltCompress exists because it helps some matrices -- MUMPS
+ICNTL(12)=2). Do NOT blanket-disable.
+
+Harness: examples/bench_qap15.rs (+ Cargo.toml [[example]]). Matrix not yet
+committed as a fixture -- candidate for external_benchmarks/ / tests/data.
+
+* 20:10 :issue-91:fix:preprocess:inertia:corpus:
+Implemented the fix: OrderingPreprocess::Auto now verifies fill instead of
+trusting pick_ordering_preprocess. `symbolic_factorize_preprocess_auto`
+(src/symbolic/mod.rs): if predicate says None, use None; if it says
+LdltCompress, run both and keep LdltCompress unless est fill > 2x None
+(PREPROCESS_FILL_INFLATION_LIMIT).
+
+First attempt was "smaller-fill-wins" (keep LdltCompress only on
+ties/improvements). Full suite caught 2 regressions in
+issue65_mc64_fallback: twirism1 (432,313,0)->(434,311,0) and sawpath
+(789,670,116)->(789,671,115). Root cause: LdltCompress's MC64 2x2 pivots
+give the oracle-correct inertia on near-singular KKTs even at +15% fill
+(twirism1 26683->30782 est); smaller-fill-wins discarded that benefit.
+Measured None vs LdltCompress est on both fixtures + qap15:
+  qap15    8.59M vs 54.45M = 6.34x  (misfire -> None)
+  twirism1 26683 vs 30782  = 1.15x  (keep LdltCompress)
+  sawpath   7548 vs  7557  = 1.00x  (keep)
+2x ceiling separates them cleanly. After the change: issue65 green,
+issue91 green, symbolic_profiler/ldlt_compress green, full corpus suite
+green (68 test result: ok, 0 failed).
+
+Result on qap15 (default, verified Auto): 15.4s -> 0.77s (20x), nnz_L
+40.9M -> 9.25M, inertia (+22275,-28605,0) unchanged. Docs: research note,
+decisions.md, tried-and-rejected.md, CHANGELOG all updated. Fixture
+tests/data/large/qap15_kkt.mtx (gitignored) + regen script added.

--- a/dev/journal/2026-07-01-03.org
+++ b/dev/journal/2026-07-01-03.org
@@ -105,3 +105,36 @@ Key finding: the BIGGEST lever was byte-exact (shape-aware scheduling),
 not the rule-breaking FMA. The area metric bug hit both gates identically.
 Caveat: synthetic fixture; re-validate tall-thin phenomenon + thresholds on
 the real qap15 + 10 cores before promoting to a hard default.
+
+* 17:30 :blas3:packed:breakthrough:byte-exact:
+Maintainer: take on the BLAS-3 GEMM. Read dev/plans/dense-kernel-blas3.md
+(Phase B-1 = register-blocked MR x NR DSYRK, byte-exact by design).
+faer-expert couldn't read faer source (not in sandbox) but confirmed #1:
+faer defers rank-bs into workspace W, flushes one triangular GEMM per
+panel (bs=64).
+
+Profiled dense-1500 front: schur = 94% at 0.33 GFLOP/s, ~10x below scalar
+peak on AVX2/AVX512/FMA CPU. Wrote examples/bench_schur_micro isolating the
+kernel: current strided kernel 0.38 GFLOP/s; a plain packed MR=8 NR=4
+register-tiled kernel = 9-10.5 GFLOP/s = 22-26x, BYTE-EXACT (0 mismatches),
+robust across sizes 512..2955, ke 16..128. Root cause: strided kernels
+re-read panel at col-stride nrow per q => n_elim scattered cache lines.
+(Refutes the 2026-06-30 'DST-bandwidth-bound' note, which packed into the
+SAME strided kernel.)
+
+Wired apply_schur_panel_range_packed into production (default on,
+FERAL_PACKED_SCHUR=0 fallback). GOTCHA: 'cargo build --release' does NOT
+rebuild examples -> my first 'packed' profile runs used STALE example
+binaries and showed no speedup. After 'cargo build --release --examples':
+dense-1500 schur 3165 -> 309 ms (10.2x); dense-2955 nofma serial 25586 ->
+3202 ms (8.0x); synth_arrow end-to-end 3379 -> 2029 ms.
+
+Byte-exact validated: full suite 736 passed / 0 failed (blocked_ldlt +
+parallel_parity + all factor parity gates green with packed default) +
+packed_matches_scalar_reference_bit_for_bit unit test.
+
+Scope: only all-1x1 panels (apply_blocked_schur fast path). 2x2 panels use
+the un-packed axpy2 fallback -> strongly indefinite fronts and the fma path
+(rounding drifts pivots to 2x2) benefit less. Phase B-2 = pack the 2x2
+fallback. Full byte-exact stack: intra-front + packed = 9247 -> 2029 ms
+(4.56x) on the synth qap15 stand-in.

--- a/dev/journal/2026-07-01-03.org
+++ b/dev/journal/2026-07-01-03.org
@@ -59,3 +59,49 @@ assembly parallelism (parallel-scaling, unvalidatable at 4 cores),
 default-on FMA / Lever 4 static-SQD (owner policy call), BLAS-3 GEMM
 (the only route to faer-class GFLOP/s). No byte-exact lever closes 3.5×,
 as the issue itself states.
+
+* 15:00 :merge:pr92:intrafront:breakthrough:
+Maintainer: rebase PR #92 (qap15 ordering fix + harness) onto this branch;
+"take chances / break rules." Merged origin refs/pull/92/head (merge-base =
+current main, clean) — brings OrderingPreprocess::Auto fix, qap15
+gen/bench/profile harnesses, dense-front research notes, and Lever B
+(INTRAFRONT_MIN_AREA 256^2 -> 256x128). Conflicts: Cargo.toml (kept all 3
+example targets), CHANGELOG (kept both Unreleased entries).
+
+Real qap15 fixture unobtainable (gen needs POUNCE+highspy+qap15.mps, absent).
+Wrote dev/scripts/gen_synth_kkt.py: arrowhead stand-in, dense K=2000 border
+(root front) + L=30000 degree-2 leaves (LdltCompress signature). 32000^2,
+2.06M nnz. Runs end-to-end via bench_qap15.
+
+END-TO-END (bench_qap15, 4 cores, REPS=2):
+  default              9686 ms   inertia (+30000,-2000,0)
+  static_pivot(1e-8)   8746 ms   1.11x
+  sqd_mode             8293 ms   1.17x
+  default+fma          5763 ms   1.68x
+  sqd_mode+fma         5543 ms   1.75x
+All inertia identical. FMA end-to-end (1.68x) matches single-front (1.66x).
+
+But default+fma_large(256^2 area) gave NO speedup while global fma did.
+=> gate not firing. profile_qap15 revealed why: the dense border factors as
+~117 tall-thin fronts of 2000x16 (99.9% of schur loop), NOT one 2000 front
+(leaves break amalgamation). nrow*ncol = 32000 < 65536 (fma gate) AND
+(nrow-j)*n_elim = 31744 < 32768 (intrafront gate). BOTH area gates blind to
+tall-thin fronts (work ~ n_elim*trailing_cols^2, large despite small area).
+
+Confirmed intrafront hypothesis with env override:
+  FERAL_INTRAFRONT_MIN_AREA=16384 default: 9247 -> 4354 ms (2.1x) BYTE-EXACT.
+
+Fixes:
+- Lever 1 (byte-exact): intrafront_tall_gate(cols>=512 && n_elim>=8) OR-ed
+  with area gate. default 9247 -> 3457 ms (2.68x), inertia unchanged.
+- Lever 3: fma_min_front_area -> fma_min_front_rows, gate nrow>=t. Now fires;
+  default+fma_large(256rows) = 2350 ms == global fma (2347). 3.94x total.
+
+Correctness: full suite 735 passed / 0 failed. parallel_parity (parallel ==
+sequential bit-for-bit) GREEN => intrafront change byte-exact as claimed.
+clippy -D warnings clean.
+
+Key finding: the BIGGEST lever was byte-exact (shape-aware scheduling),
+not the rule-breaking FMA. The area metric bug hit both gates identically.
+Caveat: synthetic fixture; re-validate tall-thin phenomenon + thresholds on
+the real qap15 + 10 cores before promoting to a hard default.

--- a/dev/journal/2026-07-01-03.org
+++ b/dev/journal/2026-07-01-03.org
@@ -138,3 +138,26 @@ the un-packed axpy2 fallback -> strongly indefinite fronts and the fma path
 (rounding drifts pivots to 2x2) benefit less. Phase B-2 = pack the 2x2
 fallback. Full byte-exact stack: intra-front + packed = 9247 -> 2029 ms
 (4.56x) on the synth qap15 stand-in.
+
+* 19:00 :blas3:phaseB2:packed:2x2:byte-exact:
+Maintainer: take on Phase B-2 (pack the 2x2 fallback). Extended
+apply_schur_panel_range_packed to a mixed 1x1/2x2/zero-d pivot stream:
+per element, walk q; 1x1 -> mul-sub / mul_add (skip d==0); 2x2 -> fused
+dl0*L_q + dl1*L_{q+1} add-then-sub (nofma) / two chained FMAs (fma), with
+dl0=d11*L[j,q]+d21*L[j,q+1], dl1=d21*L[j,q]+d22*L[j,q+1]. Byte-exact with
+do_1x1_update/do_2x2_update + axpy/axpy2. Threaded subdiag through
+apply_blocked_schur -> panel -> range -> packed; apply_blocked_schur now
+routes EVERY panel through packed when enabled (strided fast+fallback under
+FERAL_PACKED_SCHUR=0).
+
+Validated: full suite 736/0 incl. indefinite/2x2 gates (blocked_ldlt,
+kkt_matrices, delayed_pivoting, rook_rescue, parallel_parity) byte-exact
+with packed default; packed_matches_scalar_reference_bit_for_bit unit test
+now sweeps 1x1/2x2/zero-d in both fma modes.
+
+Perf: indefinite 2955 front nofma serial 25586 -> 2780 ms (9.2x, 3.09
+GFLOP/s). fma-serial STILL 14188 ms (clean, not contention) vs nofma 2780
+at SAME inertia -> confirmed a matrix-specific BK pivoting interaction of
+fma rounding on the degenerate +-n-diagonal synthetic (both paths packed),
+not a kernel effect. Not a regression (fma was ~15s here at session start).
+Reinforces FMA opt-in.

--- a/dev/journal/2026-07-01-03.org
+++ b/dev/journal/2026-07-01-03.org
@@ -1,0 +1,61 @@
+* 2026-07-01-03 :issue99:dense-front:fma:performance:
+
+* 09:00 :orientation:blocker:
+Task: "loop over all levers until faer-level performance" on issue #99
+(dense-front throughput, ~3.5× gap to faer on qap15 conic KKT).
+Discovered the issue's premises are not reproducible on this branch:
+- PR #92 (the OrderingPreprocess::Auto fix that made qap15 tractable, and
+  the qap15 fixture generator + bench harnesses) is OPEN/UNMERGED
+  (branch issue-91-preprocess-misfire). This branch is off current main
+  and lacks it: INTRAFRONT_MIN_AREA is still 256*256 (not #92's 256*128).
+- The qap15 fixture (tests/data/large/qap15_kkt.mtx, gitignored), its
+  generator, examples/{profile,bench}_qap15.rs, and the two research
+  notes the issue cites all exist on NO remote branch.
+- This container has 4 cores; the issue's numbers are 10-core.
+Conclusion: end-to-end qap15 cannot be reproduced; parallel-scaling levers
+(1 assembly, 2 schur) cannot be validated vs the 10-core target here.
+Tried to ask the owner the fixture + policy questions via AskUserQuestion;
+the tool failed ("permission stream closed"). Proceeded autonomously with
+the defensible subset: byte-exact / additive / measurable-here work only.
+
+* 10:30 :harness:measurement:
+Built examples/bench_dense_front.rs — self-contained synthetic indefinite
+front (SplitMix64, alternating-sign dominant diagonal → 1×1-pivot W-2 fast
+path), factored via the real factor_frontal_blocked path, timing
+nofma/FMA × serial/intrafront with an inertia-equality gate.
+n=2955 (qap15 root size), 4 threads, best of 5:
+  nofma serial     25586 ms  0.34 GFLOP/s  1.00x
+  nofma intrafront  8632 ms  1.00 GFLOP/s  2.96x
+  fma   serial     15423 ms  0.56 GFLOP/s  1.66x
+  fma   intrafront  5143 ms  1.67 GFLOP/s  4.98x
+inertia (+1478,-1477,0) identical across all four. FMA = real 1.66x
+per-core win, inertia-preserving. But 1.67 GFLOP/s ceiling is ~50x below a
+tuned BLAS-3 core → the deep gap is the memory-bandwidth-bound rank-panel
+update vs 2-D tiled GEMM (dense-kernel-blas3.md), not any single lever.
+
+* 12:00 :implement:fma-gate:
+Lever 3 as an opt-in, default-off knob: BunchKaufmanParams::fma_min_front_area
+= Option<usize>; effective_front_fma(params,nrow,ncol) helper; gated at the
+single dense-front entry factor_frontal_blocked_in_place_with_scratch by
+shadowing params with an fma-flipped clone only when the gate fires (unarmed
+path pays nothing). Solver::with_fma_large_fronts writes straight to
+numeric_params.bk (no NumericParams field/funnel — first tried the
+NumericParams-field-mirror-of-fma approach but it broke ~dozens of
+fully-enumerated NumericParams literals across tests/examples/diagnostics;
+the bk-only design is lower churn since bk is nearly always ..default()).
+
+* 13:15 :verify:
+tests/issue99_fma_front_gate.rs (4 tests): gate>=threshold bit-identical to
+fma=true; below-threshold bit-identical to nofma default; inertia preserved;
+threshold is exactly nrow*ncol with >=. Full suite: 734 passed, 0 failed.
+cargo fmt + clippy --all-targets -D warnings clean. bench --release: no
+failures (default path byte-for-byte unchanged since gate defaults None).
+
+* 13:40 :scope:handoff:
+Delivered: FMA size gate + Solver setter + bench harness + tests + research
+note. Deferred (blocked, documented): Lever 1 adaptive INTRAFRONT_MIN_AREA
+(needs bench corpus + representative cores to prove no-regression), Lever 2
+assembly parallelism (parallel-scaling, unvalidatable at 4 cores),
+default-on FMA / Lever 4 static-SQD (owner policy call), BLAS-3 GEMM
+(the only route to faer-class GFLOP/s). No byte-exact lever closes 3.5×,
+as the issue itself states.

--- a/dev/research/issue-91-dense-kernel-profile-2026-06-30.md
+++ b/dev/research/issue-91-dense-kernel-profile-2026-06-30.md
@@ -87,3 +87,30 @@ kernel is preferred as the durable, inertia-safe win.
 Harness: `examples/profile_qap15.rs` (per-front buckets + top fronts, nofma vs
 fma). Note the numbers above are the *sequential* driver (~1.75 s); the parallel
 default factor is ~0.67–0.77 s, but the per-front *attribution* is what matters.
+
+## Update (same day) — B-1a packing measured and rejected; root is DST-bandwidth-bound
+
+Implemented B-1a (pack the L panel, feed the existing kernels, byte-exact) and
+measured: **net slowdown** — sequential loop 1747 → 1976 ms (+13%), the 2955²
+root 736 → 818 ms (+11%), parallel default 771 → 945 ms (+22%). Byte-exact
+parity held (blocked_ldlt 21/21, inertia/nnz_L unchanged). Reverted. See
+`dev/tried-and-rejected.md` 2026-06-30.
+
+**Corrected model of the bottleneck.** The panel (~1.5 MB) is already
+L2-resident; packing it optimizes the wrong operand. The 2955×2955 root is
+**DST-bandwidth-bound**: right-looking blocked factorization streams the ~70 MB
+trailing block once per rank-`bs` panel (~46 passes at `bs=64`), so total DST
+traffic ≈ Σ trailing-sizes ≫ panel size. The lever is reducing DST passes:
+
+- **Phase C — cache-blocked / recursive dense-root** (`nrow==ncol && ncol large`,
+  e.g. the 2955² front): factor in cache-sized tiles so a trailing tile is
+  reused across many panels before eviction — O(n³/√cache) bandwidth instead of
+  O(n³). Bit-exact (same arithmetic, reordered blocking). This is the real,
+  durable win and the correct next build.
+- **Larger panel width** (`bs` 64 → 96/128, capped by `MAX_N_ELIM=128`): more
+  flops per DST stream, fewer passes. Cheaper to try; bounded by the panel
+  factorization cost and 2×2-pivot handling. Worth a quick A/B before Phase C.
+- **FMA-on-large**: still +23%, but a reproducibility-policy change (opt-in),
+  not bit-exact — separate decision.
+
+Source-side packing (B-1a/B-1b as originally scoped) is off the table.

--- a/dev/research/issue-91-dense-kernel-profile-2026-06-30.md
+++ b/dev/research/issue-91-dense-kernel-profile-2026-06-30.md
@@ -1,0 +1,89 @@
+# issue #91 follow-up — dense-kernel profile of the fixed qap15 factor — 2026-06-30
+
+After the `OrderingPreprocess::Auto` fix (PR #92), qap15's residual gap to
+faer is **entirely dense-kernel throughput**. Evidence: post-fix feral stores
+*fewer* nonzeros than faer (9.25M vs 13.4M) yet is ~3× slower — so it is
+per-flop MFLOP/s, not fill.
+
+## Profile (sequential driver, `examples/profile_qap15.rs`, release)
+
+Per-supernode profiler (`NumericParams::profiler`), `with_parallel(false)`:
+
+```
+fma=false  loop=1747 ms   n_supernodes=13352   nnz_L=9,247,544
+  front-size (nrow)  count   sum_ms   %loop
+    <=8             11716     48.9     2.8
+    9-16             1579     33.5     1.9
+    33-64              21      8.6     0.5
+    >128               36   1656.0    94.8      <-- dominates
+  top fronts (nrow x ncol -> ms):
+    2955 x 2955  -> 736.6 ms  (42.2% of loop)   <-- the root front
+    3313 x 108   -> 107.0 ms  ( 6.1%)
+    3205 x 115   -> 106.8 ms  ( 6.1%)
+    3090 x 108   ->  91.7 ms  ( 5.2%)
+    3059 x 49    ->  48.0 ms  ( 2.7%)
+    ... (tall-skinny 3000 x {16..115} tail)
+fma=true   loop=1341 ms  (-23%);  2955x2955 root 736 -> 499 ms (-32%)
+```
+
+## Reading
+
+- **The >128 bucket is 94.8 % of the loop; 36 fronts.** Everything ≤128 is
+  ~5 %. Optimize the large fronts or nothing.
+- **One 2955×2955 near-square root front is 42 % of the loop.** This is the
+  assignment-structure Schur complement — a large dense LDLᵀ. It is the single
+  highest-value target (Phase C "cache-blocked dense root" in
+  `dev/plans/dense-kernel-blas3.md`).
+- The rest of the >128 mass is tall-skinny fronts (nrow≈3000, ncol≈16–115):
+  trailing-update-bound, the Phase B-1 DSYRK target.
+- **FMA alone = 23 % overall / 32 % on the root**, with identical inertia
+  `(+22275,−28605,0)` and identical `nnz_L` — but it changes bit patterns and
+  was deliberately kept opt-in (pivot-classification drift on 4 small-front KKTs,
+  `dev/tried-and-rejected.md` 2026-04-14). So FMA is *not* the correctness-safe
+  lever.
+
+## Throughput math
+
+2955×2955 LDLᵀ ≈ 2955³/3 ≈ 8.6 GFLOP. At 736 ms (nofma) that is ~11.7 GFLOP/s;
+499 ms (fma) ~17 GFLOP/s. A register-tiled, packed f64 kernel on this core
+(Apple M-series NEON, 2 FMA pipes × 2 lanes × ~3.5 GHz ≈ 28 GFLOP/s peak with
+FMA, ~14 without) should reach ~2–3× the nofma rate. So the bit-exact (no-FMA)
+ceiling is ~25–30 GFLOP/s ⇒ the 2955² root ~300 ms, and the whole loop toward
+faer's range — without touching rounding.
+
+## Current kernel state
+
+The trailing update (`apply_schur_panel_range`, `src/dense/factor.rs:3239`)
+already tiles NR=4 columns (`schur_panel_minus_nofma_strided_quad`) with 4-way
+row-SIMD and q-inner accumulation — an ~8×4 register tile. What it lacks vs a
+real BLAS-3 kernel:
+
+1. **No panel packing.** The n_elim eliminated columns are re-read *strided*
+   from `head` (column stride = nrow ≈ 2955) for every trailing column-group,
+   thrashing cache/TLB on the big fronts. The panel is reused across all
+   trailing column-groups, so packing it once into a contiguous buffer is a
+   bit-exact (values/order unchanged) cache win — the classic GEMM pack.
+2. **No dedicated dense-root path.** The 2955² root runs the generic
+   tall-front blocked path; a square-root path (Phase C) can block both
+   dimensions.
+
+## Plan (bit-exact, correctness-first — no rounding change)
+
+Priority order, each byte-identical to the current `_nofma` output (parity
+oracle = existing strided kernel + scalar reference):
+
+- **B-1a — pack the L panel** into a contiguous `[n_elim × trailing]` scratch
+  buffer once per panel; kernels read unit-stride from it. Bit-exact; targets
+  the cache/TLB bottleneck. Bounded change, own parity test.
+- **B-1b — widen/schedule the packed microkernel** (larger MR×NR with more
+  independent accumulators) now that reads are contiguous.
+- **C — cache-blocked dense-root** path for `nrow==ncol && ncol>=256` (the
+  2955² root), blocking both dimensions over the packed kernel.
+
+FMA-on-large is left as a separate, opt-in-gated lever (23 %) because it changes
+bit patterns and the project keeps `nofma` the default; the bit-exact packed
+kernel is preferred as the durable, inertia-safe win.
+
+Harness: `examples/profile_qap15.rs` (per-front buckets + top fronts, nofma vs
+fma). Note the numbers above are the *sequential* driver (~1.75 s); the parallel
+default factor is ~0.67–0.77 s, but the per-front *attribution* is what matters.

--- a/dev/research/issue-91-parallel-dense-front-2026-06-30.md
+++ b/dev/research/issue-91-parallel-dense-front-2026-06-30.md
@@ -145,3 +145,40 @@ proven bit-exact vs the scalar reference). Benchmark on qap15 + corpus.
 `examples/bench_qap15.rs` (configs incl. block-size A/B), `examples/profile_qap15.rs`
 (per-front buckets, nofma vs fma). Fixture `tests/data/large/qap15_kkt.mtx`
 (gitignored; `dev/scripts/regen_qap15_kkt.sh`).
+
+## Update — Lever A premise REFUTED by direct measurement (step 1)
+
+Instrumented the aggregate phase split via the existing `phase_timing` counters
+(`examples/profile_qap15.rs::phase_split`, sequential factor):
+
+```
+panelfactor :    41.0 ms   (2%)   serial — the supposed look-ahead target
+scalartail  :    28.3 ms   (1.5%) serial — ramp-down
+schur       :  1426.0 ms   (75%)  parallelizable trailing update
+assembly    :   194.3 ms   (10%)  serial multifrontal scatter + extend-add
+serial fraction ≈ 0.25  → Amdahl ceiling ~3.1× on 10 cores
+```
+
+**The serial Bunch–Kaufman panel factorization is only 41 ms (2%).** Lever A
+(look-ahead to overlap it) would hide ~nothing — the premise ("serial panel
+factor is the Amdahl cap") is wrong. Do NOT build look-ahead. This is why step 1
+existed; the earlier ~0.41 Amdahl inference conflated the whole factor and
+mis-attributed the cause.
+
+Corrected diagnosis: the trailing update (schur, 75%) is *already* parallel but
+scales only ~4.7× on 10 cores (measured 2.06× overall < the 3.1× ceiling ⇒ schur
+itself is sub-linear). Revised levers, all **byte-exact** (no numerics/policy
+change):
+
+- **B (now primary) — trailing-update parallel efficiency.** Attack the ~4.7×:
+  (i) load imbalance on the triangular trailing block (equal-width column chunks
+  give the first chunk ~2× the last — use finer chunks / 2-D tiles + work
+  stealing); (ii) ramp-down — trailing blocks below `INTRAFRONT_MIN_AREA=256²`
+  run serial (measure how much of schur that is; lower the floor / parallelize
+  the panel's L21 solve); (iii) per-front fork-join overhead across ~13k fronts.
+- **Assembly parallelism** — the 194 ms (10%) serial scatter + extend-add.
+- **C — per-core kernel throughput** (FMA / wider microkernel), orthogonal.
+
+Lever D (static/SQD) still stands as the highest-ceiling path, but the cheap
+byte-exact win is now clearly Lever B (schur scaling), not A. Next: instrument
+schur's parallel-vs-serial (ramp-down) split to target B precisely.

--- a/dev/research/issue-91-parallel-dense-front-2026-06-30.md
+++ b/dev/research/issue-91-parallel-dense-front-2026-06-30.md
@@ -182,3 +182,14 @@ change):
 Lever D (static/SQD) still stands as the highest-ceiling path, but the cheap
 byte-exact win is now clearly Lever B (schur scaling), not A. Next: instrument
 schur's parallel-vs-serial (ramp-down) split to target B precisely.
+
+## Update — Lever B partial landed (ramp-down floor)
+
+`INTRAFRONT_MIN_AREA` 256² → 256×128 (`src/dense/factor.rs`). The original floor
+left each large front's trailing-update tail — and whole medium fronts — on the
+serial path. Halving it: **~17% end-to-end on qap15** (interleaved ~887 → ~739 ms,
+10 cores), byte-exact (parallel_parity 8/8, lib 375/0). A/B: lower (≤16384)
+regresses (fork/join on tiny fronts), higher (131072) regresses; 256×128 is the
+sweet spot. `FERAL_INTRAFRONT_MIN_AREA` env override retained for tuning.
+Remaining schur scaling, assembly parallelism, per-core FMA, and Lever D tracked
+in the follow-up issue.

--- a/dev/research/issue-91-parallel-dense-front-2026-06-30.md
+++ b/dev/research/issue-91-parallel-dense-front-2026-06-30.md
@@ -1,0 +1,147 @@
+# issue #91 — parallel dense-front factorization: diagnosis & design — 2026-06-30
+
+The residual qap15 gap to faer (after the ordering fix, PR #92) is dense-kernel
+throughput on ~36 large fronts, dominated by a 2955×2955 indefinite root
+(42% of the sequential factor loop). This note records the measured cause and
+the correctness-constrained design of the fix.
+
+## Measured scaling (the crux)
+
+qap15 factor, this machine (14 cores / 10 performance), `bench_qap15` steady ms:
+
+| threads | time | speedup | note |
+|---|---|---|---|
+| 1  | 1923 | 1.00× | |
+| 2  | 1422 | 1.35× | |
+| 4  | 1037 | 1.85× | |
+| 8  |  935 | 2.06× | flatlines 4→8 |
+| 8, `FERAL_INTRAFRONT=off` | 1845 | ≈1.0× | tree-parallelism alone ≈ useless |
+
+**Two facts.** (1) Tree-level (assembly-tree) parallelism does nothing here —
+the work is concentrated in a few big fronts, not a bushy tree. (2) Within-front
+(`intrafront`) parallelism carries everything but **tops out at ~2× on 10
+cores**. That ceiling × the nofma per-core kernel ≈ the ~3× gap to faer.
+
+**Amdahl fit.** Speedup 2.06× at 8 threads ⇒ effective serial fraction
+`f = (1/S − 1/P)/(1 − 1/P) ≈ (0.485 − 0.125)/0.875 ≈ 0.41`. **~40% of the
+parallel-mode work is effectively serial** — the exposed panel factorizations +
+ramp-down tail. No amount of better per-tile scheduling breaks a 40% serial
+floor; the fix must *overlap or remove the serial panel factorization* (Levers A
+and D). This is the single number that rules out incremental scheduling tweaks.
+
+Cheap levers already ruled out by measurement (`dev/tried-and-rejected.md`
+2026-06-30): source-panel packing (net slowdown), larger `block_size` (no
+change, capped at `MAX_N_ELIM=128`). FMA is +23–32% but a reproducibility-policy
+change.
+
+## Why intrafront scales only 2× — and the correctness constraint
+
+Current model (`apply_blocked_schur_panel`, `factor_frontal_blocked_in_place_with_scratch`):
+**fork-join per panel**. For each rank-`bs` (=64) panel of the front:
+
+1. **serial** `lblt_panel_frontal`: Bunch–Kaufman factorization of the panel —
+   dynamic 1×1/2×2 pivot search, growth tests, possible delayed pivots;
+2. **parallel** `apply_blocked_schur_panel`: rank-`n_elim` trailing update,
+   `par_chunks_mut` over trailing columns (bit-exact for any column partition —
+   each column reduces over ascending `q` on one thread);
+3. **join** (barrier) before the next panel.
+
+Three structural caps:
+
+- **Serial panel factorization (Amdahl).** For an *indefinite* KKT root this is
+  not cheap — full BK pivoting is inherently serial and heavier than an SPD
+  Cholesky panel. ~46 panels for the root, each a serial section with 9 idle
+  cores.
+- **No look-ahead:** panel *k+1* cannot begin until panel *k*'s entire trailing
+  update joins. The serial panel-factor is fully exposed on the critical path.
+- **Ramp-down + 1-D load imbalance:** late panels' trailing blocks fall below
+  `INTRAFRONT_MIN_AREA` (serial tail); `par_chunks_mut` uses equal-width column
+  chunks over a *triangular* trailing block (first chunks heavier).
+
+### The hard constraint: dynamic BK pivoting is not statically tileable
+
+A full 2-D tile-DAG factorization (PLASMA-style) assumes a **fixed elimination
+order**. Bunch–Kaufman reorders rows/columns *during* factorization based on
+values, and delayed pivots move work between panels — so a byte-exact tile-DAG
+of the BK factorization is **not** cleanly achievable. This is the crucial
+constraint that shapes the design: we cannot simply "tile it like faer's
+Cholesky." Two consequences:
+
+- The **trailing update** *is* statically structured once a panel's pivots are
+  fixed — it is already parallel and byte-exact. Improving *its* parallelism is
+  safe.
+- The **panel factorization** is the dynamic, serial part. It cannot be tiled,
+  but it *can* be overlapped (look-ahead) and it *can* be made cheaper
+  (static/SQD pivoting — see "Orthogonal lever").
+
+## Design — byte-exact, correctness-first, staged
+
+### Lever A — look-ahead pipelining (primary; byte-exact, no numerics change)
+
+Overlap the serial panel factorization with the parallel trailing update, the
+standard fix for exactly this Amdahl cap (LAPACK `look-ahead`, faer):
+
+- After factoring panel *k*, split its trailing update into (i) the **next
+  panel's block-column** (rows for columns `k+bs .. k+2bs`) and (ii) the **rest**
+  of the trailing block.
+- Apply (i) first, then immediately start factoring panel *k+1* **while (ii)
+  runs in parallel** on the remaining cores.
+- Byte-exact: each trailing column still accumulates panel contributions in
+  ascending panel/`q` order; look-ahead only reorders *independent* work
+  (panel *k+1*'s factor depends only on region (i), which is completed first).
+  Inertia and cross-arch bit-identity are preserved — the same invariant that
+  already licenses `par_chunks_mut`.
+- Interaction with delayed pivots: a delayed pivot from panel *k* defers a
+  column into panel *k+1*; look-ahead must apply region (i) *including* any
+  deferred columns before starting *k+1*. Handle by making the look-ahead
+  block-column the exact input `lblt_panel_frontal` reads.
+
+Expected: removes the serial-panel critical path → scaling from ~2× toward core
+count on the big fronts.
+
+### Lever B — 2-D trailing-update tiling + work-stealing (load balance)
+
+Replace equal-width column chunks with 2-D tiles (e.g. 256×256) fed to rayon so
+work-stealing balances the triangular front and the ramp-down. Byte-exact
+(per-element order unchanged). Cheaper than A; do first as an independent A/B.
+
+### Lever C — register-tiled bit-exact microkernel + opt-in FMA-on-large
+
+Per-core throughput: a wider register tile (more independent accumulators) for
+the per-tile nofma kernel, plus an opt-in FMA policy gated to large fronts (the
+measured +23–32%, keeping the 4 small-front pivot-drift KKTs on nofma). FMA is a
+reproducibility-policy decision, tracked separately.
+
+### Orthogonal lever D — static/SQD pivoting for large well-regularized fronts
+
+The deepest lever: factor large quasi-definite fronts with **static signed
+pivoting** (Vanderbei/SQD) + static-pivot perturbation for tiny (1e-10)
+regularization pivots, instead of dynamic BK. This (i) removes the serial BK
+search entirely (uncapping Lever A), and (ii) makes the front statically
+tileable (enabling a true tile-DAG). Cost: it perturbs, so inertia is of `A+Δ`
+and needs iterative refinement — a numerics/policy change the maintainer must
+accept. The existing `with_sqd_mode` trips `SqdContractViolated` on qap15's
+1e-10 pivots; pairing it with `static_pivot_threshold` (issue #38) is the route.
+Highest ceiling, highest risk — sequence after A/B/C prove out.
+
+## Implementation plan (each stage: byte-exact parity + corpus inertia gate)
+
+Parity oracle throughout = the current serial/`par_chunks_mut` path (itself
+proven bit-exact vs the scalar reference). Benchmark on qap15 + corpus.
+
+1. **Measure the serial fraction** — instrument the blocked factor to split
+   per-front time into panel-factor vs trailing-update. Confirms A is the lever
+   (expected: panel-factor is the exposed serial critical path on the root).
+2. **Lever B** (2-D tiling / work-stealing) — smaller, independent, byte-exact.
+   A/B on qap15.
+3. **Lever A** (look-ahead) — the primary scaling fix. Byte-exact; handle
+   delayed pivots in the look-ahead block-column.
+4. **Lever C** (microkernel width; opt-in FMA-on-large as a separate PR).
+5. **Lever D** (static/SQD large-front path) — only if A–C leave a gap and the
+   perturbation/refinement policy is accepted.
+
+## Harnesses
+
+`examples/bench_qap15.rs` (configs incl. block-size A/B), `examples/profile_qap15.rs`
+(per-front buckets, nofma vs fma). Fixture `tests/data/large/qap15_kkt.mtx`
+(gitignored; `dev/scripts/regen_qap15_kkt.sh`).

--- a/dev/research/issue-91-preprocess-misfire.md
+++ b/dev/research/issue-91-preprocess-misfire.md
@@ -1,0 +1,93 @@
+# issue #91 — `OrderingPreprocess::Auto` mis-fires LdltCompress on conic KKTs — 2026-06-30
+
+## Symptom
+
+feral factorizes the qap15 conic KKT (n=50880, nnz=168105, a quadratic-
+assignment LP-relaxation KKT from pounce-convex) in **~15 s** vs faer's
+**~0.22 s**. Reported as a "catastrophic slowdown" attributable to ordering
+fill and dense-kernel throughput.
+
+## Diagnosis (measured on the real matrix)
+
+Reproduced the exact matrix via pounce-convex + `POUNCE_DBG_KKT_DUMP`
+(matches issue dims byte-for-byte). Symbolic fill (`col_counts` sum,
+amalgamation-independent), via `examples/bench_qap15.rs`:
+
+| ordering | preprocessing | simplicial nnz_L |
+|---|---|---|
+| AMD | `Auto` (default) | **45,376,046** |
+| AMD | `None`           |  **7,155,773** |
+| AMF | `None`           |    7,644,543 |
+| MetisND | `None`        |   19,052,431 |
+| faer AMD (issue) | —    |   13,370,955 |
+
+Numeric factor: default (Auto) **15.4 s / nnz_L 40.9M**; `preprocess=None`
+**0.77 s / nnz_L 9.25M** (20×); +FMA **0.67 s**. Inertia
+`(+22275,−28605,0)` in every case — correct, no cascade, no delayed-pivot
+inflation.
+
+**feral's AMD ordering is excellent (7.16M, beats faer's 13.4M).** The
+entire blowup is `OrderingPreprocess::Auto`. Its predicate
+`pick_ordering_preprocess` (src/symbolic/mod.rs:485) fires `LdltCompress`
+when ≥30 % of columns have ≤2 nonzeros. A regularized quasi-definite IPM
+KKT is saturated with degree-≤2 columns (the diagonal regularization rows:
+the F block here is 22275 columns of ~1e-10 diagonal), so the structural
+proxy fires **exactly** where MC64 symmetric-matching compression destroys
+the elimination order: 7.16M → 45.4M (6.3×).
+
+Refuted along the way: delayed pivots (nnz_L identical across pivot
+strategies), amalgamation padding (nemin 1 vs 16 → identical simplicial
+fill), AMD quality (None beats faer), SQD need (orthogonal; and the
+existing SQD mode trips `SqdContractViolated` at col 0 on the 1e-10 pivot).
+
+## Fix — verify, don't predict
+
+The structural predicate is a one-way proxy; it cannot know whether
+compression actually reduces fill. Make `OrderingPreprocess::Auto` a
+**fill-verified race**, mirroring the existing `OrderingMethod::AutoRace`:
+
+- When the predicate declines (`None`), keep `None` — it is the baseline;
+  no compression cost incurred, no regression possible.
+- When the predicate recommends `LdltCompress`, run the symbolic pipeline
+  **both** ways (None and LdltCompress) and **keep LdltCompress unless it
+  inflates `factor_nnz_estimate` past a catastrophe ceiling** (2× the None
+  baseline, `PREPROCESS_FILL_INFLATION_LIMIT`). A modest fill increase
+  keeps LdltCompress; only a runaway inflation falls back to None.
+
+The asymmetric, generous threshold is deliberate, and an early "do no
+fill harm" version (keep LdltCompress only on ties/improvements) was
+**rejected** — it regressed inertia on near-singular corpus KKTs:
+
+| matrix | None est | LdltCompress est | ratio | inertia under LdltCompress |
+|---|---|---|---|---|
+| qap15    | 8.59M | 54.45M | 6.34× | catastrophic blowup |
+| twirism1 | 26683 |  30782 | 1.15× | (432,313,0) — oracle-correct |
+| sawpath  |  7548 |   7557 | 1.00× | (789,670,116) — oracle-correct |
+
+twirism1 is the key counterexample: LdltCompress costs +15 % fill but its
+MC64-matched 2×2 pivots produce the **oracle-correct** inertia, while the
+slightly-leaner `None` ordering misclassifies two near-zero pivots
+(434,311,0). Pure fill-racing would wrongly discard that benefit and
+break the `issue65_mc64_fallback` inertia gate. The 2× ceiling sits well
+above the normal ~1.1–1.2× compression overhead (keeps twirism1/sawpath)
+and well below qap15's 6.3× (catches the misfire). Validated by the full
+corpus suite (no inertia regression) plus the issue-#80 arrow-KKT
+profiler test (a fill tie → LdltCompress retained). The extra symbolic
+pipeline only runs when LdltCompress was going to be applied anyway, and
+its MC64 matching (the dominant cost) runs regardless.
+
+Profiler handling mirrors `symbolic_factorize_race`: each candidate gets a
+fresh profiler; the winner's is copied into the caller's shared one.
+
+## Residual
+
+After the fix feral is ~0.67–0.77 s vs faer ~0.22 s (~3×). The remainder is
+dense-kernel throughput on large supernodes (FMA-on-large → BLAS-3 GEMM,
+`dev/plans/dense-kernel-blas3.md`) — the real, durable kernel work, now the
+only remaining lever rather than buried under a 20× heuristic bug.
+
+## Regression fixture
+
+`tests/data/large/qap15_kkt.mtx` (the reproduced matrix). Test asserts
+`Auto` simplicial fill ≤ `None` fill and that `Auto` resolves below the
+old 45.4M on this pattern.

--- a/dev/research/issue-99-dense-front-fma-gate.md
+++ b/dev/research/issue-99-dense-front-fma-gate.md
@@ -1,4 +1,61 @@
-# Issue #99 — dense-front throughput: per-front FMA size gate (Lever 3)
+# Issue #99 — dense-front throughput: shape-aware intra-front gate (Lever 1) + FMA row gate (Lever 3)
+
+## UPDATE 2 (2026-07-01, session -03 cont.) — PR #92 merged, and the real win found
+
+The maintainer authorized (a) merging PR #92's ordering fix + qap15 harness onto
+this branch and (b) breaking the bit-exactness/inertia rules to see what is
+possible. Both done. The headline result is **not** FMA — it is a **byte-exact**
+intra-front parallelism fix (issue #99 Lever 1), found by profiling.
+
+**Fixture:** the real qap15 KKT still cannot be regenerated (its generator needs
+POUNCE + highspy + qap15.mps, absent here). So `dev/scripts/gen_synth_kkt.py`
+synthesizes an *arrowhead* stand-in — a dense `K`-node border (the root front)
+plus `L` degree-2 leaf columns (the LdltCompress signature) — runnable end-to-end
+through `examples/bench_qap15`. Default `K=2000, L=30000` ⇒ 32000×32000, 2.06M nnz.
+
+**The profile (`profile_qap15`) exposed the real bottleneck.** The dense border
+does **not** factor as one 2000-wide front; the leaves break supernode
+amalgamation so it becomes **~117 tall-thin fronts of `2000 × 16`** carrying
+99.9 % of the schur loop. Both size gates key on *area*:
+
+- the **FMA gate** was `nrow * ncol >= 65536`; `2000 * 16 = 32000` — never fired.
+- the **intra-front parallel gate** is `(nrow-j_start) * n_elim >= 32768`;
+  `1984 * 16 = 31744` — **just under**, so intra-front parallelism **never fired**
+  and the dominant fronts ran serially even on the parallel driver.
+
+Area is the wrong metric for tall-thin fronts: their parallelizable work is
+`~n_elim * trailing_cols²`, large despite small area. Two fixes:
+
+1. **Lever 1 (byte-exact) — shape-aware intra-front gate.** Fire intra-front
+   parallelism when a front is wide enough to split (`trailing_cols >=
+   INTRAFRONT_TALL_MIN_COLS = 512`) AND deep enough to amortize the fork
+   (`n_elim >= INTRAFRONT_TALL_MIN_ELIM = 8`), **OR-ed** with the existing area
+   gate so no already-parallel front regresses. Pure scheduling ⇒ byte-exact
+   (each trailing column still reduced on one thread; `parallel_parity` holds).
+2. **Lever 3 (opt-in) — FMA gate keyed on `nrow`, not area.** Renamed
+   `fma_min_front_area` → `fma_min_front_rows`; fire FMA when `nrow >= t`. Catches
+   the tall fronts an area gate misses.
+
+**Measured end-to-end on the synthetic KKT (32000², 2000×16 fronts, 4-core x86_64,
+`bench_qap15` steady):**
+
+| config | ms | vs orig default | correctness |
+|---|---:|---:|---|
+| original default (area gates, pre-fix) | ~9247 | 1.00× | byte-exact |
+| **+ shape-aware intra-front (Lever 1)** | **3457** | **2.68×** | **byte-exact** |
+| **+ FMA (Lever 3, opt-in)** | **2347** | **3.94×** | opt-in (inertia identical) |
+
+Inertia `(+30000, −2000, 0)` identical across every config. Confirmed the
+diagnosis with a pure-scheduling env override (`FERAL_INTRAFRONT_MIN_AREA=16384`:
+9247 → 4354 ms byte-exact) before writing the shape-aware gate (which does better,
+3457 ms, without globally lowering the floor). `with_fma_large_fronts(256)` matches
+global FMA end-to-end (2350 vs 2347 ms), proving the row gate fires.
+
+**Takeaway:** the largest lever on this workload was **byte-exact** (fix the
+parallel gate's shape blindness, 2.68×), not the rule-breaking FMA (a further
+1.47× on top). The area→shape metric bug affected *both* gates identically.
+
+---
 
 ## Session context & discovered blockers (2026-07-01)
 

--- a/dev/research/issue-99-dense-front-fma-gate.md
+++ b/dev/research/issue-99-dense-front-fma-gate.md
@@ -32,13 +32,36 @@ reduced over ascending `q` with the identical `mul → sub` (nofma) / `mul_add`
 | dense 2955 front, nofma serial | 25586 ms | 3202 ms | **8.0×** (0.34→2.69 GFLOP/s) | inertia identical |
 | synth qap15 stand-in end-to-end (+ intra-front) | 3379 ms | 2029 ms | **1.67×** on top | inertia identical |
 
-**Scope / limit.** The packed path is reached only for **all-1×1-pivot panels**
-(the W-2 fast path in `apply_blocked_schur`). Panels with a 2×2 pivot fall to the
-un-packed `axpy2` fallback — so *strongly indefinite* fronts (and, notably, the
-`fma` path, whose rounding drifts more pivots to 2×2) see less benefit. Definite,
-quasi-definite (SQD/regularized KKT), and SPD fronts — a large and important
-class, including the synthetic qap15 border — get the full win. Packing the 2×2
-fallback is **Phase B-2**, the clear next step.
+**Scope (B-1).** As shipped in B-1 the packed path was reached only for
+**all-1×1-pivot panels**; panels with a 2×2 pivot fell to the un-packed `axpy2`
+fallback. **Phase B-2 (below) lifted this** — the packed kernel now handles a
+mixed 1×1/2×2/zero-d stream byte-exactly, so strongly-indefinite fronts get the
+win too.
+
+## UPDATE 4 — Phase B-2: packed mixed 1×1/2×2/zero-d streams (byte-exact)
+
+`apply_schur_panel_range_packed` now walks the pivot stream per element: 1×1 →
+`acc -= (L[j,q]·d_q)·L[i,q]` (`mul→sub` / `mul_add`, skipping `d_q==0`); 2×2 →
+the fused `acc -= dl0·L[i,q] + dl1·L[i,q+1]` (add-then-sub nofma / two chained
+FMAs) with `dl0=d11·L[j,q]+d21·L[j,q+1]`, `dl1=d21·L[j,q]+d22·L[j,q+1]`. Byte-exact
+with `do_1x1_update`/`do_2x2_update` and the strided `axpy`/`axpy2` fallback.
+`subdiag` is threaded through the panel dispatch; `apply_blocked_schur` routes
+**every** panel through packed when enabled (strided fast-path + fallback stay
+under `FERAL_PACKED_SCHUR=0`).
+
+- Correctness: full suite **736 / 0**, incl. the indefinite/2×2 KKT parity gates
+  byte-exact with packed default; `packed_matches_scalar_reference_bit_for_bit`
+  sweeps 1×1/2×2/zero-d in both fma modes.
+- Perf: indefinite 2955 front nofma serial **25586 → 2780 ms (9.2×**, 0.34 →
+  3.09 GFLOP/s).
+- FMA note: on the degenerate ±n-diagonal `bench_dense_front` synthetic, fma is
+  ~5× slower than nofma at equal inertia — a matrix-specific BK pivoting
+  interaction (fma rounding shifts 1×1-vs-2×2 choices), not a kernel effect (both
+  packed). Not a regression. Reinforces FMA opt-in.
+
+Remaining headroom (untuned): 8×4 tile, L2 cache-blocking, explicit-SIMD (pulp)
+packed kernel, FMA-in-packed — re-tune on target hardware; and re-validate on the
+real qap15 KKT (needs POUNCE) at 10 cores.
 
 **Full byte-exact stack on the synth qap15 stand-in (32000², 4 cores):**
 `9247 → 3457 (intra-front) → 2029 ms (+packed)` = **4.56× byte-exact**, inertia

--- a/dev/research/issue-99-dense-front-fma-gate.md
+++ b/dev/research/issue-99-dense-front-fma-gate.md
@@ -1,0 +1,132 @@
+# Issue #99 — dense-front throughput: per-front FMA size gate (Lever 3)
+
+## Session context & discovered blockers (2026-07-01)
+
+Issue #99 is a **follow-up to PR #92**, but PR #92 (`issue-91-preprocess-misfire`,
+the `OrderingPreprocess::Auto` fill-verification fix that made qap15 tractable)
+is **open/unmerged**. This branch (`claude/issue-99-b9zphx`) is cut from current
+`main` (`a17fb7a`) and therefore does **not** contain:
+
+- the qap15 fixture `tests/data/large/qap15_kkt.mtx` (gitignored) or its
+  generator `dev/scripts/{gen,regen}_qap15_kkt.{py,sh}` (live only in PR #92);
+- the harnesses `examples/{profile_qap15,bench_qap15}.rs`;
+- the two research notes the issue cites for "the full diagnosis"
+  (`issue-91-parallel-dense-front-2026-06-30.md`,
+  `…-dense-kernel-profile-2026-06-30.md`) — these exist on **no** remote branch
+  (unpushed/lost work);
+- PR #92's `INTRAFRONT_MIN_AREA` recalibration (still `256*256` here).
+
+Consequence: the end-to-end qap15 number that *defines* the issue's target
+cannot be reproduced on this branch, and this container has **4 cores** (the
+issue's numbers are 10-core). So parallel-scaling levers (1 assembly, 2 schur
+scaling) cannot be validated against the issue's targets here.
+
+What **is** reproducible and measurable on this hardware is the **per-core**
+kernel-throughput lever (issue Lever 3): FMA vs nofma on a large indefinite
+front. That is the subject of this note. A self-contained stand-in harness,
+`examples/bench_dense_front.rs`, builds a synthetic indefinite front of a chosen
+size (default 2955 = the qap15 root) and factors it through the real
+blocked-panel path, timing nofma/FMA × serial/intrafront with an
+inertia-equality gate.
+
+## The lever
+
+The trailing-update kernel has two numerically-distinct SIMD paths, both already
+implemented in `src/dense/schur_kernel.rs`:
+
+- `schur_panel_minus_nofma_strided*` — explicit `mul` then `sub`, two roundings
+  per multiply-accumulate; **bit-exact** cross-arch with the scalar reference.
+  This is the production default (`BunchKaufmanParams::fma = false`).
+- `schur_panel_minus_fma_strided*` — one `mul_add` per accumulate (single
+  rounding). ~2× arithmetic throughput on x86 V3 (AVX2+FMA) and aarch64 NEON.
+  One ULP per accumulate off the nofma reference; **not** bit-exact cross-arch.
+
+FMA is opt-in and **global** today: `Solver::with_fma(true)` →
+`NumericParams::fma` → (solver.rs:966) `bk.fma` → every front uses FMA. The owner
+kept it opt-in on purpose (`dev/tried-and-rejected.md` 2026-04-14): on 4 KKT
+matrices (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851) the FMA rounding
+perturbs the Bunch-Kaufman pivot classification.
+
+## Design — additive, default-off, front-size gated
+
+Add `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`).
+When `Some(t)` **and** the front's `nrow * ncol >= t`, the dense front factor
+uses the FMA kernels **even if `bk.fma == false`**; small fronts stay nofma.
+This is exactly the issue's Lever 3 ask: "opt-in FMA-on-large-fronts gated so the
+4 small-front pivot-drift KKTs keep nofma."
+
+- **Single insertion point:** `factor_frontal_blocked_in_place_with_scratch`
+  (`src/dense/factor.rs`) — both the sequential and parallel multifrontal drivers
+  funnel every front through it. At entry, derive
+  `effective_fma = params.fma || area_ge_threshold`, and if it differs from
+  `params.fma`, shadow `params` with a local clone carrying `fma = effective_fma`.
+  Everything downstream reads `params.fma` unchanged.
+- **Plumbing mirrors `fma` exactly:** `NumericParams::fma_min_front_area`
+  (default `None`) → funnel at solver.rs alongside `bk.fma = fma` →
+  `Solver::with_fma_large_fronts(area)` setter.
+- **Default `None` ⇒ zero behavior change** anywhere. No CI/corpus regression
+  risk; the production bit-exact contract is untouched. This delivers the lever
+  as a knob with measured evidence, leaving the *default-on* policy decision
+  (which changes cross-arch bit patterns) to the owner.
+
+## Correctness
+
+- `bench_dense_front` asserts inertia is identical across nofma/FMA/serial/
+  intrafront on the synthetic root (the throughput-lever correctness gate).
+- A unit test factors one large front with `fma_min_front_area = Some(small)`
+  vs the default and asserts (a) the gate flips FMA on for a large front
+  (result matches an explicitly `fma=true` factor, bit-for-bit) and (b) a
+  below-threshold front is byte-identical to the nofma default.
+
+## RESULTS (measured on this 4-core x86_64 container)
+
+`cargo run --release --example bench_dense_front 2955 5` (n=2955 = qap15 root
+size, best of 5 reps), rayon_threads=4:
+
+| variant           | time (ms) | GFLOP/s | vs nofma-serial |
+|-------------------|----------:|--------:|----------------:|
+| nofma serial      |  25586.15 |    0.34 |           1.00× |
+| nofma intrafront  |   8631.85 |    1.00 |           2.96× |
+| **fma serial**    |  15422.96 |    0.56 |       **1.66×** |
+| **fma intrafront**|   5142.82 |    1.67 |       **4.98×** |
+
+`inertia = (+1478, −1477, 0)` — **identical across all four variants** ✓.
+
+Findings:
+
+1. **FMA is a real per-core win here: 1.66× serial** (25586 → 15423 ms), holding
+   at **1.67× inside the intrafront path** (8632 → 5143 ms). Larger than the
+   issue's cited +23–32% because this measures the *pure* front with no
+   assembly/tree overhead diluting it. Inertia is unchanged — the gate is safe on
+   a well-conditioned indefinite root. This confirms Lever 3 is worth wiring.
+2. **FMA and intrafront compose multiplicatively** → 4.98× over the nofma-serial
+   baseline on 4 cores.
+3. **The absolute ceiling is still low: 1.67 GFLOP/s.** A tuned BLAS-3 core is
+   ~50–100 GFLOP/s. feral's rank-`n_elim` panel update streams the whole trailing
+   submatrix per panel (O(1) arithmetic per byte loaded, memory-bandwidth-bound),
+   whereas faer's 2-D register-tiled GEMM gets O(n) arithmetic per byte. That
+   ~30–50× structural gap is the `dev/plans/dense-kernel-blas3.md` rewrite — a
+   multi-session effort, **not** something any single lever in this issue closes.
+   FMA-on-large is the largest *single, low-risk, contract-preserving* step
+   available on this hardware.
+
+## Scope delivered this session vs. deferred
+
+**Delivered (additive, default-off, parity-tested):** the per-front FMA size gate
++ `Solver::with_fma_large_fronts` + `bench_dense_front` harness + this note.
+`tests/issue99_fma_front_gate.rs` pins bit-identity to `fma=true` above the
+threshold, bit-identity to nofma below it, and inertia preservation.
+
+**Deferred (blocked here):**
+- **Lever 1 (adaptive `INTRAFRONT_MIN_AREA`)** — the issue requires "verify no
+  regression across the bench corpus," which needs the bench corpus + a
+  representative core count. Not validatable on this 4-core box without the
+  fixtures; a speculative retune could silently regress the tuned constant.
+- **Lever 2 (assembly parallelism)** — deep, and its win is parallel-scaling,
+  unvalidatable against the issue's 10-core target here.
+- **Default-on FMA-large / Lever 4 (static-SQD)** — cross-arch bit-pattern /
+  inertia-perturbation policy calls the owner deliberately deferred (see the
+  interactive question that the harness failed to deliver). The gate is left
+  **opt-in**; flipping a default is not this session's call to make.
+- **BLAS-3 2-D tiled GEMM** — the only path to faer-class GFLOP/s; tracked by
+  `dev/plans/dense-kernel-blas3.md`.

--- a/dev/research/issue-99-dense-front-fma-gate.md
+++ b/dev/research/issue-99-dense-front-fma-gate.md
@@ -1,3 +1,57 @@
+# Issue #99 — dense-front throughput: packed BLAS-3 kernel + shape-aware intra-front + FMA gate
+
+## UPDATE 3 (2026-07-01) — packed BLAS-3 trailing update: byte-exact ~8–10× on dense fronts
+
+The maintainer asked to take on the BLAS-3 GEMM as a dedicated follow-up. The
+result is a **byte-exact** win, bigger than expected.
+
+**Diagnosis.** A full dense-front profile attributes ~94 % of factor time to the
+trailing Schur update, yet it measured only **0.33–0.39 GFLOP/s** — ~10× below
+even scalar peak, on a CPU with AVX2/AVX-512/FMA. An isolated kernel microbench
+(`examples/bench_schur_micro`) pinned the cause: the production strided kernels
+re-read the eliminated panel at **column-stride `nrow` every `q`**, so the inner
+rank-`n_elim` loop touches `n_elim` cache lines spread across memory — cache
+latency, not compute or DST bandwidth. (The 2026-06-30 "DST-bandwidth-bound"
+conclusion, reached from a *source-panel-pack-into-same-strided-kernel* variant,
+does not hold for a proper packed micro-kernel on this hardware.)
+
+**Fix.** A packed, register-tiled (`MR=8 × NR=4`) trailing update
+(`apply_schur_panel_range_packed`): pack the panel into `q`-contiguous MR/NR
+micro-panels so the inner `q` loop is L1-resident, then a plain register-tiled
+kernel the compiler autovectorizes. **Byte-exact** — each `A[i,j]` (i≥j) is still
+reduced over ascending `q` with the identical `mul → sub` (nofma) / `mul_add`
+(fma); packing changes only memory layout, not arithmetic order. Default on;
+`FERAL_PACKED_SCHUR=0` restores the strided path.
+
+**Measured (4-core x86_64):**
+
+| case | strided | packed | speedup | correctness |
+|---|---:|---:|---:|---|
+| isolated kernel `bench_schur_micro` (any size) | 0.38 GFLOP/s | 9–10.5 GFLOP/s | **22–26×** | byte-exact ✓ |
+| dense 1500 front, schur phase | 3165 ms | 309 ms | **10.2×** | byte-exact |
+| dense 2955 front, nofma serial | 25586 ms | 3202 ms | **8.0×** (0.34→2.69 GFLOP/s) | inertia identical |
+| synth qap15 stand-in end-to-end (+ intra-front) | 3379 ms | 2029 ms | **1.67×** on top | inertia identical |
+
+**Scope / limit.** The packed path is reached only for **all-1×1-pivot panels**
+(the W-2 fast path in `apply_blocked_schur`). Panels with a 2×2 pivot fall to the
+un-packed `axpy2` fallback — so *strongly indefinite* fronts (and, notably, the
+`fma` path, whose rounding drifts more pivots to 2×2) see less benefit. Definite,
+quasi-definite (SQD/regularized KKT), and SPD fronts — a large and important
+class, including the synthetic qap15 border — get the full win. Packing the 2×2
+fallback is **Phase B-2**, the clear next step.
+
+**Full byte-exact stack on the synth qap15 stand-in (32000², 4 cores):**
+`9247 → 3457 (intra-front) → 2029 ms (+packed)` = **4.56× byte-exact**, inertia
+`(+30000,−2000,0)` unchanged; stacks further with opt-in FMA on all-1×1 fronts.
+
+Correctness gates: the byte-exact factor-parity suite (`blocked_ldlt` 21,
+`dense_ldlt` 17, `parallel_parity` 8, `parity` 8, `factor_workspace_parity` 21)
+all green with packed as default, plus a dedicated
+`packed_matches_scalar_reference_bit_for_bit` unit test (size sweep incl.
+non-multiple-of-tile and chunk-offset cases).
+
+---
+
 # Issue #99 — dense-front throughput: shape-aware intra-front gate (Lever 1) + FMA row gate (Lever 3)
 
 ## UPDATE 2 (2026-07-01, session -03 cont.) — PR #92 merged, and the real win found

--- a/dev/scripts/gen_qap15_kkt.py
+++ b/dev/scripts/gen_qap15_kkt.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Generate tests/data/large/qap15_kkt.mtx — the issue #91 regression KKT.
+
+Parses qap15.mps (Mittelmann lpopt) with HiGHS, rebuilds the LP in
+pounce.qp.solve_qp's (A,b,G,h,lb,ub) form, runs a couple of conic-IPM
+iterations with POUNCE_DBG_KKT_DUMP set so the shared linsol layer dumps
+the iteration-0 KKT, then writes it as a symmetric MatrixMarket file.
+
+Reproduces the issue #91 matrix byte-for-byte: dim=50880, nnz=168105 (a
+quasi-definite conic KKT whose diagonal regularization rows trip the
+LdltCompress preprocessing predicate). See
+`dev/research/issue-91-preprocess-misfire.md`.
+
+Requires: the `pounce` Python package, `highspy`, `scipy`, and the
+`qap15.mps.bz2` input. Override paths via the env vars below.
+"""
+import os, sys, bz2, tempfile
+import numpy as np
+import scipy.sparse as sp
+
+MPS_BZ2 = os.environ.get(
+    "QAP15_MPS",
+    os.path.expanduser("~/projects/pounce/benchmarks/lpopt/mps/qap15.mps.bz2"),
+)
+OUT = os.environ.get("OUT", "tests/data/large/qap15_kkt.mtx")
+INF = 1e20
+
+
+def read_mps_highs(path_bz2):
+    import highspy
+
+    with bz2.open(path_bz2, "rb") as f:
+        data = f.read()
+    with tempfile.NamedTemporaryFile(suffix=".mps", delete=False) as tf:
+        tf.write(data)
+        mps_path = tf.name
+    h = highspy.Highs()
+    h.setOptionValue("output_flag", False)
+    h.readModel(mps_path)
+    os.unlink(mps_path)
+    lp = h.getLp()
+    A = sp.csc_matrix(
+        (
+            np.array(lp.a_matrix_.value_, float),
+            np.array(lp.a_matrix_.index_, int),
+            np.array(lp.a_matrix_.start_, int),
+        ),
+        shape=(lp.num_row_, lp.num_col_),
+    ).tocsr()
+    return dict(
+        c=np.array(lp.col_cost_, float),
+        cl=np.array(lp.col_lower_, float),
+        cu=np.array(lp.col_upper_, float),
+        rl=np.array(lp.row_lower_, float),
+        ru=np.array(lp.row_upper_, float),
+        A=A,
+        nrow=lp.num_row_,
+    )
+
+
+def build_lp(m):
+    A, rl, ru = m["A"], m["rl"], m["ru"]
+    eq_rows, beq, leq, geq = [], [], [], []
+    for i in range(m["nrow"]):
+        lo, hi = rl[i], ru[i]
+        if lo == hi:
+            eq_rows.append(i)
+            beq.append(lo)
+        else:
+            if hi < INF:
+                leq.append((i, hi))
+            if lo > -INF:
+                geq.append((i, lo))
+    Aeq = A[eq_rows].tocsc() if eq_rows else None
+    beq = np.array(beq) if eq_rows else None
+    G, h = [], []
+    if leq:
+        G.append(A[[i for i, _ in leq]])
+        h += [v for _, v in leq]
+    if geq:
+        G.append(-A[[i for i, _ in geq]])
+        h += [-v for _, v in geq]
+    G = sp.vstack(G).tocsc() if G else None
+    h = np.array(h) if h else None
+    return Aeq, beq, G, h
+
+
+def main():
+    m = read_mps_highs(MPS_BZ2)
+    Aeq, beq, G, h = build_lp(m)
+    dump = tempfile.NamedTemporaryFile(suffix=".bin", delete=False).name
+    os.environ["POUNCE_DBG_KKT_DUMP"] = dump
+    os.environ["POUNCE_DBG_KKT_DUMP_SKIP"] = "0"
+    from pounce.qp import solve_qp
+
+    solve_qp(P=None, c=m["c"], A=Aeq, b=beq, G=G, h=h, lb=m["cl"], ub=m["cu"], max_iter=2)
+    if not os.path.exists(dump):
+        sys.exit("no KKT dump produced — is this pounce build linsol-dump-capable?")
+
+    with open(dump, "rb") as f:
+        dim, nnz, _ = (int(x) for x in np.frombuffer(f.read(24), dtype="<u8"))
+        airn = np.frombuffer(f.read(8 * nnz), dtype="<i8")  # 1-based lower triangle
+        ajcn = np.frombuffer(f.read(8 * nnz), dtype="<i8")
+        vals = np.frombuffer(f.read(8 * nnz), dtype="<f8")
+    os.unlink(dump)
+
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as o:
+        o.write("%%MatrixMarket matrix coordinate real symmetric\n")
+        o.write(f"{dim} {dim} {nnz}\n")
+        o.writelines(
+            f"{i} {j} {v:.17e}\n"
+            for i, j, v in zip(airn.tolist(), ajcn.tolist(), vals.tolist())
+        )
+    print(f"wrote {OUT}: dim={dim} nnz={nnz}")
+    assert (dim, nnz) == (50880, 168105), "qap15 KKT dims drifted from issue #91"
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/scripts/gen_synth_kkt.py
+++ b/dev/scripts/gen_synth_kkt.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Generate a synthetic arrowhead conic-KKT stand-in for the qap15 fixture.
+
+The real issue #91/#99 fixture (tests/data/large/qap15_kkt.mtx) is generated
+from POUNCE + qap15.mps and cannot be reproduced in this container. This script
+synthesizes a matrix with the same two structural features that drive the
+issue #99 dense-front story, using only the Python standard library:
+
+  1. A large *dense* border block of size `K` (default 2000) — an explicit
+     clique that AMD eliminates last as a single dense root supernode, exactly
+     like qap15's 2955x2955 indefinite root front (the dense-kernel bottleneck).
+  2. `L` degree-2 "regularization" leaf columns (default 30000) — each a
+     positive diagonal plus one off-diagonal to a random border node. With
+     L/(L+K) ~ 94% of columns at <= 2 nonzeros, this trips the LdltCompress
+     predicate (>=30% low-degree columns), exercising the issue #91
+     OrderingPreprocess::Auto fill-verification fix on the end-to-end path.
+
+Quasi-definite by construction: leaf diagonals > 0, border diagonals < 0.
+
+Writes a symmetric MatrixMarket file (lower triangle, 1-indexed). Deterministic
+(fixed seed). Env: K, L, OUT, SEED.
+"""
+import os
+import random
+
+K = int(os.environ.get("K", "2000"))       # dense border (root front size)
+L = int(os.environ.get("L", "30000"))       # degree-2 leaf columns
+OUT = os.environ.get("OUT", "tests/data/large/synth_arrow_kkt.mtx")
+SEED = int(os.environ.get("SEED", "20260701"))
+
+rng = random.Random(SEED)
+N = L + K
+border0 = L  # first border index (0-based)
+
+# Collect lower-triangle entries (i >= j), 1-indexed on write.
+# Border block: dense clique on indices [border0, N).
+#   diagonal negative & dominant; small symmetric off-diagonal noise.
+# Leaf block: indices [0, L). diagonal positive & dominant; one off-diagonal
+#   to a random border node (creates the degree-2 signature and couples the
+#   leaf into the border front).
+rows = []  # (i, j, val) with i >= j
+
+# Leaves.
+for i in range(L):
+    rows.append((i, i, 2.0 + rng.random()))          # positive diagonal
+    b = border0 + rng.randrange(K)                    # one border neighbor
+    # store lower triangle: (max, min)
+    hi, lo = (b, i) if b > i else (i, b)
+    rows.append((hi, lo, rng.uniform(-1.0, 1.0)))
+
+# Dense border clique.
+for a in range(border0, N):
+    rows.append((a, a, -(float(K) + rng.random())))  # negative diagonal
+    for b in range(border0, a):
+        rows.append((a, b, 0.01 * rng.uniform(-1.0, 1.0)))
+
+nnz = len(rows)
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+with open(OUT, "w") as f:
+    f.write("%%MatrixMarket matrix coordinate real symmetric\n")
+    f.write(f"% synthetic arrowhead conic-KKT stand-in (K={K} dense border, "
+            f"L={L} degree-2 leaves, seed={SEED})\n")
+    f.write(f"{N} {N} {nnz}\n")
+    for (i, j, v) in rows:
+        f.write(f"{i + 1} {j + 1} {v:.12g}\n")
+
+print(f"wrote {OUT}: dim={N} nnz={nnz} (border={K} dense, leaves={L} deg-2)")

--- a/dev/scripts/regen_qap15_kkt.sh
+++ b/dev/scripts/regen_qap15_kkt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Regenerate the issue #91 preprocessing-misfire fixture.
+#
+# qap15's conic-IPM iteration-0 KKT is a *generated* matrix (pounce-convex
+# on qap15.mps), not a SuiteSparse download. It is the regression fixture
+# for the `OrderingPreprocess::Auto` fill-verified race: the structural
+# predicate mistakenly recommends LdltCompress on this quasi-definite KKT,
+# inflating fill ~6x (7.16M -> 45.4M) and factor time ~20x (0.8s -> 15s).
+#
+# Produces tests/data/large/qap15_kkt.mtx (gitignored). The regression
+# test `tests/issue91_preprocess_misfire.rs` skips cleanly when it is
+# absent, so running this is optional and local-only.
+#
+# Requires the `pounce` Python package (linsol-dump-capable build),
+# `highspy`, `scipy`, and qap15.mps.bz2. Override paths via env vars.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEST="${REPO_ROOT}/tests/data/large/qap15_kkt.mtx"
+
+PYTHON="${PYTHON:-python3}"
+GEN="${REPO_ROOT}/dev/scripts/gen_qap15_kkt.py"
+QAP15_MPS="${QAP15_MPS:-${HOME}/projects/pounce/benchmarks/lpopt/mps/qap15.mps.bz2}"
+
+if [[ ! -f "${QAP15_MPS}" ]]; then
+  echo "ERROR: qap15 MPS not found at ${QAP15_MPS} (set QAP15_MPS)." >&2
+  exit 1
+fi
+
+QAP15_MPS="${QAP15_MPS}" OUT="${DEST}" "${PYTHON}" "${GEN}"
+echo "Regenerated ${DEST}"

--- a/dev/sessions/2026-06-30-01.md
+++ b/dev/sessions/2026-06-30-01.md
@@ -1,10 +1,3 @@
-# FERAL Context (auto-generated)
-
-Generated: 2026-07-01T00:01:39Z
-
-## Latest Session
-File: dev/sessions/2026-06-30-01.md
-```
 # Session 2026-06-30-01
 
 ## Goal
@@ -55,16 +48,23 @@ Standard `cargo run --bin bench --release`: see the run captured this session
 
 ## Decisions Made
 - `OrderingPreprocess::Auto` resolves by verified fill race with a 2×
-```
+  catastrophe ceiling, not structural prediction. Appended to
+  `dev/decisions.md` (2026-06-30 entry).
 
-## Git Status
-```
-f037285 release: feral v0.11.3
-a5c789f issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter (#90)
-a9cea82 issue #87: Forrest–Tomlin row-elimination LU update (O(bump²) → O(bump)) (#88)
-380459c issue #87: gate FT invariant self-check behind off-by-default feature (CI: alloc probe)
-47a3d66 issue #87: fix duplicate-column bug in FT row gather (CI: casctanks drift)
-```
+## Abandoned Approaches
+- "Smaller-fill-wins" Auto race (keep LdltCompress only on ties/improvements):
+  regressed inertia on near-singular KKTs (twirism1, sawpath) because
+  LdltCompress's MC64 2×2 pivots give the oracle-correct inertia at a modest
+  fill cost. Appended to `dev/tried-and-rejected.md`.
 
-## Test Status
-```
+## Next Session Should
+- **Dense-kernel throughput** is now the only remaining gap to faer (~0.67 s vs
+  ~0.22 s, ~3×): FMA-on-large-supernodes by default and/or the BLAS-3
+  cache-blocked GEMM trailing update (`dev/plans/dense-kernel-blas3.md`). This
+  helps every matrix with large dense fronts, not just qap15.
+- Consider whether the fixed `OrderingPreprocess::Auto` makes the standalone
+  `with_sqd_mode` / static-pivot paths redundant for conic KKTs, or whether the
+  SQD contract should tolerate tiny (1e-10) regularization pivots (it currently
+  trips `SqdContractViolated` at column 0 on qap15).
+- Land qap15 (or a family of conic KKTs) into the standard bench corpus so this
+  stays measured.

--- a/dev/sessions/2026-07-01-03.md
+++ b/dev/sessions/2026-07-01-03.md
@@ -1,0 +1,121 @@
+# Session 2026-07-01-03
+
+## Goal
+
+Issue #99: "loop over all levers until faer-level performance" on the dense-front
+factorization throughput gap (~3.5× to faer on the qap15 conic KKT, dominated by
+a 2955×2955 indefinite root).
+
+## Reality check (reported up-front, per protocol)
+
+The issue's premises are **not reproducible on this branch**, and I established
+this before writing code:
+
+- **PR #92 is open/unmerged.** It (issue #91) contains the `OrderingPreprocess::Auto`
+  fill-verification fix that made qap15 tractable *and* the qap15 fixture
+  generator + `bench_qap15` harness. This branch is cut from current `main` and
+  lacks all of it — `INTRAFRONT_MIN_AREA` is still `256*256`, not #92's `256*128`.
+- **The qap15 fixture, its generator, `examples/{profile,bench}_qap15.rs`, and the
+  two research notes the issue cites for "the full diagnosis" exist on no remote
+  branch** (unpushed/lost work). The end-to-end qap15 number that defines the
+  target cannot be reproduced here.
+- **This container has 4 cores; the issue's numbers are 10-core.** The
+  parallel-scaling levers (1 assembly, 2 schur scaling) cannot be validated
+  against the issue's targets here.
+- The issue itself states **no byte-exact lever closes 3.5×**; faer-class needs a
+  policy decision (default-on FMA / static-SQD) the owner deliberately deferred.
+
+I attempted to ask the owner the fixture-strategy and policy questions via
+`AskUserQuestion`; the harness failed to deliver it (permission-stream error).
+Told to continue, I proceeded autonomously with the **defensible subset**:
+additive, default-off, byte-exact-preserving, measurable-here work only — no
+unilateral default flips, no unvalidatable parallel retunes.
+
+## Accomplished
+
+**Issue #99 Lever 3 (per-core kernel throughput) — delivered as an opt-in knob.**
+
+- New `examples/bench_dense_front.rs`: self-contained synthetic indefinite front
+  (no external fixture), factored through the real `factor_frontal_blocked` path,
+  timing nofma/FMA × serial/intrafront with an inertia-equality gate. Fills the
+  measurement-harness hole the issue's (missing) `bench_qap15` left.
+- New `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) +
+  `effective_front_fma(params, nrow, ncol)` helper. Gated at the single dense
+  front-factor entry `factor_frontal_blocked_in_place_with_scratch` by shadowing
+  `params` with an fma-flipped clone **only when the gate fires** (unarmed path
+  pays nothing). Both multifrontal drivers funnel through this entry, so one
+  insertion covers all.
+- New `Solver::with_fma_large_fronts(min_area)` — writes straight to
+  `numeric_params.bk` (no `NumericParams` field / funnel needed; low churn).
+- `None` default ⇒ strict no-op: the production cross-arch bit-exact contract is
+  untouched. Enabling changes bit patterns only on the gated large fronts.
+
+### Evidence
+
+- `bench_dense_front 2955 5` (4-core x86_64), best of 5:
+
+  | variant          | ms      | GFLOP/s | vs nofma-serial |
+  |------------------|--------:|--------:|----------------:|
+  | nofma serial     | 25586   | 0.34    | 1.00×           |
+  | nofma intrafront | 8632    | 1.00    | 2.96×           |
+  | fma serial       | 15423   | 0.56    | **1.66×**       |
+  | fma intrafront   | 5143    | 1.67    | **4.98×**       |
+
+  Inertia `(+1478, −1477, 0)` **identical across all four** — the throughput-lever
+  correctness gate holds. FMA and intrafront compose multiplicatively.
+- `tests/issue99_fma_front_gate.rs` (4 tests, all pass): gate ≥ threshold is
+  bit-identical to `fma=true`; below threshold bit-identical to nofma default;
+  inertia preserved; threshold is exactly `nrow*ncol` with `>=` semantics.
+- **Full suite: 734 passed, 0 failed.** `cargo fmt --check` + `cargo clippy
+  --all-targets -- -D warnings` clean. `bench --release`: no failures (default
+  path byte-for-byte unchanged).
+
+## Benchmark Results
+
+```
+cargo run --bin bench --release  →  Sparse failure analysis: no failures
+Dense ∩ Sparse failure overlap: 0 / 0 / 0
+(no oracle timings loaded in this environment; perf partitions N/A)
+Default path unchanged (gate defaults None) → residual gate identical to the
+2026-07-01-02 baseline (2/2, worst residual 1.26e-16).
+
+examples/bench_dense_front 2955 5 (the new issue-99 harness):
+  nofma serial     25586.15 ms  0.34 GFLOP/s  1.00×
+  nofma intrafront  8631.85 ms  1.00 GFLOP/s  2.96×
+  fma   serial     15422.96 ms  0.56 GFLOP/s  1.66×
+  fma   intrafront  5142.82 ms  1.67 GFLOP/s  4.98×
+  inertia (+1478,−1477,0) identical across all four variants ✓
+```
+
+## Decisions Made
+
+- Opt-in per-front FMA size gate on `BunchKaufmanParams`, default `None`, set via
+  `Solver::with_fma_large_fronts`. Full rationale in `dev/decisions.md`
+  (2026-07-01) and `dev/research/issue-99-dense-front-fma-gate.md`.
+
+## Abandoned Approaches
+
+- Mirroring the `fma` plumbing with a **separate `NumericParams::fma_min_front_area`
+  field + solver funnel** — broke dozens of fully-enumerated `NumericParams`
+  literals across tests/examples/diagnostics. Replaced with a `BunchKaufmanParams`-
+  only field written straight into `bk` by the builder (bk is nearly always
+  `..Default::default()`, so zero churn). Not a research dead-end — a plumbing
+  choice — so not logged in tried-and-rejected.
+
+## Next Session Should
+
+1. **Merge/rebase PR #92 first** (or regenerate the qap15 fixture) so issue #99
+   can be measured end-to-end. Everything below is blocked on a runnable target
+   and a representative core count.
+2. **Owner policy call** (the question the harness dropped): (a) flip
+   FMA-on-large to default via the new gate — measured 1.66× per-core, inertia
+   identical on the tested front — accepting cross-arch bit-pattern change on
+   large fronts; and/or (b) authorize Lever 4 (static-SQD perturbation + iterative
+   refinement). Byte-exact ceiling is ~1.8× (issue's own analysis); faer-class
+   needs one of these.
+3. **Lever 1** — recalibrate/adapt `INTRAFRONT_MIN_AREA` (front-shape aware) with
+   a no-regression sweep across the *actual* bench corpus.
+4. **Lever 2** — parallelize the multifrontal assembly (the serial ~10%).
+5. **The real ceiling: 2-D tiled BLAS-3 GEMM** (`dev/plans/dense-kernel-blas3.md`)
+   — the measured 1.67 GFLOP/s vs ~50–100 for a tuned core is the structural gap;
+   no single issue-#99 lever closes it.

--- a/dev/sessions/2026-07-01-03.md
+++ b/dev/sessions/2026-07-01-03.md
@@ -196,3 +196,30 @@ Reached only for all-1×1-pivot panels; 2×2 panels (strongly indefinite fronts,
 and the fma path) use the un-packed fallback → **Phase B-2** (pack the 2×2 path)
 is the clear next step. Gotcha logged: `cargo build --release` does not rebuild
 examples — the first "packed" measurements used stale example binaries.
+
+---
+
+## UPDATE 4 — Phase B-2: packed 2×2 pivot streams (byte-exact)
+
+Extended the packed trailing update to a **mixed 1×1/2×2/zero-d pivot stream**,
+so strongly-indefinite fronts (2×2-pivot panels) get the packed win too — not
+only definite/SQD/SPD fronts. Each element walks the stream: 1×1 → `mul→sub` /
+`mul_add`; 2×2 → the fused `dl0·L_q + dl1·L_{q+1}` add-then-sub (nofma) / two
+chained FMAs (fma). Byte-exact with `do_1x1_update`/`do_2x2_update` and the
+strided `axpy`/`axpy2` fallback. `subdiag` threaded through the panel dispatch;
+`apply_blocked_schur` now routes every panel through packed (strided fast-path +
+fallback stay under `FERAL_PACKED_SCHUR=0`).
+
+- **Correctness:** full suite **736 / 0**, incl. the indefinite/2×2 KKT parity
+  gates byte-exact with packed default; `packed_matches_scalar_reference_bit_for_bit`
+  now sweeps 1×1/2×2/zero-d in both fma modes.
+- **Perf:** indefinite 2955 front nofma serial **25586 → 2780 ms (9.2×**, 0.34 →
+  3.09 GFLOP/s).
+- **FMA note:** on the degenerate ±n-diagonal `bench_dense_front` synthetic, fma
+  is ~5× slower than nofma at equal inertia — a BK pivoting interaction (fma
+  rounding shifts 1×1-vs-2×2 choices), not a kernel effect; both use packed. Not
+  a regression. Reinforces keeping FMA opt-in.
+
+**Remaining follow-ups:** tune absolute packed throughput (8×4 tile, L2
+cache-blocking, explicit-SIMD packed kernel, FMA-in-packed) on target hardware;
+and re-validate the whole stack on the real qap15 KKT (needs POUNCE) at 10 cores.

--- a/dev/sessions/2026-07-01-03.md
+++ b/dev/sessions/2026-07-01-03.md
@@ -169,3 +169,30 @@ phenomenon and the `512/8` thresholds should be re-validated on the *real* qap15
 (needs POUNCE) at 10 cores before promoting to a hard default. The remaining gap
 to faer-class per-core GFLOP/s is still the 2-D tiled BLAS-3 GEMM
 (`dev/plans/dense-kernel-blas3.md`), which no gate closes.
+
+---
+
+## UPDATE 3 — packed BLAS-3 trailing update (maintainer: "take on the GEMM")
+
+Profiling showed the dense trailing update (~94% of a dense factor) ran at only
+~0.35 GFLOP/s — ~10× below scalar peak. `examples/bench_schur_micro` isolated the
+cause: the strided per-column kernels re-read the panel at column-stride `nrow`
+every `q`, scattering cache lines. A packed, register-tiled (MR=8×NR=4) kernel
+(`apply_schur_panel_range_packed`) with a contiguous `q`-loop is **22–26× faster
+in isolation and byte-exact**, giving:
+
+| case | strided | packed | speedup |
+|---|---:|---:|---:|
+| dense-1500 schur phase | 3165 ms | 309 ms | 10.2× |
+| dense-2955 nofma serial | 25586 ms | 3202 ms | 8.0× (0.34→2.69 GFLOP/s) |
+| synth qap15 stand-in end-to-end | 3379 ms | 2029 ms | 1.67× on top of intra-front |
+
+**Full byte-exact stack** (shape-aware intra-front + packed) on the synth qap15
+stand-in: **9247 → 2029 ms = 4.56×**, inertia `(+30000,−2000,0)` unchanged.
+Suite **736 passed / 0 failed** (all byte-exact parity gates green with packed
+default) + a dedicated packed-vs-scalar unit test; clippy clean.
+
+Reached only for all-1×1-pivot panels; 2×2 panels (strongly indefinite fronts,
+and the fma path) use the un-packed fallback → **Phase B-2** (pack the 2×2 path)
+is the clear next step. Gotcha logged: `cargo build --release` does not rebuild
+examples — the first "packed" measurements used stale example binaries.

--- a/dev/sessions/2026-07-01-03.md
+++ b/dev/sessions/2026-07-01-03.md
@@ -119,3 +119,53 @@ examples/bench_dense_front 2955 5 (the new issue-99 harness):
 5. **The real ceiling: 2-D tiled BLAS-3 GEMM** (`dev/plans/dense-kernel-blas3.md`)
    — the measured 1.67 GFLOP/s vs ~50–100 for a tuned core is the structural gap;
    no single issue-#99 lever closes it.
+
+---
+
+## UPDATE 2 — PR #92 merged; byte-exact intra-front win found (maintainer: "break the rules")
+
+The maintainer asked to rebase PR #92 (qap15 ordering fix + harness) onto this
+branch and to break the bit-exactness/inertia rules to see what is possible.
+
+**Merged PR #92** (`refs/pull/92/head`; merge-base = current main, clean): the
+`OrderingPreprocess::Auto` fix, the qap15 gen/bench/profile harnesses, the
+dense-front research notes, and Lever B (`INTRAFRONT_MIN_AREA` 256² → 256×128).
+
+**The real qap15 fixture is unobtainable** (its generator needs POUNCE + highspy
++ qap15.mps). Wrote `dev/scripts/gen_synth_kkt.py` — an arrowhead stand-in (dense
+`K=2000` border = root front + `L=30000` degree-2 leaves = LdltCompress
+signature), 32000×32000, runnable end-to-end via `bench_qap15`.
+
+**Profiling found the real bottleneck (not what the issue assumed).** The dense
+border factors as **~117 tall-thin fronts of `2000 × 16`** (leaves break
+supernode amalgamation), carrying 99.9% of the schur loop. **Both** per-front
+gates key on *area* and miss this shape:
+- FMA gate `nrow*ncol` = 32000 < 65536 — never fired.
+- intra-front parallel gate `(nrow-j)*n_elim` = 31744 < 32768 — never fired, so
+  the dominant fronts ran **serially** even on the parallel driver.
+
+**Fixes + results (synthetic KKT, 32000², 4-core x86_64, `bench_qap15` steady):**
+
+| config | ms | vs orig | correctness |
+|---|---:|---:|---|
+| original default | 9247 | 1.00× | byte-exact |
+| **+ shape-aware intra-front (Lever 1)** | **3457** | **2.68×** | **byte-exact** |
+| **+ FMA (Lever 3, opt-in)** | **2347** | **3.94×** | opt-in (inertia identical) |
+
+- **Lever 1 (byte-exact):** `intrafront_tall_gate(cols≥512 && n_elim≥8)` OR-ed
+  with the area gate. Pure scheduling; `parallel_parity` (parallel==sequential
+  bit-for-bit) stays green. Confirmed first via `FERAL_INTRAFRONT_MIN_AREA=16384`
+  (9.25→4.35 s byte-exact).
+- **Lever 3:** `fma_min_front_area` → `fma_min_front_rows`, gate on `nrow≥t`
+  (fixes the same area blindness). `with_fma_large_fronts(256)` == global FMA
+  end-to-end.
+
+**The biggest lever was byte-exact**, not the rule-breaking FMA — the area metric
+was a latent scheduling bug hitting both gates. Full suite **735 passed / 0
+failed**; clippy clean; inertia `(+30000,−2000,0)` identical throughout.
+
+**Caveat / next:** the synthetic fixture is a stand-in. The tall-thin-front
+phenomenon and the `512/8` thresholds should be re-validated on the *real* qap15
+(needs POUNCE) at 10 cores before promoting to a hard default. The remaining gap
+to faer-class per-core GFLOP/s is still the 2-D tiled BLAS-3 GEMM
+(`dev/plans/dense-kernel-blas3.md`), which no gate closes.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4884,3 +4884,29 @@ inertia benefit on the +15 % cases, still catches qap15's 6.3× misfire.
 The numerical benefit of `LdltCompress` is not visible in symbolic fill, so a
 fill-only race is the wrong criterion; only a *runaway* fill increase signals a
 predicate misfire.
+
+## 2026-06-30 — B-1a panel packing for the dense trailing update (issue #91)
+
+**Tried.** Pack the eliminated panel (columns `k..k+n_elim` of `head`, column
+stride `nrow`) into a contiguous `[n_elim × span]` buffer once per
+`apply_schur_panel_range`, then feed the *same* strided kernels from it (tight
+stride `span`), gated to large fronts (`nrow>128`). Byte-exact by construction.
+
+**Rejected — net slowdown on qap15.** Byte-exact parity held (blocked_ldlt
+21/21, inertia/nnz_L unchanged) but it was *slower* everywhere: sequential
+factor loop 1747 → 1976 ms (+13%), the 2955×2955 root front 736 → 818 ms
+(+11%), parallel default 771 → 945 ms (+22%).
+
+**Why.** The root's early panels have `span ≈ nrow`, so packing does not reduce
+the K-stride — it just adds an alloc + copy. More fundamentally, profiling of
+the root shows it is **DST-bandwidth-bound, not panel-bound**: the ~70 MB
+trailing block (2955×2955 f64) is streamed ~46 times (once per rank-64 panel),
+which dwarfs the ~1.5 MB panel (already L2-resident). Packing the *source* panel
+optimizes the wrong operand.
+
+**Implication for the plan.** The effective lever is reducing DST traffic:
+cache-blocked / recursive dense-root factorization (Phase C — reuse a
+cache-sized trailing tile across many panels) or a larger panel width (more
+flops per DST stream). A source-side pack (B-1a) is off the table. FMA remains a
++23% option but is a reproducibility-policy change (kept opt-in), not a
+bit-exact win.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4858,3 +4858,29 @@ max_width=2157, avg_density=0.1346 (all bumps) / 0.0023 (width>500),
 avg_axpy=23.9, avg_merge_work=233.4. Step 1 end-to-end: casctanks LP solve
 82.4 s → 5.2 s debug (15.8×), optimum −167.751 unchanged. Journal:
 dev/journal/2026-06-18-01.org.
+
+## 2026-06-30 — Auto-preprocess "smaller-fill-wins" race (issue #91)
+
+**Tried.** For `OrderingPreprocess::Auto`, when the predicate recommends
+`LdltCompress`, race None vs LdltCompress and keep whichever has the smaller
+`factor_nnz_estimate` (ties → keep LdltCompress).
+
+**Rejected.** Regressed inertia on near-singular corpus KKTs. `LdltCompress`'s
+MC64-matched 2×2 pivots give the oracle-correct inertia on twirism1 and sawpath
+even though that ordering costs slightly more fill (twirism1 +15 %: 26683 →
+30782 est). Smaller-fill-wins flipped both to the leaner `None` ordering, which
+misclassified near-zero pivots: twirism1 (432,313,0) → (434,311,0), sawpath
+(789,670,116) → (789,671,115). `tests/issue65_mc64_fallback.rs` failed:
+`explicit_infnorm_is_respected_no_fallback` and
+`twirism1_iter0_auto_stays_infnorm_no_spurious_fallback`.
+
+**Symptom.** `assertion left == right failed ... got Inertia { positive: 789,
+negative: 671, zero: 115 }` (want 789,670,116); twirism1 got (434,311,0) (want
+432,313,0).
+
+**Replaced by.** Keep `LdltCompress` unless it inflates fill past a 2×
+catastrophe ceiling (`PREPROCESS_FILL_INFLATION_LIMIT`). Preserves the
+inertia benefit on the +15 % cases, still catches qap15's 6.3× misfire.
+The numerical benefit of `LdltCompress` is not visible in symbolic fill, so a
+fill-only race is the wrong criterion; only a *runaway* fill increase signals a
+predicate misfire.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4910,3 +4910,21 @@ cache-sized trailing tile across many panels) or a larger panel width (more
 flops per DST stream). A source-side pack (B-1a) is off the table. FMA remains a
 +23% option but is a reproducibility-policy change (kept opt-in), not a
 bit-exact win.
+
+## 2026-07-01 — UPDATE: packed micro-kernel succeeds where B-1a source-pack failed (issue #99)
+
+The 2026-06-30 "B-1a panel packing" entry above rejected source-panel packing as a
+net slowdown and concluded the root front is DST-bandwidth-bound. That conclusion
+was **specific to the variant tried** — packing the source into a tighter stride
+but *feeding the same strided kernels*, which keep the per-`q` `as_simd` + strided
+access. It does **not** generalize to a proper packed micro-kernel.
+
+A different design — pack the panel into `q`-contiguous MR=8×NR=4 micro-panels and
+run a register-tiled kernel with a **contiguous inner `q`-loop**
+(`apply_schur_panel_range_packed`) — is **22–26× faster in isolation and
+byte-exact** (`examples/bench_schur_micro`), and gives 8–10× on real dense fronts.
+So the bottleneck was strided-`q` cache latency, not DST bandwidth, on this
+hardware. Not a rejection — a correction of scope. See
+`dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
+2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
+rejected; the packed micro-kernel is the shipped design.

--- a/examples/bench_dense_front.rs
+++ b/examples/bench_dense_front.rs
@@ -1,0 +1,133 @@
+//! Single-front dense LDLᵀ micro-benchmark.
+//!
+//! Issue #99 tracks closing the dense-front throughput gap to faer on
+//! large conic-KKT roots (the qap15 root is a 2955×2955 indefinite
+//! front, 42% of the sequential factor loop). The qap15 fixture and its
+//! harnesses referenced by the issue are not present on this branch, so
+//! this example provides a *self-contained, reproducible* stand-in: it
+//! builds a synthetic indefinite front of a chosen size and factors it
+//! through the real blocked-panel path (`factor_frontal_blocked`),
+//! exercising exactly the trailing-Schur kernel (W-2 rank-`n_elim`
+//! accumulator + intra-front parallelism + optional FMA) that the issue
+//! identifies as the bottleneck.
+//!
+//! It measures the two per-core / parallel levers directly:
+//!   * nofma vs FMA kernel throughput (issue Lever 3)
+//!   * serial vs intra-front-parallel trailing update (issue Lever 1)
+//!
+//! and asserts the inertia is identical across all four variants — the
+//! correctness gate that any throughput lever must preserve.
+//!
+//! Usage:
+//!   cargo run --release --example bench_dense_front [-- N REPS]
+//! Defaults: N = 2955 (the qap15 root size), REPS = 5.
+
+use feral::dense::factor::factor_frontal_blocked;
+use feral::{BunchKaufmanParams, Inertia, SymmetricMatrix};
+use std::time::Instant;
+
+/// Deterministic SplitMix64-style PRNG so the fixture is reproducible
+/// without a `rand` dependency or the forbidden `Math.random`/`Date`.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        // SplitMix64.
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        // Map to [-1, 1).
+        (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+    }
+}
+
+/// Build a synthetic symmetric *indefinite* front that factors mostly
+/// through 1×1 pivots (so it hits the W-2 all-1×1 fast path the issue
+/// profiles). Diagonal carries alternating-sign dominant entries;
+/// off-diagonals are small deterministic noise. Column-major lower
+/// triangle, matching `SymmetricMatrix`'s storage.
+fn build_front(n: usize) -> SymmetricMatrix {
+    let mut rng = Rng(0x1234_5678_9ABC_DEF0);
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            let v = if i == j {
+                // Strong, sign-alternating diagonal → indefinite,
+                // 1×1-pivot dominated, well away from singular.
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                sign * (n as f64) + rng.next_f64()
+            } else {
+                0.30 * rng.next_f64()
+            };
+            data[j * n + i] = v;
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+fn time_variant(
+    matrix: &SymmetricMatrix,
+    fma: bool,
+    intrafront: bool,
+    reps: usize,
+) -> (f64, Inertia) {
+    let params = BunchKaufmanParams {
+        fma,
+        intrafront_parallel: intrafront,
+        ..BunchKaufmanParams::default()
+    };
+    let n = matrix.n;
+    let mut best = f64::INFINITY;
+    let mut inertia = Inertia {
+        positive: 0,
+        negative: 0,
+        zero: 0,
+    };
+    for _ in 0..reps {
+        let t = Instant::now();
+        // Root front: every column is fully summed (ncol == nrow),
+        // no delayed pivots.
+        let ff = factor_frontal_blocked(matrix, n, false, &params).expect("factor failed");
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        inertia = ff.inertia;
+        best = best.min(ms);
+    }
+    (best, inertia)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2955);
+    let reps: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let threads = rayon::current_num_threads();
+    println!("bench_dense_front: n={n} reps={reps} rayon_threads={threads}");
+    let gflop = (n as f64).powi(3) / 3.0 / 1e9; // ≈ LDLᵀ flop count
+
+    let matrix = build_front(n);
+
+    let (t_nofma_ser, i0) = time_variant(&matrix, false, false, reps);
+    let (t_nofma_par, i1) = time_variant(&matrix, false, true, reps);
+    let (t_fma_ser, i2) = time_variant(&matrix, true, false, reps);
+    let (t_fma_par, i3) = time_variant(&matrix, true, true, reps);
+
+    let report = |label: &str, ms: f64| {
+        println!(
+            "  {label:<22} {ms:8.2} ms   {:6.2} GFLOP/s   {:5.2}× vs nofma-serial",
+            gflop / (ms / 1e3),
+            t_nofma_ser / ms
+        );
+    };
+    println!("inertia (must match): {i0:?}");
+    report("nofma  serial", t_nofma_ser);
+    report("nofma  intrafront", t_nofma_par);
+    report("fma    serial", t_fma_ser);
+    report("fma    intrafront", t_fma_par);
+
+    // Correctness gate: every throughput lever must preserve inertia.
+    assert_eq!(i0, i1, "intrafront changed inertia (nofma)");
+    assert_eq!(i0, i2, "fma changed inertia");
+    assert_eq!(i0, i3, "fma+intrafront changed inertia");
+    println!("inertia identical across all four variants ✓");
+}

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -1,0 +1,251 @@
+//! Ad-hoc benchmark for the qap15 conic KKT (issue #91).
+//!
+//! Loads a symmetric MatrixMarket KKT and factors it under several
+//! Solver configurations, reporting wall time and fill. Not a
+//! committed fixture/test — a measurement harness for the issue #91
+//! diagnosis (delayed-pivot blowup on a quasi-definite conic KKT).
+//!
+//! Usage: cargo run --release --example bench_qap15 -- <path.mtx>
+
+use feral::symbolic::{
+    pick_ordering_preprocess, symbolic_factorize_with_method, total_factor_nnz,
+    AmalgamationStrategy, OrderingMethod, OrderingPreprocess, SupernodeParams,
+};
+use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+/// Symbolic-only fill report: isolates AMD ordering quality (simplicial
+/// `col_counts` fill, comparable to faer's `len_val`) from supernode
+/// amalgamation padding (`factor_nnz_estimate`).
+fn symbolic_report(csc: &CscMatrix) {
+    println!("--- symbolic fill (no numeric factor) ---");
+    for (mname, method) in [
+        ("AMD", OrderingMethod::Amd),
+        ("AMF", OrderingMethod::Amf),
+        ("MetisND", OrderingMethod::MetisND),
+    ] {
+        for (sname, sn) in [
+            ("default(Auto-prep)", SupernodeParams::default()),
+            (
+                "preprocess=None",
+                SupernodeParams {
+                    preprocess: OrderingPreprocess::None,
+                    ..SupernodeParams::default()
+                },
+            ),
+            (
+                "nemin=1,None,Adjac",
+                SupernodeParams {
+                    nemin: 1,
+                    preprocess: OrderingPreprocess::None,
+                    amalgamation_strategy: AmalgamationStrategy::Adjacency,
+                    ..SupernodeParams::default()
+                },
+            ),
+        ] {
+            match symbolic_factorize_with_method(csc, &sn, method) {
+                Ok(sym) => {
+                    let simplicial = total_factor_nnz(&sym.col_counts);
+                    println!(
+                        "  {mname:<8} {sname:<20} simplicial_nnz_L={simplicial:>10}  \
+                         amalgamated_est={:>10}  n_supernodes={}",
+                        sym.factor_nnz_estimate,
+                        sym.supernodes.len()
+                    );
+                }
+                Err(e) => println!("  {mname:<8} {sname:<20} ERR {e:?}"),
+            }
+        }
+    }
+    println!("  (faer AMD len_val reference = 13,370,955)");
+
+    // None vs LdltCompress on the default ordering, to size the fill effect
+    // of preprocessing (issue #91 race criterion).
+    println!("--- preprocess None vs LdltCompress (default method) ---");
+    println!("  predicate fires: {:?}", pick_ordering_preprocess(csc));
+    for (pname, pp) in [
+        ("None", OrderingPreprocess::None),
+        ("LdltCompress", OrderingPreprocess::LdltCompress),
+    ] {
+        let sn = SupernodeParams {
+            preprocess: pp,
+            ..SupernodeParams::default()
+        };
+        match symbolic_factorize_with_method(csc, &sn, OrderingMethod::Amd) {
+            Ok(sym) => println!(
+                "  {pname:<14} simplicial_nnz_L={:>10}  est={:>10}",
+                total_factor_nnz(&sym.col_counts),
+                sym.factor_nnz_estimate
+            ),
+            Err(e) => println!("  {pname:<14} ERR {e:?}"),
+        }
+    }
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+fn run(name: &str, csc: &CscMatrix, build: impl Fn() -> Solver, reps: usize) {
+    // Warm one factor to populate symbolic cache the way an IPM would
+    // (symbolic is amortized across iterations; we want the per-factor
+    // numeric cost, but report both first-call and steady-state).
+    let mut first_ms = f64::NAN;
+    let mut times = Vec::new();
+    let mut nnz_l = 0usize;
+    let mut fill = 0.0;
+    let mut inertia = (0usize, 0usize, 0usize);
+    let mut min_piv = 0.0;
+    let mut max_piv = 0.0;
+    let mut status = String::new();
+    let mut solver = build();
+    for r in 0..reps {
+        let t = Instant::now();
+        let st = solver.factor(csc, None);
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        if r == 0 {
+            first_ms = ms;
+            status = format!("{st:?}");
+            if let Some(s) = solver.last_factor_stats() {
+                nnz_l = s.nnz_l;
+                fill = s.fill_ratio;
+                inertia = (s.inertia.positive, s.inertia.negative, s.inertia.zero);
+                min_piv = s.min_abs_pivot;
+                max_piv = s.max_abs_pivot;
+            }
+        } else {
+            times.push(ms);
+        }
+    }
+    let steady = if times.is_empty() {
+        first_ms
+    } else {
+        median(times)
+    };
+    println!(
+        "{name:<24} first={first_ms:>9.1}ms steady={steady:>9.1}ms  \
+         nnz_L={nnz_l:>10} fill={fill:>6.1}x  \
+         inertia=(+{},-{},0:{})  |piv|=[{:.2e},{:.2e}]  {status}",
+        inertia.0, inertia.1, inertia.2, min_piv, max_piv
+    );
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| panic!("usage: bench_qap15 <path.mtx>"));
+    let mtx = read_mtx(Path::new(&path)).expect("read mtx");
+    let csc = mtx.to_csc().expect("to_csc");
+    println!(
+        "matrix: n={} nnz={}  (faer AMD len_val reference = 13,370,955)",
+        csc.n,
+        csc.row_idx.len()
+    );
+    if std::env::var("SYMBOLIC").is_ok() {
+        symbolic_report(&csc);
+        return;
+    }
+
+    let reps: usize = std::env::var("REPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2);
+    // Comma-separated config selector via CONFIGS env (default: all).
+    let want = std::env::var("CONFIGS").unwrap_or_else(|_| "default,sqd,sqdfma,static,fma".into());
+    let want: Vec<&str> = want.split(',').collect();
+    let has = |k: &str| want.contains(&k);
+
+    if has("default") {
+        run("default (BK+delayed)", &csc, Solver::new, reps);
+    }
+    if has("sqd") {
+        run("sqd_mode", &csc, || Solver::new().with_sqd_mode(true), reps);
+    }
+    if has("sqdfma") {
+        run(
+            "sqd_mode+fma",
+            &csc,
+            || Solver::new().with_sqd_mode(true).with_fma(true),
+            reps,
+        );
+    }
+    if has("static") {
+        run(
+            "static_pivot(1e-8)",
+            &csc,
+            || Solver::new().with_static_pivot_threshold(1e-8),
+            reps,
+        );
+    }
+    if has("fma") {
+        run("default+fma", &csc, || Solver::new().with_fma(true), reps);
+    }
+    if has("noprep") {
+        run(
+            "preprocess=None",
+            &csc,
+            || {
+                Solver::with_params(
+                    NumericParams::default(),
+                    SupernodeParams {
+                        preprocess: OrderingPreprocess::None,
+                        ..SupernodeParams::default()
+                    },
+                )
+            },
+            reps,
+        );
+    }
+    if has("noprepfma") {
+        run(
+            "preprocess=None+fma",
+            &csc,
+            || {
+                Solver::with_params(
+                    NumericParams::default(),
+                    SupernodeParams {
+                        preprocess: OrderingPreprocess::None,
+                        ..SupernodeParams::default()
+                    },
+                )
+                .with_fma(true)
+            },
+            reps,
+        );
+    }
+    if has("nemin1") {
+        run(
+            "nemin=1 (no-amalg)",
+            &csc,
+            || {
+                Solver::with_params(
+                    NumericParams::default(),
+                    SupernodeParams {
+                        nemin: 1,
+                        ..SupernodeParams::default()
+                    },
+                )
+            },
+            reps,
+        );
+    }
+    if has("nemin1fma") {
+        run(
+            "nemin=1+fma",
+            &csc,
+            || {
+                Solver::with_params(
+                    NumericParams::default(),
+                    SupernodeParams {
+                        nemin: 1,
+                        ..SupernodeParams::default()
+                    },
+                )
+                .with_fma(true)
+            },
+            reps,
+        );
+    }
+}

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -11,8 +11,18 @@ use feral::symbolic::{
     pick_ordering_preprocess, symbolic_factorize_with_method, total_factor_nnz,
     AmalgamationStrategy, OrderingMethod, OrderingPreprocess, SupernodeParams,
 };
-use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+use feral::{read_mtx, BunchKaufmanParams, CscMatrix, NumericParams, Solver};
 use std::path::Path;
+
+fn np_with_block_size(bs: usize) -> NumericParams {
+    NumericParams {
+        bk: BunchKaufmanParams {
+            block_size: bs,
+            ..BunchKaufmanParams::default()
+        },
+        ..NumericParams::default()
+    }
+}
 use std::time::Instant;
 
 /// Symbolic-only fill report: isolates AMD ordering quality (simplicial
@@ -214,6 +224,16 @@ fn main() {
             },
             reps,
         );
+    }
+    for bs in [96usize, 128, 160, 192] {
+        if has(&format!("bs{bs}")) {
+            run(
+                &format!("block_size={bs}"),
+                &csc,
+                || Solver::with_params(np_with_block_size(bs), SupernodeParams::default()),
+                reps,
+            );
+        }
     }
     if has("nemin1") {
         run(

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -163,7 +163,8 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(2);
     // Comma-separated config selector via CONFIGS env (default: all).
-    let want = std::env::var("CONFIGS").unwrap_or_else(|_| "default,sqd,sqdfma,static,fma".into());
+    let want = std::env::var("CONFIGS")
+        .unwrap_or_else(|_| "default,sqd,sqdfma,static,fma,fmalarge".into());
     let want: Vec<&str> = want.split(',').collect();
     let has = |k: &str| want.contains(&k);
 
@@ -191,6 +192,16 @@ fn main() {
     }
     if has("fma") {
         run("default+fma", &csc, || Solver::new().with_fma(true), reps);
+    }
+    if has("fmalarge") {
+        // Issue #99 Lever 3: FMA only on fronts with >= 256 rows;
+        // small fronts stay bit-exact nofma.
+        run(
+            "default+fma_large(256rows)",
+            &csc,
+            || Solver::new().with_fma_large_fronts(256),
+            reps,
+        );
     }
     if has("noprep") {
         run(

--- a/examples/bench_schur_micro.rs
+++ b/examples/bench_schur_micro.rs
@@ -1,0 +1,215 @@
+//! Isolated throughput microbenchmark for the dense trailing-update
+//! kernel (issue #99, BLAS-3 follow-up).
+//!
+//! The full-front profile attributes ~94% of a dense factor to the
+//! trailing Schur update yet measures only ~0.33 GFLOP/s — far below
+//! even scalar peak. This harness isolates the *kernel* from the
+//! factorization (pivot search, alpha precompute, per-panel setup) to
+//! answer one question: is the kernel itself slow, or is it the
+//! surrounding factorization overhead?
+//!
+//! It computes a rectangular rank-`ke` update `C[i,j] -= Σ_q L[i,q] *
+//! alpha[j,q]` (`C` is m×n, `L` is m×ke, `alpha` is n×ke) two ways:
+//!   * BASELINE — the production per-column strided kernel
+//!     (`schur_panel_minus_nofma_strided`), one dispatch per column,
+//!     reading the panel at column-stride `m` (the strided access the
+//!     factor uses).
+//!   * PACKED   — pack `L` into MR-row micro-panels (contiguous in the
+//!     `q` loop) and run a plain MR×NR register-tiled kernel. Same
+//!     per-element `mul → sub` order ⇒ byte-exact with BASELINE.
+//!
+//! Reports ms and GFLOP/s for each, plus a byte-exactness check. If
+//! PACKED is much faster, the strided `q`-access is the bottleneck and a
+//! packed micro-kernel is worth wiring in; if not, the ceiling is DST
+//! bandwidth (→ Phase C cache-blocked factor).
+//!
+//! Usage: cargo run --release --example bench_schur_micro [-- M N KE REPS]
+
+use feral::dense::schur_kernel::schur_panel_minus_nofma_strided;
+use std::time::Instant;
+
+fn mix(state: &mut u64) -> f64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+}
+
+/// BASELINE: production per-column strided kernel, one call per column.
+fn run_baseline(c: &mut [f64], l: &[f64], alpha: &[f64], m: usize, n: usize, ke: usize) {
+    let mut alphas = vec![0.0f64; ke];
+    for j in 0..n {
+        for q in 0..ke {
+            alphas[q] = alpha[j + q * n];
+        }
+        let dst = &mut c[j * m..j * m + m];
+        // src_block = L (col-major, col-stride m); src_first_col 0,
+        // src_row_offset 0, len m.
+        schur_panel_minus_nofma_strided(dst, l, 0, ke, m, 0, m, &alphas);
+    }
+}
+
+/// Pack `L` (m×ke col-major) into MR-row micro-panels: for panel p
+/// (rows p*MR..), store q-major MR-contiguous blocks so the kernel's
+/// inner q-loop reads sequential memory. `apack[p*(ke*MR) + q*MR + ir]`.
+const MR: usize = 8;
+const NR: usize = 4;
+
+fn pack_a(l: &[f64], m: usize, ke: usize) -> Vec<f64> {
+    let npanels = m.div_ceil(MR);
+    let mut apack = vec![0.0f64; npanels * ke * MR];
+    for p in 0..npanels {
+        let i0 = p * MR;
+        for q in 0..ke {
+            for ir in 0..MR {
+                let i = i0 + ir;
+                let v = if i < m { l[i + q * m] } else { 0.0 };
+                apack[p * (ke * MR) + q * MR + ir] = v;
+            }
+        }
+    }
+    apack
+}
+
+fn pack_b(alpha: &[f64], n: usize, ke: usize) -> Vec<f64> {
+    let npanels = n.div_ceil(NR);
+    let mut bpack = vec![0.0f64; npanels * ke * NR];
+    for p in 0..npanels {
+        let j0 = p * NR;
+        for q in 0..ke {
+            for jr in 0..NR {
+                let j = j0 + jr;
+                let v = if j < n { alpha[j + q * n] } else { 0.0 };
+                bpack[p * (ke * NR) + q * NR + jr] = v;
+            }
+        }
+    }
+    bpack
+}
+
+/// PACKED: MR×NR register-tiled kernel over packed operands. Plain
+/// arrays; LLVM autovectorizes the contiguous MR inner axis. Per
+/// element `acc -= a*b` in ascending q — byte-exact with BASELINE.
+#[allow(clippy::needless_range_loop)]
+fn run_packed(c: &mut [f64], apack: &[f64], bpack: &[f64], m: usize, n: usize, ke: usize) {
+    let np_j = n.div_ceil(NR);
+    for pj in 0..np_j {
+        let j0 = pj * NR;
+        let bbase = pj * (ke * NR);
+        let np_i = m.div_ceil(MR);
+        for pi in 0..np_i {
+            let i0 = pi * MR;
+            let abase = pi * (ke * MR);
+            // MR×NR accumulator tile, loaded from C.
+            let mut acc = [[0.0f64; MR]; NR];
+            for (jr, accj) in acc.iter_mut().enumerate() {
+                let j = j0 + jr;
+                if j >= n {
+                    continue;
+                }
+                for ir in 0..MR {
+                    let i = i0 + ir;
+                    accj[ir] = if i < m { c[i + j * m] } else { 0.0 };
+                }
+            }
+            for q in 0..ke {
+                let a = &apack[abase + q * MR..abase + q * MR + MR];
+                for jr in 0..NR {
+                    let b = bpack[bbase + q * NR + jr];
+                    let accj = &mut acc[jr];
+                    for ir in 0..MR {
+                        accj[ir] -= b * a[ir];
+                    }
+                }
+            }
+            for (jr, accj) in acc.iter().enumerate() {
+                let j = j0 + jr;
+                if j >= n {
+                    continue;
+                }
+                for ir in 0..MR {
+                    let i = i0 + ir;
+                    if i < m {
+                        c[i + j * m] = accj[ir];
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let m: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1500);
+    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1500);
+    let ke: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(64);
+    let reps: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    let mut s = 0xDEAD_BEEF_1234u64;
+    let l: Vec<f64> = (0..m * ke).map(|_| mix(&mut s)).collect();
+    let alpha: Vec<f64> = (0..n * ke).map(|_| mix(&mut s)).collect();
+    let c0: Vec<f64> = (0..m * n).map(|_| mix(&mut s)).collect();
+
+    let gflop = 2.0 * m as f64 * n as f64 * ke as f64 / 1e9;
+    println!("bench_schur_micro: m={m} n={n} ke={ke} reps={reps}  ({gflop:.3} GFLOP/update)");
+
+    // BASELINE
+    let mut best_base = f64::INFINITY;
+    let mut c_base = c0.clone();
+    for _ in 0..reps {
+        c_base.copy_from_slice(&c0);
+        let t = Instant::now();
+        run_baseline(&mut c_base, &l, &alpha, m, n, ke);
+        best_base = best_base.min(t.elapsed().as_secs_f64());
+    }
+    println!(
+        "  baseline (strided per-col) {:8.2} ms   {:6.2} GFLOP/s",
+        best_base * 1e3,
+        gflop / best_base
+    );
+
+    // PACKED (packing timed separately + fused)
+    let mut best_pack = f64::INFINITY;
+    let mut best_pack_all = f64::INFINITY;
+    let mut c_pack = c0.clone();
+    for _ in 0..reps {
+        c_pack.copy_from_slice(&c0);
+        let t_all = Instant::now();
+        let apack = pack_a(&l, m, ke);
+        let bpack = pack_b(&alpha, n, ke);
+        let t_k = Instant::now();
+        run_packed(&mut c_pack, &apack, &bpack, m, n, ke);
+        best_pack = best_pack.min(t_k.elapsed().as_secs_f64());
+        best_pack_all = best_pack_all.min(t_all.elapsed().as_secs_f64());
+    }
+    println!(
+        "  packed kernel only         {:8.2} ms   {:6.2} GFLOP/s",
+        best_pack * 1e3,
+        gflop / best_pack
+    );
+    println!(
+        "  packed incl. pack          {:8.2} ms   {:6.2} GFLOP/s",
+        best_pack_all * 1e3,
+        gflop / best_pack_all
+    );
+
+    // Byte-exactness check.
+    let mut mism = 0usize;
+    for (x, y) in c_base.iter().zip(&c_pack) {
+        if x.to_bits() != y.to_bits() {
+            mism += 1;
+        }
+    }
+    if mism == 0 {
+        println!("  byte-exact: baseline == packed ✓");
+    } else {
+        println!("  BYTE MISMATCH in {mism} / {} elements ✗", c_base.len());
+    }
+    println!(
+        "  speedup (kernel only): {:.2}×   (incl. pack): {:.2}×",
+        best_base / best_pack,
+        best_base / best_pack_all
+    );
+}

--- a/examples/profile_qap15.rs
+++ b/examples/profile_qap15.rs
@@ -4,11 +4,56 @@
 //!
 //! Usage: cargo run --release --example profile_qap15 -- <path.mtx>
 
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
 use feral::numeric::factorize::{Profiler, SupernodeTiming};
 use feral::{read_mtx, CscMatrix, NumericParams, Solver};
 use std::path::Path;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+
+/// Aggregate phase split (Lever A step 1): what fraction of a *sequential*
+/// factor is the serial panel factorization (`panelfactor` + `scalartail`)
+/// vs the parallelizable trailing update (`schur`)? The serial fraction is
+/// the Amdahl ceiling look-ahead must attack.
+fn phase_split(csc: &CscMatrix) {
+    PHASE_TIMING_ENABLED.store(true, Ordering::Relaxed);
+    phase_timing::reset();
+    // Sequential: intrafront parallelism off, so panel and schur are both
+    // wall-serial and their ratio is the true per-front work split.
+    let mut solver = Solver::new().with_parallel(false);
+    let t = Instant::now();
+    let st = solver.factor(csc, None);
+    let wall = t.elapsed().as_secs_f64() * 1e3;
+    let (assembly, densefactor, panel, schur, scalartail) = phase_timing::snapshot();
+    PHASE_TIMING_ENABLED.store(false, Ordering::Relaxed);
+
+    let ns = |x: u64| x as f64 / 1e6; // ns → ms
+    let panel_ms = ns(panel);
+    let schur_ms = ns(schur);
+    let tail_ms = ns(scalartail);
+    let asm_ms = ns(assembly);
+    let df_ms = ns(densefactor);
+    // "serial" under the parallelize-trailing-only model = everything except
+    // the trailing Schur update.
+    let serial_ms = panel_ms + tail_ms + asm_ms + (df_ms - panel_ms - schur_ms).max(0.0);
+    let par_ms = schur_ms;
+    let frac = serial_ms / (serial_ms + par_ms).max(1e-9);
+    println!("--- phase split (sequential, {st:?}, wall={wall:.0}ms) ---");
+    println!("  panelfactor : {panel_ms:>8.1} ms   (serial — the look-ahead target)");
+    println!("  scalartail  : {tail_ms:>8.1} ms   (serial — ramp-down)");
+    println!("  schur       : {schur_ms:>8.1} ms   (parallelizable trailing update)");
+    println!("  assembly    : {asm_ms:>8.1} ms   (densefactor total {df_ms:.1} ms)");
+    println!(
+        "  => serial (non-schur) {serial_ms:.0} ms vs parallel (schur) {par_ms:.0} ms  \
+         ⇒ serial fraction ≈ {:.2}",
+        frac
+    );
+    println!(
+        "  Amdahl ceiling on 10 cores if only schur parallelizes: {:.1}×",
+        1.0 / (frac + (1.0 - frac) / 10.0)
+    );
+}
 
 fn profile_once(csc: &CscMatrix, fma: bool) {
     let prof = Arc::new(Mutex::new(Profiler::new()));
@@ -85,6 +130,7 @@ fn main() {
         .and_then(|m| m.to_csc())
         .expect("read mtx");
     println!("matrix: n={} nnz={}", csc.n, csc.row_idx.len());
+    phase_split(&csc); // Lever A step 1: measure the serial split
     profile_once(&csc, false); // default nofma
     profile_once(&csc, true); // fma
 }

--- a/examples/profile_qap15.rs
+++ b/examples/profile_qap15.rs
@@ -1,0 +1,90 @@
+//! Per-supernode profile of the (fixed) qap15 conic-KKT factor — issue #91
+//! follow-up (dense-kernel throughput). Answers: where does the ~0.7 s go,
+//! by front size, and how much does FMA move the large-front buckets?
+//!
+//! Usage: cargo run --release --example profile_qap15 -- <path.mtx>
+
+use feral::numeric::factorize::{Profiler, SupernodeTiming};
+use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+fn profile_once(csc: &CscMatrix, fma: bool) {
+    let prof = Arc::new(Mutex::new(Profiler::new()));
+    let np = NumericParams {
+        profiler: Some(Arc::clone(&prof)),
+        fma,
+        ..NumericParams::default()
+    };
+    // Sequential driver: the per-supernode profiler is only populated on
+    // the sequential path.
+    let mut solver =
+        Solver::with_params(np, feral::symbolic::SupernodeParams::default()).with_parallel(false);
+
+    let t = Instant::now();
+    let st = solver.factor(csc, None);
+    let wall_ms = t.elapsed().as_secs_f64() * 1e3;
+
+    let p = prof.lock().expect("profiler lock");
+    let report = p.report();
+    let stats = solver.last_factor_stats();
+
+    println!(
+        "\n=== fma={fma}  wall={wall_ms:.1}ms  status={st:?}  nnz_L={}  n_supernodes={} ===",
+        stats.as_ref().map(|s| s.nnz_l).unwrap_or(0),
+        report.n_supernodes
+    );
+    println!(
+        "  loop={:.1}ms  prologue={:.1}ms  epilogue={:.1}ms  overhead={:.1}%",
+        report.loop_us as f64 / 1e3,
+        report.prologue_us as f64 / 1e3,
+        report.epilogue_us as f64 / 1e3,
+        report.overhead_pct
+    );
+    println!("  front-size buckets (by nrow):");
+    println!(
+        "    {:>8}  {:>7}  {:>10}  {:>7}  {:>10}",
+        "range", "count", "sum_ms", "%loop", "avg_us"
+    );
+    for b in &report.buckets {
+        println!(
+            "    {:>8}  {:>7}  {:>10.1}  {:>6.1}%  {:>10.1}",
+            b.range,
+            b.count,
+            b.sum_us as f64 / 1e3,
+            b.pct_of_total,
+            b.avg_us
+        );
+    }
+
+    // Top fronts by time — the concrete targets for a blocked kernel.
+    let mut timings: Vec<SupernodeTiming> = p.timings().to_vec();
+    timings.sort_by_key(|b| std::cmp::Reverse(b.us));
+    println!("  top fronts by time (nrow x ncol -> ms):");
+    let loop_us = report.loop_us.max(1) as f64;
+    for t in timings.iter().take(10) {
+        println!(
+            "    {:>6} x {:<6} -> {:>8.2} ms  ({:>4.1}% of loop)",
+            t.nrow,
+            t.ncol,
+            t.us as f64 / 1e3,
+            t.us as f64 * 100.0 / loop_us
+        );
+    }
+    if !report.validation_warnings.is_empty() {
+        println!("  warnings: {:?}", report.validation_warnings);
+    }
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| panic!("usage: profile_qap15 <path.mtx>"));
+    let csc = read_mtx(Path::new(&path))
+        .and_then(|m| m.to_csc())
+        .expect("read mtx");
+    println!("matrix: n={} nnz={}", csc.n, csc.row_idx.len());
+    profile_once(&csc, false); // default nofma
+    profile_once(&csc, true); // fma
+}

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -648,25 +648,33 @@ pub struct BunchKaufmanParams {
     pub intrafront_parallel: bool,
 
     /// Opt-in per-front FMA size gate (issue #99, Lever 3). Default
-    /// `None`. When `Some(t)`, a front whose trailing-update area
-    /// `nrow * ncol >= t` uses the FMA trailing-Schur kernels **even
-    /// when [`fma`](Self::fma) is `false`**; fronts below the threshold
-    /// keep the bit-exact `*_nofma` kernels. This lets one factorization
-    /// run the fast (single-rounding) FMA path on its large roots while
+    /// `None`. When `Some(t)`, a front with at least `t` rows
+    /// (`nrow >= t`) uses the FMA trailing-Schur kernels **even when
+    /// [`fma`](Self::fma) is `false`**; smaller fronts keep the bit-exact
+    /// `*_nofma` kernels. This lets one factorization run the fast
+    /// (single-rounding) FMA path on its throughput-dominant fronts while
     /// small fronts — where FMA rounding can perturb Bunch-Kaufman pivot
     /// classification on sensitive KKTs (`dev/tried-and-rejected.md`
     /// 2026-04-14) — stay on the reference kernels.
     ///
+    /// The gate is on `nrow` (the front's row count = the size of its
+    /// trailing update), **not** `nrow * ncol` area: on real conic KKTs
+    /// the throughput-dominant fronts are *tall and thin* — e.g. the
+    /// synthetic qap15 stand-in factors its dense border as ~117 fronts
+    /// of `2000 × 16`, whose trailing-update cost (`~ncol * nrow²`) is
+    /// large even though their area is small. An area gate silently
+    /// misses exactly these fronts; a row gate catches them while still
+    /// protecting genuinely small fronts. See
+    /// `dev/research/issue-99-dense-front-fma-gate.md`.
+    ///
     /// `None` (default) is a strict no-op: every front honors `fma` as
     /// before, so the production cross-arch bit-exactness contract is
     /// untouched. Enabling this changes cross-arch bit patterns on the
-    /// gated large fronts (single vs double rounding), so it is a
-    /// deliberate opt-in, not a default. Inertia is preserved on
-    /// well-conditioned fronts (the FMA path is one ULP per accumulate
-    /// off nofma; see
+    /// gated fronts (single vs double rounding), so it is a deliberate
+    /// opt-in, not a default. Inertia is preserved on well-conditioned
+    /// fronts (the FMA path is one ULP per accumulate off nofma; see
     /// `schur_kernel::fma_vs_nofma_panel_kernels_within_n_elim_ulps`).
-    /// See `dev/research/issue-99-dense-front-fma-gate.md`.
-    pub fma_min_front_area: Option<usize>,
+    pub fma_min_front_rows: Option<usize>,
 }
 
 /// Minimum trailing-update area `(nrow - j_start) * n_elim` below which
@@ -698,6 +706,37 @@ fn intrafront_min_area() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(INTRAFRONT_MIN_AREA)
+}
+
+/// Issue #99 Lever 1 — shape-aware intra-front trigger for *tall, thin*
+/// fronts. The [`INTRAFRONT_MIN_AREA`] gate is `trailing_cols * n_elim`,
+/// which under-counts fronts with a large trailing width but small
+/// elimination depth: their parallelizable trailing update costs
+/// `~n_elim * trailing_cols²` (each of `trailing_cols` independent
+/// columns does an `n_elim`-deep rank update over a length that scales
+/// with the width), yet their *area* is small. On the qap15 conic-KKT
+/// stand-in the throughput-dominant fronts are ~`2000 × 16`: area 31 744,
+/// just under the 32 768 floor, so intra-front parallelism never fired and
+/// 99.9 % of the schur loop ran serially.
+///
+/// This trigger fires when the front is both wide enough to split across
+/// workers ([`INTRAFRONT_TALL_MIN_COLS`]) and deep enough per column to
+/// amortize the fork ([`INTRAFRONT_TALL_MIN_ELIM`]). It is **OR-ed** with
+/// the area gate, so every front that parallelized before still does —
+/// this can only *add* parallelism to large-work fronts, never remove it,
+/// which is why it cannot regress the area gate's measured calibration.
+/// Byte-exact (pure scheduling; each trailing column is still reduced on a
+/// single thread). See `dev/research/issue-99-dense-front-fma-gate.md`.
+pub const INTRAFRONT_TALL_MIN_COLS: usize = 512;
+/// Companion depth floor for [`INTRAFRONT_TALL_MIN_COLS`]; see there.
+pub const INTRAFRONT_TALL_MIN_ELIM: usize = 8;
+
+/// Whether the tall-front intra-front trigger fires for a trailing update
+/// of `trailing_cols` columns at elimination depth `n_elim`. Issue #99
+/// Lever 1.
+#[inline]
+fn intrafront_tall_gate(trailing_cols: usize, n_elim: usize) -> bool {
+    trailing_cols >= INTRAFRONT_TALL_MIN_COLS && n_elim >= INTRAFRONT_TALL_MIN_ELIM
 }
 
 /// Action to take when a near-zero pivot is encountered.
@@ -823,24 +862,22 @@ impl Default for BunchKaufmanParams {
             tpp_method: TppMethod::Plain,
             static_pivot_floor: 0.0,
             intrafront_parallel: false,
-            fma_min_front_area: None,
+            fma_min_front_rows: None,
         }
     }
 }
 
-/// Resolve the effective FMA flag for a front of `nrow` rows and `ncol`
-/// fully-summed columns under `params`. Returns `true` when the global
-/// [`BunchKaufmanParams::fma`] is set, or when the per-front size gate
-/// [`BunchKaufmanParams::fma_min_front_area`] is armed and this front's
-/// trailing-update area `nrow * ncol` reaches the threshold. The `nrow *
-/// ncol` product saturates so a pathological front cannot wrap. Issue
-/// #99 Lever 3.
+/// Resolve the effective FMA flag for a front of `nrow` rows under
+/// `params`. Returns `true` when the global [`BunchKaufmanParams::fma`]
+/// is set, or when the per-front size gate
+/// [`BunchKaufmanParams::fma_min_front_rows`] is armed and this front is
+/// at least that tall (`nrow >= t`). Gating on `nrow` (not `nrow * ncol`
+/// area) is deliberate: the throughput-dominant fronts on real conic
+/// KKTs are tall and thin (large `nrow`, small `ncol`), so an area gate
+/// misses them. Issue #99 Lever 3.
 #[inline]
-pub(crate) fn effective_front_fma(params: &BunchKaufmanParams, nrow: usize, ncol: usize) -> bool {
-    params.fma
-        || params
-            .fma_min_front_area
-            .is_some_and(|t| nrow.saturating_mul(ncol) >= t)
+pub(crate) fn effective_front_fma(params: &BunchKaufmanParams, nrow: usize) -> bool {
+    params.fma || params.fma_min_front_rows.is_some_and(|t| nrow >= t)
 }
 
 /// Factorization result: P·L·D_bk·Lᵀ·Pᵀ = D_eq·A·D_eq.
@@ -2010,7 +2047,7 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
     // `params.fma` unchanged.
     let gated_params;
     let params: &BunchKaufmanParams = {
-        let eff = effective_front_fma(params, nrow, ncol);
+        let eff = effective_front_fma(params, nrow);
         if eff != params.fma {
             gated_params = BunchKaufmanParams {
                 fma: eff,
@@ -3267,8 +3304,14 @@ fn apply_blocked_schur_panel(
     let (head, tail) = a.split_at_mut(j_start * nrow);
     let head: &[f64] = head;
 
-    let area = (nrow - j_start).saturating_mul(n_elim);
-    if intrafront_parallel && area >= intrafront_min_area() {
+    let trailing_cols = nrow - j_start;
+    let area = trailing_cols.saturating_mul(n_elim);
+    // Fire on the classic area gate OR the shape-aware tall-front gate
+    // (issue #99 Lever 1) — the latter catches wide, shallow fronts the
+    // area metric misses. OR means no already-parallel front regresses.
+    if intrafront_parallel
+        && (area >= intrafront_min_area() || intrafront_tall_gate(trailing_cols, n_elim))
+    {
         use rayon::prelude::*;
         let ncol = nrow - j_start;
         let nthreads = rayon::current_num_threads().max(1);

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -646,6 +646,27 @@ pub struct BunchKaufmanParams {
     /// rayon work (pounce#79 oversubscription guarantee). See
     /// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
     pub intrafront_parallel: bool,
+
+    /// Opt-in per-front FMA size gate (issue #99, Lever 3). Default
+    /// `None`. When `Some(t)`, a front whose trailing-update area
+    /// `nrow * ncol >= t` uses the FMA trailing-Schur kernels **even
+    /// when [`fma`](Self::fma) is `false`**; fronts below the threshold
+    /// keep the bit-exact `*_nofma` kernels. This lets one factorization
+    /// run the fast (single-rounding) FMA path on its large roots while
+    /// small fronts — where FMA rounding can perturb Bunch-Kaufman pivot
+    /// classification on sensitive KKTs (`dev/tried-and-rejected.md`
+    /// 2026-04-14) — stay on the reference kernels.
+    ///
+    /// `None` (default) is a strict no-op: every front honors `fma` as
+    /// before, so the production cross-arch bit-exactness contract is
+    /// untouched. Enabling this changes cross-arch bit patterns on the
+    /// gated large fronts (single vs double rounding), so it is a
+    /// deliberate opt-in, not a default. Inertia is preserved on
+    /// well-conditioned fronts (the FMA path is one ULP per accumulate
+    /// off nofma; see
+    /// `schur_kernel::fma_vs_nofma_panel_kernels_within_n_elim_ulps`).
+    /// See `dev/research/issue-99-dense-front-fma-gate.md`.
+    pub fma_min_front_area: Option<usize>,
 }
 
 /// Minimum trailing-update area `(nrow - j_start) * n_elim` below which
@@ -779,8 +800,24 @@ impl Default for BunchKaufmanParams {
             tpp_method: TppMethod::Plain,
             static_pivot_floor: 0.0,
             intrafront_parallel: false,
+            fma_min_front_area: None,
         }
     }
+}
+
+/// Resolve the effective FMA flag for a front of `nrow` rows and `ncol`
+/// fully-summed columns under `params`. Returns `true` when the global
+/// [`BunchKaufmanParams::fma`] is set, or when the per-front size gate
+/// [`BunchKaufmanParams::fma_min_front_area`] is armed and this front's
+/// trailing-update area `nrow * ncol` reaches the threshold. The `nrow *
+/// ncol` product saturates so a pathological front cannot wrap. Issue
+/// #99 Lever 3.
+#[inline]
+pub(crate) fn effective_front_fma(params: &BunchKaufmanParams, nrow: usize, ncol: usize) -> bool {
+    params.fma
+        || params
+            .fma_min_front_area
+            .is_some_and(|t| nrow.saturating_mul(ncol) >= t)
 }
 
 /// Factorization result: P·L·D_bk·Lᵀ·Pᵀ = D_eq·A·D_eq.
@@ -1940,6 +1977,27 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
     scratch: &mut FactorScratch,
 ) -> Result<FrontalFactors, FeralError> {
     let nrow = matrix.n;
+
+    // Issue #99 Lever 3: opt-in per-front FMA size gate. When
+    // `fma_min_front_area` is armed and this front's trailing area is
+    // large enough, factor it with the FMA trailing-Schur kernels even
+    // if the global `fma` flag is off. Shadow `params` with a local
+    // clone only when the gate actually changes the flag, so the common
+    // (unarmed) path pays nothing; everything downstream reads
+    // `params.fma` unchanged.
+    let gated_params;
+    let params: &BunchKaufmanParams = {
+        let eff = effective_front_fma(params, nrow, ncol);
+        if eff != params.fma {
+            gated_params = BunchKaufmanParams {
+                fma: eff,
+                ..params.clone()
+            };
+            &gated_params
+        } else {
+            params
+        }
+    };
 
     if ncol > nrow {
         return Err(FeralError::InvalidInput(format!(

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -3371,6 +3371,20 @@ fn apply_schur_panel_range(
     );
     let ncol = block.len() / nrow;
 
+    // Issue #99 BLAS-3: the packed, register-tiled trailing update is
+    // ~25× faster than the strided per-column kernels below on this
+    // hardware (measured `examples/bench_schur_micro`) and **byte-exact**
+    // with them — each `A[i,j]` (i>=j) is reduced over ascending q with
+    // the identical `mul → sub` (nofma) or `mul_add` (fma). The strided
+    // kernels re-read the panel at column-stride `nrow` every q, which
+    // cache-thrashes; the packed path reads L1-resident micro-panels.
+    // Default on; `FERAL_PACKED_SCHUR=0` restores the strided path for
+    // A/B benchmarking and as a safety override.
+    if packed_schur_enabled() {
+        apply_schur_panel_range_packed(head, block, col_start, nrow, k, n_elim, d_panel, fma);
+        return;
+    }
+
     let mut alphas0_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas1_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas2_buf = [0.0f64; MAX_N_ELIM];
@@ -3498,6 +3512,172 @@ fn apply_schur_panel_range(
                     trailing_len,
                     alphas,
                 );
+            }
+        }
+    }
+}
+
+/// Whether the packed BLAS-3 trailing update (issue #99) is enabled.
+/// Default `true`; `FERAL_PACKED_SCHUR=0|off|false|no` restores the
+/// strided per-column kernels for A/B benchmarking or as a safety
+/// override. Byte-exact either way. Read once per panel dispatch (a
+/// relaxed env read, negligible beside the trailing-update cost).
+#[inline]
+fn packed_schur_enabled() -> bool {
+    !matches!(
+        std::env::var("FERAL_PACKED_SCHUR").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("no")
+    )
+}
+
+/// Packed, register-tiled equivalent of [`apply_schur_panel_range`]
+/// (issue #99, BLAS-3). Computes the same lower-triangular rank-`n_elim`
+/// trailing update `A[i,j] -= Σ_q (L[j,q]·d_q)·L[i,q]` for `i >= j`, but
+/// packs the panel into `q`-contiguous `MR`/`NR` micro-panels so the
+/// inner `q` loop reads L1-resident memory instead of the strided
+/// `col_stride = nrow` access that bottlenecks the strided kernels.
+///
+/// **Byte-exact** with [`apply_schur_panel_range`]: every element is
+/// reduced over ascending `q` with the same `mul → sub` (nofma) or
+/// `mul_add` (fma) as the reference — packing changes only memory
+/// layout, not arithmetic order (verified bit-for-bit in
+/// `examples/bench_schur_micro` and by the byte-exact factor parity
+/// suite). A zero `alpha` contributes `acc − round(0·L) = acc` for
+/// finite `L`, matching the strided kernels' explicit zero-skip; the
+/// packed path (reached only for all-1×1 panels with non-zero `d`) never
+/// sees a non-finite `L`, so no skip is needed.
+#[allow(clippy::too_many_arguments)]
+fn apply_schur_panel_range_packed(
+    head: &[f64],
+    block: &mut [f64],
+    col_start: usize,
+    nrow: usize,
+    k: usize,
+    n_elim: usize,
+    d_panel: &[f64],
+    fma: bool,
+) {
+    let ncol = block.len() / nrow;
+    if ncol == 0 || n_elim == 0 {
+        return;
+    }
+    // Register-tile dimensions. MR rows × NR cols per tile; the MR (row)
+    // axis is the contiguous SIMD axis the compiler autovectorizes.
+    const MR: usize = 8;
+    const NR: usize = 4;
+
+    // Column j (absolute) updates rows [j, nrow); the lowest column is
+    // `col_start`, so the source/destination rows span [col_start, nrow).
+    let row0 = col_start;
+    let rowspan = nrow - row0;
+    let col_end = col_start + ncol;
+    let npanels_i = rowspan.div_ceil(MR);
+    let npanels_j = ncol.div_ceil(NR);
+
+    // Pack A (source rows) and B (D-scaled source columns) into
+    // `q`-contiguous micro-panels. `L[x, k+q] = head[(k+q)*nrow + x]`.
+    //   apack[pi*(n_elim*MR) + q*MR + ir] = L[row0 + pi*MR + ir, k+q]
+    //   bpack[pj*(n_elim*NR) + q*NR + jr] = L[col_start + pj*NR + jr, k+q] * d_q
+    let mut apack = vec![0.0f64; npanels_i * n_elim * MR];
+    for pi in 0..npanels_i {
+        let i0 = row0 + pi * MR;
+        for q in 0..n_elim {
+            let base = (k + q) * nrow;
+            let out = &mut apack[pi * (n_elim * MR) + q * MR..][..MR];
+            for (ir, o) in out.iter_mut().enumerate() {
+                let i = i0 + ir;
+                *o = if i < nrow { head[base + i] } else { 0.0 };
+            }
+        }
+    }
+    let mut bpack = vec![0.0f64; npanels_j * n_elim * NR];
+    for pj in 0..npanels_j {
+        let j0 = col_start + pj * NR;
+        for q in 0..n_elim {
+            let base = (k + q) * nrow;
+            let dq = d_panel[q];
+            let out = &mut bpack[pj * (n_elim * NR) + q * NR..][..NR];
+            for (jr, o) in out.iter_mut().enumerate() {
+                let j = j0 + jr;
+                *o = if j < col_end {
+                    head[base + j] * dq
+                } else {
+                    0.0
+                };
+            }
+        }
+    }
+
+    // Tiled update over the lower triangle (i >= j).
+    for pj in 0..npanels_j {
+        let j0 = col_start + pj * NR;
+        let bbase = pj * (n_elim * NR);
+        for pi in 0..npanels_i {
+            let i0 = row0 + pi * MR;
+            // Skip tiles entirely in the strict upper triangle: the
+            // largest row `i0 + MR - 1` is still below the smallest
+            // column `j0`, so no element satisfies i >= j.
+            if i0 + MR <= j0 {
+                continue;
+            }
+            let abase = pi * (n_elim * MR);
+
+            // Load the C tile (lower-triangle, in-range elements only;
+            // out-of-range/upper stay 0 and are never stored).
+            let mut acc = [[0.0f64; MR]; NR];
+            for (jr, accj) in acc.iter_mut().enumerate() {
+                let j = j0 + jr;
+                if j >= col_end {
+                    continue;
+                }
+                let colblk = (j - col_start) * nrow;
+                for (ir, a) in accj.iter_mut().enumerate() {
+                    let i = i0 + ir;
+                    if i < nrow && i >= j {
+                        *a = block[colblk + i];
+                    }
+                }
+            }
+
+            // Accumulate over the whole q range. Out-of-range lanes carry
+            // packed zeros (0·L = 0), so they are inert and never stored.
+            if fma {
+                for q in 0..n_elim {
+                    let a = &apack[abase + q * MR..][..MR];
+                    let b = &bpack[bbase + q * NR..][..NR];
+                    for (jr, accj) in acc.iter_mut().enumerate() {
+                        let nb = -b[jr];
+                        for (ir, acci) in accj.iter_mut().enumerate() {
+                            *acci = nb.mul_add(a[ir], *acci);
+                        }
+                    }
+                }
+            } else {
+                for q in 0..n_elim {
+                    let a = &apack[abase + q * MR..][..MR];
+                    let b = &bpack[bbase + q * NR..][..NR];
+                    for (jr, accj) in acc.iter_mut().enumerate() {
+                        let bj = b[jr];
+                        for (ir, acci) in accj.iter_mut().enumerate() {
+                            *acci -= bj * a[ir];
+                        }
+                    }
+                }
+            }
+
+            // Store back the lower-triangle, in-range elements.
+            for (jr, accj) in acc.iter().enumerate() {
+                let j = j0 + jr;
+                if j >= col_end {
+                    continue;
+                }
+                let colblk = (j - col_start) * nrow;
+                for (ir, a) in accj.iter().enumerate() {
+                    let i = i0 + ir;
+                    if i < nrow && i >= j {
+                        block[colblk + i] = *a;
+                    }
+                }
             }
         }
     }
@@ -5780,6 +5960,113 @@ mod ncol_zero_contrib_tests {
                     0.0,
                     "contrib strict upper triangle ({ci},{cj}) must be zero, not stale pooled-buffer data"
                 );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod packed_schur_tests {
+    use super::*;
+
+    /// Scalar reference for the lower-triangular rank-`n_elim` trailing
+    /// update: `A[i,j] -= Σ_q (L[j,q]·d_q)·L[i,q]` for `i >= j`, ascending
+    /// q, explicit `mul → sub` (nofma) — the exact per-element contract
+    /// every dense kernel must reproduce bit-for-bit.
+    fn scalar_ref(
+        head: &[f64],
+        block: &mut [f64],
+        col_start: usize,
+        nrow: usize,
+        k: usize,
+        n_elim: usize,
+        d_panel: &[f64],
+    ) {
+        let ncol = block.len() / nrow;
+        for lc in 0..ncol {
+            let j = col_start + lc;
+            for i in j..nrow {
+                let mut acc = block[lc * nrow + i];
+                for q in 0..n_elim {
+                    let base = (k + q) * nrow;
+                    let alpha = head[base + j] * d_panel[q];
+                    acc -= alpha * head[base + i];
+                }
+                block[lc * nrow + i] = acc;
+            }
+        }
+    }
+
+    /// `apply_schur_panel_range_packed` is byte-identical to the scalar
+    /// reference across a size sweep (including non-multiple-of-MR/NR
+    /// row/col counts, and `col_start > k + n_elim` chunk offsets).
+    #[test]
+    fn packed_matches_scalar_reference_bit_for_bit() {
+        // Deterministic pseudo-random front data.
+        let mut s = 0x51ED_270B_5A11_CE17u64;
+        let mut next = || {
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((s >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+        };
+        for &(nrow, k, n_elim, col_start) in &[
+            (40usize, 0usize, 8usize, 8usize),
+            (37, 0, 5, 5),
+            (64, 0, 16, 16),
+            (100, 0, 12, 30), // chunk offset > k+n_elim
+            (23, 0, 3, 3),
+            (9, 0, 2, 2),
+        ] {
+            let head: Vec<f64> = (0..nrow * (k + n_elim)).map(|_| next()).collect();
+            let d_panel: Vec<f64> = (0..n_elim).map(|_| 0.5 + next().abs()).collect();
+            let ncol = nrow - col_start;
+            let block0: Vec<f64> = (0..ncol * nrow).map(|_| next()).collect();
+
+            let mut b_ref = block0.clone();
+            scalar_ref(&head, &mut b_ref, col_start, nrow, k, n_elim, &d_panel);
+
+            for fma in [false, true] {
+                let mut b_packed = block0.clone();
+                apply_schur_panel_range_packed(
+                    &head,
+                    &mut b_packed,
+                    col_start,
+                    nrow,
+                    k,
+                    n_elim,
+                    &d_panel,
+                    fma,
+                );
+                if !fma {
+                    // nofma packed must be byte-identical to the scalar
+                    // mul→sub reference on the lower triangle.
+                    for lc in 0..ncol {
+                        let j = col_start + lc;
+                        for i in j..nrow {
+                            assert_eq!(
+                                b_packed[lc * nrow + i].to_bits(),
+                                b_ref[lc * nrow + i].to_bits(),
+                                "nofma packed != scalar at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
+                            );
+                        }
+                    }
+                } else {
+                    // fma packed is within n_elim ULPs (single vs double
+                    // rounding); just assert it stays close and finite.
+                    for lc in 0..ncol {
+                        let j = col_start + lc;
+                        for i in j..nrow {
+                            let p = b_packed[lc * nrow + i];
+                            let r = b_ref[lc * nrow + i];
+                            assert!(p.is_finite());
+                            assert!(
+                                (p - r).abs() <= 1e-9 * (1.0 + r.abs()),
+                                "fma packed drifted too far at (i={i},j={j}): {p} vs {r}"
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -652,9 +652,32 @@ pub struct BunchKaufmanParams {
 /// the intra-front parallel Schur path stays serial even when
 /// [`BunchKaufmanParams::intrafront_parallel`] is set. Small fronts do
 /// not amortize the rayon fork/join; this floor keeps them on the
-/// zero-overhead serial path. Calibrated in
-/// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
-pub const INTRAFRONT_MIN_AREA: usize = 256 * 256;
+/// zero-overhead serial path.
+///
+/// Lever B (issue #91): lowered from the original `256*256` to `256*128`.
+/// On large-fill conic KKTs (qap15's 2955² root) the original floor left
+/// the tail of each front's trailing update — and whole medium fronts —
+/// on the serial path, capping schur scaling. Halving the floor pushes
+/// that work onto the (byte-exact) parallel path for a measured **~17%**
+/// end-to-end factor speedup on qap15 (interleaved: ~887 ms → ~739 ms,
+/// 10 cores), with no correctness change (per-column reduction is
+/// thread-independent). Going lower (≤ 16384) regressed — fork/join
+/// overhead on genuinely tiny fronts — so `256*128` is the measured sweet
+/// spot, not a floor-to-zero. See
+/// `dev/research/issue-91-parallel-dense-front-2026-06-30.md` and the
+/// original calibration `dev/research/lever-1.1-intrafront-parallel-schur.md`.
+pub const INTRAFRONT_MIN_AREA: usize = 256 * 128;
+
+/// Env override for [`INTRAFRONT_MIN_AREA`] (issue #91 Lever B tuning knob,
+/// mirroring `FERAL_INTRAFRONT`/`FERAL_PARALLEL`). Byte-exact (pure
+/// scheduling). Read once per parallel dispatch — a relaxed env read is
+/// negligible beside the front's factor cost.
+fn intrafront_min_area() -> usize {
+    std::env::var("FERAL_INTRAFRONT_MIN_AREA")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(INTRAFRONT_MIN_AREA)
+}
 
 /// Action to take when a near-zero pivot is encountered.
 #[derive(Debug, Clone)]
@@ -3187,11 +3210,11 @@ fn apply_blocked_schur_panel(
     let head: &[f64] = head;
 
     let area = (nrow - j_start).saturating_mul(n_elim);
-    if intrafront_parallel && area >= INTRAFRONT_MIN_AREA {
+    if intrafront_parallel && area >= intrafront_min_area() {
         use rayon::prelude::*;
         let ncol = nrow - j_start;
         let nthreads = rayon::current_num_threads().max(1);
-        // ~4 chunks per worker for load balance. Bit-exactness does not
+        // ~N chunks per worker for load balance. Bit-exactness does not
         // depend on chunk size (each column reduced on one thread), so
         // this is purely a scheduling knob.
         let chunk_cols = ncol.div_ceil(nthreads * 4).max(1);

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -3165,14 +3165,39 @@ fn apply_blocked_schur(
         return;
     }
 
-    // W-2 fast path: when the panel produced n_elim 1×1 pivots all
-    // with non-zero d AND no 2×2 pivots, run the rank-`n_elim`
-    // accumulator. The 2×2 gate is a correctness requirement (Phase
-    // A, dev/plans/dense-kernel-blas3.md): the rank-bs kernel
-    // accumulates contributions per-q sequentially (`acc -= a_q *
-    // s_q`), which is bit-exact with sequential rank-1 axpys but NOT
-    // with axpy2's fused `(a_0*s_0 + a_1*s_1)` add-then-sub
-    // ordering. Lifting this gate is Phase B-2.
+    // Issue #99 Phase B-2: the packed trailing update
+    // (`apply_schur_panel_range_packed`) handles a **mixed** 1×1 / 2×2 /
+    // zero-d pivot stream byte-exactly — each element walks the pivot
+    // stream in order, applying `mul → sub` for 1×1 and the fused
+    // `(dl0·L_q + dl1·L_{q+1})` add-then-sub for 2×2, matching the scalar
+    // reference and the strided fallback below. So when packing is
+    // enabled route **every** panel through it (not only all-1×1),
+    // extending the ~8–10× dense-front win to strongly-indefinite fronts
+    // and the FMA path (whose rounding drifts more pivots to 2×2).
+    if packed_schur_enabled() {
+        apply_blocked_schur_panel(
+            a,
+            nrow,
+            k,
+            n_elim,
+            j_start,
+            d_panel,
+            subdiag,
+            fma,
+            intrafront_parallel,
+        );
+        return;
+    }
+
+    // --- Strided path (`FERAL_PACKED_SCHUR=0`) ---
+    // W-2 fast path: when the panel produced n_elim 1×1 pivots all with
+    // non-zero d AND no 2×2 pivots, run the rank-`n_elim` accumulator.
+    // The 2×2 gate is a correctness requirement for the *strided* kernel:
+    // `schur_panel_minus_*_strided` accumulates per-q sequentially
+    // (`acc -= a_q · s_q`), bit-exact with sequential rank-1 axpys but
+    // NOT with axpy2's fused `(a_0·s_0 + a_1·s_1)` add-then-sub. (The
+    // packed path above lifts this because it walks the stream and emits
+    // the fused form for 2×2 pairs.)
     const W2_RANK_BS_MIN: usize = 2;
     let any_zero_d = d_panel.iter().take(n_elim).any(|&d| d.abs() == 0.0);
     let has_2x2 = subdiag[k..k + n_elim].iter().any(|&s| s != 0.0);
@@ -3185,6 +3210,7 @@ fn apply_blocked_schur(
             n_elim,
             j_start,
             d_panel,
+            subdiag,
             fma,
             intrafront_parallel,
         );
@@ -3276,6 +3302,7 @@ fn apply_blocked_schur_panel(
     n_elim: usize,
     j_start: usize,
     d_panel: &[f64],
+    subdiag: &[f64],
     fma: bool,
     intrafront_parallel: bool,
 ) {
@@ -3323,10 +3350,12 @@ fn apply_blocked_schur_panel(
             .enumerate()
             .for_each(|(ci, block)| {
                 let col_start = j_start + ci * chunk_cols;
-                apply_schur_panel_range(head, block, col_start, nrow, k, n_elim, d_panel, fma);
+                apply_schur_panel_range(
+                    head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+                );
             });
     } else {
-        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, fma);
+        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, subdiag, fma);
     }
 }
 
@@ -3360,6 +3389,7 @@ fn apply_schur_panel_range(
     k: usize,
     n_elim: usize,
     d_panel: &[f64],
+    subdiag: &[f64],
     fma: bool,
 ) {
     const MAX_N_ELIM: usize = 128;
@@ -3381,9 +3411,15 @@ fn apply_schur_panel_range(
     // Default on; `FERAL_PACKED_SCHUR=0` restores the strided path for
     // A/B benchmarking and as a safety override.
     if packed_schur_enabled() {
-        apply_schur_panel_range_packed(head, block, col_start, nrow, k, n_elim, d_panel, fma);
+        apply_schur_panel_range_packed(
+            head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+        );
         return;
     }
+    // Strided path below handles 1×1 pivots only; the caller
+    // (`apply_blocked_schur`) guarantees an all-1×1 panel here, so
+    // `subdiag` is unused on this path.
+    let _ = subdiag;
 
     let mut alphas0_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas1_buf = [0.0f64; MAX_N_ELIM];
@@ -3531,21 +3567,31 @@ fn packed_schur_enabled() -> bool {
 }
 
 /// Packed, register-tiled equivalent of [`apply_schur_panel_range`]
-/// (issue #99, BLAS-3). Computes the same lower-triangular rank-`n_elim`
-/// trailing update `A[i,j] -= Σ_q (L[j,q]·d_q)·L[i,q]` for `i >= j`, but
-/// packs the panel into `q`-contiguous `MR`/`NR` micro-panels so the
-/// inner `q` loop reads L1-resident memory instead of the strided
-/// `col_stride = nrow` access that bottlenecks the strided kernels.
+/// (issue #99, BLAS-3 — Phase B-2). Computes the same lower-triangular
+/// rank-`n_elim` trailing update for `i >= j`, packing the panel into
+/// `q`-contiguous `MR`/`NR` micro-panels so the inner loop reads
+/// L1-resident memory instead of the strided `col_stride = nrow` access
+/// that bottlenecks the strided kernels (~25× isolated,
+/// `examples/bench_schur_micro`).
 ///
-/// **Byte-exact** with [`apply_schur_panel_range`]: every element is
-/// reduced over ascending `q` with the same `mul → sub` (nofma) or
-/// `mul_add` (fma) as the reference — packing changes only memory
-/// layout, not arithmetic order (verified bit-for-bit in
-/// `examples/bench_schur_micro` and by the byte-exact factor parity
-/// suite). A zero `alpha` contributes `acc − round(0·L) = acc` for
-/// finite `L`, matching the strided kernels' explicit zero-skip; the
-/// packed path (reached only for all-1×1 panels with non-zero `d`) never
-/// sees a non-finite `L`, so no skip is needed.
+/// Handles a **mixed 1×1 / 2×2 / zero-d pivot stream**: each element
+/// walks the stream in `q` order and emits, per step,
+/// - **1×1** (`subdiag[k+q] == 0`): `acc -= (L[j,q]·d_q)·L[i,q]`
+///   (`mul → sub` nofma / `mul_add` fma), skipping `d_q == 0` exactly as
+///   the fallback does;
+/// - **2×2** (`subdiag[k+q] != 0`, `q+1 < n_elim`): the fused rank-2
+///   contribution `acc -= dl0·L[i,q] + dl1·L[i,q+1]` with
+///   `dl0 = d11·L[j,q] + d21·L[j,q+1]`, `dl1 = d21·L[j,q] + d22·L[j,q+1]`
+///   (`d11=d_panel[q]`, `d22=d_panel[q+1]`, `d21=subdiag[k+q]`), and
+///   advances two.
+///
+/// **Byte-exact** with the strided kernels and the scalar reference:
+/// packing changes only memory layout; the per-element rounding
+/// sequence — `mul → sub` for 1×1 and add-then-sub / two-FMA for 2×2 —
+/// matches `axpy_minus_unroll4*` / `axpy2_minus_unroll4*`
+/// (`do_1x1_update` / `do_2x2_update`) exactly. Verified by the
+/// `packed_matches_scalar_reference_bit_for_bit` unit test (mixed
+/// streams) and the byte-exact factor-parity suite.
 #[allow(clippy::too_many_arguments)]
 fn apply_schur_panel_range_packed(
     head: &[f64],
@@ -3555,6 +3601,7 @@ fn apply_schur_panel_range_packed(
     k: usize,
     n_elim: usize,
     d_panel: &[f64],
+    subdiag: &[f64],
     fma: bool,
 ) {
     let ncol = block.len() / nrow;
@@ -3566,6 +3613,12 @@ fn apply_schur_panel_range_packed(
     const MR: usize = 8;
     const NR: usize = 4;
 
+    // A 2×2 pivot pair starts at `q` when `subdiag[k+q] != 0` and `q+1`
+    // is still in-panel. Same predicate as the strided fallback; the
+    // walk below consumes such pairs two-at-a-time so the second element
+    // (`q+1`) is never re-entered as a start.
+    let is_2x2_start = |q: usize| q + 1 < n_elim && subdiag[k + q] != 0.0;
+
     // Column j (absolute) updates rows [j, nrow); the lowest column is
     // `col_start`, so the source/destination rows span [col_start, nrow).
     let row0 = col_start;
@@ -3574,10 +3627,8 @@ fn apply_schur_panel_range_packed(
     let npanels_i = rowspan.div_ceil(MR);
     let npanels_j = ncol.div_ceil(NR);
 
-    // Pack A (source rows) and B (D-scaled source columns) into
-    // `q`-contiguous micro-panels. `L[x, k+q] = head[(k+q)*nrow + x]`.
-    //   apack[pi*(n_elim*MR) + q*MR + ir] = L[row0 + pi*MR + ir, k+q]
-    //   bpack[pj*(n_elim*NR) + q*NR + jr] = L[col_start + pj*NR + jr, k+q] * d_q
+    // Pack A (source rows): `apack[pi][q][ir] = L[row0+pi*MR+ir, k+q]`,
+    // `L[x, k+q] = head[(k+q)*nrow + x]`.
     let mut apack = vec![0.0f64; npanels_i * n_elim * MR];
     for pi in 0..npanels_i {
         let i0 = row0 + pi * MR;
@@ -3590,20 +3641,40 @@ fn apply_schur_panel_range_packed(
             }
         }
     }
-    let mut bpack = vec![0.0f64; npanels_j * n_elim * NR];
+    // Pack B0 and B1 (D-scaled source columns). At a 1×1 step,
+    // `B0 = L[j,q]·d_q` (`B1` unused). At a 2×2 start, `B0 = dl0`,
+    // `B1 = dl1` (the block-scaled coefficients above). 2×2-second and
+    // zero-d-1×1 positions carry a value that the accumulation walk
+    // never reads.
+    let mut bpack0 = vec![0.0f64; npanels_j * n_elim * NR];
+    let mut bpack1 = vec![0.0f64; npanels_j * n_elim * NR];
     for pj in 0..npanels_j {
         let j0 = col_start + pj * NR;
         for q in 0..n_elim {
             let base = (k + q) * nrow;
-            let dq = d_panel[q];
-            let out = &mut bpack[pj * (n_elim * NR) + q * NR..][..NR];
-            for (jr, o) in out.iter_mut().enumerate() {
-                let j = j0 + jr;
-                *o = if j < col_end {
-                    head[base + j] * dq
-                } else {
-                    0.0
-                };
+            let off = pj * (n_elim * NR) + q * NR;
+            if is_2x2_start(q) {
+                let d11 = d_panel[q];
+                let d22 = d_panel[q + 1];
+                let d21 = subdiag[k + q];
+                let base1 = (k + q + 1) * nrow;
+                for jr in 0..NR {
+                    let j = j0 + jr;
+                    if j < col_end {
+                        let l_jq = head[base + j];
+                        let l_jq1 = head[base1 + j];
+                        bpack0[off + jr] = d11 * l_jq + d21 * l_jq1;
+                        bpack1[off + jr] = d21 * l_jq + d22 * l_jq1;
+                    }
+                }
+            } else {
+                let dq = d_panel[q];
+                for jr in 0..NR {
+                    let j = j0 + jr;
+                    if j < col_end {
+                        bpack0[off + jr] = head[base + j] * dq;
+                    }
+                }
             }
         }
     }
@@ -3639,29 +3710,57 @@ fn apply_schur_panel_range_packed(
                 }
             }
 
-            // Accumulate over the whole q range. Out-of-range lanes carry
-            // packed zeros (0·L = 0), so they are inert and never stored.
-            if fma {
-                for q in 0..n_elim {
-                    let a = &apack[abase + q * MR..][..MR];
-                    let b = &bpack[bbase + q * NR..][..NR];
-                    for (jr, accj) in acc.iter_mut().enumerate() {
-                        let nb = -b[jr];
-                        for (ir, acci) in accj.iter_mut().enumerate() {
-                            *acci = nb.mul_add(a[ir], *acci);
+            // Walk the pivot stream in `q` order. Out-of-range column
+            // lanes carry packed 0 coefficients (0·L = 0), so they are
+            // inert and never stored.
+            let mut q = 0usize;
+            while q < n_elim {
+                if is_2x2_start(q) {
+                    let a0 = &apack[abase + q * MR..][..MR];
+                    let a1 = &apack[abase + (q + 1) * MR..][..MR];
+                    let b0 = &bpack0[bbase + q * NR..][..NR];
+                    let b1 = &bpack1[bbase + q * NR..][..NR];
+                    if fma {
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let n0 = -b0[jr];
+                            let n1 = -b1[jr];
+                            for (ir, acci) in accj.iter_mut().enumerate() {
+                                // Two FMAs, matching axpy2_minus_unroll4.
+                                *acci = n1.mul_add(a1[ir], n0.mul_add(a0[ir], *acci));
+                            }
+                        }
+                    } else {
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let (d0, d1) = (b0[jr], b1[jr]);
+                            for (ir, acci) in accj.iter_mut().enumerate() {
+                                // Add-then-sub, matching axpy2_minus_unroll4_nofma.
+                                *acci -= d0 * a0[ir] + d1 * a1[ir];
+                            }
                         }
                     }
-                }
-            } else {
-                for q in 0..n_elim {
-                    let a = &apack[abase + q * MR..][..MR];
-                    let b = &bpack[bbase + q * NR..][..NR];
-                    for (jr, accj) in acc.iter_mut().enumerate() {
-                        let bj = b[jr];
-                        for (ir, acci) in accj.iter_mut().enumerate() {
-                            *acci -= bj * a[ir];
+                    q += 2;
+                } else {
+                    // 1×1; skip a zero pivot exactly as the fallback does.
+                    if d_panel[q] != 0.0 {
+                        let a0 = &apack[abase + q * MR..][..MR];
+                        let b0 = &bpack0[bbase + q * NR..][..NR];
+                        if fma {
+                            for (jr, accj) in acc.iter_mut().enumerate() {
+                                let nb = -b0[jr];
+                                for (ir, acci) in accj.iter_mut().enumerate() {
+                                    *acci = nb.mul_add(a0[ir], *acci);
+                                }
+                            }
+                        } else {
+                            for (jr, accj) in acc.iter_mut().enumerate() {
+                                let bj = b0[jr];
+                                for (ir, acci) in accj.iter_mut().enumerate() {
+                                    *acci -= bj * a0[ir];
+                                }
+                            }
                         }
                     }
+                    q += 1;
                 }
             }
 
@@ -5969,10 +6068,18 @@ mod ncol_zero_contrib_tests {
 mod packed_schur_tests {
     use super::*;
 
-    /// Scalar reference for the lower-triangular rank-`n_elim` trailing
-    /// update: `A[i,j] -= Σ_q (L[j,q]·d_q)·L[i,q]` for `i >= j`, ascending
-    /// q, explicit `mul → sub` (nofma) — the exact per-element contract
-    /// every dense kernel must reproduce bit-for-bit.
+    /// Scalar reference for the mixed 1×1 / 2×2 / zero-d trailing update,
+    /// walking the pivot stream in `q` order with the exact per-element
+    /// rounding the kernels must reproduce:
+    /// - 1×1 (`subdiag[k+q]==0`, `d_q!=0`): `acc -= (L[j,q]·d_q)·L[i,q]`,
+    ///   as `mul→sub` (nofma) or a single `mul_add` (fma);
+    /// - 2×2 (`subdiag[k+q]!=0`): `acc -= dl0·L[i,q] + dl1·L[i,q+1]` as
+    ///   add-then-sub (nofma) or two chained FMAs (fma).
+    ///
+    /// This mirrors `axpy_minus_unroll4*` / `axpy2_minus_unroll4*` exactly,
+    /// so the packed kernel must be **byte-identical** for both `fma`
+    /// modes.
+    #[allow(clippy::too_many_arguments)]
     fn scalar_ref(
         head: &[f64],
         block: &mut [f64],
@@ -5981,16 +6088,42 @@ mod packed_schur_tests {
         k: usize,
         n_elim: usize,
         d_panel: &[f64],
+        subdiag: &[f64],
+        fma: bool,
     ) {
         let ncol = block.len() / nrow;
         for lc in 0..ncol {
             let j = col_start + lc;
             for i in j..nrow {
                 let mut acc = block[lc * nrow + i];
-                for q in 0..n_elim {
-                    let base = (k + q) * nrow;
-                    let alpha = head[base + j] * d_panel[q];
-                    acc -= alpha * head[base + i];
+                let mut q = 0usize;
+                while q < n_elim {
+                    if q + 1 < n_elim && subdiag[k + q] != 0.0 {
+                        let d11 = d_panel[q];
+                        let d22 = d_panel[q + 1];
+                        let d21 = subdiag[k + q];
+                        let b0 = (k + q) * nrow;
+                        let b1 = (k + q + 1) * nrow;
+                        let dl0 = d11 * head[b0 + j] + d21 * head[b1 + j];
+                        let dl1 = d21 * head[b0 + j] + d22 * head[b1 + j];
+                        if fma {
+                            acc = (-dl1).mul_add(head[b1 + i], (-dl0).mul_add(head[b0 + i], acc));
+                        } else {
+                            acc -= dl0 * head[b0 + i] + dl1 * head[b1 + i];
+                        }
+                        q += 2;
+                    } else {
+                        if d_panel[q] != 0.0 {
+                            let base = (k + q) * nrow;
+                            let alpha = head[base + j] * d_panel[q];
+                            if fma {
+                                acc = (-alpha).mul_add(head[base + i], acc);
+                            } else {
+                                acc -= alpha * head[base + i];
+                            }
+                        }
+                        q += 1;
+                    }
                 }
                 block[lc * nrow + i] = acc;
             }
@@ -5998,8 +6131,10 @@ mod packed_schur_tests {
     }
 
     /// `apply_schur_panel_range_packed` is byte-identical to the scalar
-    /// reference across a size sweep (including non-multiple-of-MR/NR
-    /// row/col counts, and `col_start > k + n_elim` chunk offsets).
+    /// reference across a size sweep — for both `fma` modes and for pivot
+    /// streams mixing 1×1, 2×2, and zero-d pivots — including
+    /// non-multiple-of-MR/NR row/col counts and `col_start > k+n_elim`
+    /// chunk offsets.
     #[test]
     fn packed_matches_scalar_reference_bit_for_bit() {
         // Deterministic pseudo-random front data.
@@ -6010,23 +6145,45 @@ mod packed_schur_tests {
                 .wrapping_add(1442695040888963407);
             ((s >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
         };
-        for &(nrow, k, n_elim, col_start) in &[
-            (40usize, 0usize, 8usize, 8usize),
-            (37, 0, 5, 5),
-            (64, 0, 16, 16),
-            (100, 0, 12, 30), // chunk offset > k+n_elim
-            (23, 0, 3, 3),
-            (9, 0, 2, 2),
+        // (nrow, k, n_elim, col_start, subdiag-pattern). Patterns:
+        //   "1x1"  — all 1×1
+        //   "2x2"  — 2×2 pairs at q = 2 and q = 5 (where they fit)
+        //   "zero" — a zero-d 1×1 at q = 1
+        for &(nrow, k, n_elim, col_start, pat) in &[
+            (40usize, 0usize, 8usize, 8usize, "1x1"),
+            (37, 0, 5, 5, "1x1"),
+            (64, 0, 16, 16, "2x2"),
+            (100, 0, 12, 30, "2x2"), // chunk offset > k+n_elim, with 2×2
+            (23, 0, 8, 3, "2x2"),
+            (40, 0, 8, 8, "zero"),
+            (50, 0, 10, 10, "2x2"),
+            (9, 0, 2, 2, "1x1"),
         ] {
             let head: Vec<f64> = (0..nrow * (k + n_elim)).map(|_| next()).collect();
-            let d_panel: Vec<f64> = (0..n_elim).map(|_| 0.5 + next().abs()).collect();
+            let mut d_panel: Vec<f64> = (0..n_elim).map(|_| 0.5 + next().abs()).collect();
+            let mut subdiag = vec![0.0f64; k + n_elim];
+            match pat {
+                "2x2" => {
+                    if 2 + 1 < n_elim {
+                        subdiag[k + 2] = 0.3 + next().abs();
+                    }
+                    if 5 + 1 < n_elim {
+                        subdiag[k + 5] = -(0.3 + next().abs());
+                    }
+                }
+                "zero" => {
+                    d_panel[1] = 0.0;
+                }
+                _ => {}
+            }
             let ncol = nrow - col_start;
             let block0: Vec<f64> = (0..ncol * nrow).map(|_| next()).collect();
 
-            let mut b_ref = block0.clone();
-            scalar_ref(&head, &mut b_ref, col_start, nrow, k, n_elim, &d_panel);
-
             for fma in [false, true] {
+                let mut b_ref = block0.clone();
+                scalar_ref(
+                    &head, &mut b_ref, col_start, nrow, k, n_elim, &d_panel, &subdiag, fma,
+                );
                 let mut b_packed = block0.clone();
                 apply_schur_panel_range_packed(
                     &head,
@@ -6036,35 +6193,17 @@ mod packed_schur_tests {
                     k,
                     n_elim,
                     &d_panel,
+                    &subdiag,
                     fma,
                 );
-                if !fma {
-                    // nofma packed must be byte-identical to the scalar
-                    // mul→sub reference on the lower triangle.
-                    for lc in 0..ncol {
-                        let j = col_start + lc;
-                        for i in j..nrow {
-                            assert_eq!(
-                                b_packed[lc * nrow + i].to_bits(),
-                                b_ref[lc * nrow + i].to_bits(),
-                                "nofma packed != scalar at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
-                            );
-                        }
-                    }
-                } else {
-                    // fma packed is within n_elim ULPs (single vs double
-                    // rounding); just assert it stays close and finite.
-                    for lc in 0..ncol {
-                        let j = col_start + lc;
-                        for i in j..nrow {
-                            let p = b_packed[lc * nrow + i];
-                            let r = b_ref[lc * nrow + i];
-                            assert!(p.is_finite());
-                            assert!(
-                                (p - r).abs() <= 1e-9 * (1.0 + r.abs()),
-                                "fma packed drifted too far at (i={i},j={j}): {p} vs {r}"
-                            );
-                        }
+                for lc in 0..ncol {
+                    let j = col_start + lc;
+                    for i in j..nrow {
+                        assert_eq!(
+                            b_packed[lc * nrow + i].to_bits(),
+                            b_ref[lc * nrow + i].to_bits(),
+                            "packed != scalar (fma={fma}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
+                        );
                     }
                 }
             }

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -469,6 +469,31 @@ impl Solver {
         self
     }
 
+    /// Opt into the FMA trailing-Schur kernels on **large fronts only**
+    /// (issue #99, Lever 3). Every front whose trailing-update area
+    /// `nrow * ncol >= min_area` uses the single-rounding FMA kernels
+    /// (~1.7× measured per-core on a 2955-row indefinite root, x86 V3);
+    /// smaller fronts keep the bit-exact `*_nofma` path. This lets one
+    /// factorization run the fast path on its throughput-dominant roots
+    /// while sensitive small KKT fronts — where FMA rounding can perturb
+    /// Bunch-Kaufman pivot classification — stay on the reference
+    /// kernels.
+    ///
+    /// Unlike [`with_fma`](Self::with_fma) (all-or-nothing), this leaves
+    /// small fronts bit-exact. It still changes cross-arch bit patterns
+    /// on the gated large fronts, so it is a deliberate opt-in. Inertia
+    /// is preserved on well-conditioned fronts. A reasonable starting
+    /// `min_area` is `256 * 256`. See
+    /// `dev/research/issue-99-dense-front-fma-gate.md`.
+    pub fn with_fma_large_fronts(mut self, min_area: usize) -> Self {
+        // Written straight to `bk` — the params the dense front factor
+        // reads — so no separate `NumericParams` field or funnel is
+        // needed (contrast `with_fma`, kept separate for historical
+        // reasons). Both multifrontal drivers pass `bk` per front.
+        self.numeric_params.bk.fma_min_front_area = Some(min_area);
+        self
+    }
+
     /// Disable delayed pivoting. When `on = true`, every supernode
     /// runs as if it were the root: pivots failing the BK threshold
     /// or 2×2 Duff–Reid test are force-accepted in place via

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -469,28 +469,31 @@ impl Solver {
         self
     }
 
-    /// Opt into the FMA trailing-Schur kernels on **large fronts only**
-    /// (issue #99, Lever 3). Every front whose trailing-update area
-    /// `nrow * ncol >= min_area` uses the single-rounding FMA kernels
-    /// (~1.7× measured per-core on a 2955-row indefinite root, x86 V3);
+    /// Opt into the FMA trailing-Schur kernels on **tall fronts only**
+    /// (issue #99, Lever 3). Every front with at least `min_rows` rows
+    /// (`nrow >= min_rows`) uses the single-rounding FMA kernels (~1.6×
+    /// measured end-to-end on the synthetic qap15 stand-in, x86 V3);
     /// smaller fronts keep the bit-exact `*_nofma` path. This lets one
-    /// factorization run the fast path on its throughput-dominant roots
+    /// factorization run the fast path on its throughput-dominant fronts
     /// while sensitive small KKT fronts — where FMA rounding can perturb
     /// Bunch-Kaufman pivot classification — stay on the reference
     /// kernels.
     ///
-    /// Unlike [`with_fma`](Self::with_fma) (all-or-nothing), this leaves
-    /// small fronts bit-exact. It still changes cross-arch bit patterns
-    /// on the gated large fronts, so it is a deliberate opt-in. Inertia
-    /// is preserved on well-conditioned fronts. A reasonable starting
-    /// `min_area` is `256 * 256`. See
+    /// The gate is on **rows**, not `nrow * ncol` area: real conic-KKT
+    /// factorizations spend their time in *tall, thin* fronts (large
+    /// `nrow`, small `ncol` — e.g. `2000 × 16`), which an area gate
+    /// misses entirely. Unlike [`with_fma`](Self::with_fma)
+    /// (all-or-nothing), this leaves small fronts bit-exact. It still
+    /// changes cross-arch bit patterns on the gated fronts, so it is a
+    /// deliberate opt-in. Inertia is preserved on well-conditioned
+    /// fronts. A reasonable starting `min_rows` is `256`. See
     /// `dev/research/issue-99-dense-front-fma-gate.md`.
-    pub fn with_fma_large_fronts(mut self, min_area: usize) -> Self {
+    pub fn with_fma_large_fronts(mut self, min_rows: usize) -> Self {
         // Written straight to `bk` — the params the dense front factor
         // reads — so no separate `NumericParams` field or funnel is
         // needed (contrast `with_fma`, kept separate for historical
         // reasons). Both multifrontal drivers pass `bk` per front.
-        self.numeric_params.bk.fma_min_front_area = Some(min_area);
+        self.numeric_params.bk.fma_min_front_rows = Some(min_rows);
         self
     }
 

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -680,6 +680,108 @@ fn symbolic_factorize_race(
     })
 }
 
+/// Resolve [`OrderingPreprocess::Auto`] by verifying fill rather than
+/// trusting [`pick_ordering_preprocess`] alone.
+///
+/// The predicate is a structural one-way proxy and can recommend
+/// `LdltCompress` on patterns where MC64 symmetric-matching compression
+/// *inflates* fill instead of reducing it (issue #91). To make `Auto`
+/// safe on every input we:
+///
+/// - keep `None` with no extra work when the predicate declines — `None`
+///   is the baseline, so no regression is possible; and
+/// - when the predicate recommends `LdltCompress`, run the symbolic
+///   pipeline both ways and keep whichever has the smaller
+///   `factor_nnz_estimate`.
+///
+/// This guarantees `Auto` fill ≤ `None` fill for every matrix while
+/// preserving `LdltCompress`'s wins where it genuinely helps (cf. MUMPS
+/// `ICNTL(12)=2`). The extra pipeline runs only when `LdltCompress` was
+/// going to be applied anyway; its MC64 matching (the dominant cost)
+/// runs regardless.
+///
+/// Profiler handling mirrors [`symbolic_factorize_race`]: each candidate
+/// gets a fresh profiler and the winner's is copied into the caller's
+/// shared one, so the report reflects exactly one run.
+fn symbolic_factorize_preprocess_auto(
+    matrix: &CscMatrix,
+    snode_params: &SupernodeParams,
+    method: OrderingMethod,
+) -> Result<SymbolicFactorization, FeralError> {
+    debug_assert_eq!(snode_params.preprocess, OrderingPreprocess::Auto);
+
+    // Run one concrete preprocessor with an isolated profiler. Returns
+    // `(symbolic, profiler-snapshot)` so the caller can keep the winner's.
+    let run = |pp: OrderingPreprocess| -> Result<(SymbolicFactorization, Option<SymbolicProfiler>), FeralError> {
+        let cand_prof = snode_params
+            .symbolic_profiler
+            .as_ref()
+            .map(|_| std::sync::Arc::new(std::sync::Mutex::new(SymbolicProfiler::new())));
+        let cand_params = SupernodeParams {
+            preprocess: pp,
+            symbolic_profiler: cand_prof.clone(),
+            ..snode_params.clone()
+        };
+        let sym = symbolic_factorize_with_method(matrix, &cand_params, method)?;
+        let snap = cand_prof.and_then(|a| a.lock().ok().map(|g| g.clone()));
+        Ok((sym, snap))
+    };
+
+    let copy_profiler = |snap: Option<SymbolicProfiler>| {
+        if let (Some(shared), Some(winner)) = (snode_params.symbolic_profiler.as_ref(), snap) {
+            if let Ok(mut p) = shared.lock() {
+                *p = winner;
+            }
+        }
+    };
+
+    // The predicate is the *only* thing that could recommend compression;
+    // when it declines, `None` is the baseline and there is nothing to
+    // verify against.
+    if pick_ordering_preprocess(matrix) == OrderingPreprocess::None {
+        let (sym, snap) = run(OrderingPreprocess::None)?;
+        copy_profiler(snap);
+        return Ok(sym);
+    }
+
+    // Predicate recommends compression — honor it *unless* it inflates
+    // fill catastrophically. LdltCompress (MUMPS ICNTL(12)=2 for SYM=2)
+    // carries a numerical benefit — MC64-matched 2×2 pivots that give the
+    // oracle-correct inertia on near-singular KKTs (e.g. twirism1, where
+    // LdltCompress is +15 % fill but its ordering is the inertia-correct
+    // one) — that symbolic `factor_nnz_estimate` does not capture. So a
+    // modest fill increase keeps it; only a runaway inflation (the qap15
+    // pathology: 6.3× fill, 20× slower factor) overrides the predicate and
+    // falls back to None. `PREPROCESS_FILL_INFLATION_LIMIT` sits well above
+    // the normal ~1.1–1.2× compression overhead and well below qap15's
+    // 6.3×. Validated by the full corpus suite (no inertia regression) plus
+    // `tests/issue91_preprocess_misfire.rs`.
+    let none = run(OrderingPreprocess::None)?;
+    let none_limit = (none.0.factor_nnz_estimate as f64) * PREPROCESS_FILL_INFLATION_LIMIT;
+    match run(OrderingPreprocess::LdltCompress) {
+        Ok((comp_sym, comp_snap)) if (comp_sym.factor_nnz_estimate as f64) <= none_limit => {
+            copy_profiler(comp_snap);
+            Ok(comp_sym)
+        }
+        // LdltCompress inflates fill past the catastrophe limit (or failed)
+        // — use None.
+        _ => {
+            copy_profiler(none.1);
+            Ok(none.0)
+        }
+    }
+}
+
+/// Fill-inflation ceiling for the [`OrderingPreprocess::Auto`] race. When
+/// the structural predicate recommends `LdltCompress`, the verified race
+/// keeps it unless its symbolic `factor_nnz_estimate` exceeds this
+/// multiple of the `None` baseline — i.e. compression must not more than
+/// double the fill. Above this it is treated as a predicate misfire
+/// (issue #91: qap15 conic KKT inflates 6.3×) and `None` is used instead.
+/// Set generously above the normal ~1.1–1.2× compression overhead so the
+/// inertia benefit of `LdltCompress` on near-singular KKTs is preserved.
+const PREPROCESS_FILL_INFLATION_LIMIT: f64 = 2.0;
+
 /// Like [`symbolic_factorize`] but lets the caller pick the
 /// fill-reducing ordering via [`OrderingMethod`].
 ///
@@ -696,6 +798,17 @@ pub fn symbolic_factorize_with_method(
     // `OrderingMethod`, so there is no infinite loop.
     if method == OrderingMethod::AutoRace {
         return symbolic_factorize_race(matrix, snode_params);
+    }
+    // `OrderingPreprocess::Auto` is resolved by *verifying* fill, not by
+    // trusting the structural predicate alone. `pick_ordering_preprocess`
+    // is a one-way proxy ("many low-degree columns ⇒ compression helps")
+    // that mis-fires on regularized quasi-definite IPM KKTs — their
+    // diagonal regularization rows are degree-≤2 columns, so the proxy
+    // recommends `LdltCompress` exactly where MC64 compression *inflates*
+    // fill (issue #91: qap15 conic KKT, 7.16M → 45.4M, 0.77s → 15.4s).
+    // Race None vs LdltCompress on symbolic fill and keep the smaller.
+    if snode_params.preprocess == OrderingPreprocess::Auto {
+        return symbolic_factorize_preprocess_auto(matrix, snode_params, method);
     }
     let n = matrix.n;
 

--- a/tests/issue91_preprocess_misfire.rs
+++ b/tests/issue91_preprocess_misfire.rs
@@ -1,0 +1,96 @@
+//! Issue #91 regression: `OrderingPreprocess::Auto` must not inflate fill
+//! on a quasi-definite conic KKT.
+//!
+//! The qap15 conic KKT (n=50880, nnz=168105) is saturated with degree-≤2
+//! columns (the diagonal regularization rows), so the structural predicate
+//! `pick_ordering_preprocess` recommends `LdltCompress` — exactly where
+//! MC64 compression *inflates* fill: simplicial nnz_L jumps from ≈7.16M
+//! (preprocess=None) to ≈45.4M, and the numeric factor from ≈0.8s to ≈15s.
+//! The fix makes `Auto` verify fill (race None vs LdltCompress) instead of
+//! trusting the predicate, so `Auto` fill ≤ `None` fill always.
+//!
+//! The fixture `tests/data/large/qap15_kkt.mtx` is a generated conic-IPM
+//! KKT (pounce-convex on qap15.mps), not a SuiteSparse download, so it is
+//! gitignored and regenerated on demand via
+//! `dev/scripts/regen_qap15_kkt.sh`. When absent (e.g. CI), this test
+//! prints a SKIP line and passes — a local/opt-in regression guard, not a
+//! CI gate.
+//!
+//! Oracle (external — measured on the real matrix, cf.
+//! `dev/research/issue-91-preprocess-misfire.md`): preprocess=None ≈7.16M,
+//! the buggy Auto-via-predicate ≈45.4M. The `< 20M` threshold separates
+//! them with wide margin and is robust to ordering-impl drift.
+
+use feral::read_mtx;
+use feral::symbolic::{
+    pick_ordering_preprocess, symbolic_factorize_with_method, total_factor_nnz, OrderingMethod,
+    OrderingPreprocess, SupernodeParams,
+};
+use std::path::Path;
+
+#[test]
+fn qap15_auto_preprocess_does_not_inflate_fill() {
+    let path = Path::new("tests/data/large/qap15_kkt.mtx");
+    if !path.is_file() {
+        eprintln!(
+            "SKIP: {} not present. Regenerate with dev/scripts/regen_qap15_kkt.sh.",
+            path.display()
+        );
+        return;
+    }
+
+    let m = read_mtx(path)
+        .and_then(|mtx| mtx.to_csc())
+        .expect("read qap15_kkt.mtx");
+    assert_eq!(m.n, 50880, "unexpected qap15 KKT dimension");
+
+    // The predicate *does* recommend compression on this pattern — that is
+    // the trap the race must defuse. (Documents the regression trigger; if
+    // the predicate ever stops firing here, this matrix no longer guards
+    // the bug and the fixture should be revisited.)
+    assert_eq!(
+        pick_ordering_preprocess(&m),
+        OrderingPreprocess::LdltCompress,
+        "issue #91: predicate is expected to (mistakenly) recommend LdltCompress here"
+    );
+
+    // Compare Auto vs None under the *same* ordering method to isolate the
+    // preprocessing effect.
+    let auto_params = SupernodeParams {
+        preprocess: OrderingPreprocess::Auto,
+        ..SupernodeParams::default()
+    };
+    let none_params = SupernodeParams {
+        preprocess: OrderingPreprocess::None,
+        ..SupernodeParams::default()
+    };
+    let auto = symbolic_factorize_with_method(&m, &auto_params, OrderingMethod::Amd)
+        .expect("symbolic factorize qap15 (Auto)");
+    let none = symbolic_factorize_with_method(&m, &none_params, OrderingMethod::Amd)
+        .expect("symbolic factorize qap15 (None)");
+
+    let auto_nnz = total_factor_nnz(&auto.col_counts);
+    let none_nnz = total_factor_nnz(&none.col_counts);
+
+    // Core invariant: the verified race can never do worse than None.
+    assert!(
+        auto_nnz <= none_nnz,
+        "issue #91: Auto fill {auto_nnz} must not exceed None fill {none_nnz}"
+    );
+
+    // Regression guard: the buggy predicate path produced ≈45.4M; the fixed
+    // race lands at ≈7.16M. 20M separates them with wide margin.
+    assert!(
+        auto_nnz < 20_000_000,
+        "issue #91: Auto nnz_L = {auto_nnz} should be < 20M \
+         (None ≈ 7.16M; the predicate-trusting regression was ≈ 45.4M)",
+        auto_nnz = auto_nnz
+    );
+
+    // And the verified Auto must have rejected LdltCompress here.
+    assert_eq!(
+        auto.resolved_preprocess,
+        OrderingPreprocess::None,
+        "issue #91: verified Auto must resolve to None on qap15 (LdltCompress inflates fill)"
+    );
+}

--- a/tests/issue99_fma_front_gate.rs
+++ b/tests/issue99_fma_front_gate.rs
@@ -1,0 +1,183 @@
+//! Issue #99, Lever 3: opt-in per-front FMA size gate.
+//!
+//! `BunchKaufmanParams::fma_min_front_area = Some(t)` routes a front to
+//! the FMA trailing-Schur kernels when `nrow * ncol >= t`, even when the
+//! global `fma` flag is off — while leaving smaller fronts on the
+//! bit-exact `*_nofma` path. These tests pin that behavior:
+//!
+//!  1. gate-armed + large front  ==  explicit `fma = true`   (bit-for-bit)
+//!  2. gate-armed + small front  ==  default `fma = false`   (bit-for-bit)
+//!  3. gate does not change inertia on a well-conditioned front.
+//!
+//! The oracle for (1) and (2) is another feral factorization with the
+//! effective flag set explicitly — a self-consistency contract, not an
+//! external numeric oracle, so no tolerance is involved: the assertion is
+//! byte equality (`f64::to_bits`).
+
+use feral::dense::factor::factor_frontal_blocked;
+use feral::{BunchKaufmanParams, SymmetricMatrix};
+
+/// Deterministic SplitMix64 → [-1, 1). Reproducible fixture, no `rand`.
+fn mix(state: &mut u64) -> f64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+}
+
+/// Symmetric indefinite front (alternating-sign dominant diagonal, small
+/// off-diagonal noise) that factors through the all-1×1-pivot fast path.
+fn build_front(n: usize) -> SymmetricMatrix {
+    let mut s = 0x1234_5678_9ABC_DEF0u64;
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            data[j * n + i] = if i == j {
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                sign * (n as f64) + mix(&mut s)
+            } else {
+                0.30 * mix(&mut s)
+            };
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+fn factor(
+    matrix: &SymmetricMatrix,
+    params: &BunchKaufmanParams,
+) -> feral::dense::factor::FrontalFactors {
+    // Root front: every column fully summed, no delayed pivots.
+    factor_frontal_blocked(matrix, matrix.n, false, params).expect("factor failed")
+}
+
+fn assert_bits_eq(a: &[f64], b: &[f64], what: &str) {
+    assert_eq!(a.len(), b.len(), "{what}: length mismatch");
+    for (i, (x, y)) in a.iter().zip(b).enumerate() {
+        assert_eq!(
+            x.to_bits(),
+            y.to_bits(),
+            "{what}: element {i} differs ({x} vs {y})"
+        );
+    }
+}
+
+fn assert_factors_bit_identical(
+    x: &feral::dense::factor::FrontalFactors,
+    y: &feral::dense::factor::FrontalFactors,
+    what: &str,
+) {
+    assert_bits_eq(&x.l, &y.l, &format!("{what}: l"));
+    assert_bits_eq(&x.d_diag, &y.d_diag, &format!("{what}: d_diag"));
+    assert_bits_eq(&x.d_subdiag, &y.d_subdiag, &format!("{what}: d_subdiag"));
+    assert_bits_eq(&x.contrib, &y.contrib, &format!("{what}: contrib"));
+    assert_eq!(x.perm, y.perm, "{what}: perm");
+    assert_eq!(x.inertia, y.inertia, "{what}: inertia");
+}
+
+#[test]
+fn gate_on_large_front_matches_explicit_fma() {
+    let n = 96;
+    let matrix = build_front(n);
+
+    // Gate armed with a threshold this front clears (n*n = 9216 >= 1).
+    let gated = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_area: Some(1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    // Oracle: the same front factored with FMA turned on globally.
+    let explicit_fma = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: true,
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_factors_bit_identical(&gated, &explicit_fma, "gate-on-large vs explicit-fma");
+}
+
+#[test]
+fn gate_below_threshold_matches_nofma_default() {
+    let n = 96;
+    let matrix = build_front(n);
+
+    // Gate armed but threshold unreachable → must stay on nofma.
+    let gated_but_small = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_area: Some(usize::MAX),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let nofma_default = factor(&matrix, &BunchKaufmanParams::default());
+    assert_factors_bit_identical(
+        &gated_but_small,
+        &nofma_default,
+        "gate-below-threshold vs nofma-default",
+    );
+}
+
+#[test]
+fn gate_preserves_inertia() {
+    let n = 96;
+    let matrix = build_front(n);
+    let nofma = factor(&matrix, &BunchKaufmanParams::default());
+    let gated = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_area: Some(1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_eq!(
+        nofma.inertia, gated.inertia,
+        "FMA size gate must not change inertia on a well-conditioned front"
+    );
+    // Sanity: this fixture is genuinely indefinite (both signs present).
+    assert!(nofma.inertia.positive > 0 && nofma.inertia.negative > 0);
+}
+
+/// The threshold is on `nrow * ncol`, so a boundary value must gate
+/// exactly: area == t fires (>=), area == t+1'th smaller front does not.
+#[test]
+fn gate_threshold_is_area_nrow_times_ncol() {
+    let n = 96;
+    let matrix = build_front(n);
+    let area = n * n; // ncol == nrow == n for a root front.
+
+    // Exactly at the boundary: `>=` means it fires → matches fma=true.
+    let at_boundary = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma_min_front_area: Some(area),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let explicit_fma = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: true,
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_factors_bit_identical(&at_boundary, &explicit_fma, "area==t boundary fires");
+
+    // One above the area: does not fire → matches nofma.
+    let just_above = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma_min_front_area: Some(area + 1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let nofma_default = factor(&matrix, &BunchKaufmanParams::default());
+    assert_factors_bit_identical(&just_above, &nofma_default, "area<t does not fire");
+}

--- a/tests/issue99_fma_front_gate.rs
+++ b/tests/issue99_fma_front_gate.rs
@@ -1,7 +1,7 @@
 //! Issue #99, Lever 3: opt-in per-front FMA size gate.
 //!
-//! `BunchKaufmanParams::fma_min_front_area = Some(t)` routes a front to
-//! the FMA trailing-Schur kernels when `nrow * ncol >= t`, even when the
+//! `BunchKaufmanParams::fma_min_front_rows = Some(t)` routes a front to
+//! the FMA trailing-Schur kernels when `nrow >= t`, even when the
 //! global `fma` flag is off — while leaving smaller fronts on the
 //! bit-exact `*_nofma` path. These tests pin that behavior:
 //!
@@ -82,12 +82,12 @@ fn gate_on_large_front_matches_explicit_fma() {
     let n = 96;
     let matrix = build_front(n);
 
-    // Gate armed with a threshold this front clears (n*n = 9216 >= 1).
+    // Gate armed with a threshold this front clears (nrow = 96 >= 1).
     let gated = factor(
         &matrix,
         &BunchKaufmanParams {
             fma: false,
-            fma_min_front_area: Some(1),
+            fma_min_front_rows: Some(1),
             ..BunchKaufmanParams::default()
         },
     );
@@ -112,7 +112,7 @@ fn gate_below_threshold_matches_nofma_default() {
         &matrix,
         &BunchKaufmanParams {
             fma: false,
-            fma_min_front_area: Some(usize::MAX),
+            fma_min_front_rows: Some(usize::MAX),
             ..BunchKaufmanParams::default()
         },
     );
@@ -133,7 +133,7 @@ fn gate_preserves_inertia() {
         &matrix,
         &BunchKaufmanParams {
             fma: false,
-            fma_min_front_area: Some(1),
+            fma_min_front_rows: Some(1),
             ..BunchKaufmanParams::default()
         },
     );
@@ -145,19 +145,19 @@ fn gate_preserves_inertia() {
     assert!(nofma.inertia.positive > 0 && nofma.inertia.negative > 0);
 }
 
-/// The threshold is on `nrow * ncol`, so a boundary value must gate
-/// exactly: area == t fires (>=), area == t+1'th smaller front does not.
+/// The threshold is on `nrow`, so a boundary value must gate exactly:
+/// `nrow == t` fires (`>=`), `nrow == t+1` (threshold one past nrow) does
+/// not.
 #[test]
-fn gate_threshold_is_area_nrow_times_ncol() {
+fn gate_threshold_is_front_rows() {
     let n = 96;
     let matrix = build_front(n);
-    let area = n * n; // ncol == nrow == n for a root front.
 
-    // Exactly at the boundary: `>=` means it fires → matches fma=true.
+    // Exactly at the boundary: nrow == t → `>=` fires → matches fma=true.
     let at_boundary = factor(
         &matrix,
         &BunchKaufmanParams {
-            fma_min_front_area: Some(area),
+            fma_min_front_rows: Some(n),
             ..BunchKaufmanParams::default()
         },
     );
@@ -168,16 +168,16 @@ fn gate_threshold_is_area_nrow_times_ncol() {
             ..BunchKaufmanParams::default()
         },
     );
-    assert_factors_bit_identical(&at_boundary, &explicit_fma, "area==t boundary fires");
+    assert_factors_bit_identical(&at_boundary, &explicit_fma, "nrow==t boundary fires");
 
-    // One above the area: does not fire → matches nofma.
+    // One row past nrow: does not fire → matches nofma.
     let just_above = factor(
         &matrix,
         &BunchKaufmanParams {
-            fma_min_front_area: Some(area + 1),
+            fma_min_front_rows: Some(n + 1),
             ..BunchKaufmanParams::default()
         },
     );
     let nofma_default = factor(&matrix, &BunchKaufmanParams::default());
-    assert_factors_bit_identical(&just_above, &nofma_default, "area<t does not fire");
+    assert_factors_bit_identical(&just_above, &nofma_default, "nrow<t does not fire");
 }

--- a/tests/parallel_parity.rs
+++ b/tests/parallel_parity.rs
@@ -236,7 +236,7 @@ fn deep_chain_tree_no_stack_overflow() {
 
 /// Lever 1.1 gate: the intra-front parallel Schur update must be
 /// bit-exact with the serial path, and the parallel path must actually
-/// fire (a front wide enough to clear `INTRAFRONT_MIN_AREA = 256*256`).
+/// fire (a front wide enough to clear `INTRAFRONT_MIN_AREA = 256*128`).
 ///
 /// A dense, diagonally dominant SPD matrix factorizes into a single wide
 /// root supernode of all-1×1 pivots — exactly the


### PR DESCRIPTION
What: OrderingPreprocess::Auto now resolves by *verifying* fill rather than
trusting the pick_ordering_preprocess structural predicate. When the predicate
recommends LdltCompress, the symbolic pipeline is run both ways and LdltCompress
is kept only if it does not inflate factor_nnz_estimate past 2× the None
baseline (PREPROCESS_FILL_INFLATION_LIMIT); otherwise None is used. New
`symbolic_factorize_preprocess_auto` in src/symbolic/mod.rs.

Why: pick_ordering_preprocess fires MC64 LdltCompress whenever ≥30% of columns
have ≤2 nonzeros — which a regularized quasi-definite IPM KKT has in abundance
(its diagonal regularization rows). On the qap15 conic KKT (n=50880, nnz=168105,
from POUNCE's convex IPM) that compression *inflated* simplicial fill 6.3×
(7.16M → 45.4M) and factor time 20× (0.77s → 15.4s). Measured and refuted every
other candidate: nnz_L is identical across pivot strategies (not delayed
pivots), nemin 1 vs 16 gives identical simplicial fill (not amalgamation), and
feral's AMD ordering with preprocess=None is 7.16M — below faer's 13.4M (AMD is
excellent). The predicate is a one-way structural proxy that cannot know whether
compression helps; verifying fill makes Auto robust to this and future misfires.

Why a 2× ceiling, not smaller-fill-wins: an initial pure-fill race regressed
inertia on near-singular corpus KKTs. LdltCompress's MC64-matched 2×2 pivots
produce the oracle-correct inertia on twirism1 (432,313,0) and sawpath
(789,670,116) even though its ordering costs +15%/+0.1% fill; smaller-fill-wins
flipped them to the leaner None ordering and misclassified near-zero pivots
(twirism1 → 434,311,0), failing tests/issue65_mc64_fallback.rs. LdltCompress
carries a numerical benefit that symbolic fill does not capture, so the guard
must fire only on a catastrophic inflation. 2× sits above the normal ~1.1–1.2×
compression overhead and below qap15's 6.3×.

Evidence: qap15 default factor 15.4s → 0.77s (20×), nnz_L 40.9M → 9.25M, inertia
(+22275,−28605,0) unchanged; +with_fma 0.67s. Full corpus test suite green (68
test result: ok, 0 failed); fmt + clippy clean. Regression guard
tests/issue91_preprocess_misfire.rs against the gitignored fixture
tests/data/large/qap15_kkt.mtx (regen via dev/scripts/regen_qap15_kkt.sh).
Research note dev/research/issue-91-preprocess-misfire.md; measurement harness
examples/bench_qap15.rs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qdeiBpcLWXK7cvvgztMvi