### PR TITLE
issue #102: fix parallel dense-front re-entrant deadlock (0% CPU stall)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — parallel dense-front re-entrant deadlock on some conic KKTs (issue #102)
+
+PR #92 regressed two POUNCE mittelmann problems (cont5_2_4_l, dirichlet120) from
+converged to a 300 s timeout at ~0 % CPU. The parallel multifrontal driver held
+a per-thread workspace `Mutex` across the intra-front `par_chunks_mut`; the
+nested rayon let the blocked worker steal another `process_one_supernode` task
+onto the same thread, which re-locked the already-held mutex → self-deadlock.
+The driver now `try_lock`s the per-thread workspace (which is only ever locked by
+its own worker, so `WouldBlock` uniquely means nested re-entry) and factors with
+a throwaway workspace on re-entry — byte-exact (results go to separate output
+mutexes), and independent of the ordering choice. Latent since intra-front
+parallelism was introduced; #92 exposed it. See
+`dev/research/issue-102-intrafront-deadlock.md`.
+
 ### Performance — packed BLAS-3 dense trailing update, byte-exact ~8–10× on dense fronts (issue #99)
 
 The dense trailing Schur update (~94 % of a dense factor) ran at only

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5796,3 +5796,31 @@ effect (both use packed). Reinforces keeping FMA opt-in.
 still below a fully-tuned BLAS-3 core; the 8×4 tile, L2 cache-blocking, an
 explicit-SIMD (pulp) packed kernel, and FMA-in-packed are untuned, and this is a
 4-core container. Re-tune on target hardware.
+
+## 2026-07-01 — Parallel driver `try_lock`s the per-thread workspace (issue #102)
+
+**Decision.** In `factorize_multifrontal_supernodal_parallel`, acquire the
+per-thread `thread_ws[i]` workspace with `try_lock` rather than `lock`, and on
+`WouldBlock` factor with a fresh throwaway `FactorWorkspace`.
+
+**Why.** The mutex was held across `factor_one_supernode` → `factor_frontal` →
+the intra-front `par_chunks_mut`. That nested rayon lets the blocked worker steal
+another `process_one_supernode` onto the same thread, which re-locks
+`thread_ws[i]` (already held by the outer frame) → non-reentrant `std::sync::Mutex`
+self-deadlock at 0 % CPU (issue #102: cont5_2_4_l / dirichlet120 converged → 300 s
+timeout). Each `thread_ws` slot is only ever locked by its own worker, so a
+`WouldBlock` uniquely identifies nested re-entry; the throwaway workspace is
+correct because the factor writes results to the separate `contrib_blocks` /
+`node_factors_out` mutexes, not the workspace (only pooled scratch differs).
+
+**Why not the alternatives.** Reverting Lever B does not help — the old 256²
+intra-front floor deadlocks on these problems too (it is not Lever-B-specific).
+Gating the ordering on a dense-front cost signal (issue #102 direction #1) only
+avoids *selecting* a stall-prone front; the deadlock is latent for any ordering
+that clears the intra-front area gate, so fixing the mutex is the robust fix. A
+separate rayon pool for intra-front would also work but adds a pool and
+oversubscription; `try_lock` is minimal and byte-exact.
+
+**Evidence.** dirichlet120 KKT: STALL → ~0.4 s factor, inertia (+54122,−241,0).
+Byte-exact: parallel_parity 8/8, blocked_ldlt 21, parity 8, factor_workspace_parity
+21, lib 394/0. Regression guard `tests/issue102_intrafront_deadlock.rs`.

--- a/dev/research/issue-102-intrafront-deadlock.md
+++ b/dev/research/issue-102-intrafront-deadlock.md
@@ -1,0 +1,77 @@
+# issue #102 — parallel dense-front re-entrant deadlock (0% CPU stall) — 2026-07-01
+
+PR #92 regressed two POUNCE mittelmann problems (`cont5_2_4_l`, `dirichlet120`)
+from converged to a **300 s timeout at ~0 % CPU** — a synchronization stall in
+the parallel dense-front factorization, not slow arithmetic.
+
+## Root cause — nested-rayon re-entrant workspace-mutex deadlock
+
+The parallel multifrontal driver (`factorize_multifrontal_supernodal_parallel`)
+gives each rayon worker a per-thread workspace `thread_ws[current_thread_index()]`,
+guarded by a `Mutex`. `process_one_supernode` **locks** that mutex and **holds it
+across** `factor_one_supernode` → `factor_frontal_blocked_in_place_with_scratch`
+→ the intra-front `apply_blocked_schur_panel` `par_chunks_mut`.
+
+That nested `par_chunks_mut` is rayon-on-rayon. While the outer worker waits for
+its nested chunks (`WorkerThread::wait_until_cold`), rayon has it **steal another
+scope job — another `process_one_supernode`** — and run it *on the same thread*.
+That stolen task computes `thread_idx = current_thread_index()` = the **same
+index**, and tries to lock `thread_ws[i]` — which its own outer frame already
+holds. `std::sync::Mutex` is not re-entrant ⇒ **self-deadlock**, 0 % CPU forever.
+
+Confirmed by `sample` on the hung factor (dirichlet120 KKT, feral `main`):
+
+```
+factor_one_supernode → factor_frontal_blocked_in_place_with_scratch
+  → rayon ParallelIterator::for_each (intra-front par_chunks_mut)
+    → WorkerThread::wait_until_cold            (outer worker steals…)
+      → ScopeBase::execute_job_closure         (…another process_one_supernode)
+        → std::sync::Mutex::lock → __psynch_mutexwait   (re-locks held thread_ws[i])
+```
+
+## What the toggles proved (dirichlet120 KKT factored in feral `main`)
+
+| config | result |
+|---|---|
+| default (`main`) | **STALL** (>45 s, 0 % CPU) |
+| `FERAL_INTRAFRONT=off` | solves, ~765 ms |
+| `FERAL_INTRAFRONT_MIN_AREA=65536` (old 256² floor) | **still STALLS** |
+
+So (1) the stall **is** the intra-front nested-rayon path, and (2) it is **not
+Lever-B-specific** — the pre-#92 floor deadlocks too. PR #92's *ordering* change
+(verify-`LdltCompress`-by-fill, which drops `LdltCompress` here) merely selects a
+front that clears the intra-front area gate; 0.11.3's `LdltCompress` ordering
+produced a front that stayed under it. The deadlock itself was **latent** since
+intra-front parallelism was introduced.
+
+## Fix — `try_lock` the per-thread workspace, throwaway fallback on re-entry
+
+Each `thread_ws[i]` slot is only ever locked by rayon worker `i` (or the donated
+caller, last slot), so **cross-thread contention never happens** — a `try_lock`
+that `WouldBlock` *uniquely* means this thread already holds it via a nested
+re-entry. The driver now `try_lock`s and, on `WouldBlock`, factors with a fresh
+throwaway `FactorWorkspace` instead of blocking. Correct because the factor result
+is written to the separate `contrib_blocks` / `node_factors_out` mutexes, not the
+workspace — only the pooled scratch buffers differ (re-allocated on the rare
+nested path). Non-nested calls take the fast path unchanged.
+
+This is the robust fix: it makes intra-front nesting *safe under any ordering*,
+rather than papering over #92's ordering choice (which is the correct fill
+choice). It preserves byte-exactness (parallel_parity 8/8, blocked_ldlt 21/8,
+parity 8/8, factor_workspace_parity 21/21, lib 394/0) and the intra-front speedup.
+
+Result: dirichlet120 KKT factors in ~0.4–0.5 s (10-core), inertia
+`(+54122,−241,0)`.
+
+## Regression guard
+
+`tests/issue102_intrafront_deadlock.rs` factors `tests/data/large/dirichlet120_kkt.mtx`
+(gitignored; `dev/scripts/regen_dirichlet120_kkt.sh`) on a worker thread with a
+120 s wall-clock guard — a returning deadlock fails the test instead of hanging.
+
+## Follow-up (out of scope)
+
+The issue's direction #1 (a dense-front-aware ordering cost signal) is now moot
+for correctness — the deadlock is fixed regardless of ordering. It remains a
+possible *performance* refinement if a chosen front parallelizes poorly, tracked
+under the #99 dense-front-throughput umbrella.

--- a/dev/scripts/regen_dirichlet120_kkt.sh
+++ b/dev/scripts/regen_dirichlet120_kkt.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regenerate the issue #102 regression fixture: dirichlet120's conic iter-0 KKT.
+#
+# This is the POUNCE mittelmann problem whose parallel dense-front factorization
+# deadlocked at 0 % CPU under PR #92's ordering (issue #102). The KKT triplets
+# are feral-version-independent (feral only *factors* the matrix), so any POUNCE
+# build that reaches the first factorization can dump it — feral 0.11.3 solves
+# it fine and dumps the same matrix feral `main` deadlocks on.
+#
+# Produces tests/data/large/dirichlet120_kkt.mtx (gitignored). The regression
+# test `tests/issue102_intrafront_deadlock.rs` skips cleanly when absent.
+#
+# Requires a built `pounce` binary and dirichlet120.nl. Override via env vars.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEST="${REPO_ROOT}/tests/data/large/dirichlet120_kkt.mtx"
+
+POUNCE_BIN="${POUNCE_BIN:-${HOME}/projects/pounce/target/release/pounce}"
+NL="${NL:-${HOME}/projects/pounce/benchmarks/mittelmann/nl/dirichlet120.nl}"
+PYTHON="${PYTHON:-python3}"
+BIN_DUMP="$(mktemp -t dirichlet120_kkt.XXXX.bin)"
+
+for f in "${POUNCE_BIN}" "${NL}"; do
+  [[ -f "$f" ]] || { echo "ERROR: missing $f" >&2; exit 1; }
+done
+
+# max_iter=0 still runs the initial least-squares equality-multiplier factor,
+# which is the first (and dumped) `multi_solve`.
+POUNCE_DBG_KKT_DUMP="${BIN_DUMP}" "${POUNCE_BIN}" "${NL}" print_level=0 max_iter=0 >/dev/null 2>&1 || true
+
+[[ -s "${BIN_DUMP}" ]] || { echo "ERROR: no KKT dump produced" >&2; exit 1; }
+
+# Binary dump (little-endian): u64 dim,nnz,nrhs; i64[nnz] airn (1-based lower);
+# i64[nnz] ajcn; f64[nnz] vals; f64[dim*nrhs] rhs. Emit symmetric MatrixMarket.
+OUT="${DEST}" BIN="${BIN_DUMP}" "${PYTHON}" - <<'PY'
+import os, numpy as np
+b = os.environ["BIN"]; out = os.environ["OUT"]
+with open(b, "rb") as f:
+    dim, nnz, _ = (int(x) for x in np.frombuffer(f.read(24), dtype="<u8"))
+    airn = np.frombuffer(f.read(8 * nnz), dtype="<i8")
+    ajcn = np.frombuffer(f.read(8 * nnz), dtype="<i8")
+    vals = np.frombuffer(f.read(8 * nnz), dtype="<f8")
+with open(out, "w") as o:
+    o.write("%%MatrixMarket matrix coordinate real symmetric\n")
+    o.write(f"{dim} {dim} {nnz}\n")
+    o.writelines(f"{i} {j} {v:.17e}\n"
+                 for i, j, v in zip(airn.tolist(), ajcn.tolist(), vals.tolist()))
+print(f"wrote {out}: dim={dim} nnz={nnz}")
+PY
+
+rm -f "${BIN_DUMP}"
+echo "Regenerated ${DEST}"

--- a/dev/sessions/2026-07-01-05.md
+++ b/dev/sessions/2026-07-01-05.md
@@ -1,0 +1,51 @@
+# Session 2026-07-01-05
+
+## Goal
+Pick up issue #102: PR #92 regressed two POUNCE mittelmann problems
+(`cont5_2_4_l`, `dirichlet120`) from converged to a 300 s timeout at ~0 % CPU —
+a stall in the parallel dense-front factorization.
+
+## Accomplished
+- **Root-caused a nested-rayon re-entrant deadlock.** The parallel multifrontal
+  driver holds a per-thread workspace `Mutex` across `factor_one_supernode` →
+  `factor_frontal` → the intra-front `par_chunks_mut`; the nested rayon lets the
+  blocked worker steal another `process_one_supernode` onto the same thread,
+  which re-locks the already-held `thread_ws[i]` → self-deadlock (0 % CPU).
+  Confirmed by `sample` of the hung factor (stack: intra-front for_each →
+  wait_until_cold → execute_job_closure → Mutex::lock → __psynch_mutexwait).
+- **Reproduced at the feral level** by dumping dirichlet120's iter-0 KKT via the
+  existing pounce binary (matrix is feral-version-independent) and factoring it
+  in feral `main` → deterministic stall.
+- **Isolated the cause with toggles:** `FERAL_INTRAFRONT=off` → solves (765 ms);
+  `FERAL_INTRAFRONT_MIN_AREA=65536` (old floor) → still stalls. So it is the
+  intra-front nested-rayon path, and **not** Lever-B-specific — a latent bug #92's
+  ordering merely exposed. (My initial Lever-B hypothesis was wrong; the synthetic
+  block-diagonal reproducer did not trigger it — needed the real matrix.)
+- **Fixed:** the driver `try_lock`s the per-thread workspace and falls back to a
+  throwaway workspace on `WouldBlock` (which uniquely means nested re-entry).
+  Byte-exact; independent of ordering.
+- Regression guard `tests/issue102_intrafront_deadlock.rs` (fixture
+  `tests/data/large/dirichlet120_kkt.mtx`, regen `dev/scripts/regen_dirichlet120_kkt.sh`),
+  timeout-guarded so a returning deadlock fails rather than hangs.
+
+## Benchmark Results
+dirichlet120 KKT (n=54363), parallel factor: **STALL (>300 s) → ~0.4–0.5 s**
+(10 cores), inertia (+54122,−241,0). Byte-exact: parallel_parity 8/8,
+blocked_ldlt 21, parity 8, factor_workspace_parity 21, lib 394/0.
+
+## Decisions Made
+- Parallel driver `try_lock`s the per-thread workspace (issue #102) — appended to
+  `dev/decisions.md`.
+
+## Abandoned Approaches
+- Initial hypothesis that Lever B (INTRAFRONT_MIN_AREA lowering) was the trigger —
+  refuted by the old-floor-still-stalls toggle. The synthetic block-diagonal
+  reproducer (many 640² fronts) did not deadlock; the real dirichlet120 KKT was
+  required. (Lesson reinforced: reproduce before fixing.)
+
+## Next Session Should
+- Optional: issue #102 direction #1 (dense-front-aware ordering cost signal) — now
+  a performance-only refinement under the #99 umbrella, not a correctness need.
+- Confirm cont5_2_4_l end-to-end in POUNCE once feral is bumped (dirichlet120
+  verified at the feral level; the fix is at the mechanism level so both are
+  covered).

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -3304,14 +3304,38 @@ fn run_parallel_task<'a>(
         let mut prof_us: Option<u64> = None;
         let (result, own_contrib) = {
             let t_ws_wait = telemetry.map(|_| std::time::Instant::now());
-            let mut ws_guard = match ws_mtx.lock() {
-                Ok(g) => g,
-                Err(p) => p.into_inner(),
+            // Issue #102: `thread_ws[i]` is only ever locked by the rayon
+            // worker whose `current_thread_index()` is `i` (or the donated
+            // caller, for the last slot), so cross-thread contention never
+            // happens. A `try_lock` that WOULD block therefore means *this
+            // same thread already holds it* via an outer front whose
+            // intra-front `par_chunks_mut` blocked and stole this task back
+            // onto the same worker — a re-entrant self-deadlock. Instead of
+            // blocking (0 %-CPU hang, issue #102), fall back to a throwaway
+            // workspace: the factor result is written to
+            // `contrib_blocks`/`node_factors_out`, not the workspace, so a
+            // fresh scratch is fully correct — only the pooled buffers differ.
+            // Non-nested calls take the fast `Some` arm exactly as before.
+            let mut fallback_ws: Option<FactorWorkspace> = None;
+            let mut ws_guard_opt = match ws_mtx.try_lock() {
+                Ok(g) => Some(g),
+                Err(std::sync::TryLockError::Poisoned(p)) => Some(p.into_inner()),
+                Err(std::sync::TryLockError::WouldBlock) => None,
             };
             if let (Some(t), Some(start)) = (telemetry, t_ws_wait) {
                 t.ws_lock_wait_ns
                     .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
             }
+            let ws: &mut FactorWorkspace = match ws_guard_opt.as_deref_mut() {
+                Some(g) => g,
+                None => {
+                    let mut w = FactorWorkspace::new();
+                    w.row_map.resize(symbolic.n, usize::MAX);
+                    w.build_seen.resize(symbolic.n, false);
+                    w.local_contribs.resize_with(n_snodes, || None);
+                    fallback_ws.insert(w)
+                }
+            };
 
             // Move the pooled local_contribs out of the workspace so
             // we can hand `&mut FactorWorkspace` and `&mut Vec<...>`
@@ -3320,7 +3344,7 @@ fn run_parallel_task<'a>(
             // guaranteed `None` going in (postcondition of the prior
             // task on this worker took both children's slots and the
             // own_contrib slot below).
-            let mut local_contribs = std::mem::take(&mut ws_guard.local_contribs);
+            let mut local_contribs = std::mem::take(&mut ws.local_contribs);
 
             // Stage child contributions: shared lock held only for
             // the drain, not across the factor body.
@@ -3356,7 +3380,7 @@ fn run_parallel_task<'a>(
                 scaling_pivot_order,
                 is_root,
                 params,
-                &mut ws_guard,
+                ws,
                 &mut local_contribs,
                 0, // nvschur: parallel path is not used by Schur API
             );
@@ -3371,8 +3395,10 @@ fn run_parallel_task<'a>(
             let own = local_contribs[snode_idx].take();
             // Return the pooled vec to the workspace. All slots are
             // `None` (children were taken into us above; own was just
-            // taken out), so no clearing is needed.
-            ws_guard.local_contribs = local_contribs;
+            // taken out), so no clearing is needed. (On the issue-#102
+            // fallback path this writes into the throwaway workspace, which
+            // is then dropped — harmless.)
+            ws.local_contribs = local_contribs;
             (res, own)
         };
 

--- a/tests/issue102_intrafront_deadlock.rs
+++ b/tests/issue102_intrafront_deadlock.rs
@@ -1,0 +1,79 @@
+//! Issue #102 regression: the parallel dense-front factorization must not
+//! deadlock on the `dirichlet120` / `cont5_2_4_l` mittelmann KKTs.
+//!
+//! Root cause: the parallel multifrontal driver locked a per-thread workspace
+//! `thread_ws[current_thread_index()]` and held it across `factor_one_supernode`
+//! → `factor_frontal` → the intra-front `par_chunks_mut`. That nested rayon
+//! let the blocked worker steal *another* `process_one_supernode` task onto the
+//! **same** thread index, which re-locked the already-held mutex → self-deadlock
+//! at 0 % CPU (converged → 300 s timeout in POUNCE). PR #92's ordering exposed
+//! it by selecting a front that clears the intra-front area gate on these
+//! problems; it is not Lever-B-specific (the old 256² floor deadlocks too).
+//!
+//! Fix: the driver `try_lock`s the per-thread workspace and falls back to a
+//! throwaway workspace on `WouldBlock` (which uniquely means nested re-entry,
+//! since each `thread_ws` slot is only ever locked by its own worker).
+//!
+//! The fixture `tests/data/large/dirichlet120_kkt.mtx` is a generated conic
+//! iter-0 KKT (POUNCE on `dirichlet120.nl`), gitignored and regenerated via
+//! `dev/scripts/regen_dirichlet120_kkt.sh`; absent (e.g. CI) → SKIP. The factor
+//! runs on a spawned thread with a wall-clock guard so a *returning* deadlock
+//! fails the test instead of hanging the suite.
+
+use feral::{read_mtx, Solver};
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[test]
+fn dirichlet120_parallel_factor_does_not_deadlock() {
+    let path = Path::new("tests/data/large/dirichlet120_kkt.mtx");
+    if !path.is_file() {
+        eprintln!(
+            "SKIP: {} not present. Regenerate with dev/scripts/regen_dirichlet120_kkt.sh.",
+            path.display()
+        );
+        return;
+    }
+
+    let csc = read_mtx(path)
+        .and_then(|m| m.to_csc())
+        .expect("read dirichlet120_kkt.mtx");
+    assert_eq!(csc.n, 54363, "unexpected dirichlet120 KKT dimension");
+
+    // Factor on a worker thread; guard with a generous wall-clock timeout. The
+    // healthy factor is well under 1 s (10-core) / a few s single-threaded; the
+    // pre-fix bug hung indefinitely at 0 % CPU. 120 s cleanly separates them.
+    let (tx, rx) = mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let mut solver = Solver::new(); // parallel driver (flops > PAR_MIN_FLOPS)
+        let status = solver.factor(&csc, None);
+        let inertia = solver.inertia().cloned();
+        let _ = tx.send((format!("{status:?}"), inertia));
+    });
+
+    match rx.recv_timeout(Duration::from_secs(120)) {
+        Ok((status, inertia)) => {
+            handle.join().expect("factor thread panicked");
+            assert_eq!(
+                status, "Success",
+                "dirichlet120 factor did not succeed: {status}"
+            );
+            // Quasi-definite KKT: no zero eigenvalues expected.
+            let inertia = inertia.expect("inertia recorded");
+            assert_eq!(inertia.zero, 0, "unexpected zero pivots: {inertia:?}");
+            assert_eq!(
+                inertia.positive + inertia.negative,
+                54363,
+                "inertia partition does not cover n: {inertia:?}"
+            );
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "issue #102 regression: parallel dense-front factor of dirichlet120 \
+                 did not finish in 120 s — the intra-front re-entrant deadlock is back"
+            );
+        }
+        Err(e) => panic!("factor thread channel error: {e:?}"),
+    }
+}


### PR DESCRIPTION
Fixes #102.

## Root cause — nested-rayon re-entrant workspace-mutex deadlock

The parallel multifrontal driver locks the per-thread workspace
`thread_ws[current_thread_index()]` and **holds it across**
`factor_one_supernode` → `factor_frontal_blocked_in_place_with_scratch` → the
intra-front `par_chunks_mut`. That nested rayon lets the blocked worker steal
another `process_one_supernode` scope job onto the **same** thread index, which
re-locks the already-held mutex → non-reentrant `std::sync::Mutex` self-deadlock
at 0 % CPU (converged → 300 s timeout in POUNCE).

Confirmed by `sample` of the hung factor:
```
factor_one_supernode → factor_frontal_blocked_in_place_with_scratch
  → rayon for_each (intra-front par_chunks_mut) → WorkerThread::wait_until_cold
    → ScopeBase::execute_job_closure (stolen process_one_supernode)
      → Mutex::lock → __psynch_mutexwait
```

## Not Lever-B-specific

Dumped dirichlet120's iter-0 KKT (feral-version-independent) and factored it in
feral `main`:

| config | result |
|---|---|
| default | **STALL** |
| `FERAL_INTRAFRONT=off` | solves, 765 ms |
| `FERAL_INTRAFRONT_MIN_AREA=65536` (old 256² floor) | **still STALLS** |

So the deadlock is latent in the intra-front nested-rayon path for any ordering
that clears the area gate; #92's ordering merely selected such a front.

## Fix

Each `thread_ws[i]` slot is only ever locked by rayon worker `i`, so a `try_lock`
that `WouldBlock` **uniquely** means nested re-entry. The driver now `try_lock`s
and factors with a throwaway `FactorWorkspace` on re-entry instead of blocking.
Byte-exact (results go to the separate `contrib_blocks`/`node_factors_out`
mutexes; only pooled scratch differs on the rare nested path). Independent of the
ordering choice — the robust fix, not a band-aid on #92.

## Evidence

dirichlet120 KKT: **STALL → ~0.4–0.5 s**, inertia `(+54122,−241,0)`. Byte-exact:
`parallel_parity` 8/8, `blocked_ldlt` 21, `parity` 8, `factor_workspace_parity`
21, lib **394/0**; fmt clean. Regression guard
`tests/issue102_intrafront_deadlock.rs` (timeout-guarded; fixture gitignored,
regen `dev/scripts/regen_dirichlet120_kkt.sh`). Note:
`dev/research/issue-102-intrafront-deadlock.md`.
