### PR TITLE
issue #102 follow-up: escalate ordering to LdltCompress on pivot growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — ordering-quality regression: escalate to LdltCompress on pivot growth (issue #102 follow-up)
+
+After the #102 deadlock fix, cont5_2_4_l still failed to converge: PR #92's
+`OrderingPreprocess::Auto` verify drops `LdltCompress` on symbolic *fill*, but its
+value is *numerical* — MC64 matching of near-singular ±ε diagonals into stable
+2×2 pivots. On cont5's late IPM KKTs (μ→0) the fill-preferred `None` ordering
+yields ~1e-16 1×1 pivots with pivot growth ~4e32; iterative refinement floors at
+~1e-2, breaking convergence. `Solver::factor` now escalates: when `Auto` dropped
+an available `LdltCompress` and the factor's `max|piv|/min|piv|` exceeds
+`ordering_escalation_growth` (default 1e24), it re-factors with `LdltCompress`
+and latches it for the pattern. Per-factor and free (growth is in `FactorStats`);
+qap15/dirichlet120 and cont5's early iterations keep the fast `None` path.
+Configurable via `Solver::with_ordering_escalation`. Byte-exact for the
+non-escalated path. See `dev/research/issue-102-ordering-escalation.md`.
+
 ### Fixed — parallel dense-front re-entrant deadlock on some conic KKTs (issue #102)
 
 PR #92 regressed two POUNCE mittelmann problems (cont5_2_4_l, dirichlet120) from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,6 @@ name = "profile_qap15"
 
 [profile.release]
 debug = true
+
+[[example]]
+name = "cmp_ordering_accuracy"

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5824,3 +5824,38 @@ oversubscription; `try_lock` is minimal and byte-exact.
 **Evidence.** dirichlet120 KKT: STALL → ~0.4 s factor, inertia (+54122,−241,0).
 Byte-exact: parallel_parity 8/8, blocked_ldlt 21, parity 8, factor_workspace_parity
 21, lib 394/0. Regression guard `tests/issue102_intrafront_deadlock.rs`.
+
+## 2026-07-01 — Ordering escalation on pivot growth (issue #102 follow-up)
+
+**Decision.** `Solver::factor` monitors per-factor pivot growth
+(`max|piv|/min|piv|`). When the caller requested `OrderingPreprocess::Auto`, the
+resolved preprocess was `None` (i.e. Auto dropped an available `LdltCompress` on
+fill), the predicate wanted `LdltCompress`, and growth exceeds
+`ordering_escalation_growth` (default `1e24`), it re-factors with `LdltCompress`
+and latches that for the pattern (reset on pattern change).
+`Solver::with_ordering_escalation(Option<f64>)` tunes/disables it.
+
+**Why.** PR #92 gates `LdltCompress` on symbolic fill, but `LdltCompress`'s value
+is numerical stability (MC64 matching of near-singular diagonals → 2×2 pivots),
+which fill cannot see. On cont5_2_4_l's late IPM KKTs, dropping it leaves `None`
+with pivot growth ~4e32 (min-pivot ~1e-16); refinement floors at ~1e-2 → IPM
+non-convergence. LdltCompress: growth ~1e15, refined resid ~1e-16.
+
+**Why growth, per-factor, Auto-only.** No symbolic/first-KKT signal separates
+"None fine" (qap15, cont5 iter 0) from "None broken" (cont5 late): all fire the
+predicate, all have large growth, all first-KKTs refine cleanly. Only the
+late-iteration factor's growth distinguishes them (12-order gap: ≤7.5e19 healthy
+vs 4.1e32 broken), so the check must be per-factor and numeric. Escalating only
+`Auto` respects explicit `None`/`LdltCompress`. Latching keeps early iters fast.
+
+**Alternatives rejected.** Reverting #92 (always LdltCompress) re-breaks qap15
+(13.7s vs 0.7s, even with the #103 packed kernel — measured). Fill-ratio
+threshold tuning is fragile (cont5's ratio flips 1.81×/>2× by ordering method).
+A refined-residual probe is more direct but needs a per-factor solve + RHS;
+growth is free and separates the known corpus with wide margin (a residual gate
+is a possible future refinement).
+
+**Evidence.** late cont5 Auto: growth 4e32→1.4e15, refined 1.4e-2→3.2e-16;
+qap15/cont5-iter0/dirichlet120 unchanged. Byte-exact non-escalated path; lib
+394/0, parallel_parity/issue91/issue65/ldlt_compress/symbolic_profiler green.
+Guard `tests/issue102_ordering_escalation.rs`.

--- a/dev/research/issue-102-ordering-escalation.md
+++ b/dev/research/issue-102-ordering-escalation.md
@@ -1,0 +1,80 @@
+# issue #102 follow-up — ordering quality: escalate on pivot growth — 2026-07-01
+
+The #102 deadlock fix (PR #104) unblocked cont5_2_4_l/dirichlet120, and revealed
+a **second, distinct regression** on cont5_2_4_l: converged in 14 iters on feral
+0.11.3, but on `main` the IPM oscillates near the solution (inf_du floor ~1e-5,
+restoration) and hits the CPU cap. Isolated (by the reporter and confirmed here)
+to PR #92's `OrderingPreprocess::Auto` verify — not #99, not the deadlock fix
+(dirichlet120 is bit-identical to 0.11.3).
+
+## Root cause — fill is the wrong axis for the LdltCompress decision
+
+`OrderingPreprocess::Auto` keeps `LdltCompress` only if its symbolic fill ≤ 2×
+`None`. But `LdltCompress`'s value is **numerical**, not fill: its MC64 matching
+pairs near-singular ±ε diagonals into stable 2×2 pivots. cont5's KKT has ~half
+its diagonals at ∓1e-8 (μ-regularization); as the IPM drives μ→0 the diagonals
+approach zero. On the late KKTs, dropping `LdltCompress` for fill leaves `None`
+making ~1e-16 1×1 pivots.
+
+Measured (feral-level, dumped cont5 KKTs; `examples/cmp_ordering_accuracy`):
+
+| cont5 KKT | ordering | pivot growth | refined resid |
+|---|---|---|---|
+| iter 0 | None | 7.5e19 | 1.5e-11 (recoverable) |
+| **late** | **None** | **4.1e32** | **1.4e-2** (refinement can't recover) |
+| late | LdltCompress | 1.4e15 | 3.2e-16 |
+
+The late-KKT None factor is garbage (growth 4e32); refinement floors at 1.4e-2 →
+inaccurate IPM step → no convergence. Exactly the observed inf_du ~1e-5 floor.
+
+## Why no *symbolic* / cheap gate works
+
+None of fill-ratio, first-KKT residual, or predicate cleanly separates "None is
+fine" from "None is broken": both qap15 and cont5 fire the predicate (≈50 %
+low-degree cols), both have huge pivot growth, and both first-KKTs recover under
+refinement. **Only the late-iteration factor's pivot growth distinguishes them**,
+and only per-factor (iter 0 is fine, iter 12 is broken). So the decision must be
+made numerically, per factor.
+
+| matrix (None) | growth | converges? |
+|---|---|---|
+| dirichlet120 | ~2 | ✅ |
+| qap15 | 4.5e18 | ✅ |
+| cont5 iter 0 | 7.5e19 | ✅ |
+| cont5 late | **4.1e32** | ❌ |
+
+12-order gap between "fine" (≤7.5e19) and "broken" (4.1e32).
+
+## Fix — per-factor ordering escalation on pivot growth (feral Solver)
+
+`Solver::factor`: after the numeric factor, if the caller requested `Auto`, the
+resolved preprocess was `None`, the predicate wanted `LdltCompress`, and the
+factor's `max|piv|/min|piv|` exceeds `ordering_escalation_growth` (default
+`1e24`, in the gap), re-factor with `LdltCompress` and latch it for the pattern
+(reset on pattern change). Growth is checked first (cheap, from `FactorStats`);
+the O(nnz) predicate probe runs only in the rare high-growth case. Clears just
+the symbolic cache (keeps the fingerprint, so the latch survives the recursive
+re-factor).
+
+Design choices:
+- **feral, not pounce** (per maintainer): self-contained, no IPM feedback needed.
+- **Only `Auto`**: an explicit `None`/`LdltCompress` request is respected.
+- **Per-factor, latched**: cont5's early iters (growth ≤7.5e19) stay on fast
+  `None`; the late iter escalates to `LdltCompress` and stays there. qap15 /
+  dirichlet120 never escalate → keep the #92 fast path.
+- Configurable/disableable via `Solver::with_ordering_escalation(Option<f64>)`.
+
+Validated (`examples/cmp_ordering_accuracy`): late cont5 Auto now matches
+LdltCompress (growth 1.4e15, refined 3.2e-16); qap15 / cont5-iter0 unchanged
+(fast None). Byte-exact for the non-escalated path; full lib 394/0,
+parallel_parity/issue91/issue65/ldlt_compress/symbolic_profiler all green.
+Regression guard `tests/issue102_ordering_escalation.rs` (gitignored fixture
+`tests/data/large/cont5_late_kkt.mtx`; dump via POUNCE `POUNCE_DBG_KKT_DUMP` +
+`POUNCE_DBG_KKT_DUMP_SKIP=12` on cont5_2_4_l.nl).
+
+## Residual note
+
+The growth ceiling is a heuristic (a pivot-growth proxy for solve inaccuracy),
+not a proof. It cleanly separates the known corpus with a 12-order margin; a
+future refinement could gate on an actual refined-solve backward error if a
+matrix is found where growth mis-predicts. Tracked as a possible follow-up.

--- a/dev/sessions/2026-07-01-06.md
+++ b/dev/sessions/2026-07-01-06.md
@@ -1,0 +1,50 @@
+# Session 2026-07-01-06
+
+## Goal
+Address the #102 follow-up: the deadlock fix (PR #104) unblocked cont5_2_4_l but
+revealed a *second* regression — PR #92's `OrderingPreprocess::Auto` verify picks
+a numerically worse ordering that fails to converge cont5_2_4_l (14 it → 111+
+with restoration).
+
+## Accomplished
+- **Root-caused + validated at the feral level.** Dumped cont5's iter-0 and a
+  late-iteration KKT via POUNCE (`POUNCE_DBG_KKT_DUMP[_SKIP]`, matrix is
+  feral-version-independent). Auto drops `LdltCompress` (fill verify) → `None`
+  ordering → near-singular ∓1e-8 diagonals become ~1e-16 1×1 pivots, pivot
+  growth ~4e32 on the late KKT; refinement floors at 1.4e-2 → IPM non-convergence.
+  `LdltCompress` (MC64 matching → 2×2 pivots): growth ~1e15, refined 3.2e-16.
+- **Established there's no cheap symbolic gate**: fill-ratio, first-KKT residual,
+  and the predicate all fail to separate qap15 (None fine) from cont5 (None
+  broken). Only the late-iteration factor's pivot growth distinguishes them
+  (12-order gap). Confirmed reverting #92 re-breaks qap15 (still 13.7s with the
+  #103 packed kernel).
+- **Fixed (feral Solver):** per-factor ordering escalation on pivot growth. When
+  `Auto` dropped an available `LdltCompress` and `max|piv|/min|piv|` > 1e24,
+  re-factor with `LdltCompress`, latched per pattern. Growth-checked first
+  (free); Auto-only (explicit None/LdltCompress respected);
+  `Solver::with_ordering_escalation` to tune/disable.
+- Regression guard `tests/issue102_ordering_escalation.rs` (fixture
+  `tests/data/large/cont5_late_kkt.mtx`, gitignored).
+
+## Benchmark Results
+late cont5 KKT (n=180900): Auto growth **4.1e32 → 1.4e15**, refined resid
+**1.4e-2 → 3.2e-16** (matches LdltCompress). qap15 (4.5e18) / cont5 iter-0
+(7.5e19) / dirichlet120 (~2) unchanged — no escalation, fast `None`.
+Byte-exact non-escalated path: lib 394/0; parallel_parity 8, issue91 3, issue65
+1, ldlt_compress 3, symbolic_profiler 5 — all green.
+
+## Decisions Made
+- Per-factor ordering escalation on pivot growth (issue #102 follow-up) —
+  appended to `dev/decisions.md`.
+
+## Abandoned Approaches
+- Reverting #92 (always LdltCompress): re-breaks qap15's 20× (measured).
+- Fill-ratio threshold tuning: fragile (cont5's ratio flips by ordering method).
+- One-time / first-KKT accuracy check: misses it (badness appears only at late
+  IPM iterations; iter 0 is fine).
+
+## Next Session Should
+- Optional: replace the pivot-growth heuristic with a refined-residual backward-
+  error gate if a matrix is found where growth mis-predicts (noted in the
+  research note).
+- Confirm cont5_2_4_l end-to-end convergence in POUNCE once feral is bumped.

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -190,6 +190,22 @@ fn main() {
             reps,
         );
     }
+    if has("ldlt") {
+        run(
+            "force LdltCompress",
+            &csc,
+            || {
+                Solver::with_params(
+                    NumericParams::default(),
+                    SupernodeParams {
+                        preprocess: OrderingPreprocess::LdltCompress,
+                        ..SupernodeParams::default()
+                    },
+                )
+            },
+            reps,
+        );
+    }
     if has("fma") {
         run("default+fma", &csc, || Solver::new().with_fma(true), reps);
     }

--- a/examples/cmp_ordering_accuracy.rs
+++ b/examples/cmp_ordering_accuracy.rs
@@ -1,0 +1,103 @@
+//! Issue #102 follow-up: does the OrderingPreprocess choice change solve
+//! ACCURACY (not just fill)? Factor a dumped KKT under None / LdltCompress /
+//! Auto, solve the real RHS, and report the relative residual + min pivot.
+//!
+//! Usage: cargo run --release --example cmp_ordering_accuracy -- <kkt.mtx> [rhs.txt]
+
+use feral::symbolic::{OrderingPreprocess, SupernodeParams};
+use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+use std::path::Path;
+
+/// y = A·x for a symmetric matrix stored as lower-triangle CSC.
+fn sym_matvec(a: &CscMatrix, x: &[f64]) -> Vec<f64> {
+    let mut y = vec![0.0f64; a.n];
+    for j in 0..a.n {
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let i = a.row_idx[k];
+            let v = a.values[k];
+            y[i] += v * x[j];
+            if i != j {
+                y[j] += v * x[i];
+            }
+        }
+    }
+    y
+}
+
+fn rel_residual(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let ax = sym_matvec(a, x);
+    let mut rnum = 0.0f64;
+    let mut bden = 0.0f64;
+    for i in 0..a.n {
+        rnum = rnum.max((ax[i] - b[i]).abs());
+        bden = bden.max(b[i].abs());
+    }
+    rnum / bden.max(1e-300)
+}
+
+fn run(name: &str, a: &CscMatrix, b: &[f64], build: impl Fn() -> Solver) {
+    let mut s = build();
+    let st = s.factor(a, None);
+    let (nnz_l, minp, maxp) = s
+        .last_factor_stats()
+        .map(|f| (f.nnz_l, f.min_abs_pivot, f.max_abs_pivot))
+        .unwrap_or((0, 0.0, 0.0));
+    let (res, res_ref) = match s.solve(b) {
+        Ok(x) => {
+            let r = rel_residual(a, &x, b);
+            let rr = s
+                .solve_refined(a, b)
+                .map(|xr| rel_residual(a, &xr, b))
+                .unwrap_or(f64::NAN);
+            (r, rr)
+        }
+        Err(e) => {
+            println!("  {name:<20} factor={st:?} solve ERR {e:?}");
+            return;
+        }
+    };
+    println!(
+        "  {name:<20} nnz_L={nnz_l:>9} |piv|=[{minp:.2e},{maxp:.2e}] growth={:.1e}  \
+         resid={res:.3e}  refined={res_ref:.3e}  {st:?}",
+        maxp / minp.max(1e-300)
+    );
+}
+
+fn main() {
+    let mtx = std::env::args().nth(1).expect("usage: <kkt.mtx> [rhs.txt]");
+    let a = read_mtx(Path::new(&mtx))
+        .and_then(|m| m.to_csc())
+        .expect("read mtx");
+    let b: Vec<f64> = match std::env::args().nth(2) {
+        Some(p) => std::fs::read_to_string(p)
+            .expect("read rhs")
+            .split_whitespace()
+            .map(|s| s.parse().expect("rhs f64"))
+            .collect(),
+        None => vec![1.0; a.n],
+    };
+    assert_eq!(b.len(), a.n, "rhs length != n");
+    println!("matrix: n={} nnz={}", a.n, a.row_idx.len());
+
+    let none = || {
+        Solver::with_params(
+            NumericParams::default(),
+            SupernodeParams {
+                preprocess: OrderingPreprocess::None,
+                ..SupernodeParams::default()
+            },
+        )
+    };
+    let ldlt = || {
+        Solver::with_params(
+            NumericParams::default(),
+            SupernodeParams {
+                preprocess: OrderingPreprocess::LdltCompress,
+                ..SupernodeParams::default()
+            },
+        )
+    };
+    run("Auto (default)", &a, &b, Solver::new);
+    run("None", &a, &b, none);
+    run("LdltCompress", &a, &b, ldlt);
+}

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -285,6 +285,19 @@ pub struct Solver {
     /// 1D-banded KKTs (#33 suggested action §3, supernode-shape
     /// thesis).
     ordering: OrderingMethod,
+    /// Issue #102 follow-up: pivot-growth ceiling above which `factor()`
+    /// escalates the ordering. When `OrderingPreprocess::Auto` dropped an
+    /// available `LdltCompress` (predicate fired but the fill verify chose
+    /// `None`), a factor whose pivot growth `max|piv|/min|piv|` exceeds this
+    /// bound is numerically inadequate (the MC64 matching `LdltCompress`
+    /// provides was needed) — feral re-factors with `LdltCompress`. `None`
+    /// disables. Default sits in the measured gap between healthy
+    /// (≤7.5e19: qap15, cont5 early) and broken (4.1e32: cont5 late).
+    ordering_escalation_growth: Option<f64>,
+    /// Runtime latch: once a factor on this pattern has escalated to
+    /// `LdltCompress` (above), every subsequent factor on the same pattern
+    /// forces `LdltCompress` directly (no re-probe). Reset on pattern change.
+    ordering_escalated: bool,
     /// Warm cascade-break auto-arm threshold. `Some(β)` means: at the
     /// start of `factor()`, if the previous factor on this pattern
     /// generated a supernode with `n_delayed_in >= β·n`, locally set
@@ -407,6 +420,8 @@ impl Solver {
             use_parallel: true,
             parallel_pool: None,
             ordering: OrderingMethod::Auto,
+            ordering_escalation_growth: Some(1e24),
+            ordering_escalated: false,
             auto_cascade_break_beta: None,
             prev_max_n_delayed_in: None,
             auto_arm_latched: false,
@@ -466,6 +481,18 @@ impl Solver {
     /// detailed on [`NumericParams::fma`].
     pub fn with_fma(mut self, fma: bool) -> Self {
         self.numeric_params.fma = fma;
+        self
+    }
+
+    /// Set the pivot-growth ceiling for ordering escalation (issue #102
+    /// follow-up), or `None` to disable it. When `OrderingPreprocess::Auto`
+    /// drops an available `LdltCompress` on symbolic fill but the resulting
+    /// factor has `max|piv|/min|piv|` above this bound, `factor()` re-factors
+    /// with `LdltCompress` (the MC64 matching the near-singular pivots
+    /// needed). Default `Some(1e24)`. Only affects `Auto`; an explicit
+    /// `None`/`LdltCompress` preprocess request is respected as-is.
+    pub fn with_ordering_escalation(mut self, growth_ceiling: Option<f64>) -> Self {
+        self.ordering_escalation_growth = growth_ceiling;
         self
     }
 
@@ -857,6 +884,9 @@ impl Solver {
             // means the prior n_delayed observation no longer applies.
             self.prev_max_n_delayed_in = None;
             self.auto_arm_latched = false;
+            // Issue #102 follow-up: a new pattern re-tries the fill-preferred
+            // (fast) ordering; escalation is re-decided from its pivot growth.
+            self.ordering_escalated = false;
             // Track B2: the MC64 scaling cache is keyed on the
             // pattern fingerprint; a new pattern voids it.
             self.mc64_scaling_cache = None;
@@ -879,11 +909,20 @@ impl Solver {
             // profiling is off, we pass `&self.snode_params` directly
             // — zero allocation, byte-identical to pre-issue-52
             // behavior.
-            let result = if self.profiling_enabled {
-                let arc = Arc::new(Mutex::new(SymbolicProfiler::new()));
-                self.last_symbolic_profiler = Some(Arc::clone(&arc));
+            // Issue #102 follow-up: after escalation, force `LdltCompress`
+            // (its MC64 matching stabilizes the near-singular pivots the fast
+            // `None` ordering mishandled). Otherwise use the caller's config.
+            let escalated = self.ordering_escalated;
+            let result = if self.profiling_enabled || escalated {
                 let mut sp = self.snode_params.clone();
-                sp.symbolic_profiler = Some(arc);
+                if self.profiling_enabled {
+                    let arc = Arc::new(Mutex::new(SymbolicProfiler::new()));
+                    self.last_symbolic_profiler = Some(Arc::clone(&arc));
+                    sp.symbolic_profiler = Some(arc);
+                }
+                if escalated {
+                    sp.preprocess = crate::symbolic::OrderingPreprocess::LdltCompress;
+                }
                 symbolic_factorize_with_method(matrix, &sp, self.ordering)
             } else {
                 symbolic_factorize_with_method(matrix, &self.snode_params, self.ordering)
@@ -1360,6 +1399,42 @@ impl Solver {
                 // factor itself. Two unconditional integer writes.
                 self.last_nnz_a = Some(matrix.nnz());
                 self.last_pattern_reused = Some(pattern_reused);
+
+                // Issue #102 follow-up: escalate the ordering on catastrophic
+                // pivot growth. `OrderingPreprocess::Auto`'s fill verify can
+                // drop a `LdltCompress` the matrix numerically *needs* (its
+                // MC64 matching stabilizes near-singular ±ε diagonals); this
+                // is invisible to symbolic fill but shows as huge pivot growth
+                // in the resulting factor (e.g. cont5_2_4_l's late IPM KKTs:
+                // ~4e32 with None vs ~1e15 with LdltCompress, breaking IPM
+                // convergence). When growth exceeds the ceiling and Auto did
+                // drop an available LdltCompress, re-factor with LdltCompress.
+                // Growth is checked first (cheap); the O(nnz) predicate probe
+                // only runs in the rare high-growth case. Clears just the
+                // symbolic cache (keeps the pattern fingerprint, so the
+                // escalation latch survives the recursive re-factor).
+                if !self.ordering_escalated
+                    && self.snode_params.preprocess == crate::symbolic::OrderingPreprocess::Auto
+                {
+                    if let Some(limit) = self.ordering_escalation_growth {
+                        let growth = match (self.min_pivot_magnitude(), self.max_pivot_magnitude())
+                        {
+                            (Some(mn), Some(mx)) if mn > 0.0 => mx / mn,
+                            _ => 0.0,
+                        };
+                        if growth > limit
+                            && self.last_symbolic.as_ref().is_some_and(|s| {
+                                s.resolved_preprocess == crate::symbolic::OrderingPreprocess::None
+                            })
+                            && crate::symbolic::pick_ordering_preprocess(matrix)
+                                == crate::symbolic::OrderingPreprocess::LdltCompress
+                        {
+                            self.ordering_escalated = true;
+                            self.last_symbolic = None;
+                            return self.factor(matrix, check_inertia);
+                        }
+                    }
+                }
                 if partial_singular {
                     FactorStatus::Singular
                 } else if let Some(expected) = check_inertia {

--- a/tests/issue102_ordering_escalation.rs
+++ b/tests/issue102_ordering_escalation.rs
@@ -1,0 +1,73 @@
+//! Issue #102 follow-up regression: `OrderingPreprocess::Auto` must escalate to
+//! `LdltCompress` when the fill-preferred `None` ordering yields a numerically
+//! catastrophic factor.
+//!
+//! Background: PR #92's Auto verify drops `LdltCompress` on symbolic fill. On
+//! cont5_2_4_l's late IPM KKTs (μ→0, ~all diagonals near-singular), `None`
+//! becomes 1×1 pivots of magnitude ~1e-16 with pivot growth ~4e32 — a garbage
+//! factor that iterative refinement can't recover (refined resid ~1e-2),
+//! breaking IPM convergence. `LdltCompress`'s MC64 matching pairs those into
+//! stable 2×2 pivots (min-pivot ~2.7e-8, growth ~1e15, refined resid ~1e-16).
+//! Fill can't see this; pivot growth can, so `factor()` escalates.
+//!
+//! Fixture `tests/data/large/cont5_late_kkt.mtx` is a late-iteration cont5 KKT
+//! dumped from POUNCE (gitignored). Absent (e.g. CI) → SKIP.
+
+use feral::symbolic::{OrderingPreprocess, SupernodeParams};
+use feral::{read_mtx, NumericParams, Solver};
+use std::path::Path;
+
+#[test]
+fn cont5_late_kkt_escalates_ordering_to_stable_pivots() {
+    let path = Path::new("tests/data/large/cont5_late_kkt.mtx");
+    if !path.is_file() {
+        eprintln!("SKIP: {} not present.", path.display());
+        return;
+    }
+    let csc = read_mtx(path)
+        .and_then(|m| m.to_csc())
+        .expect("read cont5 late KKT");
+
+    // Default Auto: must escalate to LdltCompress on the catastrophic growth.
+    let mut auto = Solver::new();
+    assert!(matches!(
+        auto.factor(&csc, None),
+        feral::FactorStatus::Success
+    ));
+    let min_piv = auto.min_pivot_magnitude().expect("min pivot");
+    let max_piv = auto.max_pivot_magnitude().expect("max pivot");
+    let growth = max_piv / min_piv;
+    assert!(
+        growth < 1e24,
+        "Auto did not escalate: pivot growth {growth:.1e} (min {min_piv:.2e}) — the \
+         numerically-unstable None ordering was kept"
+    );
+
+    // Explicit None is respected (not escalated) → catastrophic growth remains.
+    let mut none = Solver::with_params(
+        NumericParams::default(),
+        SupernodeParams {
+            preprocess: OrderingPreprocess::None,
+            ..SupernodeParams::default()
+        },
+    );
+    assert!(matches!(
+        none.factor(&csc, None),
+        feral::FactorStatus::Success
+    ));
+    let none_growth = none.max_pivot_magnitude().unwrap() / none.min_pivot_magnitude().unwrap();
+    assert!(
+        none_growth > 1e24,
+        "explicit None unexpectedly stable ({none_growth:.1e}); fixture may have drifted"
+    );
+
+    // Disabling escalation makes Auto behave like None (catastrophic).
+    let mut auto_off = Solver::new().with_ordering_escalation(None);
+    let _ = auto_off.factor(&csc, None);
+    let off_growth =
+        auto_off.max_pivot_magnitude().unwrap() / auto_off.min_pivot_magnitude().unwrap();
+    assert!(
+        off_growth > 1e24,
+        "escalation-off Auto should match None ({off_growth:.1e})"
+    );
+}


### PR DESCRIPTION
Addresses the follow-up on #102 (the ordering-quality half; the deadlock half was fixed in #104).

## The regression

After #104 unblocked cont5_2_4_l, it still failed to converge (14 it on feral 0.11.3 → 111+ with restoration on main). Isolated to PR #92's `OrderingPreprocess::Auto` verify — not #99, not the deadlock fix (dirichlet120 is bit-identical to 0.11.3).

## Root cause — fill is the wrong axis for the LdltCompress decision

Auto keeps `LdltCompress` only if its symbolic fill ≤ 2× `None`. But `LdltCompress`'s value is **numerical**: MC64 matching pairs near-singular ±ε diagonals into stable 2×2 pivots. cont5 has ~half its diagonals at ∓1e-8; as the IPM drives μ→0, dropping `LdltCompress` leaves `None` making ~1e-16 1×1 pivots.

Measured on dumped cont5 KKTs (`examples/cmp_ordering_accuracy`):

| cont5 KKT | ordering | pivot growth | refined resid |
|---|---|---|---|
| iter 0 | None | 7.5e19 | 1.5e-11 (recoverable) |
| **late** | **None** | **4.1e32** | **1.4e-2** (refinement can't recover) |
| late | LdltCompress | 1.4e15 | 3.2e-16 |

## Why there's no cheap symbolic gate

Neither fill-ratio, first-KKT residual, nor the predicate separates "None fine" (qap15, cont5 iter 0) from "None broken" (cont5 late) — all fire the predicate, all have huge growth, all first-KKTs refine cleanly. Only the **late-iteration** factor's pivot growth distinguishes them (12-order gap: ≤7.5e19 healthy vs 4.1e32 broken), so the decision must be **numeric and per-factor**.

| matrix (None) | growth | converges? |
|---|---|---|
| dirichlet120 | ~2 | ✅ |
| qap15 | 4.5e18 | ✅ |
| cont5 iter 0 | 7.5e19 | ✅ |
| cont5 late | **4.1e32** | ❌ |

## Fix — per-factor ordering escalation on pivot growth (feral Solver)

After each factor: if the caller requested `Auto`, Auto dropped an available `LdltCompress`, and `max|piv|/min|piv|` > `ordering_escalation_growth` (default `1e24`), re-factor with `LdltCompress` and latch it for the pattern. Growth is checked first (free, from `FactorStats`); the O(nnz) predicate probe runs only in the rare high-growth case. Auto-only (explicit `None`/`LdltCompress` respected); tunable via `Solver::with_ordering_escalation`.

- late cont5 Auto → escalates (growth 4e32→1.4e15, refined 1.4e-2→**3.2e-16**)
- qap15 / cont5-iter0 / dirichlet120 → never escalate, keep the fast #92 `None` path
- Reverting #92 instead re-breaks qap15 (13.7 s vs 0.7 s even with #103's packed kernel — measured)

## Evidence

Byte-exact non-escalated path; lib **394/0**; `parallel_parity`/`issue91`/`issue65`/`ldlt_compress`/`symbolic_profiler` all green. Regression guard `tests/issue102_ordering_escalation.rs` (gitignored fixture `tests/data/large/cont5_late_kkt.mtx`). Note: `dev/research/issue-102-ordering-escalation.md`.
