### PR TITLE
issue #99: packed BLAS-3 dense trailing update (byte-exact) + opt-in FMA gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,79 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — packed BLAS-3 dense trailing update, byte-exact ~8–10× on dense fronts (issue #99)
+
+The dense trailing Schur update (~94 % of a dense factor) ran at only
+~0.35 GFLOP/s — ~10× below scalar peak on an AVX2/FMA CPU — because the strided
+per-column kernels re-read the eliminated panel at column-stride `nrow` every
+elimination step, thrashing cache. A new packed, register-tiled (`MR=8 × NR=4`)
+trailing update (`apply_schur_panel_range_packed`) packs the panel into
+`q`-contiguous micro-panels so the inner loop is L1-resident. It is **byte-exact**
+with the strided kernels (each `A[i,j]`, `i≥j`, reduced over ascending `q` with
+the identical `mul → sub` / `mul_add`; packing changes only memory layout) and
+runs ~22–26× faster in isolation (`examples/bench_schur_micro`), giving **10.2×**
+on a dense-1500 front's schur phase and **8.0×** on a 2955 front (0.34 → 2.69
+GFLOP/s, nofma). Default on; `FERAL_PACKED_SCHUR=0` restores the strided path.
+
+The packed path handles a **mixed 1×1 / 2×2 / zero-d pivot stream** (Phase B-2):
+each element walks the stream in `q` order, emitting `mul → sub` for a 1×1 pivot
+and the fused `dl0·L_q + dl1·L_{q+1}` add-then-sub (or two chained FMAs) for a 2×2
+pivot — byte-exact with the scalar `do_1x1_update` / `do_2x2_update` and the
+strided `axpy`/`axpy2` fallback. So **strongly-indefinite fronts** now get the
+packed win too, not only definite / quasi-definite (SQD, regularized KKT) / SPD
+fronts. Combined with the shape-aware intra-front gate, the synthetic qap15
+stand-in factors **9.25 s → 2.03 s (4.56×), byte-exact**, inertia
+`(+30000, −2000, 0)` unchanged. Correctness: the full byte-exact factor-parity
+suite (incl. indefinite/2×2 KKT suites) green with packed default, plus a
+`packed_matches_scalar_reference_bit_for_bit` unit test covering 1×1/2×2/zero-d
+streams in both `fma` modes. See `dev/research/issue-99-dense-front-fma-gate.md`.
+
+### Performance — shape-aware intra-front parallel gate for tall, thin fronts (issue #99, Lever 1, byte-exact)
+
+The intra-front parallel Schur update fired only when a front's
+`(nrow - j_start) * n_elim` **area** cleared `INTRAFRONT_MIN_AREA`. That area
+metric is blind to *tall, thin* fronts — large trailing width, small elimination
+depth — whose parallelizable work is `~n_elim * trailing_cols²` (large) even
+though their area is small. On real conic KKTs these dominate: the synthetic
+qap15 stand-in factors its dense border as ~117 fronts of `2000 × 16` (area
+31 744, just under the 32 768 floor), so intra-front parallelism never fired and
+99.9 % of the schur loop ran serially even on the parallel driver.
+
+A new **shape-aware trigger** additionally fires when a front is wide enough to
+split (`trailing_cols >= INTRAFRONT_TALL_MIN_COLS = 512`) AND deep enough to
+amortize the fork (`n_elim >= INTRAFRONT_TALL_MIN_ELIM = 8`), **OR-ed** with the
+area gate so no front that parallelized before regresses. Pure scheduling —
+**byte-exact** (each trailing column is still reduced on a single thread;
+`parallel_parity` holds). Measured on the synthetic KKT (32000², 4-core x86_64):
+end-to-end factor **9.25 s → 3.46 s (2.68×)**, inertia `(+30000, −2000, 0)`
+unchanged. See `dev/research/issue-99-dense-front-fma-gate.md`.
+
+### Added — opt-in per-front FMA gate for tall dense fronts (issue #99, Lever 3)
+
+`Solver::with_fma_large_fronts(min_rows)` and the underlying
+`BunchKaufmanParams::fma_min_front_rows: Option<usize>` (default `None`) route a
+dense front to the single-rounding FMA trailing-Schur kernels when it has at
+least `min_rows` rows (`nrow >= min_rows`), **while leaving smaller fronts on the
+bit-exact `*_nofma` path**. The gate is on **rows**, not `nrow * ncol` area,
+because the throughput-dominant fronts on real conic KKTs are tall and thin (an
+area gate silently misses them — the same blindness fixed in the intra-front gate
+above). Unlike the all-or-nothing `with_fma`/`NumericParams::fma`, this lets one
+factorization run the fast kernel on its dominant fronts while sensitive small
+KKT fronts — where FMA rounding can perturb Bunch-Kaufman pivot classification
+(`dev/tried-and-rejected.md` 2026-04-14) — keep the reference kernels. `None` is
+a strict no-op, so the default cross-arch bit-exactness contract is unchanged;
+enabling the gate changes cross-arch bit patterns only on the gated fronts.
+
+Measured (4-core x86_64): **1.66× per-core** on a synthetic 2955×2955 indefinite
+root (`examples/bench_dense_front`), and **1.47× on top of the byte-exact
+intra-front win** end-to-end on the synthetic qap15 stand-in (`bench_qap15`:
+3.46 s → 2.35 s, `with_fma_large_fronts(256)` matching global FMA), inertia
+identical throughout. Issue #99 Lever 3, opt-in; reaching faer-class per-core
+GFLOP/s additionally needs the 2-D tiled BLAS-3 GEMM
+(`dev/plans/dense-kernel-blas3.md`). See
+`dev/research/issue-99-dense-front-fma-gate.md`.
+
+
 ### Performance — `OrderingPreprocess::Auto` no longer inflates fill on conic KKTs (issue #91)
 
 feral factorized a 50,880×50,880 quasi-definite conic KKT (the qap15 QAP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,12 @@ harness = false
 name = "ft_dense_bump"
 
 [[example]]
+name = "bench_dense_front"
+
+[[example]]
+name = "bench_schur_micro"
+
+[[example]]
 name = "bench_qap15"
 
 [[example]]

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5628,3 +5628,171 @@ of sparse's `update_work_total >= factor_nnz()`.
 **Evidence.** +9 unit tests (each cause + both recommendation getters), 381 lib
 tests green, fmt/clippy clean, no numerical change (bench: no failures). Design
 note: `dev/research/refactor-signal-2026-07-01.md`.
+
+## 2026-07-01 — Opt-in per-front FMA size gate (issue #99, Lever 3)
+
+**Decision.** Add `BunchKaufmanParams::fma_min_front_area: Option<usize>`
+(default `None`) and `Solver::with_fma_large_fronts(min_area)`. When armed, a
+dense front whose trailing-update area `nrow * ncol >= min_area` uses the FMA
+trailing-Schur kernels even when the global `fma` flag is off; smaller fronts
+keep the bit-exact `*_nofma` kernels. The gate lives on `BunchKaufmanParams`
+(read directly by the dense front factor) and is set straight into
+`numeric_params.bk` by the builder — no new `NumericParams` field and no funnel,
+so the change is low-churn (every `..Default::default()` site is unaffected) and
+`None` is a strict no-op.
+
+**Why.** Issue #99's Lever 3: the trailing-update kernel is nofma (bit-exact) and
+~1.3–2× below FMA peak; large indefinite roots dominate the factor loop but the 4
+small-front pivot-drift KKTs (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851)
+need nofma to keep their Bunch-Kaufman pivot classification. The existing `fma`
+flag is all-or-nothing, so it cannot serve both. A front-size gate does: fast
+kernel on the roots, reference kernel on the sensitive small fronts.
+
+**Why opt-in / default `None`.** Enabling FMA changes cross-arch bit patterns
+(single vs double rounding) on the gated fronts — the reproducibility policy the
+owner deliberately kept opt-in (`dev/tried-and-rejected.md` 2026-04-14). This
+session had no authorization to flip a default (the interactive policy question
+could not be delivered — harness permission-stream failure), so the lever is
+shipped as a knob with measured evidence, leaving the default-on decision to the
+owner.
+
+**Evidence.** `examples/bench_dense_front 2955 5` (4-core x86_64): FMA 1.66×
+per-core serial (25.6 s → 15.4 s), 1.67× inside intrafront (8.6 s → 5.1 s),
+inertia `(+1478,−1477,0)` identical across all four nofma/FMA × serial/intrafront
+variants. `tests/issue99_fma_front_gate.rs` (4 tests): gate above threshold is
+bit-identical to `fma=true`, below threshold bit-identical to nofma default,
+inertia preserved, threshold is exactly `nrow*ncol` with `>=`. Full suite 734
+passed / 0 failed; fmt + clippy `-D warnings` clean; bench residual gate
+unchanged (default path byte-for-byte identical). Note:
+`dev/research/issue-99-dense-front-fma-gate.md`.
+
+**Not closed.** This does not reach faer-class throughput — the best variant is
+1.67 GFLOP/s vs ~50–100 for a tuned BLAS-3 core. The structural gap is feral's
+memory-bandwidth-bound rank-panel update vs a 2-D register-tiled GEMM
+(`dev/plans/dense-kernel-blas3.md`), a multi-session rewrite. Levers 1 (adaptive
+`INTRAFRONT_MIN_AREA`) and 2 (assembly parallelism) are parallel-scaling levers
+that need the bench corpus + a representative core count to validate no-regression
+— not possible on this 4-core box without the (unmerged-PR-#92) qap15 fixtures.
+
+## 2026-07-01 — Shape-aware intra-front gate + FMA row gate (issue #99, Levers 1 & 3)
+
+**Context.** After merging PR #92 (issue #91 ordering fix + qap15 harness) onto
+this branch at the maintainer's request, profiling the synthetic qap15 stand-in
+(`dev/scripts/gen_synth_kkt.py`) exposed that the dense border factors as ~117
+*tall, thin* fronts of `2000 × 16` carrying 99.9% of the schur loop — not one
+wide root. Both per-front gates key on **area** and miss exactly this shape.
+
+**Decision 1 (byte-exact, Lever 1).** Add a shape-aware intra-front trigger
+`intrafront_tall_gate(trailing_cols, n_elim) = trailing_cols >=
+INTRAFRONT_TALL_MIN_COLS(512) && n_elim >= INTRAFRONT_TALL_MIN_ELIM(8)`, OR-ed
+with the existing `(nrow-j_start)*n_elim >= INTRAFRONT_MIN_AREA` gate. The area
+metric under-counts tall-thin fronts whose parallelizable work is
+`~n_elim * trailing_cols²`; `2000×16` has area 31744, just under the 32768 floor,
+so intra-front parallelism never fired. OR-ing can only *add* parallelism to
+large-work fronts, so it cannot regress the area gate's measured calibration.
+Pure scheduling ⇒ byte-exact (each trailing column reduced on one thread).
+
+**Decision 2 (opt-in, Lever 3).** The FMA gate had the identical area blind spot
+(`nrow*ncol`); rename `BunchKaufmanParams::fma_min_front_area` →
+`fma_min_front_rows` and gate on `nrow >= t` (front rows = trailing-update size).
+`Solver::with_fma_large_fronts(min_rows)` accordingly. Same opt-in / default-None
+policy as before.
+
+**Why rows/shape, not area.** On real conic KKTs the time is in tall-thin fronts
+(large `nrow`, small `ncol`), created when regularization leaves break supernode
+amalgamation of a dense block. An area gate silently misses them; a
+rows/width-based gate catches them while still protecting genuinely small fronts.
+
+**Evidence (synthetic KKT, 32000², 2000×16 fronts, 4-core x86_64, `bench_qap15`).**
+Original default 9.25 s → **3.46 s (2.68×) byte-exact** with the shape-aware
+intra-front gate → **2.35 s (3.94× total)** adding opt-in FMA. Inertia
+`(+30000, −2000, 0)` identical across every config. Confirmed the intra-front
+diagnosis first via `FERAL_INTRAFRONT_MIN_AREA=16384` (9.25 → 4.35 s byte-exact).
+Full suite **735 passed / 0 failed** — `parallel_parity` (parallel==sequential
+bit-for-bit) green, so the intra-front change is byte-exact as claimed. clippy
+`-D warnings` clean.
+
+**Note.** The largest lever on this workload was **byte-exact** (the shape-aware
+gate), not the rule-breaking FMA. The maintainer authorized breaking
+bit-exactness/inertia to explore; the exploration instead surfaced a byte-exact
+scheduling bug affecting *both* gates. The synthetic fixture is a stand-in — the
+real qap15 KKT needs POUNCE (unavailable here); the tall-thin-front phenomenon and
+its 10-core behavior should be re-validated on the real matrix before promoting
+the thresholds to a hard default. See `dev/research/issue-99-dense-front-fma-gate.md`.
+
+## 2026-07-01 — Packed BLAS-3 dense trailing update (issue #99, byte-exact)
+
+**Decision.** Add `apply_schur_panel_range_packed` — a packed, register-tiled
+(MR=8×NR=4) implementation of the dense rank-`n_elim` trailing Schur update — and
+make it the default (env `FERAL_PACKED_SCHUR=0` restores the strided kernels).
+Byte-exact with the strided path.
+
+**Why.** The trailing update is ~94% of a dense factor yet ran at ~0.35 GFLOP/s
+(~10× below scalar peak on an AVX2/FMA CPU). An isolated microbench
+(`examples/bench_schur_micro`) showed the strided per-column kernels re-read the
+eliminated panel at column-stride `nrow` every `q`, touching `n_elim` scattered
+cache lines — cache latency, not compute or DST bandwidth. Packing the panel into
+`q`-contiguous MR/NR micro-panels makes the inner loop L1-resident; a plain
+register-tiled kernel then autovectorizes to 9–10.5 GFLOP/s (22–26× isolated).
+
+**Supersedes** the 2026-06-30 `tried-and-rejected` "DST-bandwidth-bound"
+conclusion for this hardware: that came from packing the source into the *same
+strided kernel* (which kept the strided `q`-access and only shrank the stride).
+A proper packed micro-kernel with a contiguous `q`-loop is a different design and
+wins decisively. Recorded there, not overwriting the prior entry.
+
+**Byte-exactness.** Each `A[i,j]` (i≥j) is reduced over ascending `q` with the
+identical `mul → sub` (nofma) / `mul_add` (fma) as the reference — packing changes
+only memory layout, not arithmetic order. A zero alpha gives `acc − round(0·L) =
+acc` for finite `L`, matching the strided zero-skip. Validated: full byte-exact
+factor-parity suite green with packed default + `packed_matches_scalar_reference_
+bit_for_bit` unit test.
+
+**Scope.** Reached only for all-1×1-pivot panels (the `apply_blocked_schur` W-2
+fast path). 2×2-pivot panels fall to the un-packed `axpy2` fallback, so strongly
+indefinite fronts — and the `fma` path, whose rounding drifts more pivots to 2×2 —
+benefit less. Definite / quasi-definite (SQD, regularized KKT) / SPD fronts get
+the full win. Packing the 2×2 fallback (Phase B-2) is the next step.
+
+**Evidence.** dense-1500 schur 3165→309 ms (10.2×); dense-2955 nofma serial
+25586→3202 ms (8.0×, 0.34→2.69 GFLOP/s); synth qap15 stand-in end-to-end
+3379→2029 ms; full byte-exact stack (intra-front + packed) 9247→2029 ms (4.56×),
+inertia `(+30000,−2000,0)` unchanged. Suite 736 passed / 0 failed; clippy clean.
+
+**Caveat.** Absolute GFLOP/s (packed ~10, vs a fully-tuned BLAS-3 core ~30–50) is
+partly this 4-core container; the tile (8×4) and the lack of L2 cache-blocking /
+FMA-in-packed leave headroom. Re-tune on target hardware. The `fma` packed path
+exists (bit-matches the fma reference) but is not the default.
+
+## 2026-07-01 — Packed trailing update: Phase B-2 mixed 1×1/2×2 streams (issue #99, byte-exact)
+
+**Decision.** Extend `apply_schur_panel_range_packed` to handle a mixed
+1×1/2×2/zero-d pivot stream, and route **every** panel through the packed path
+when packing is enabled (previously only all-1×1 panels; 2×2 panels used the
+un-packed `axpy2` fallback). `subdiag` is threaded
+`apply_blocked_schur → apply_blocked_schur_panel → apply_schur_panel_range → packed`.
+
+**Why.** The B-1 packed kernel gave ~8–10× on all-1×1 panels but strongly
+indefinite fronts (and the fma path, whose rounding drifts more pivots to 2×2)
+fell to the slow strided fallback for their 2×2 panels. B-2 closes that gap.
+
+**Byte-exactness.** Each element walks the stream in `q` order: 1×1 →
+`acc -= (L[j,q]·d_q)·L[i,q]` (`mul→sub` / `mul_add`), skipping `d_q==0` as the
+fallback does; 2×2 → the fused `acc -= dl0·L[i,q] + dl1·L[i,q+1]` (add-then-sub
+nofma / two chained FMAs) with `dl0=d11·L[j,q]+d21·L[j,q+1]`,
+`dl1=d21·L[j,q]+d22·L[j,q+1]`. This matches `do_1x1_update`/`do_2x2_update` and
+`axpy`/`axpy2_minus_unroll4*` exactly. Validated: full suite 736/0 incl. the
+indefinite/2×2 KKT parity gates green with packed default, plus the
+`packed_matches_scalar_reference_bit_for_bit` unit test sweeping 1×1/2×2/zero-d
+in both fma modes.
+
+**Evidence.** Indefinite 2955 front nofma serial 25586 → 2780 ms (9.2×, 0.34 →
+3.09 GFLOP/s). Note: on the degenerate ±n-diagonal `bench_dense_front` synthetic,
+the fma factorization is ~5× slower than nofma at equal inertia — a matrix-specific
+BK pivoting interaction (fma rounding shifts 1×1-vs-2×2 choices), *not* a kernel
+effect (both use packed). Reinforces keeping FMA opt-in.
+
+**Remaining headroom (not done).** Absolute packed throughput (~3–10 GFLOP/s) is
+still below a fully-tuned BLAS-3 core; the 8×4 tile, L2 cache-blocking, an
+explicit-SIMD (pulp) packed kernel, and FMA-in-packed are untuned, and this is a
+4-core container. Re-tune on target hardware.

--- a/dev/journal/2026-07-01-04.org
+++ b/dev/journal/2026-07-01-04.org
@@ -1,0 +1,163 @@
+* 2026-07-01-04 :issue99:dense-front:fma:performance:
+
+* 09:00 :orientation:blocker:
+Task: "loop over all levers until faer-level performance" on issue #99
+(dense-front throughput, ~3.5× gap to faer on qap15 conic KKT).
+Discovered the issue's premises are not reproducible on this branch:
+- PR #92 (the OrderingPreprocess::Auto fix that made qap15 tractable, and
+  the qap15 fixture generator + bench harnesses) is OPEN/UNMERGED
+  (branch issue-91-preprocess-misfire). This branch is off current main
+  and lacks it: INTRAFRONT_MIN_AREA is still 256*256 (not #92's 256*128).
+- The qap15 fixture (tests/data/large/qap15_kkt.mtx, gitignored), its
+  generator, examples/{profile,bench}_qap15.rs, and the two research
+  notes the issue cites all exist on NO remote branch.
+- This container has 4 cores; the issue's numbers are 10-core.
+Conclusion: end-to-end qap15 cannot be reproduced; parallel-scaling levers
+(1 assembly, 2 schur) cannot be validated vs the 10-core target here.
+Tried to ask the owner the fixture + policy questions via AskUserQuestion;
+the tool failed ("permission stream closed"). Proceeded autonomously with
+the defensible subset: byte-exact / additive / measurable-here work only.
+
+* 10:30 :harness:measurement:
+Built examples/bench_dense_front.rs — self-contained synthetic indefinite
+front (SplitMix64, alternating-sign dominant diagonal → 1×1-pivot W-2 fast
+path), factored via the real factor_frontal_blocked path, timing
+nofma/FMA × serial/intrafront with an inertia-equality gate.
+n=2955 (qap15 root size), 4 threads, best of 5:
+  nofma serial     25586 ms  0.34 GFLOP/s  1.00x
+  nofma intrafront  8632 ms  1.00 GFLOP/s  2.96x
+  fma   serial     15423 ms  0.56 GFLOP/s  1.66x
+  fma   intrafront  5143 ms  1.67 GFLOP/s  4.98x
+inertia (+1478,-1477,0) identical across all four. FMA = real 1.66x
+per-core win, inertia-preserving. But 1.67 GFLOP/s ceiling is ~50x below a
+tuned BLAS-3 core → the deep gap is the memory-bandwidth-bound rank-panel
+update vs 2-D tiled GEMM (dense-kernel-blas3.md), not any single lever.
+
+* 12:00 :implement:fma-gate:
+Lever 3 as an opt-in, default-off knob: BunchKaufmanParams::fma_min_front_area
+= Option<usize>; effective_front_fma(params,nrow,ncol) helper; gated at the
+single dense-front entry factor_frontal_blocked_in_place_with_scratch by
+shadowing params with an fma-flipped clone only when the gate fires (unarmed
+path pays nothing). Solver::with_fma_large_fronts writes straight to
+numeric_params.bk (no NumericParams field/funnel — first tried the
+NumericParams-field-mirror-of-fma approach but it broke ~dozens of
+fully-enumerated NumericParams literals across tests/examples/diagnostics;
+the bk-only design is lower churn since bk is nearly always ..default()).
+
+* 13:15 :verify:
+tests/issue99_fma_front_gate.rs (4 tests): gate>=threshold bit-identical to
+fma=true; below-threshold bit-identical to nofma default; inertia preserved;
+threshold is exactly nrow*ncol with >=. Full suite: 734 passed, 0 failed.
+cargo fmt + clippy --all-targets -D warnings clean. bench --release: no
+failures (default path byte-for-byte unchanged since gate defaults None).
+
+* 13:40 :scope:handoff:
+Delivered: FMA size gate + Solver setter + bench harness + tests + research
+note. Deferred (blocked, documented): Lever 1 adaptive INTRAFRONT_MIN_AREA
+(needs bench corpus + representative cores to prove no-regression), Lever 2
+assembly parallelism (parallel-scaling, unvalidatable at 4 cores),
+default-on FMA / Lever 4 static-SQD (owner policy call), BLAS-3 GEMM
+(the only route to faer-class GFLOP/s). No byte-exact lever closes 3.5×,
+as the issue itself states.
+
+* 15:00 :merge:pr92:intrafront:breakthrough:
+Maintainer: rebase PR #92 (qap15 ordering fix + harness) onto this branch;
+"take chances / break rules." Merged origin refs/pull/92/head (merge-base =
+current main, clean) — brings OrderingPreprocess::Auto fix, qap15
+gen/bench/profile harnesses, dense-front research notes, and Lever B
+(INTRAFRONT_MIN_AREA 256^2 -> 256x128). Conflicts: Cargo.toml (kept all 3
+example targets), CHANGELOG (kept both Unreleased entries).
+
+Real qap15 fixture unobtainable (gen needs POUNCE+highspy+qap15.mps, absent).
+Wrote dev/scripts/gen_synth_kkt.py: arrowhead stand-in, dense K=2000 border
+(root front) + L=30000 degree-2 leaves (LdltCompress signature). 32000^2,
+2.06M nnz. Runs end-to-end via bench_qap15.
+
+END-TO-END (bench_qap15, 4 cores, REPS=2):
+  default              9686 ms   inertia (+30000,-2000,0)
+  static_pivot(1e-8)   8746 ms   1.11x
+  sqd_mode             8293 ms   1.17x
+  default+fma          5763 ms   1.68x
+  sqd_mode+fma         5543 ms   1.75x
+All inertia identical. FMA end-to-end (1.68x) matches single-front (1.66x).
+
+But default+fma_large(256^2 area) gave NO speedup while global fma did.
+=> gate not firing. profile_qap15 revealed why: the dense border factors as
+~117 tall-thin fronts of 2000x16 (99.9% of schur loop), NOT one 2000 front
+(leaves break amalgamation). nrow*ncol = 32000 < 65536 (fma gate) AND
+(nrow-j)*n_elim = 31744 < 32768 (intrafront gate). BOTH area gates blind to
+tall-thin fronts (work ~ n_elim*trailing_cols^2, large despite small area).
+
+Confirmed intrafront hypothesis with env override:
+  FERAL_INTRAFRONT_MIN_AREA=16384 default: 9247 -> 4354 ms (2.1x) BYTE-EXACT.
+
+Fixes:
+- Lever 1 (byte-exact): intrafront_tall_gate(cols>=512 && n_elim>=8) OR-ed
+  with area gate. default 9247 -> 3457 ms (2.68x), inertia unchanged.
+- Lever 3: fma_min_front_area -> fma_min_front_rows, gate nrow>=t. Now fires;
+  default+fma_large(256rows) = 2350 ms == global fma (2347). 3.94x total.
+
+Correctness: full suite 735 passed / 0 failed. parallel_parity (parallel ==
+sequential bit-for-bit) GREEN => intrafront change byte-exact as claimed.
+clippy -D warnings clean.
+
+Key finding: the BIGGEST lever was byte-exact (shape-aware scheduling),
+not the rule-breaking FMA. The area metric bug hit both gates identically.
+Caveat: synthetic fixture; re-validate tall-thin phenomenon + thresholds on
+the real qap15 + 10 cores before promoting to a hard default.
+
+* 17:30 :blas3:packed:breakthrough:byte-exact:
+Maintainer: take on the BLAS-3 GEMM. Read dev/plans/dense-kernel-blas3.md
+(Phase B-1 = register-blocked MR x NR DSYRK, byte-exact by design).
+faer-expert couldn't read faer source (not in sandbox) but confirmed #1:
+faer defers rank-bs into workspace W, flushes one triangular GEMM per
+panel (bs=64).
+
+Profiled dense-1500 front: schur = 94% at 0.33 GFLOP/s, ~10x below scalar
+peak on AVX2/AVX512/FMA CPU. Wrote examples/bench_schur_micro isolating the
+kernel: current strided kernel 0.38 GFLOP/s; a plain packed MR=8 NR=4
+register-tiled kernel = 9-10.5 GFLOP/s = 22-26x, BYTE-EXACT (0 mismatches),
+robust across sizes 512..2955, ke 16..128. Root cause: strided kernels
+re-read panel at col-stride nrow per q => n_elim scattered cache lines.
+(Refutes the 2026-06-30 'DST-bandwidth-bound' note, which packed into the
+SAME strided kernel.)
+
+Wired apply_schur_panel_range_packed into production (default on,
+FERAL_PACKED_SCHUR=0 fallback). GOTCHA: 'cargo build --release' does NOT
+rebuild examples -> my first 'packed' profile runs used STALE example
+binaries and showed no speedup. After 'cargo build --release --examples':
+dense-1500 schur 3165 -> 309 ms (10.2x); dense-2955 nofma serial 25586 ->
+3202 ms (8.0x); synth_arrow end-to-end 3379 -> 2029 ms.
+
+Byte-exact validated: full suite 736 passed / 0 failed (blocked_ldlt +
+parallel_parity + all factor parity gates green with packed default) +
+packed_matches_scalar_reference_bit_for_bit unit test.
+
+Scope: only all-1x1 panels (apply_blocked_schur fast path). 2x2 panels use
+the un-packed axpy2 fallback -> strongly indefinite fronts and the fma path
+(rounding drifts pivots to 2x2) benefit less. Phase B-2 = pack the 2x2
+fallback. Full byte-exact stack: intra-front + packed = 9247 -> 2029 ms
+(4.56x) on the synth qap15 stand-in.
+
+* 19:00 :blas3:phaseB2:packed:2x2:byte-exact:
+Maintainer: take on Phase B-2 (pack the 2x2 fallback). Extended
+apply_schur_panel_range_packed to a mixed 1x1/2x2/zero-d pivot stream:
+per element, walk q; 1x1 -> mul-sub / mul_add (skip d==0); 2x2 -> fused
+dl0*L_q + dl1*L_{q+1} add-then-sub (nofma) / two chained FMAs (fma), with
+dl0=d11*L[j,q]+d21*L[j,q+1], dl1=d21*L[j,q]+d22*L[j,q+1]. Byte-exact with
+do_1x1_update/do_2x2_update + axpy/axpy2. Threaded subdiag through
+apply_blocked_schur -> panel -> range -> packed; apply_blocked_schur now
+routes EVERY panel through packed when enabled (strided fast+fallback under
+FERAL_PACKED_SCHUR=0).
+
+Validated: full suite 736/0 incl. indefinite/2x2 gates (blocked_ldlt,
+kkt_matrices, delayed_pivoting, rook_rescue, parallel_parity) byte-exact
+with packed default; packed_matches_scalar_reference_bit_for_bit unit test
+now sweeps 1x1/2x2/zero-d in both fma modes.
+
+Perf: indefinite 2955 front nofma serial 25586 -> 2780 ms (9.2x, 3.09
+GFLOP/s). fma-serial STILL 14188 ms (clean, not contention) vs nofma 2780
+at SAME inertia -> confirmed a matrix-specific BK pivoting interaction of
+fma rounding on the degenerate +-n-diagonal synthetic (both paths packed),
+not a kernel effect. Not a regression (fma was ~15s here at session start).
+Reinforces FMA opt-in.

--- a/dev/research/issue-99-dense-front-fma-gate.md
+++ b/dev/research/issue-99-dense-front-fma-gate.md
@@ -1,0 +1,266 @@
+# Issue #99 — dense-front throughput: packed BLAS-3 kernel + shape-aware intra-front + FMA gate
+
+## UPDATE 3 (2026-07-01) — packed BLAS-3 trailing update: byte-exact ~8–10× on dense fronts
+
+The maintainer asked to take on the BLAS-3 GEMM as a dedicated follow-up. The
+result is a **byte-exact** win, bigger than expected.
+
+**Diagnosis.** A full dense-front profile attributes ~94 % of factor time to the
+trailing Schur update, yet it measured only **0.33–0.39 GFLOP/s** — ~10× below
+even scalar peak, on a CPU with AVX2/AVX-512/FMA. An isolated kernel microbench
+(`examples/bench_schur_micro`) pinned the cause: the production strided kernels
+re-read the eliminated panel at **column-stride `nrow` every `q`**, so the inner
+rank-`n_elim` loop touches `n_elim` cache lines spread across memory — cache
+latency, not compute or DST bandwidth. (The 2026-06-30 "DST-bandwidth-bound"
+conclusion, reached from a *source-panel-pack-into-same-strided-kernel* variant,
+does not hold for a proper packed micro-kernel on this hardware.)
+
+**Fix.** A packed, register-tiled (`MR=8 × NR=4`) trailing update
+(`apply_schur_panel_range_packed`): pack the panel into `q`-contiguous MR/NR
+micro-panels so the inner `q` loop is L1-resident, then a plain register-tiled
+kernel the compiler autovectorizes. **Byte-exact** — each `A[i,j]` (i≥j) is still
+reduced over ascending `q` with the identical `mul → sub` (nofma) / `mul_add`
+(fma); packing changes only memory layout, not arithmetic order. Default on;
+`FERAL_PACKED_SCHUR=0` restores the strided path.
+
+**Measured (4-core x86_64):**
+
+| case | strided | packed | speedup | correctness |
+|---|---:|---:|---:|---|
+| isolated kernel `bench_schur_micro` (any size) | 0.38 GFLOP/s | 9–10.5 GFLOP/s | **22–26×** | byte-exact ✓ |
+| dense 1500 front, schur phase | 3165 ms | 309 ms | **10.2×** | byte-exact |
+| dense 2955 front, nofma serial | 25586 ms | 3202 ms | **8.0×** (0.34→2.69 GFLOP/s) | inertia identical |
+| synth qap15 stand-in end-to-end (+ intra-front) | 3379 ms | 2029 ms | **1.67×** on top | inertia identical |
+
+**Scope (B-1).** As shipped in B-1 the packed path was reached only for
+**all-1×1-pivot panels**; panels with a 2×2 pivot fell to the un-packed `axpy2`
+fallback. **Phase B-2 (below) lifted this** — the packed kernel now handles a
+mixed 1×1/2×2/zero-d stream byte-exactly, so strongly-indefinite fronts get the
+win too.
+
+## UPDATE 4 — Phase B-2: packed mixed 1×1/2×2/zero-d streams (byte-exact)
+
+`apply_schur_panel_range_packed` now walks the pivot stream per element: 1×1 →
+`acc -= (L[j,q]·d_q)·L[i,q]` (`mul→sub` / `mul_add`, skipping `d_q==0`); 2×2 →
+the fused `acc -= dl0·L[i,q] + dl1·L[i,q+1]` (add-then-sub nofma / two chained
+FMAs) with `dl0=d11·L[j,q]+d21·L[j,q+1]`, `dl1=d21·L[j,q]+d22·L[j,q+1]`. Byte-exact
+with `do_1x1_update`/`do_2x2_update` and the strided `axpy`/`axpy2` fallback.
+`subdiag` is threaded through the panel dispatch; `apply_blocked_schur` routes
+**every** panel through packed when enabled (strided fast-path + fallback stay
+under `FERAL_PACKED_SCHUR=0`).
+
+- Correctness: full suite **736 / 0**, incl. the indefinite/2×2 KKT parity gates
+  byte-exact with packed default; `packed_matches_scalar_reference_bit_for_bit`
+  sweeps 1×1/2×2/zero-d in both fma modes.
+- Perf: indefinite 2955 front nofma serial **25586 → 2780 ms (9.2×**, 0.34 →
+  3.09 GFLOP/s).
+- FMA note: on the degenerate ±n-diagonal `bench_dense_front` synthetic, fma is
+  ~5× slower than nofma at equal inertia — a matrix-specific BK pivoting
+  interaction (fma rounding shifts 1×1-vs-2×2 choices), not a kernel effect (both
+  packed). Not a regression. Reinforces FMA opt-in.
+
+Remaining headroom (untuned): 8×4 tile, L2 cache-blocking, explicit-SIMD (pulp)
+packed kernel, FMA-in-packed — re-tune on target hardware; and re-validate on the
+real qap15 KKT (needs POUNCE) at 10 cores.
+
+**Full byte-exact stack on the synth qap15 stand-in (32000², 4 cores):**
+`9247 → 3457 (intra-front) → 2029 ms (+packed)` = **4.56× byte-exact**, inertia
+`(+30000,−2000,0)` unchanged; stacks further with opt-in FMA on all-1×1 fronts.
+
+Correctness gates: the byte-exact factor-parity suite (`blocked_ldlt` 21,
+`dense_ldlt` 17, `parallel_parity` 8, `parity` 8, `factor_workspace_parity` 21)
+all green with packed as default, plus a dedicated
+`packed_matches_scalar_reference_bit_for_bit` unit test (size sweep incl.
+non-multiple-of-tile and chunk-offset cases).
+
+---
+
+# Issue #99 — dense-front throughput: shape-aware intra-front gate (Lever 1) + FMA row gate (Lever 3)
+
+## UPDATE 2 (2026-07-01, session -03 cont.) — PR #92 merged, and the real win found
+
+The maintainer authorized (a) merging PR #92's ordering fix + qap15 harness onto
+this branch and (b) breaking the bit-exactness/inertia rules to see what is
+possible. Both done. The headline result is **not** FMA — it is a **byte-exact**
+intra-front parallelism fix (issue #99 Lever 1), found by profiling.
+
+**Fixture:** the real qap15 KKT still cannot be regenerated (its generator needs
+POUNCE + highspy + qap15.mps, absent here). So `dev/scripts/gen_synth_kkt.py`
+synthesizes an *arrowhead* stand-in — a dense `K`-node border (the root front)
+plus `L` degree-2 leaf columns (the LdltCompress signature) — runnable end-to-end
+through `examples/bench_qap15`. Default `K=2000, L=30000` ⇒ 32000×32000, 2.06M nnz.
+
+**The profile (`profile_qap15`) exposed the real bottleneck.** The dense border
+does **not** factor as one 2000-wide front; the leaves break supernode
+amalgamation so it becomes **~117 tall-thin fronts of `2000 × 16`** carrying
+99.9 % of the schur loop. Both size gates key on *area*:
+
+- the **FMA gate** was `nrow * ncol >= 65536`; `2000 * 16 = 32000` — never fired.
+- the **intra-front parallel gate** is `(nrow-j_start) * n_elim >= 32768`;
+  `1984 * 16 = 31744` — **just under**, so intra-front parallelism **never fired**
+  and the dominant fronts ran serially even on the parallel driver.
+
+Area is the wrong metric for tall-thin fronts: their parallelizable work is
+`~n_elim * trailing_cols²`, large despite small area. Two fixes:
+
+1. **Lever 1 (byte-exact) — shape-aware intra-front gate.** Fire intra-front
+   parallelism when a front is wide enough to split (`trailing_cols >=
+   INTRAFRONT_TALL_MIN_COLS = 512`) AND deep enough to amortize the fork
+   (`n_elim >= INTRAFRONT_TALL_MIN_ELIM = 8`), **OR-ed** with the existing area
+   gate so no already-parallel front regresses. Pure scheduling ⇒ byte-exact
+   (each trailing column still reduced on one thread; `parallel_parity` holds).
+2. **Lever 3 (opt-in) — FMA gate keyed on `nrow`, not area.** Renamed
+   `fma_min_front_area` → `fma_min_front_rows`; fire FMA when `nrow >= t`. Catches
+   the tall fronts an area gate misses.
+
+**Measured end-to-end on the synthetic KKT (32000², 2000×16 fronts, 4-core x86_64,
+`bench_qap15` steady):**
+
+| config | ms | vs orig default | correctness |
+|---|---:|---:|---|
+| original default (area gates, pre-fix) | ~9247 | 1.00× | byte-exact |
+| **+ shape-aware intra-front (Lever 1)** | **3457** | **2.68×** | **byte-exact** |
+| **+ FMA (Lever 3, opt-in)** | **2347** | **3.94×** | opt-in (inertia identical) |
+
+Inertia `(+30000, −2000, 0)` identical across every config. Confirmed the
+diagnosis with a pure-scheduling env override (`FERAL_INTRAFRONT_MIN_AREA=16384`:
+9247 → 4354 ms byte-exact) before writing the shape-aware gate (which does better,
+3457 ms, without globally lowering the floor). `with_fma_large_fronts(256)` matches
+global FMA end-to-end (2350 vs 2347 ms), proving the row gate fires.
+
+**Takeaway:** the largest lever on this workload was **byte-exact** (fix the
+parallel gate's shape blindness, 2.68×), not the rule-breaking FMA (a further
+1.47× on top). The area→shape metric bug affected *both* gates identically.
+
+---
+
+## Session context & discovered blockers (2026-07-01)
+
+Issue #99 is a **follow-up to PR #92**, but PR #92 (`issue-91-preprocess-misfire`,
+the `OrderingPreprocess::Auto` fill-verification fix that made qap15 tractable)
+is **open/unmerged**. This branch (`claude/issue-99-b9zphx`) is cut from current
+`main` (`a17fb7a`) and therefore does **not** contain:
+
+- the qap15 fixture `tests/data/large/qap15_kkt.mtx` (gitignored) or its
+  generator `dev/scripts/{gen,regen}_qap15_kkt.{py,sh}` (live only in PR #92);
+- the harnesses `examples/{profile_qap15,bench_qap15}.rs`;
+- the two research notes the issue cites for "the full diagnosis"
+  (`issue-91-parallel-dense-front-2026-06-30.md`,
+  `…-dense-kernel-profile-2026-06-30.md`) — these exist on **no** remote branch
+  (unpushed/lost work);
+- PR #92's `INTRAFRONT_MIN_AREA` recalibration (still `256*256` here).
+
+Consequence: the end-to-end qap15 number that *defines* the issue's target
+cannot be reproduced on this branch, and this container has **4 cores** (the
+issue's numbers are 10-core). So parallel-scaling levers (1 assembly, 2 schur
+scaling) cannot be validated against the issue's targets here.
+
+What **is** reproducible and measurable on this hardware is the **per-core**
+kernel-throughput lever (issue Lever 3): FMA vs nofma on a large indefinite
+front. That is the subject of this note. A self-contained stand-in harness,
+`examples/bench_dense_front.rs`, builds a synthetic indefinite front of a chosen
+size (default 2955 = the qap15 root) and factors it through the real
+blocked-panel path, timing nofma/FMA × serial/intrafront with an
+inertia-equality gate.
+
+## The lever
+
+The trailing-update kernel has two numerically-distinct SIMD paths, both already
+implemented in `src/dense/schur_kernel.rs`:
+
+- `schur_panel_minus_nofma_strided*` — explicit `mul` then `sub`, two roundings
+  per multiply-accumulate; **bit-exact** cross-arch with the scalar reference.
+  This is the production default (`BunchKaufmanParams::fma = false`).
+- `schur_panel_minus_fma_strided*` — one `mul_add` per accumulate (single
+  rounding). ~2× arithmetic throughput on x86 V3 (AVX2+FMA) and aarch64 NEON.
+  One ULP per accumulate off the nofma reference; **not** bit-exact cross-arch.
+
+FMA is opt-in and **global** today: `Solver::with_fma(true)` →
+`NumericParams::fma` → (solver.rs:966) `bk.fma` → every front uses FMA. The owner
+kept it opt-in on purpose (`dev/tried-and-rejected.md` 2026-04-14): on 4 KKT
+matrices (ACOPP14_0001, ACOPP30_0004, FBRAIN3LS_0848/0851) the FMA rounding
+perturbs the Bunch-Kaufman pivot classification.
+
+## Design — additive, default-off, front-size gated
+
+Add `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`).
+When `Some(t)` **and** the front's `nrow * ncol >= t`, the dense front factor
+uses the FMA kernels **even if `bk.fma == false`**; small fronts stay nofma.
+This is exactly the issue's Lever 3 ask: "opt-in FMA-on-large-fronts gated so the
+4 small-front pivot-drift KKTs keep nofma."
+
+- **Single insertion point:** `factor_frontal_blocked_in_place_with_scratch`
+  (`src/dense/factor.rs`) — both the sequential and parallel multifrontal drivers
+  funnel every front through it. At entry, derive
+  `effective_fma = params.fma || area_ge_threshold`, and if it differs from
+  `params.fma`, shadow `params` with a local clone carrying `fma = effective_fma`.
+  Everything downstream reads `params.fma` unchanged.
+- **Plumbing mirrors `fma` exactly:** `NumericParams::fma_min_front_area`
+  (default `None`) → funnel at solver.rs alongside `bk.fma = fma` →
+  `Solver::with_fma_large_fronts(area)` setter.
+- **Default `None` ⇒ zero behavior change** anywhere. No CI/corpus regression
+  risk; the production bit-exact contract is untouched. This delivers the lever
+  as a knob with measured evidence, leaving the *default-on* policy decision
+  (which changes cross-arch bit patterns) to the owner.
+
+## Correctness
+
+- `bench_dense_front` asserts inertia is identical across nofma/FMA/serial/
+  intrafront on the synthetic root (the throughput-lever correctness gate).
+- A unit test factors one large front with `fma_min_front_area = Some(small)`
+  vs the default and asserts (a) the gate flips FMA on for a large front
+  (result matches an explicitly `fma=true` factor, bit-for-bit) and (b) a
+  below-threshold front is byte-identical to the nofma default.
+
+## RESULTS (measured on this 4-core x86_64 container)
+
+`cargo run --release --example bench_dense_front 2955 5` (n=2955 = qap15 root
+size, best of 5 reps), rayon_threads=4:
+
+| variant           | time (ms) | GFLOP/s | vs nofma-serial |
+|-------------------|----------:|--------:|----------------:|
+| nofma serial      |  25586.15 |    0.34 |           1.00× |
+| nofma intrafront  |   8631.85 |    1.00 |           2.96× |
+| **fma serial**    |  15422.96 |    0.56 |       **1.66×** |
+| **fma intrafront**|   5142.82 |    1.67 |       **4.98×** |
+
+`inertia = (+1478, −1477, 0)` — **identical across all four variants** ✓.
+
+Findings:
+
+1. **FMA is a real per-core win here: 1.66× serial** (25586 → 15423 ms), holding
+   at **1.67× inside the intrafront path** (8632 → 5143 ms). Larger than the
+   issue's cited +23–32% because this measures the *pure* front with no
+   assembly/tree overhead diluting it. Inertia is unchanged — the gate is safe on
+   a well-conditioned indefinite root. This confirms Lever 3 is worth wiring.
+2. **FMA and intrafront compose multiplicatively** → 4.98× over the nofma-serial
+   baseline on 4 cores.
+3. **The absolute ceiling is still low: 1.67 GFLOP/s.** A tuned BLAS-3 core is
+   ~50–100 GFLOP/s. feral's rank-`n_elim` panel update streams the whole trailing
+   submatrix per panel (O(1) arithmetic per byte loaded, memory-bandwidth-bound),
+   whereas faer's 2-D register-tiled GEMM gets O(n) arithmetic per byte. That
+   ~30–50× structural gap is the `dev/plans/dense-kernel-blas3.md` rewrite — a
+   multi-session effort, **not** something any single lever in this issue closes.
+   FMA-on-large is the largest *single, low-risk, contract-preserving* step
+   available on this hardware.
+
+## Scope delivered this session vs. deferred
+
+**Delivered (additive, default-off, parity-tested):** the per-front FMA size gate
++ `Solver::with_fma_large_fronts` + `bench_dense_front` harness + this note.
+`tests/issue99_fma_front_gate.rs` pins bit-identity to `fma=true` above the
+threshold, bit-identity to nofma below it, and inertia preservation.
+
+**Deferred (blocked here):**
+- **Lever 1 (adaptive `INTRAFRONT_MIN_AREA`)** — the issue requires "verify no
+  regression across the bench corpus," which needs the bench corpus + a
+  representative core count. Not validatable on this 4-core box without the
+  fixtures; a speculative retune could silently regress the tuned constant.
+- **Lever 2 (assembly parallelism)** — deep, and its win is parallel-scaling,
+  unvalidatable against the issue's 10-core target here.
+- **Default-on FMA-large / Lever 4 (static-SQD)** — cross-arch bit-pattern /
+  inertia-perturbation policy calls the owner deliberately deferred (see the
+  interactive question that the harness failed to deliver). The gate is left
+  **opt-in**; flipping a default is not this session's call to make.
+- **BLAS-3 2-D tiled GEMM** — the only path to faer-class GFLOP/s; tracked by
+  `dev/plans/dense-kernel-blas3.md`.

--- a/dev/scripts/gen_synth_kkt.py
+++ b/dev/scripts/gen_synth_kkt.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Generate a synthetic arrowhead conic-KKT stand-in for the qap15 fixture.
+
+The real issue #91/#99 fixture (tests/data/large/qap15_kkt.mtx) is generated
+from POUNCE + qap15.mps and cannot be reproduced in this container. This script
+synthesizes a matrix with the same two structural features that drive the
+issue #99 dense-front story, using only the Python standard library:
+
+  1. A large *dense* border block of size `K` (default 2000) — an explicit
+     clique that AMD eliminates last as a single dense root supernode, exactly
+     like qap15's 2955x2955 indefinite root front (the dense-kernel bottleneck).
+  2. `L` degree-2 "regularization" leaf columns (default 30000) — each a
+     positive diagonal plus one off-diagonal to a random border node. With
+     L/(L+K) ~ 94% of columns at <= 2 nonzeros, this trips the LdltCompress
+     predicate (>=30% low-degree columns), exercising the issue #91
+     OrderingPreprocess::Auto fill-verification fix on the end-to-end path.
+
+Quasi-definite by construction: leaf diagonals > 0, border diagonals < 0.
+
+Writes a symmetric MatrixMarket file (lower triangle, 1-indexed). Deterministic
+(fixed seed). Env: K, L, OUT, SEED.
+"""
+import os
+import random
+
+K = int(os.environ.get("K", "2000"))       # dense border (root front size)
+L = int(os.environ.get("L", "30000"))       # degree-2 leaf columns
+OUT = os.environ.get("OUT", "tests/data/large/synth_arrow_kkt.mtx")
+SEED = int(os.environ.get("SEED", "20260701"))
+
+rng = random.Random(SEED)
+N = L + K
+border0 = L  # first border index (0-based)
+
+# Collect lower-triangle entries (i >= j), 1-indexed on write.
+# Border block: dense clique on indices [border0, N).
+#   diagonal negative & dominant; small symmetric off-diagonal noise.
+# Leaf block: indices [0, L). diagonal positive & dominant; one off-diagonal
+#   to a random border node (creates the degree-2 signature and couples the
+#   leaf into the border front).
+rows = []  # (i, j, val) with i >= j
+
+# Leaves.
+for i in range(L):
+    rows.append((i, i, 2.0 + rng.random()))          # positive diagonal
+    b = border0 + rng.randrange(K)                    # one border neighbor
+    # store lower triangle: (max, min)
+    hi, lo = (b, i) if b > i else (i, b)
+    rows.append((hi, lo, rng.uniform(-1.0, 1.0)))
+
+# Dense border clique.
+for a in range(border0, N):
+    rows.append((a, a, -(float(K) + rng.random())))  # negative diagonal
+    for b in range(border0, a):
+        rows.append((a, b, 0.01 * rng.uniform(-1.0, 1.0)))
+
+nnz = len(rows)
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+with open(OUT, "w") as f:
+    f.write("%%MatrixMarket matrix coordinate real symmetric\n")
+    f.write(f"% synthetic arrowhead conic-KKT stand-in (K={K} dense border, "
+            f"L={L} degree-2 leaves, seed={SEED})\n")
+    f.write(f"{N} {N} {nnz}\n")
+    for (i, j, v) in rows:
+        f.write(f"{i + 1} {j + 1} {v:.12g}\n")
+
+print(f"wrote {OUT}: dim={N} nnz={nnz} (border={K} dense, leaves={L} deg-2)")

--- a/dev/sessions/2026-07-01-04.md
+++ b/dev/sessions/2026-07-01-04.md
@@ -1,0 +1,225 @@
+# Session 2026-07-01-04
+
+## Goal
+
+Issue #99: "loop over all levers until faer-level performance" on the dense-front
+factorization throughput gap (~3.5× to faer on the qap15 conic KKT, dominated by
+a 2955×2955 indefinite root).
+
+## Reality check (reported up-front, per protocol)
+
+The issue's premises are **not reproducible on this branch**, and I established
+this before writing code:
+
+- **PR #92 is open/unmerged.** It (issue #91) contains the `OrderingPreprocess::Auto`
+  fill-verification fix that made qap15 tractable *and* the qap15 fixture
+  generator + `bench_qap15` harness. This branch is cut from current `main` and
+  lacks all of it — `INTRAFRONT_MIN_AREA` is still `256*256`, not #92's `256*128`.
+- **The qap15 fixture, its generator, `examples/{profile,bench}_qap15.rs`, and the
+  two research notes the issue cites for "the full diagnosis" exist on no remote
+  branch** (unpushed/lost work). The end-to-end qap15 number that defines the
+  target cannot be reproduced here.
+- **This container has 4 cores; the issue's numbers are 10-core.** The
+  parallel-scaling levers (1 assembly, 2 schur scaling) cannot be validated
+  against the issue's targets here.
+- The issue itself states **no byte-exact lever closes 3.5×**; faer-class needs a
+  policy decision (default-on FMA / static-SQD) the owner deliberately deferred.
+
+I attempted to ask the owner the fixture-strategy and policy questions via
+`AskUserQuestion`; the harness failed to deliver it (permission-stream error).
+Told to continue, I proceeded autonomously with the **defensible subset**:
+additive, default-off, byte-exact-preserving, measurable-here work only — no
+unilateral default flips, no unvalidatable parallel retunes.
+
+## Accomplished
+
+**Issue #99 Lever 3 (per-core kernel throughput) — delivered as an opt-in knob.**
+
+- New `examples/bench_dense_front.rs`: self-contained synthetic indefinite front
+  (no external fixture), factored through the real `factor_frontal_blocked` path,
+  timing nofma/FMA × serial/intrafront with an inertia-equality gate. Fills the
+  measurement-harness hole the issue's (missing) `bench_qap15` left.
+- New `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) +
+  `effective_front_fma(params, nrow, ncol)` helper. Gated at the single dense
+  front-factor entry `factor_frontal_blocked_in_place_with_scratch` by shadowing
+  `params` with an fma-flipped clone **only when the gate fires** (unarmed path
+  pays nothing). Both multifrontal drivers funnel through this entry, so one
+  insertion covers all.
+- New `Solver::with_fma_large_fronts(min_area)` — writes straight to
+  `numeric_params.bk` (no `NumericParams` field / funnel needed; low churn).
+- `None` default ⇒ strict no-op: the production cross-arch bit-exact contract is
+  untouched. Enabling changes bit patterns only on the gated large fronts.
+
+### Evidence
+
+- `bench_dense_front 2955 5` (4-core x86_64), best of 5:
+
+  | variant          | ms      | GFLOP/s | vs nofma-serial |
+  |------------------|--------:|--------:|----------------:|
+  | nofma serial     | 25586   | 0.34    | 1.00×           |
+  | nofma intrafront | 8632    | 1.00    | 2.96×           |
+  | fma serial       | 15423   | 0.56    | **1.66×**       |
+  | fma intrafront   | 5143    | 1.67    | **4.98×**       |
+
+  Inertia `(+1478, −1477, 0)` **identical across all four** — the throughput-lever
+  correctness gate holds. FMA and intrafront compose multiplicatively.
+- `tests/issue99_fma_front_gate.rs` (4 tests, all pass): gate ≥ threshold is
+  bit-identical to `fma=true`; below threshold bit-identical to nofma default;
+  inertia preserved; threshold is exactly `nrow*ncol` with `>=` semantics.
+- **Full suite: 734 passed, 0 failed.** `cargo fmt --check` + `cargo clippy
+  --all-targets -- -D warnings` clean. `bench --release`: no failures (default
+  path byte-for-byte unchanged).
+
+## Benchmark Results
+
+```
+cargo run --bin bench --release  →  Sparse failure analysis: no failures
+Dense ∩ Sparse failure overlap: 0 / 0 / 0
+(no oracle timings loaded in this environment; perf partitions N/A)
+Default path unchanged (gate defaults None) → residual gate identical to the
+2026-07-01-02 baseline (2/2, worst residual 1.26e-16).
+
+examples/bench_dense_front 2955 5 (the new issue-99 harness):
+  nofma serial     25586.15 ms  0.34 GFLOP/s  1.00×
+  nofma intrafront  8631.85 ms  1.00 GFLOP/s  2.96×
+  fma   serial     15422.96 ms  0.56 GFLOP/s  1.66×
+  fma   intrafront  5142.82 ms  1.67 GFLOP/s  4.98×
+  inertia (+1478,−1477,0) identical across all four variants ✓
+```
+
+## Decisions Made
+
+- Opt-in per-front FMA size gate on `BunchKaufmanParams`, default `None`, set via
+  `Solver::with_fma_large_fronts`. Full rationale in `dev/decisions.md`
+  (2026-07-01) and `dev/research/issue-99-dense-front-fma-gate.md`.
+
+## Abandoned Approaches
+
+- Mirroring the `fma` plumbing with a **separate `NumericParams::fma_min_front_area`
+  field + solver funnel** — broke dozens of fully-enumerated `NumericParams`
+  literals across tests/examples/diagnostics. Replaced with a `BunchKaufmanParams`-
+  only field written straight into `bk` by the builder (bk is nearly always
+  `..Default::default()`, so zero churn). Not a research dead-end — a plumbing
+  choice — so not logged in tried-and-rejected.
+
+## Next Session Should
+
+1. **Merge/rebase PR #92 first** (or regenerate the qap15 fixture) so issue #99
+   can be measured end-to-end. Everything below is blocked on a runnable target
+   and a representative core count.
+2. **Owner policy call** (the question the harness dropped): (a) flip
+   FMA-on-large to default via the new gate — measured 1.66× per-core, inertia
+   identical on the tested front — accepting cross-arch bit-pattern change on
+   large fronts; and/or (b) authorize Lever 4 (static-SQD perturbation + iterative
+   refinement). Byte-exact ceiling is ~1.8× (issue's own analysis); faer-class
+   needs one of these.
+3. **Lever 1** — recalibrate/adapt `INTRAFRONT_MIN_AREA` (front-shape aware) with
+   a no-regression sweep across the *actual* bench corpus.
+4. **Lever 2** — parallelize the multifrontal assembly (the serial ~10%).
+5. **The real ceiling: 2-D tiled BLAS-3 GEMM** (`dev/plans/dense-kernel-blas3.md`)
+   — the measured 1.67 GFLOP/s vs ~50–100 for a tuned core is the structural gap;
+   no single issue-#99 lever closes it.
+
+---
+
+## UPDATE 2 — PR #92 merged; byte-exact intra-front win found (maintainer: "break the rules")
+
+The maintainer asked to rebase PR #92 (qap15 ordering fix + harness) onto this
+branch and to break the bit-exactness/inertia rules to see what is possible.
+
+**Merged PR #92** (`refs/pull/92/head`; merge-base = current main, clean): the
+`OrderingPreprocess::Auto` fix, the qap15 gen/bench/profile harnesses, the
+dense-front research notes, and Lever B (`INTRAFRONT_MIN_AREA` 256² → 256×128).
+
+**The real qap15 fixture is unobtainable** (its generator needs POUNCE + highspy
++ qap15.mps). Wrote `dev/scripts/gen_synth_kkt.py` — an arrowhead stand-in (dense
+`K=2000` border = root front + `L=30000` degree-2 leaves = LdltCompress
+signature), 32000×32000, runnable end-to-end via `bench_qap15`.
+
+**Profiling found the real bottleneck (not what the issue assumed).** The dense
+border factors as **~117 tall-thin fronts of `2000 × 16`** (leaves break
+supernode amalgamation), carrying 99.9% of the schur loop. **Both** per-front
+gates key on *area* and miss this shape:
+- FMA gate `nrow*ncol` = 32000 < 65536 — never fired.
+- intra-front parallel gate `(nrow-j)*n_elim` = 31744 < 32768 — never fired, so
+  the dominant fronts ran **serially** even on the parallel driver.
+
+**Fixes + results (synthetic KKT, 32000², 4-core x86_64, `bench_qap15` steady):**
+
+| config | ms | vs orig | correctness |
+|---|---:|---:|---|
+| original default | 9247 | 1.00× | byte-exact |
+| **+ shape-aware intra-front (Lever 1)** | **3457** | **2.68×** | **byte-exact** |
+| **+ FMA (Lever 3, opt-in)** | **2347** | **3.94×** | opt-in (inertia identical) |
+
+- **Lever 1 (byte-exact):** `intrafront_tall_gate(cols≥512 && n_elim≥8)` OR-ed
+  with the area gate. Pure scheduling; `parallel_parity` (parallel==sequential
+  bit-for-bit) stays green. Confirmed first via `FERAL_INTRAFRONT_MIN_AREA=16384`
+  (9.25→4.35 s byte-exact).
+- **Lever 3:** `fma_min_front_area` → `fma_min_front_rows`, gate on `nrow≥t`
+  (fixes the same area blindness). `with_fma_large_fronts(256)` == global FMA
+  end-to-end.
+
+**The biggest lever was byte-exact**, not the rule-breaking FMA — the area metric
+was a latent scheduling bug hitting both gates. Full suite **735 passed / 0
+failed**; clippy clean; inertia `(+30000,−2000,0)` identical throughout.
+
+**Caveat / next:** the synthetic fixture is a stand-in. The tall-thin-front
+phenomenon and the `512/8` thresholds should be re-validated on the *real* qap15
+(needs POUNCE) at 10 cores before promoting to a hard default. The remaining gap
+to faer-class per-core GFLOP/s is still the 2-D tiled BLAS-3 GEMM
+(`dev/plans/dense-kernel-blas3.md`), which no gate closes.
+
+---
+
+## UPDATE 3 — packed BLAS-3 trailing update (maintainer: "take on the GEMM")
+
+Profiling showed the dense trailing update (~94% of a dense factor) ran at only
+~0.35 GFLOP/s — ~10× below scalar peak. `examples/bench_schur_micro` isolated the
+cause: the strided per-column kernels re-read the panel at column-stride `nrow`
+every `q`, scattering cache lines. A packed, register-tiled (MR=8×NR=4) kernel
+(`apply_schur_panel_range_packed`) with a contiguous `q`-loop is **22–26× faster
+in isolation and byte-exact**, giving:
+
+| case | strided | packed | speedup |
+|---|---:|---:|---:|
+| dense-1500 schur phase | 3165 ms | 309 ms | 10.2× |
+| dense-2955 nofma serial | 25586 ms | 3202 ms | 8.0× (0.34→2.69 GFLOP/s) |
+| synth qap15 stand-in end-to-end | 3379 ms | 2029 ms | 1.67× on top of intra-front |
+
+**Full byte-exact stack** (shape-aware intra-front + packed) on the synth qap15
+stand-in: **9247 → 2029 ms = 4.56×**, inertia `(+30000,−2000,0)` unchanged.
+Suite **736 passed / 0 failed** (all byte-exact parity gates green with packed
+default) + a dedicated packed-vs-scalar unit test; clippy clean.
+
+Reached only for all-1×1-pivot panels; 2×2 panels (strongly indefinite fronts,
+and the fma path) use the un-packed fallback → **Phase B-2** (pack the 2×2 path)
+is the clear next step. Gotcha logged: `cargo build --release` does not rebuild
+examples — the first "packed" measurements used stale example binaries.
+
+---
+
+## UPDATE 4 — Phase B-2: packed 2×2 pivot streams (byte-exact)
+
+Extended the packed trailing update to a **mixed 1×1/2×2/zero-d pivot stream**,
+so strongly-indefinite fronts (2×2-pivot panels) get the packed win too — not
+only definite/SQD/SPD fronts. Each element walks the stream: 1×1 → `mul→sub` /
+`mul_add`; 2×2 → the fused `dl0·L_q + dl1·L_{q+1}` add-then-sub (nofma) / two
+chained FMAs (fma). Byte-exact with `do_1x1_update`/`do_2x2_update` and the
+strided `axpy`/`axpy2` fallback. `subdiag` threaded through the panel dispatch;
+`apply_blocked_schur` now routes every panel through packed (strided fast-path +
+fallback stay under `FERAL_PACKED_SCHUR=0`).
+
+- **Correctness:** full suite **736 / 0**, incl. the indefinite/2×2 KKT parity
+  gates byte-exact with packed default; `packed_matches_scalar_reference_bit_for_bit`
+  now sweeps 1×1/2×2/zero-d in both fma modes.
+- **Perf:** indefinite 2955 front nofma serial **25586 → 2780 ms (9.2×**, 0.34 →
+  3.09 GFLOP/s).
+- **FMA note:** on the degenerate ±n-diagonal `bench_dense_front` synthetic, fma
+  is ~5× slower than nofma at equal inertia — a BK pivoting interaction (fma
+  rounding shifts 1×1-vs-2×2 choices), not a kernel effect; both use packed. Not
+  a regression. Reinforces keeping FMA opt-in.
+
+**Remaining follow-ups:** tune absolute packed throughput (8×4 tile, L2
+cache-blocking, explicit-SIMD packed kernel, FMA-in-packed) on target hardware;
+and re-validate the whole stack on the real qap15 KKT (needs POUNCE) at 10 cores.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4910,3 +4910,21 @@ cache-sized trailing tile across many panels) or a larger panel width (more
 flops per DST stream). A source-side pack (B-1a) is off the table. FMA remains a
 +23% option but is a reproducibility-policy change (kept opt-in), not a
 bit-exact win.
+
+## 2026-07-01 — UPDATE: packed micro-kernel succeeds where B-1a source-pack failed (issue #99)
+
+The 2026-06-30 "B-1a panel packing" entry above rejected source-panel packing as a
+net slowdown and concluded the root front is DST-bandwidth-bound. That conclusion
+was **specific to the variant tried** — packing the source into a tighter stride
+but *feeding the same strided kernels*, which keep the per-`q` `as_simd` + strided
+access. It does **not** generalize to a proper packed micro-kernel.
+
+A different design — pack the panel into `q`-contiguous MR=8×NR=4 micro-panels and
+run a register-tiled kernel with a **contiguous inner `q`-loop**
+(`apply_schur_panel_range_packed`) — is **22–26× faster in isolation and
+byte-exact** (`examples/bench_schur_micro`), and gives 8–10× on real dense fronts.
+So the bottleneck was strided-`q` cache latency, not DST bandwidth, on this
+hardware. Not a rejection — a correction of scope. See
+`dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
+2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
+rejected; the packed micro-kernel is the shipped design.

--- a/examples/bench_dense_front.rs
+++ b/examples/bench_dense_front.rs
@@ -1,0 +1,133 @@
+//! Single-front dense LDLᵀ micro-benchmark.
+//!
+//! Issue #99 tracks closing the dense-front throughput gap to faer on
+//! large conic-KKT roots (the qap15 root is a 2955×2955 indefinite
+//! front, 42% of the sequential factor loop). The qap15 fixture and its
+//! harnesses referenced by the issue are not present on this branch, so
+//! this example provides a *self-contained, reproducible* stand-in: it
+//! builds a synthetic indefinite front of a chosen size and factors it
+//! through the real blocked-panel path (`factor_frontal_blocked`),
+//! exercising exactly the trailing-Schur kernel (W-2 rank-`n_elim`
+//! accumulator + intra-front parallelism + optional FMA) that the issue
+//! identifies as the bottleneck.
+//!
+//! It measures the two per-core / parallel levers directly:
+//!   * nofma vs FMA kernel throughput (issue Lever 3)
+//!   * serial vs intra-front-parallel trailing update (issue Lever 1)
+//!
+//! and asserts the inertia is identical across all four variants — the
+//! correctness gate that any throughput lever must preserve.
+//!
+//! Usage:
+//!   cargo run --release --example bench_dense_front [-- N REPS]
+//! Defaults: N = 2955 (the qap15 root size), REPS = 5.
+
+use feral::dense::factor::factor_frontal_blocked;
+use feral::{BunchKaufmanParams, Inertia, SymmetricMatrix};
+use std::time::Instant;
+
+/// Deterministic SplitMix64-style PRNG so the fixture is reproducible
+/// without a `rand` dependency or the forbidden `Math.random`/`Date`.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        // SplitMix64.
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        // Map to [-1, 1).
+        (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+    }
+}
+
+/// Build a synthetic symmetric *indefinite* front that factors mostly
+/// through 1×1 pivots (so it hits the W-2 all-1×1 fast path the issue
+/// profiles). Diagonal carries alternating-sign dominant entries;
+/// off-diagonals are small deterministic noise. Column-major lower
+/// triangle, matching `SymmetricMatrix`'s storage.
+fn build_front(n: usize) -> SymmetricMatrix {
+    let mut rng = Rng(0x1234_5678_9ABC_DEF0);
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            let v = if i == j {
+                // Strong, sign-alternating diagonal → indefinite,
+                // 1×1-pivot dominated, well away from singular.
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                sign * (n as f64) + rng.next_f64()
+            } else {
+                0.30 * rng.next_f64()
+            };
+            data[j * n + i] = v;
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+fn time_variant(
+    matrix: &SymmetricMatrix,
+    fma: bool,
+    intrafront: bool,
+    reps: usize,
+) -> (f64, Inertia) {
+    let params = BunchKaufmanParams {
+        fma,
+        intrafront_parallel: intrafront,
+        ..BunchKaufmanParams::default()
+    };
+    let n = matrix.n;
+    let mut best = f64::INFINITY;
+    let mut inertia = Inertia {
+        positive: 0,
+        negative: 0,
+        zero: 0,
+    };
+    for _ in 0..reps {
+        let t = Instant::now();
+        // Root front: every column is fully summed (ncol == nrow),
+        // no delayed pivots.
+        let ff = factor_frontal_blocked(matrix, n, false, &params).expect("factor failed");
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        inertia = ff.inertia;
+        best = best.min(ms);
+    }
+    (best, inertia)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2955);
+    let reps: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let threads = rayon::current_num_threads();
+    println!("bench_dense_front: n={n} reps={reps} rayon_threads={threads}");
+    let gflop = (n as f64).powi(3) / 3.0 / 1e9; // ≈ LDLᵀ flop count
+
+    let matrix = build_front(n);
+
+    let (t_nofma_ser, i0) = time_variant(&matrix, false, false, reps);
+    let (t_nofma_par, i1) = time_variant(&matrix, false, true, reps);
+    let (t_fma_ser, i2) = time_variant(&matrix, true, false, reps);
+    let (t_fma_par, i3) = time_variant(&matrix, true, true, reps);
+
+    let report = |label: &str, ms: f64| {
+        println!(
+            "  {label:<22} {ms:8.2} ms   {:6.2} GFLOP/s   {:5.2}× vs nofma-serial",
+            gflop / (ms / 1e3),
+            t_nofma_ser / ms
+        );
+    };
+    println!("inertia (must match): {i0:?}");
+    report("nofma  serial", t_nofma_ser);
+    report("nofma  intrafront", t_nofma_par);
+    report("fma    serial", t_fma_ser);
+    report("fma    intrafront", t_fma_par);
+
+    // Correctness gate: every throughput lever must preserve inertia.
+    assert_eq!(i0, i1, "intrafront changed inertia (nofma)");
+    assert_eq!(i0, i2, "fma changed inertia");
+    assert_eq!(i0, i3, "fma+intrafront changed inertia");
+    println!("inertia identical across all four variants ✓");
+}

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -163,7 +163,8 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(2);
     // Comma-separated config selector via CONFIGS env (default: all).
-    let want = std::env::var("CONFIGS").unwrap_or_else(|_| "default,sqd,sqdfma,static,fma".into());
+    let want = std::env::var("CONFIGS")
+        .unwrap_or_else(|_| "default,sqd,sqdfma,static,fma,fmalarge".into());
     let want: Vec<&str> = want.split(',').collect();
     let has = |k: &str| want.contains(&k);
 
@@ -191,6 +192,16 @@ fn main() {
     }
     if has("fma") {
         run("default+fma", &csc, || Solver::new().with_fma(true), reps);
+    }
+    if has("fmalarge") {
+        // Issue #99 Lever 3: FMA only on fronts with >= 256 rows;
+        // small fronts stay bit-exact nofma.
+        run(
+            "default+fma_large(256rows)",
+            &csc,
+            || Solver::new().with_fma_large_fronts(256),
+            reps,
+        );
     }
     if has("noprep") {
         run(

--- a/examples/bench_schur_micro.rs
+++ b/examples/bench_schur_micro.rs
@@ -1,0 +1,215 @@
+//! Isolated throughput microbenchmark for the dense trailing-update
+//! kernel (issue #99, BLAS-3 follow-up).
+//!
+//! The full-front profile attributes ~94% of a dense factor to the
+//! trailing Schur update yet measures only ~0.33 GFLOP/s — far below
+//! even scalar peak. This harness isolates the *kernel* from the
+//! factorization (pivot search, alpha precompute, per-panel setup) to
+//! answer one question: is the kernel itself slow, or is it the
+//! surrounding factorization overhead?
+//!
+//! It computes a rectangular rank-`ke` update `C[i,j] -= Σ_q L[i,q] *
+//! alpha[j,q]` (`C` is m×n, `L` is m×ke, `alpha` is n×ke) two ways:
+//!   * BASELINE — the production per-column strided kernel
+//!     (`schur_panel_minus_nofma_strided`), one dispatch per column,
+//!     reading the panel at column-stride `m` (the strided access the
+//!     factor uses).
+//!   * PACKED   — pack `L` into MR-row micro-panels (contiguous in the
+//!     `q` loop) and run a plain MR×NR register-tiled kernel. Same
+//!     per-element `mul → sub` order ⇒ byte-exact with BASELINE.
+//!
+//! Reports ms and GFLOP/s for each, plus a byte-exactness check. If
+//! PACKED is much faster, the strided `q`-access is the bottleneck and a
+//! packed micro-kernel is worth wiring in; if not, the ceiling is DST
+//! bandwidth (→ Phase C cache-blocked factor).
+//!
+//! Usage: cargo run --release --example bench_schur_micro [-- M N KE REPS]
+
+use feral::dense::schur_kernel::schur_panel_minus_nofma_strided;
+use std::time::Instant;
+
+fn mix(state: &mut u64) -> f64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+}
+
+/// BASELINE: production per-column strided kernel, one call per column.
+fn run_baseline(c: &mut [f64], l: &[f64], alpha: &[f64], m: usize, n: usize, ke: usize) {
+    let mut alphas = vec![0.0f64; ke];
+    for j in 0..n {
+        for q in 0..ke {
+            alphas[q] = alpha[j + q * n];
+        }
+        let dst = &mut c[j * m..j * m + m];
+        // src_block = L (col-major, col-stride m); src_first_col 0,
+        // src_row_offset 0, len m.
+        schur_panel_minus_nofma_strided(dst, l, 0, ke, m, 0, m, &alphas);
+    }
+}
+
+/// Pack `L` (m×ke col-major) into MR-row micro-panels: for panel p
+/// (rows p*MR..), store q-major MR-contiguous blocks so the kernel's
+/// inner q-loop reads sequential memory. `apack[p*(ke*MR) + q*MR + ir]`.
+const MR: usize = 8;
+const NR: usize = 4;
+
+fn pack_a(l: &[f64], m: usize, ke: usize) -> Vec<f64> {
+    let npanels = m.div_ceil(MR);
+    let mut apack = vec![0.0f64; npanels * ke * MR];
+    for p in 0..npanels {
+        let i0 = p * MR;
+        for q in 0..ke {
+            for ir in 0..MR {
+                let i = i0 + ir;
+                let v = if i < m { l[i + q * m] } else { 0.0 };
+                apack[p * (ke * MR) + q * MR + ir] = v;
+            }
+        }
+    }
+    apack
+}
+
+fn pack_b(alpha: &[f64], n: usize, ke: usize) -> Vec<f64> {
+    let npanels = n.div_ceil(NR);
+    let mut bpack = vec![0.0f64; npanels * ke * NR];
+    for p in 0..npanels {
+        let j0 = p * NR;
+        for q in 0..ke {
+            for jr in 0..NR {
+                let j = j0 + jr;
+                let v = if j < n { alpha[j + q * n] } else { 0.0 };
+                bpack[p * (ke * NR) + q * NR + jr] = v;
+            }
+        }
+    }
+    bpack
+}
+
+/// PACKED: MR×NR register-tiled kernel over packed operands. Plain
+/// arrays; LLVM autovectorizes the contiguous MR inner axis. Per
+/// element `acc -= a*b` in ascending q — byte-exact with BASELINE.
+#[allow(clippy::needless_range_loop)]
+fn run_packed(c: &mut [f64], apack: &[f64], bpack: &[f64], m: usize, n: usize, ke: usize) {
+    let np_j = n.div_ceil(NR);
+    for pj in 0..np_j {
+        let j0 = pj * NR;
+        let bbase = pj * (ke * NR);
+        let np_i = m.div_ceil(MR);
+        for pi in 0..np_i {
+            let i0 = pi * MR;
+            let abase = pi * (ke * MR);
+            // MR×NR accumulator tile, loaded from C.
+            let mut acc = [[0.0f64; MR]; NR];
+            for (jr, accj) in acc.iter_mut().enumerate() {
+                let j = j0 + jr;
+                if j >= n {
+                    continue;
+                }
+                for ir in 0..MR {
+                    let i = i0 + ir;
+                    accj[ir] = if i < m { c[i + j * m] } else { 0.0 };
+                }
+            }
+            for q in 0..ke {
+                let a = &apack[abase + q * MR..abase + q * MR + MR];
+                for jr in 0..NR {
+                    let b = bpack[bbase + q * NR + jr];
+                    let accj = &mut acc[jr];
+                    for ir in 0..MR {
+                        accj[ir] -= b * a[ir];
+                    }
+                }
+            }
+            for (jr, accj) in acc.iter().enumerate() {
+                let j = j0 + jr;
+                if j >= n {
+                    continue;
+                }
+                for ir in 0..MR {
+                    let i = i0 + ir;
+                    if i < m {
+                        c[i + j * m] = accj[ir];
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let m: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1500);
+    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1500);
+    let ke: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(64);
+    let reps: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    let mut s = 0xDEAD_BEEF_1234u64;
+    let l: Vec<f64> = (0..m * ke).map(|_| mix(&mut s)).collect();
+    let alpha: Vec<f64> = (0..n * ke).map(|_| mix(&mut s)).collect();
+    let c0: Vec<f64> = (0..m * n).map(|_| mix(&mut s)).collect();
+
+    let gflop = 2.0 * m as f64 * n as f64 * ke as f64 / 1e9;
+    println!("bench_schur_micro: m={m} n={n} ke={ke} reps={reps}  ({gflop:.3} GFLOP/update)");
+
+    // BASELINE
+    let mut best_base = f64::INFINITY;
+    let mut c_base = c0.clone();
+    for _ in 0..reps {
+        c_base.copy_from_slice(&c0);
+        let t = Instant::now();
+        run_baseline(&mut c_base, &l, &alpha, m, n, ke);
+        best_base = best_base.min(t.elapsed().as_secs_f64());
+    }
+    println!(
+        "  baseline (strided per-col) {:8.2} ms   {:6.2} GFLOP/s",
+        best_base * 1e3,
+        gflop / best_base
+    );
+
+    // PACKED (packing timed separately + fused)
+    let mut best_pack = f64::INFINITY;
+    let mut best_pack_all = f64::INFINITY;
+    let mut c_pack = c0.clone();
+    for _ in 0..reps {
+        c_pack.copy_from_slice(&c0);
+        let t_all = Instant::now();
+        let apack = pack_a(&l, m, ke);
+        let bpack = pack_b(&alpha, n, ke);
+        let t_k = Instant::now();
+        run_packed(&mut c_pack, &apack, &bpack, m, n, ke);
+        best_pack = best_pack.min(t_k.elapsed().as_secs_f64());
+        best_pack_all = best_pack_all.min(t_all.elapsed().as_secs_f64());
+    }
+    println!(
+        "  packed kernel only         {:8.2} ms   {:6.2} GFLOP/s",
+        best_pack * 1e3,
+        gflop / best_pack
+    );
+    println!(
+        "  packed incl. pack          {:8.2} ms   {:6.2} GFLOP/s",
+        best_pack_all * 1e3,
+        gflop / best_pack_all
+    );
+
+    // Byte-exactness check.
+    let mut mism = 0usize;
+    for (x, y) in c_base.iter().zip(&c_pack) {
+        if x.to_bits() != y.to_bits() {
+            mism += 1;
+        }
+    }
+    if mism == 0 {
+        println!("  byte-exact: baseline == packed ✓");
+    } else {
+        println!("  BYTE MISMATCH in {mism} / {} elements ✗", c_base.len());
+    }
+    println!(
+        "  speedup (kernel only): {:.2}×   (incl. pack): {:.2}×",
+        best_base / best_pack,
+        best_base / best_pack_all
+    );
+}

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -646,6 +646,35 @@ pub struct BunchKaufmanParams {
     /// rayon work (pounce#79 oversubscription guarantee). See
     /// `dev/research/lever-1.1-intrafront-parallel-schur.md`.
     pub intrafront_parallel: bool,
+
+    /// Opt-in per-front FMA size gate (issue #99, Lever 3). Default
+    /// `None`. When `Some(t)`, a front with at least `t` rows
+    /// (`nrow >= t`) uses the FMA trailing-Schur kernels **even when
+    /// [`fma`](Self::fma) is `false`**; smaller fronts keep the bit-exact
+    /// `*_nofma` kernels. This lets one factorization run the fast
+    /// (single-rounding) FMA path on its throughput-dominant fronts while
+    /// small fronts — where FMA rounding can perturb Bunch-Kaufman pivot
+    /// classification on sensitive KKTs (`dev/tried-and-rejected.md`
+    /// 2026-04-14) — stay on the reference kernels.
+    ///
+    /// The gate is on `nrow` (the front's row count = the size of its
+    /// trailing update), **not** `nrow * ncol` area: on real conic KKTs
+    /// the throughput-dominant fronts are *tall and thin* — e.g. the
+    /// synthetic qap15 stand-in factors its dense border as ~117 fronts
+    /// of `2000 × 16`, whose trailing-update cost (`~ncol * nrow²`) is
+    /// large even though their area is small. An area gate silently
+    /// misses exactly these fronts; a row gate catches them while still
+    /// protecting genuinely small fronts. See
+    /// `dev/research/issue-99-dense-front-fma-gate.md`.
+    ///
+    /// `None` (default) is a strict no-op: every front honors `fma` as
+    /// before, so the production cross-arch bit-exactness contract is
+    /// untouched. Enabling this changes cross-arch bit patterns on the
+    /// gated fronts (single vs double rounding), so it is a deliberate
+    /// opt-in, not a default. Inertia is preserved on well-conditioned
+    /// fronts (the FMA path is one ULP per accumulate off nofma; see
+    /// `schur_kernel::fma_vs_nofma_panel_kernels_within_n_elim_ulps`).
+    pub fma_min_front_rows: Option<usize>,
 }
 
 /// Minimum trailing-update area `(nrow - j_start) * n_elim` below which
@@ -677,6 +706,37 @@ fn intrafront_min_area() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(INTRAFRONT_MIN_AREA)
+}
+
+/// Issue #99 Lever 1 — shape-aware intra-front trigger for *tall, thin*
+/// fronts. The [`INTRAFRONT_MIN_AREA`] gate is `trailing_cols * n_elim`,
+/// which under-counts fronts with a large trailing width but small
+/// elimination depth: their parallelizable trailing update costs
+/// `~n_elim * trailing_cols²` (each of `trailing_cols` independent
+/// columns does an `n_elim`-deep rank update over a length that scales
+/// with the width), yet their *area* is small. On the qap15 conic-KKT
+/// stand-in the throughput-dominant fronts are ~`2000 × 16`: area 31 744,
+/// just under the 32 768 floor, so intra-front parallelism never fired and
+/// 99.9 % of the schur loop ran serially.
+///
+/// This trigger fires when the front is both wide enough to split across
+/// workers ([`INTRAFRONT_TALL_MIN_COLS`]) and deep enough per column to
+/// amortize the fork ([`INTRAFRONT_TALL_MIN_ELIM`]). It is **OR-ed** with
+/// the area gate, so every front that parallelized before still does —
+/// this can only *add* parallelism to large-work fronts, never remove it,
+/// which is why it cannot regress the area gate's measured calibration.
+/// Byte-exact (pure scheduling; each trailing column is still reduced on a
+/// single thread). See `dev/research/issue-99-dense-front-fma-gate.md`.
+pub const INTRAFRONT_TALL_MIN_COLS: usize = 512;
+/// Companion depth floor for [`INTRAFRONT_TALL_MIN_COLS`]; see there.
+pub const INTRAFRONT_TALL_MIN_ELIM: usize = 8;
+
+/// Whether the tall-front intra-front trigger fires for a trailing update
+/// of `trailing_cols` columns at elimination depth `n_elim`. Issue #99
+/// Lever 1.
+#[inline]
+fn intrafront_tall_gate(trailing_cols: usize, n_elim: usize) -> bool {
+    trailing_cols >= INTRAFRONT_TALL_MIN_COLS && n_elim >= INTRAFRONT_TALL_MIN_ELIM
 }
 
 /// Action to take when a near-zero pivot is encountered.
@@ -802,8 +862,22 @@ impl Default for BunchKaufmanParams {
             tpp_method: TppMethod::Plain,
             static_pivot_floor: 0.0,
             intrafront_parallel: false,
+            fma_min_front_rows: None,
         }
     }
+}
+
+/// Resolve the effective FMA flag for a front of `nrow` rows under
+/// `params`. Returns `true` when the global [`BunchKaufmanParams::fma`]
+/// is set, or when the per-front size gate
+/// [`BunchKaufmanParams::fma_min_front_rows`] is armed and this front is
+/// at least that tall (`nrow >= t`). Gating on `nrow` (not `nrow * ncol`
+/// area) is deliberate: the throughput-dominant fronts on real conic
+/// KKTs are tall and thin (large `nrow`, small `ncol`), so an area gate
+/// misses them. Issue #99 Lever 3.
+#[inline]
+pub(crate) fn effective_front_fma(params: &BunchKaufmanParams, nrow: usize) -> bool {
+    params.fma || params.fma_min_front_rows.is_some_and(|t| nrow >= t)
 }
 
 /// Factorization result: P·L·D_bk·Lᵀ·Pᵀ = D_eq·A·D_eq.
@@ -1964,6 +2038,27 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
 ) -> Result<FrontalFactors, FeralError> {
     let nrow = matrix.n;
 
+    // Issue #99 Lever 3: opt-in per-front FMA size gate. When
+    // `fma_min_front_area` is armed and this front's trailing area is
+    // large enough, factor it with the FMA trailing-Schur kernels even
+    // if the global `fma` flag is off. Shadow `params` with a local
+    // clone only when the gate actually changes the flag, so the common
+    // (unarmed) path pays nothing; everything downstream reads
+    // `params.fma` unchanged.
+    let gated_params;
+    let params: &BunchKaufmanParams = {
+        let eff = effective_front_fma(params, nrow);
+        if eff != params.fma {
+            gated_params = BunchKaufmanParams {
+                fma: eff,
+                ..params.clone()
+            };
+            &gated_params
+        } else {
+            params
+        }
+    };
+
     if ncol > nrow {
         return Err(FeralError::InvalidInput(format!(
             "ncol {} > nrow {}",
@@ -3070,14 +3165,39 @@ fn apply_blocked_schur(
         return;
     }
 
-    // W-2 fast path: when the panel produced n_elim 1×1 pivots all
-    // with non-zero d AND no 2×2 pivots, run the rank-`n_elim`
-    // accumulator. The 2×2 gate is a correctness requirement (Phase
-    // A, dev/plans/dense-kernel-blas3.md): the rank-bs kernel
-    // accumulates contributions per-q sequentially (`acc -= a_q *
-    // s_q`), which is bit-exact with sequential rank-1 axpys but NOT
-    // with axpy2's fused `(a_0*s_0 + a_1*s_1)` add-then-sub
-    // ordering. Lifting this gate is Phase B-2.
+    // Issue #99 Phase B-2: the packed trailing update
+    // (`apply_schur_panel_range_packed`) handles a **mixed** 1×1 / 2×2 /
+    // zero-d pivot stream byte-exactly — each element walks the pivot
+    // stream in order, applying `mul → sub` for 1×1 and the fused
+    // `(dl0·L_q + dl1·L_{q+1})` add-then-sub for 2×2, matching the scalar
+    // reference and the strided fallback below. So when packing is
+    // enabled route **every** panel through it (not only all-1×1),
+    // extending the ~8–10× dense-front win to strongly-indefinite fronts
+    // and the FMA path (whose rounding drifts more pivots to 2×2).
+    if packed_schur_enabled() {
+        apply_blocked_schur_panel(
+            a,
+            nrow,
+            k,
+            n_elim,
+            j_start,
+            d_panel,
+            subdiag,
+            fma,
+            intrafront_parallel,
+        );
+        return;
+    }
+
+    // --- Strided path (`FERAL_PACKED_SCHUR=0`) ---
+    // W-2 fast path: when the panel produced n_elim 1×1 pivots all with
+    // non-zero d AND no 2×2 pivots, run the rank-`n_elim` accumulator.
+    // The 2×2 gate is a correctness requirement for the *strided* kernel:
+    // `schur_panel_minus_*_strided` accumulates per-q sequentially
+    // (`acc -= a_q · s_q`), bit-exact with sequential rank-1 axpys but
+    // NOT with axpy2's fused `(a_0·s_0 + a_1·s_1)` add-then-sub. (The
+    // packed path above lifts this because it walks the stream and emits
+    // the fused form for 2×2 pairs.)
     const W2_RANK_BS_MIN: usize = 2;
     let any_zero_d = d_panel.iter().take(n_elim).any(|&d| d.abs() == 0.0);
     let has_2x2 = subdiag[k..k + n_elim].iter().any(|&s| s != 0.0);
@@ -3090,6 +3210,7 @@ fn apply_blocked_schur(
             n_elim,
             j_start,
             d_panel,
+            subdiag,
             fma,
             intrafront_parallel,
         );
@@ -3181,6 +3302,7 @@ fn apply_blocked_schur_panel(
     n_elim: usize,
     j_start: usize,
     d_panel: &[f64],
+    subdiag: &[f64],
     fma: bool,
     intrafront_parallel: bool,
 ) {
@@ -3209,8 +3331,14 @@ fn apply_blocked_schur_panel(
     let (head, tail) = a.split_at_mut(j_start * nrow);
     let head: &[f64] = head;
 
-    let area = (nrow - j_start).saturating_mul(n_elim);
-    if intrafront_parallel && area >= intrafront_min_area() {
+    let trailing_cols = nrow - j_start;
+    let area = trailing_cols.saturating_mul(n_elim);
+    // Fire on the classic area gate OR the shape-aware tall-front gate
+    // (issue #99 Lever 1) — the latter catches wide, shallow fronts the
+    // area metric misses. OR means no already-parallel front regresses.
+    if intrafront_parallel
+        && (area >= intrafront_min_area() || intrafront_tall_gate(trailing_cols, n_elim))
+    {
         use rayon::prelude::*;
         let ncol = nrow - j_start;
         let nthreads = rayon::current_num_threads().max(1);
@@ -3222,10 +3350,12 @@ fn apply_blocked_schur_panel(
             .enumerate()
             .for_each(|(ci, block)| {
                 let col_start = j_start + ci * chunk_cols;
-                apply_schur_panel_range(head, block, col_start, nrow, k, n_elim, d_panel, fma);
+                apply_schur_panel_range(
+                    head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+                );
             });
     } else {
-        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, fma);
+        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, subdiag, fma);
     }
 }
 
@@ -3259,6 +3389,7 @@ fn apply_schur_panel_range(
     k: usize,
     n_elim: usize,
     d_panel: &[f64],
+    subdiag: &[f64],
     fma: bool,
 ) {
     const MAX_N_ELIM: usize = 128;
@@ -3269,6 +3400,26 @@ fn apply_schur_panel_range(
         MAX_N_ELIM
     );
     let ncol = block.len() / nrow;
+
+    // Issue #99 BLAS-3: the packed, register-tiled trailing update is
+    // ~25× faster than the strided per-column kernels below on this
+    // hardware (measured `examples/bench_schur_micro`) and **byte-exact**
+    // with them — each `A[i,j]` (i>=j) is reduced over ascending q with
+    // the identical `mul → sub` (nofma) or `mul_add` (fma). The strided
+    // kernels re-read the panel at column-stride `nrow` every q, which
+    // cache-thrashes; the packed path reads L1-resident micro-panels.
+    // Default on; `FERAL_PACKED_SCHUR=0` restores the strided path for
+    // A/B benchmarking and as a safety override.
+    if packed_schur_enabled() {
+        apply_schur_panel_range_packed(
+            head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+        );
+        return;
+    }
+    // Strided path below handles 1×1 pivots only; the caller
+    // (`apply_blocked_schur`) guarantees an all-1×1 panel here, so
+    // `subdiag` is unused on this path.
+    let _ = subdiag;
 
     let mut alphas0_buf = [0.0f64; MAX_N_ELIM];
     let mut alphas1_buf = [0.0f64; MAX_N_ELIM];
@@ -3397,6 +3548,235 @@ fn apply_schur_panel_range(
                     trailing_len,
                     alphas,
                 );
+            }
+        }
+    }
+}
+
+/// Whether the packed BLAS-3 trailing update (issue #99) is enabled.
+/// Default `true`; `FERAL_PACKED_SCHUR=0|off|false|no` restores the
+/// strided per-column kernels for A/B benchmarking or as a safety
+/// override. Byte-exact either way. Read once per panel dispatch (a
+/// relaxed env read, negligible beside the trailing-update cost).
+#[inline]
+fn packed_schur_enabled() -> bool {
+    !matches!(
+        std::env::var("FERAL_PACKED_SCHUR").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("no")
+    )
+}
+
+/// Packed, register-tiled equivalent of [`apply_schur_panel_range`]
+/// (issue #99, BLAS-3 — Phase B-2). Computes the same lower-triangular
+/// rank-`n_elim` trailing update for `i >= j`, packing the panel into
+/// `q`-contiguous `MR`/`NR` micro-panels so the inner loop reads
+/// L1-resident memory instead of the strided `col_stride = nrow` access
+/// that bottlenecks the strided kernels (~25× isolated,
+/// `examples/bench_schur_micro`).
+///
+/// Handles a **mixed 1×1 / 2×2 / zero-d pivot stream**: each element
+/// walks the stream in `q` order and emits, per step,
+/// - **1×1** (`subdiag[k+q] == 0`): `acc -= (L[j,q]·d_q)·L[i,q]`
+///   (`mul → sub` nofma / `mul_add` fma), skipping `d_q == 0` exactly as
+///   the fallback does;
+/// - **2×2** (`subdiag[k+q] != 0`, `q+1 < n_elim`): the fused rank-2
+///   contribution `acc -= dl0·L[i,q] + dl1·L[i,q+1]` with
+///   `dl0 = d11·L[j,q] + d21·L[j,q+1]`, `dl1 = d21·L[j,q] + d22·L[j,q+1]`
+///   (`d11=d_panel[q]`, `d22=d_panel[q+1]`, `d21=subdiag[k+q]`), and
+///   advances two.
+///
+/// **Byte-exact** with the strided kernels and the scalar reference:
+/// packing changes only memory layout; the per-element rounding
+/// sequence — `mul → sub` for 1×1 and add-then-sub / two-FMA for 2×2 —
+/// matches `axpy_minus_unroll4*` / `axpy2_minus_unroll4*`
+/// (`do_1x1_update` / `do_2x2_update`) exactly. Verified by the
+/// `packed_matches_scalar_reference_bit_for_bit` unit test (mixed
+/// streams) and the byte-exact factor-parity suite.
+#[allow(clippy::too_many_arguments)]
+fn apply_schur_panel_range_packed(
+    head: &[f64],
+    block: &mut [f64],
+    col_start: usize,
+    nrow: usize,
+    k: usize,
+    n_elim: usize,
+    d_panel: &[f64],
+    subdiag: &[f64],
+    fma: bool,
+) {
+    let ncol = block.len() / nrow;
+    if ncol == 0 || n_elim == 0 {
+        return;
+    }
+    // Register-tile dimensions. MR rows × NR cols per tile; the MR (row)
+    // axis is the contiguous SIMD axis the compiler autovectorizes.
+    const MR: usize = 8;
+    const NR: usize = 4;
+
+    // A 2×2 pivot pair starts at `q` when `subdiag[k+q] != 0` and `q+1`
+    // is still in-panel. Same predicate as the strided fallback; the
+    // walk below consumes such pairs two-at-a-time so the second element
+    // (`q+1`) is never re-entered as a start.
+    let is_2x2_start = |q: usize| q + 1 < n_elim && subdiag[k + q] != 0.0;
+
+    // Column j (absolute) updates rows [j, nrow); the lowest column is
+    // `col_start`, so the source/destination rows span [col_start, nrow).
+    let row0 = col_start;
+    let rowspan = nrow - row0;
+    let col_end = col_start + ncol;
+    let npanels_i = rowspan.div_ceil(MR);
+    let npanels_j = ncol.div_ceil(NR);
+
+    // Pack A (source rows): `apack[pi][q][ir] = L[row0+pi*MR+ir, k+q]`,
+    // `L[x, k+q] = head[(k+q)*nrow + x]`.
+    let mut apack = vec![0.0f64; npanels_i * n_elim * MR];
+    for pi in 0..npanels_i {
+        let i0 = row0 + pi * MR;
+        for q in 0..n_elim {
+            let base = (k + q) * nrow;
+            let out = &mut apack[pi * (n_elim * MR) + q * MR..][..MR];
+            for (ir, o) in out.iter_mut().enumerate() {
+                let i = i0 + ir;
+                *o = if i < nrow { head[base + i] } else { 0.0 };
+            }
+        }
+    }
+    // Pack B0 and B1 (D-scaled source columns). At a 1×1 step,
+    // `B0 = L[j,q]·d_q` (`B1` unused). At a 2×2 start, `B0 = dl0`,
+    // `B1 = dl1` (the block-scaled coefficients above). 2×2-second and
+    // zero-d-1×1 positions carry a value that the accumulation walk
+    // never reads.
+    let mut bpack0 = vec![0.0f64; npanels_j * n_elim * NR];
+    let mut bpack1 = vec![0.0f64; npanels_j * n_elim * NR];
+    for pj in 0..npanels_j {
+        let j0 = col_start + pj * NR;
+        for q in 0..n_elim {
+            let base = (k + q) * nrow;
+            let off = pj * (n_elim * NR) + q * NR;
+            if is_2x2_start(q) {
+                let d11 = d_panel[q];
+                let d22 = d_panel[q + 1];
+                let d21 = subdiag[k + q];
+                let base1 = (k + q + 1) * nrow;
+                for jr in 0..NR {
+                    let j = j0 + jr;
+                    if j < col_end {
+                        let l_jq = head[base + j];
+                        let l_jq1 = head[base1 + j];
+                        bpack0[off + jr] = d11 * l_jq + d21 * l_jq1;
+                        bpack1[off + jr] = d21 * l_jq + d22 * l_jq1;
+                    }
+                }
+            } else {
+                let dq = d_panel[q];
+                for jr in 0..NR {
+                    let j = j0 + jr;
+                    if j < col_end {
+                        bpack0[off + jr] = head[base + j] * dq;
+                    }
+                }
+            }
+        }
+    }
+
+    // Tiled update over the lower triangle (i >= j).
+    for pj in 0..npanels_j {
+        let j0 = col_start + pj * NR;
+        let bbase = pj * (n_elim * NR);
+        for pi in 0..npanels_i {
+            let i0 = row0 + pi * MR;
+            // Skip tiles entirely in the strict upper triangle: the
+            // largest row `i0 + MR - 1` is still below the smallest
+            // column `j0`, so no element satisfies i >= j.
+            if i0 + MR <= j0 {
+                continue;
+            }
+            let abase = pi * (n_elim * MR);
+
+            // Load the C tile (lower-triangle, in-range elements only;
+            // out-of-range/upper stay 0 and are never stored).
+            let mut acc = [[0.0f64; MR]; NR];
+            for (jr, accj) in acc.iter_mut().enumerate() {
+                let j = j0 + jr;
+                if j >= col_end {
+                    continue;
+                }
+                let colblk = (j - col_start) * nrow;
+                for (ir, a) in accj.iter_mut().enumerate() {
+                    let i = i0 + ir;
+                    if i < nrow && i >= j {
+                        *a = block[colblk + i];
+                    }
+                }
+            }
+
+            // Walk the pivot stream in `q` order. Out-of-range column
+            // lanes carry packed 0 coefficients (0·L = 0), so they are
+            // inert and never stored.
+            let mut q = 0usize;
+            while q < n_elim {
+                if is_2x2_start(q) {
+                    let a0 = &apack[abase + q * MR..][..MR];
+                    let a1 = &apack[abase + (q + 1) * MR..][..MR];
+                    let b0 = &bpack0[bbase + q * NR..][..NR];
+                    let b1 = &bpack1[bbase + q * NR..][..NR];
+                    if fma {
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let n0 = -b0[jr];
+                            let n1 = -b1[jr];
+                            for (ir, acci) in accj.iter_mut().enumerate() {
+                                // Two FMAs, matching axpy2_minus_unroll4.
+                                *acci = n1.mul_add(a1[ir], n0.mul_add(a0[ir], *acci));
+                            }
+                        }
+                    } else {
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let (d0, d1) = (b0[jr], b1[jr]);
+                            for (ir, acci) in accj.iter_mut().enumerate() {
+                                // Add-then-sub, matching axpy2_minus_unroll4_nofma.
+                                *acci -= d0 * a0[ir] + d1 * a1[ir];
+                            }
+                        }
+                    }
+                    q += 2;
+                } else {
+                    // 1×1; skip a zero pivot exactly as the fallback does.
+                    if d_panel[q] != 0.0 {
+                        let a0 = &apack[abase + q * MR..][..MR];
+                        let b0 = &bpack0[bbase + q * NR..][..NR];
+                        if fma {
+                            for (jr, accj) in acc.iter_mut().enumerate() {
+                                let nb = -b0[jr];
+                                for (ir, acci) in accj.iter_mut().enumerate() {
+                                    *acci = nb.mul_add(a0[ir], *acci);
+                                }
+                            }
+                        } else {
+                            for (jr, accj) in acc.iter_mut().enumerate() {
+                                let bj = b0[jr];
+                                for (ir, acci) in accj.iter_mut().enumerate() {
+                                    *acci -= bj * a0[ir];
+                                }
+                            }
+                        }
+                    }
+                    q += 1;
+                }
+            }
+
+            // Store back the lower-triangle, in-range elements.
+            for (jr, accj) in acc.iter().enumerate() {
+                let j = j0 + jr;
+                if j >= col_end {
+                    continue;
+                }
+                let colblk = (j - col_start) * nrow;
+                for (ir, a) in accj.iter().enumerate() {
+                    let i = i0 + ir;
+                    if i < nrow && i >= j {
+                        block[colblk + i] = *a;
+                    }
+                }
             }
         }
     }
@@ -5679,6 +6059,153 @@ mod ncol_zero_contrib_tests {
                     0.0,
                     "contrib strict upper triangle ({ci},{cj}) must be zero, not stale pooled-buffer data"
                 );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod packed_schur_tests {
+    use super::*;
+
+    /// Scalar reference for the mixed 1×1 / 2×2 / zero-d trailing update,
+    /// walking the pivot stream in `q` order with the exact per-element
+    /// rounding the kernels must reproduce:
+    /// - 1×1 (`subdiag[k+q]==0`, `d_q!=0`): `acc -= (L[j,q]·d_q)·L[i,q]`,
+    ///   as `mul→sub` (nofma) or a single `mul_add` (fma);
+    /// - 2×2 (`subdiag[k+q]!=0`): `acc -= dl0·L[i,q] + dl1·L[i,q+1]` as
+    ///   add-then-sub (nofma) or two chained FMAs (fma).
+    ///
+    /// This mirrors `axpy_minus_unroll4*` / `axpy2_minus_unroll4*` exactly,
+    /// so the packed kernel must be **byte-identical** for both `fma`
+    /// modes.
+    #[allow(clippy::too_many_arguments)]
+    fn scalar_ref(
+        head: &[f64],
+        block: &mut [f64],
+        col_start: usize,
+        nrow: usize,
+        k: usize,
+        n_elim: usize,
+        d_panel: &[f64],
+        subdiag: &[f64],
+        fma: bool,
+    ) {
+        let ncol = block.len() / nrow;
+        for lc in 0..ncol {
+            let j = col_start + lc;
+            for i in j..nrow {
+                let mut acc = block[lc * nrow + i];
+                let mut q = 0usize;
+                while q < n_elim {
+                    if q + 1 < n_elim && subdiag[k + q] != 0.0 {
+                        let d11 = d_panel[q];
+                        let d22 = d_panel[q + 1];
+                        let d21 = subdiag[k + q];
+                        let b0 = (k + q) * nrow;
+                        let b1 = (k + q + 1) * nrow;
+                        let dl0 = d11 * head[b0 + j] + d21 * head[b1 + j];
+                        let dl1 = d21 * head[b0 + j] + d22 * head[b1 + j];
+                        if fma {
+                            acc = (-dl1).mul_add(head[b1 + i], (-dl0).mul_add(head[b0 + i], acc));
+                        } else {
+                            acc -= dl0 * head[b0 + i] + dl1 * head[b1 + i];
+                        }
+                        q += 2;
+                    } else {
+                        if d_panel[q] != 0.0 {
+                            let base = (k + q) * nrow;
+                            let alpha = head[base + j] * d_panel[q];
+                            if fma {
+                                acc = (-alpha).mul_add(head[base + i], acc);
+                            } else {
+                                acc -= alpha * head[base + i];
+                            }
+                        }
+                        q += 1;
+                    }
+                }
+                block[lc * nrow + i] = acc;
+            }
+        }
+    }
+
+    /// `apply_schur_panel_range_packed` is byte-identical to the scalar
+    /// reference across a size sweep — for both `fma` modes and for pivot
+    /// streams mixing 1×1, 2×2, and zero-d pivots — including
+    /// non-multiple-of-MR/NR row/col counts and `col_start > k+n_elim`
+    /// chunk offsets.
+    #[test]
+    fn packed_matches_scalar_reference_bit_for_bit() {
+        // Deterministic pseudo-random front data.
+        let mut s = 0x51ED_270B_5A11_CE17u64;
+        let mut next = || {
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((s >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+        };
+        // (nrow, k, n_elim, col_start, subdiag-pattern). Patterns:
+        //   "1x1"  — all 1×1
+        //   "2x2"  — 2×2 pairs at q = 2 and q = 5 (where they fit)
+        //   "zero" — a zero-d 1×1 at q = 1
+        for &(nrow, k, n_elim, col_start, pat) in &[
+            (40usize, 0usize, 8usize, 8usize, "1x1"),
+            (37, 0, 5, 5, "1x1"),
+            (64, 0, 16, 16, "2x2"),
+            (100, 0, 12, 30, "2x2"), // chunk offset > k+n_elim, with 2×2
+            (23, 0, 8, 3, "2x2"),
+            (40, 0, 8, 8, "zero"),
+            (50, 0, 10, 10, "2x2"),
+            (9, 0, 2, 2, "1x1"),
+        ] {
+            let head: Vec<f64> = (0..nrow * (k + n_elim)).map(|_| next()).collect();
+            let mut d_panel: Vec<f64> = (0..n_elim).map(|_| 0.5 + next().abs()).collect();
+            let mut subdiag = vec![0.0f64; k + n_elim];
+            match pat {
+                "2x2" => {
+                    if 2 + 1 < n_elim {
+                        subdiag[k + 2] = 0.3 + next().abs();
+                    }
+                    if 5 + 1 < n_elim {
+                        subdiag[k + 5] = -(0.3 + next().abs());
+                    }
+                }
+                "zero" => {
+                    d_panel[1] = 0.0;
+                }
+                _ => {}
+            }
+            let ncol = nrow - col_start;
+            let block0: Vec<f64> = (0..ncol * nrow).map(|_| next()).collect();
+
+            for fma in [false, true] {
+                let mut b_ref = block0.clone();
+                scalar_ref(
+                    &head, &mut b_ref, col_start, nrow, k, n_elim, &d_panel, &subdiag, fma,
+                );
+                let mut b_packed = block0.clone();
+                apply_schur_panel_range_packed(
+                    &head,
+                    &mut b_packed,
+                    col_start,
+                    nrow,
+                    k,
+                    n_elim,
+                    &d_panel,
+                    &subdiag,
+                    fma,
+                );
+                for lc in 0..ncol {
+                    let j = col_start + lc;
+                    for i in j..nrow {
+                        assert_eq!(
+                            b_packed[lc * nrow + i].to_bits(),
+                            b_ref[lc * nrow + i].to_bits(),
+                            "packed != scalar (fma={fma}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -469,6 +469,34 @@ impl Solver {
         self
     }
 
+    /// Opt into the FMA trailing-Schur kernels on **tall fronts only**
+    /// (issue #99, Lever 3). Every front with at least `min_rows` rows
+    /// (`nrow >= min_rows`) uses the single-rounding FMA kernels (~1.6×
+    /// measured end-to-end on the synthetic qap15 stand-in, x86 V3);
+    /// smaller fronts keep the bit-exact `*_nofma` path. This lets one
+    /// factorization run the fast path on its throughput-dominant fronts
+    /// while sensitive small KKT fronts — where FMA rounding can perturb
+    /// Bunch-Kaufman pivot classification — stay on the reference
+    /// kernels.
+    ///
+    /// The gate is on **rows**, not `nrow * ncol` area: real conic-KKT
+    /// factorizations spend their time in *tall, thin* fronts (large
+    /// `nrow`, small `ncol` — e.g. `2000 × 16`), which an area gate
+    /// misses entirely. Unlike [`with_fma`](Self::with_fma)
+    /// (all-or-nothing), this leaves small fronts bit-exact. It still
+    /// changes cross-arch bit patterns on the gated fronts, so it is a
+    /// deliberate opt-in. Inertia is preserved on well-conditioned
+    /// fronts. A reasonable starting `min_rows` is `256`. See
+    /// `dev/research/issue-99-dense-front-fma-gate.md`.
+    pub fn with_fma_large_fronts(mut self, min_rows: usize) -> Self {
+        // Written straight to `bk` — the params the dense front factor
+        // reads — so no separate `NumericParams` field or funnel is
+        // needed (contrast `with_fma`, kept separate for historical
+        // reasons). Both multifrontal drivers pass `bk` per front.
+        self.numeric_params.bk.fma_min_front_rows = Some(min_rows);
+        self
+    }
+
     /// Disable delayed pivoting. When `on = true`, every supernode
     /// runs as if it were the root: pivots failing the BK threshold
     /// or 2×2 Duff–Reid test are force-accepted in place via

--- a/tests/issue99_fma_front_gate.rs
+++ b/tests/issue99_fma_front_gate.rs
@@ -1,0 +1,183 @@
+//! Issue #99, Lever 3: opt-in per-front FMA size gate.
+//!
+//! `BunchKaufmanParams::fma_min_front_rows = Some(t)` routes a front to
+//! the FMA trailing-Schur kernels when `nrow >= t`, even when the
+//! global `fma` flag is off — while leaving smaller fronts on the
+//! bit-exact `*_nofma` path. These tests pin that behavior:
+//!
+//!  1. gate-armed + large front  ==  explicit `fma = true`   (bit-for-bit)
+//!  2. gate-armed + small front  ==  default `fma = false`   (bit-for-bit)
+//!  3. gate does not change inertia on a well-conditioned front.
+//!
+//! The oracle for (1) and (2) is another feral factorization with the
+//! effective flag set explicitly — a self-consistency contract, not an
+//! external numeric oracle, so no tolerance is involved: the assertion is
+//! byte equality (`f64::to_bits`).
+
+use feral::dense::factor::factor_frontal_blocked;
+use feral::{BunchKaufmanParams, SymmetricMatrix};
+
+/// Deterministic SplitMix64 → [-1, 1). Reproducible fixture, no `rand`.
+fn mix(state: &mut u64) -> f64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+}
+
+/// Symmetric indefinite front (alternating-sign dominant diagonal, small
+/// off-diagonal noise) that factors through the all-1×1-pivot fast path.
+fn build_front(n: usize) -> SymmetricMatrix {
+    let mut s = 0x1234_5678_9ABC_DEF0u64;
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            data[j * n + i] = if i == j {
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                sign * (n as f64) + mix(&mut s)
+            } else {
+                0.30 * mix(&mut s)
+            };
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+fn factor(
+    matrix: &SymmetricMatrix,
+    params: &BunchKaufmanParams,
+) -> feral::dense::factor::FrontalFactors {
+    // Root front: every column fully summed, no delayed pivots.
+    factor_frontal_blocked(matrix, matrix.n, false, params).expect("factor failed")
+}
+
+fn assert_bits_eq(a: &[f64], b: &[f64], what: &str) {
+    assert_eq!(a.len(), b.len(), "{what}: length mismatch");
+    for (i, (x, y)) in a.iter().zip(b).enumerate() {
+        assert_eq!(
+            x.to_bits(),
+            y.to_bits(),
+            "{what}: element {i} differs ({x} vs {y})"
+        );
+    }
+}
+
+fn assert_factors_bit_identical(
+    x: &feral::dense::factor::FrontalFactors,
+    y: &feral::dense::factor::FrontalFactors,
+    what: &str,
+) {
+    assert_bits_eq(&x.l, &y.l, &format!("{what}: l"));
+    assert_bits_eq(&x.d_diag, &y.d_diag, &format!("{what}: d_diag"));
+    assert_bits_eq(&x.d_subdiag, &y.d_subdiag, &format!("{what}: d_subdiag"));
+    assert_bits_eq(&x.contrib, &y.contrib, &format!("{what}: contrib"));
+    assert_eq!(x.perm, y.perm, "{what}: perm");
+    assert_eq!(x.inertia, y.inertia, "{what}: inertia");
+}
+
+#[test]
+fn gate_on_large_front_matches_explicit_fma() {
+    let n = 96;
+    let matrix = build_front(n);
+
+    // Gate armed with a threshold this front clears (nrow = 96 >= 1).
+    let gated = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_rows: Some(1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    // Oracle: the same front factored with FMA turned on globally.
+    let explicit_fma = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: true,
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_factors_bit_identical(&gated, &explicit_fma, "gate-on-large vs explicit-fma");
+}
+
+#[test]
+fn gate_below_threshold_matches_nofma_default() {
+    let n = 96;
+    let matrix = build_front(n);
+
+    // Gate armed but threshold unreachable → must stay on nofma.
+    let gated_but_small = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_rows: Some(usize::MAX),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let nofma_default = factor(&matrix, &BunchKaufmanParams::default());
+    assert_factors_bit_identical(
+        &gated_but_small,
+        &nofma_default,
+        "gate-below-threshold vs nofma-default",
+    );
+}
+
+#[test]
+fn gate_preserves_inertia() {
+    let n = 96;
+    let matrix = build_front(n);
+    let nofma = factor(&matrix, &BunchKaufmanParams::default());
+    let gated = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: false,
+            fma_min_front_rows: Some(1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_eq!(
+        nofma.inertia, gated.inertia,
+        "FMA size gate must not change inertia on a well-conditioned front"
+    );
+    // Sanity: this fixture is genuinely indefinite (both signs present).
+    assert!(nofma.inertia.positive > 0 && nofma.inertia.negative > 0);
+}
+
+/// The threshold is on `nrow`, so a boundary value must gate exactly:
+/// `nrow == t` fires (`>=`), `nrow == t+1` (threshold one past nrow) does
+/// not.
+#[test]
+fn gate_threshold_is_front_rows() {
+    let n = 96;
+    let matrix = build_front(n);
+
+    // Exactly at the boundary: nrow == t → `>=` fires → matches fma=true.
+    let at_boundary = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma_min_front_rows: Some(n),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let explicit_fma = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma: true,
+            ..BunchKaufmanParams::default()
+        },
+    );
+    assert_factors_bit_identical(&at_boundary, &explicit_fma, "nrow==t boundary fires");
+
+    // One row past nrow: does not fire → matches nofma.
+    let just_above = factor(
+        &matrix,
+        &BunchKaufmanParams {
+            fma_min_front_rows: Some(n + 1),
+            ..BunchKaufmanParams::default()
+        },
+    );
+    let nofma_default = factor(&matrix, &BunchKaufmanParams::default());
+    assert_factors_bit_identical(&just_above, &nofma_default, "nrow<t does not fire");
+}


### PR DESCRIPTION
Clean rebase of PR #101's issue-#99 work onto current main.

PR #101 branched before #92 merged, so it re-carried the already-merged qap15
ordering fix + Lever B and became a confusing, CONFLICTING 3691-line diff. This
PR is the same genuinely-new work rebased onto current main as one clean commit.

## What

- **Packed, register-tiled (MR=8×NR=4) dense trailing-update kernel** — pack the
  eliminated panel into q-contiguous micro-panels so the inner rank-`n_elim`
  loop is L1-resident. Handles mixed 1×1/2×2/zero-d pivot streams. **Default on**;
  `FERAL_PACKED_SCHUR=0` restores the strided path.
- **Shape-aware intra-front parallel gate** (Lever 1) for tall, thin fronts.
- **Opt-in per-front FMA gate** — `Solver::with_fma_large_fronts(min_rows)`: FMA
  on tall fronts only, small/sensitive fronts stay bit-exact. Default off.

## Byte-exact — verified locally

Packing changes only memory layout, not arithmetic order. All factor-parity gates
green (`blocked_ldlt` 21, `dense_ldlt` 17, `parallel_parity` 8, `parity` 8,
`factor_workspace_parity` 21) + the dedicated `packed_matches_scalar_reference_bit_for_bit`
sweep; full lib **394/0**; fmt clean.

## Perf (hardware-dependent, both byte-exact)

~22–26× isolated on x86 V3 (strided kernel was cache-latency-bound at 0.33–0.39
GFLOP/s), ~1.38× on Apple M-series (its prefetch already hides the stride). This
corrects the earlier "DST-bandwidth-bound / packing is a net loss" note — that was
specific to packing into the *same strided kernel*.

Supersedes #101 (which can be closed). Design/measurements:
`dev/research/issue-99-dense-front-fma-gate.md`. Original work by the issue-#99
session; rebased and verified here.
