### PR TITLE
release: feral v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-01
+
 ### Fixed — ordering-quality regression: escalate to LdltCompress on pivot growth (issue #102 follow-up)
 
 After the #102 deadlock fix, cont5_2_4_l still failed to converge: PR #92's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/examples/notebooks/01_basic_factor_solve.ipynb
+++ b/python/examples/notebooks/01_basic_factor_solve.ipynb
@@ -16,10 +16,10 @@
    "id": "270ce56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.008584Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.008467Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.040151Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.039610Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.757073Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.757008Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.791420Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.790895Z"
     }
    },
    "outputs": [
@@ -27,7 +27,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feral 0.11.0\n"
+      "feral 0.12.0\n"
      ]
     }
    ],
@@ -54,10 +54,10 @@
    "id": "63028ad5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.041638Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.041497Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.043817Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.043458Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.792870Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.792759Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.795624Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.795221Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "d28ab23a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.044999Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.044899Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.047556Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.047138Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.796913Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.796851Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.800935Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.800616Z"
     }
    },
    "outputs": [
@@ -141,10 +141,10 @@
    "id": "7a65ecf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.048971Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.048877Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.051017Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.050710Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.801970Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.801918Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.803938Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.803574Z"
     }
    },
    "outputs": [
@@ -182,10 +182,10 @@
    "id": "e8622af1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.052293Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.052218Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.053993Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.053615Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.805184Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.805122Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.806955Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.806628Z"
     }
    },
    "outputs": [
@@ -219,10 +219,10 @@
    "id": "e35c9097",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.055101Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.055042Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.057274Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.056928Z"
+     "iopub.execute_input": "2026-07-01T17:11:34.808056Z",
+     "iopub.status.busy": "2026-07-01T17:11:34.807964Z",
+     "iopub.status.idle": "2026-07-01T17:11:34.810035Z",
+     "shell.execute_reply": "2026-07-01T17:11:34.809739Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/02_multi_rhs_batched.ipynb
+++ b/python/examples/notebooks/02_multi_rhs_batched.ipynb
@@ -25,10 +25,10 @@
    "id": "f9d1eb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.844072Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.843991Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.933103Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.932618Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.283318Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.283259Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.389242Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.388698Z"
     }
    },
    "outputs": [],
@@ -59,10 +59,10 @@
    "id": "0bb21c5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.934669Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.934554Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.938384Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.937912Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.390973Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.390858Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.394875Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.394381Z"
     }
    },
    "outputs": [
@@ -104,10 +104,10 @@
    "id": "3970ca77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.939730Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.939663Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.944010Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.943324Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.396036Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.395974Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.400446Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.400008Z"
     }
    },
    "outputs": [
@@ -145,10 +145,10 @@
    "id": "d1ba172b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.945553Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.945437Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.951278Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.950863Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.401573Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.401512Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.407506Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.407197Z"
     }
    },
    "outputs": [
@@ -191,10 +191,10 @@
    "id": "1e6f555d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.952404Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.952338Z",
-     "iopub.status.idle": "2026-06-11T20:51:39.959437Z",
-     "shell.execute_reply": "2026-06-11T20:51:39.959063Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.408869Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.408815Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.416321Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.415974Z"
     }
    },
    "outputs": [
@@ -235,10 +235,10 @@
    "id": "66e9c41e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:39.960720Z",
-     "iopub.status.busy": "2026-06-11T20:51:39.960641Z",
-     "iopub.status.idle": "2026-06-11T20:51:40.195697Z",
-     "shell.execute_reply": "2026-06-11T20:51:40.195175Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.417769Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.417675Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.721498Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.721057Z"
     }
    },
    "outputs": [
@@ -283,10 +283,10 @@
    "id": "623c8936",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:40.197143Z",
-     "iopub.status.busy": "2026-06-11T20:51:40.197021Z",
-     "iopub.status.idle": "2026-06-11T20:51:40.287999Z",
-     "shell.execute_reply": "2026-06-11T20:51:40.287504Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.722839Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.722735Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.820054Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.819673Z"
     }
    },
    "outputs": [
@@ -295,8 +295,8 @@
      "output_type": "stream",
      "text": [
       " nrhs        looped       batched   speedup\n",
-      "   64      59.48 us      16.74 us    3.55x\n",
-      "  256      60.48 us      20.38 us    2.97x\n"
+      "   64      64.76 us      17.57 us    3.69x\n",
+      "  256      64.92 us      20.58 us    3.16x\n"
      ]
     }
    ],
@@ -354,10 +354,10 @@
    "id": "82f406d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:40.289300Z",
-     "iopub.status.busy": "2026-06-11T20:51:40.289224Z",
-     "iopub.status.idle": "2026-06-11T20:51:40.300804Z",
-     "shell.execute_reply": "2026-06-11T20:51:40.300356Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.821718Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.821639Z",
+     "iopub.status.idle": "2026-07-01T17:11:37.832283Z",
+     "shell.execute_reply": "2026-07-01T17:11:37.831980Z"
     }
    },
    "outputs": [
@@ -398,10 +398,10 @@
    "id": "6c1b5120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:40.302289Z",
-     "iopub.status.busy": "2026-06-11T20:51:40.302208Z",
-     "iopub.status.idle": "2026-06-11T20:51:40.566192Z",
-     "shell.execute_reply": "2026-06-11T20:51:40.565753Z"
+     "iopub.execute_input": "2026-07-01T17:11:37.833779Z",
+     "iopub.status.busy": "2026-07-01T17:11:37.833688Z",
+     "iopub.status.idle": "2026-07-01T17:11:38.109764Z",
+     "shell.execute_reply": "2026-07-01T17:11:38.109431Z"
     }
    },
    "outputs": [
@@ -410,14 +410,14 @@
      "output_type": "stream",
      "text": [
       " nrhs     loop refined    batch refined   speedup\n",
-      "   64        168.57 us         77.50 us    2.18x\n"
+      "   64        170.58 us         86.95 us    1.96x\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  256        180.22 us         83.09 us    2.17x\n"
+      "  256        187.80 us         82.07 us    2.29x\n"
      ]
     }
    ],

--- a/python/examples/notebooks/03_kkt_saddle_inertia.ipynb
+++ b/python/examples/notebooks/03_kkt_saddle_inertia.ipynb
@@ -20,10 +20,10 @@
    "id": "b7b52a48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.303017Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.302929Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.386503Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.385942Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.667269Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.667167Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.775202Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.774378Z"
     }
    },
    "outputs": [],
@@ -49,10 +49,10 @@
    "id": "e60b30ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.388195Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.388048Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.390896Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.390497Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.776974Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.776811Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.780033Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.779473Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "d366d85e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.392497Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.392360Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.395098Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.394672Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.781330Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.781263Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.784264Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.783767Z"
     }
    },
    "outputs": [
@@ -138,10 +138,10 @@
    "id": "d76cca73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.396147Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.396077Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.398361Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.397825Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.785400Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.785320Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.787644Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.787150Z"
     }
    },
    "outputs": [
@@ -176,10 +176,10 @@
    "id": "d6e873c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.399871Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.399740Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.402014Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.401651Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.788833Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.788762Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.791064Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.790482Z"
     }
    },
    "outputs": [
@@ -215,10 +215,10 @@
    "id": "f195548b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:41.403294Z",
-     "iopub.status.busy": "2026-06-11T20:51:41.403182Z",
-     "iopub.status.idle": "2026-06-11T20:51:41.405096Z",
-     "shell.execute_reply": "2026-06-11T20:51:41.404759Z"
+     "iopub.execute_input": "2026-07-01T17:11:40.792207Z",
+     "iopub.status.busy": "2026-07-01T17:11:40.792066Z",
+     "iopub.status.idle": "2026-07-01T17:11:40.794359Z",
+     "shell.execute_reply": "2026-07-01T17:11:40.793902Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/04_scipy_numpy_interop.ipynb
+++ b/python/examples/notebooks/04_scipy_numpy_interop.ipynb
@@ -16,10 +16,10 @@
    "id": "4b506150",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.195032Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.194948Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.312188Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.311651Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.307241Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.307159Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.438347Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.437883Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "id": "0354d27d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.313918Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.313779Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.332235Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.331827Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.440138Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.439972Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.456189Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.455812Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "cba4c504",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.333690Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.333607Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.335723Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.335398Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.457557Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.457475Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.459887Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.459452Z"
     }
    },
    "outputs": [
@@ -130,10 +130,10 @@
    "id": "691ea839",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.337043Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.336980Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.339437Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.339130Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.461314Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.461206Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.463916Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.463451Z"
     }
    },
    "outputs": [
@@ -170,10 +170,10 @@
    "id": "6a749326",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.340568Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.340491Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.342910Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.342515Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.465107Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.465033Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.467567Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.467275Z"
     }
    },
    "outputs": [
@@ -209,10 +209,10 @@
    "id": "18a4b721",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:42.343959Z",
-     "iopub.status.busy": "2026-06-11T20:51:42.343899Z",
-     "iopub.status.idle": "2026-06-11T20:51:42.346471Z",
-     "shell.execute_reply": "2026-06-11T20:51:42.345978Z"
+     "iopub.execute_input": "2026-07-01T17:11:43.468851Z",
+     "iopub.status.busy": "2026-07-01T17:11:43.468784Z",
+     "iopub.status.idle": "2026-07-01T17:11:43.471202Z",
+     "shell.execute_reply": "2026-07-01T17:11:43.470836Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/05_lu_and_introspection.ipynb
+++ b/python/examples/notebooks/05_lu_and_introspection.ipynb
@@ -22,10 +22,10 @@
    "id": "489e8170",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.282552Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.282469Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.309561Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.309109Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.924830Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.924687Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.953333Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.952756Z"
     }
    },
    "outputs": [
@@ -33,7 +33,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feral 0.11.0\n"
+      "feral 0.12.0\n"
      ]
     }
    ],
@@ -60,10 +60,10 @@
    "id": "dbc3a512",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.311064Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.310943Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.314097Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.313644Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.954845Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.954655Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.957696Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.957298Z"
     }
    },
    "outputs": [
@@ -109,10 +109,10 @@
    "id": "7dc29790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.315336Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.315268Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.317871Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.317515Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.958996Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.958913Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.961474Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.961082Z"
     }
    },
    "outputs": [
@@ -156,10 +156,10 @@
    "id": "77052fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.319002Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.318934Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.321123Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.320754Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.962631Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.962570Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.964432Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.964030Z"
     }
    },
    "outputs": [
@@ -200,10 +200,10 @@
    "id": "d1a3c98f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.322424Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.322363Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.324870Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.324535Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.965499Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.965422Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.967839Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.967545Z"
     }
    },
    "outputs": [
@@ -238,10 +238,10 @@
    "id": "fddf8140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.326081Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.326018Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.328981Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.328546Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.968980Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.968928Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.972050Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.971741Z"
     }
    },
    "outputs": [
@@ -294,10 +294,10 @@
    "id": "ce141edc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.330077Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.330006Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.339180Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.338859Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.973235Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.973138Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.983159Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.982883Z"
     }
    },
    "outputs": [
@@ -345,10 +345,10 @@
    "id": "be37da55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.340594Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.340499Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.343553Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.343176Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.984372Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.984292Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.987443Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.987206Z"
     }
    },
    "outputs": [
@@ -381,10 +381,10 @@
    "id": "365fdf14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T20:51:43.344523Z",
-     "iopub.status.busy": "2026-06-11T20:51:43.344466Z",
-     "iopub.status.idle": "2026-06-11T20:51:43.347159Z",
-     "shell.execute_reply": "2026-06-11T20:51:43.346771Z"
+     "iopub.execute_input": "2026-07-01T17:11:45.988710Z",
+     "iopub.status.busy": "2026-07-01T17:11:45.988652Z",
+     "iopub.status.idle": "2026-07-01T17:11:45.991244Z",
+     "shell.execute_reply": "2026-07-01T17:11:45.990821Z"
     }
    },
    "outputs": [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.11.3"
+version = "0.12.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **feral v0.12.0**.

Bumps the six version strings (root `Cargo.toml`/lock, `python/Cargo.toml`/`pyproject.toml`/lock) 0.11.3 → 0.12.0, cuts the CHANGELOG `[0.12.0]` section, and re-executes all five example notebooks against the 0.12.0 build.

## Ships (since v0.11.3)
- **#91** — `OrderingPreprocess::Auto` verifies `LdltCompress` by fill (qap15 **20×** on a quasi-definite conic KKT) + Lever B intra-front ramp-down floor.
- **#99** — packed BLAS-3 register-tiled dense trailing update (byte-exact, ~8–10× on dense fronts, x86), shape-aware intra-front gate, opt-in per-front FMA gate (`with_fma_large_fronts`).
- **#102** — fix a parallel dense-front re-entrant deadlock (0%-CPU stall) exposed by #92; and escalate ordering to `LdltCompress` on pivot growth when fast `None` is numerically inadequate (`with_ordering_escalation`).
- **#93 / #94 / #95** — LU element-growth getters, one-norm condition estimate (`condition_estimate_1`), richer `update()` instability signal (`RefactorCause`/`last_refactor`).

All additive public API + behavior fixes; no breaking change.

## Release-gate evidence
- `scripts/release-checklist.sh check`: all six strings agree on 0.12.0; no ordering crate stale (all unchanged since v0.11.3 at v0.2.1); CHANGELOG has a `[0.12.0]` section.
- Root `cargo test --release`: green (71 test binaries).
- `maturin build --release` → `feral_solver-0.12.0` (abi3); all five notebooks re-execute clean (0 error outputs) reporting `feral 0.12.0`.

After merge: tag `v0.12.0` and publish the GitHub Release to fire `release.yml` (crates.io) + `python-wheels.yml` (PyPI).
