### PR TITLE
issue #107: add OrderingMethod::External for user-supplied orderings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — user-supplied fill-reducing ordering: `OrderingMethod::External` (issue #107)
+
+`OrderingMethod` gains an `External(Vec<usize>)` variant so callers can inject a
+precomputed fill-reducing permutation (block-triangular / Schur KKT reuse per
+Parker, Garcia & Bent arXiv:2602.17968; tearing orderings from equation-oriented
+decomposition) instead of only selecting an ordering *algorithm*. This mirrors
+the existing `ScalingStrategy::External(Vec<f64>)`. The permutation is a 0-based,
+new-to-old permutation of `0..n` (the same convention `SymbolicFactorization::perm`
+uses); it is validated as a bijection up front (wrong length / out-of-range /
+duplicate → `FeralError::InvalidInput`, never a panic) and fed to the existing
+symbolic pipeline unchanged, so a valid-but-poor ordering only costs fill/time,
+never correctness. `External` forces `OrderingPreprocess::None` (the `LdltCompress`
+preprocessor reorders a compressed super-graph and cannot consume a full-length
+user permutation). Reachable via `Solver::with_ordering(OrderingMethod::External(..))`
+and `symbolic_factorize_with_method`; programmatic-only (a string option cannot
+express a vector). `OrderingMethod` is now `Clone` but no longer `Copy`. See
+`dev/research/issue-107-external-ordering.md`.
+
 ## [0.12.0] - 2026-07-01
 
 ### Fixed — ordering-quality regression: escalate to LdltCompress on pivot growth (issue #102 follow-up)

--- a/crates/feral-diagnostics/src/bin/bench_orderings.rs
+++ b/crates/feral-diagnostics/src/bin/bench_orderings.rs
@@ -42,7 +42,7 @@ fn measure(
     method: OrderingMethod,
 ) -> Option<(u64, u128)> {
     let t = Instant::now();
-    let sym = symbolic_factorize_with_method(matrix, params, method).ok()?;
+    let sym = symbolic_factorize_with_method(matrix, params, method.clone()).ok()?;
     let us = t.elapsed().as_micros();
     Some((sym.factor_nnz_estimate as u64, us))
 }

--- a/crates/feral-diagnostics/src/bin/diag_chainwoo.rs
+++ b/crates/feral-diagnostics/src/bin/diag_chainwoo.rs
@@ -35,9 +35,9 @@ fn main() {
         "{:>10}  {:>10}  {:>12}  {:>12}  {:>10}  {:>10}  {:>10}",
         "method", "n_snodes", "sym_nnz_est", "num_nnz_l", "max_front", "sym_us", "num_us"
     );
-    for &m in &methods {
+    for m in &methods {
         let t_sym = Instant::now();
-        let sym = match symbolic_factorize_with_method(&csc, &snode_params, m) {
+        let sym = match symbolic_factorize_with_method(&csc, &snode_params, m.clone()) {
             Ok(s) => s,
             Err(e) => {
                 println!("{:>10}  symbolic failed: {}", format!("{:?}", m), e);

--- a/crates/feral-diagnostics/src/bin/diag_fill_parity.rs
+++ b/crates/feral-diagnostics/src/bin/diag_fill_parity.rs
@@ -153,7 +153,7 @@ fn factor_under(
     np: &NumericParams,
 ) -> Option<u64> {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let sym = symbolic_factorize_with_method(csc, snode, method)?;
+        let sym = symbolic_factorize_with_method(csc, snode, method.clone())?;
         factorize_multifrontal(csc, &sym, np)
     }));
     match result {
@@ -261,7 +261,7 @@ fn run_one(mtx_path: &Path, po: &mut PerOrdering, max_n: usize, verbose: bool) {
         (OrderingMethod::Amd, &mut po.amd),
         (OrderingMethod::MetisND, &mut po.metis),
     ] {
-        match factor_under(&csc, method, &snode, &np) {
+        match factor_under(&csc, method.clone(), &snode, &np) {
             Some(nnz_l) => record(agg, &name, nnz_a, nnz_l, nnz_l_mumps, nnz_l_ssids),
             None => {
                 // Cannot distinguish panic vs Err without a second match,

--- a/crates/feral-diagnostics/src/bin/diag_fill_tail.rs
+++ b/crates/feral-diagnostics/src/bin/diag_fill_tail.rs
@@ -37,7 +37,7 @@ fn run(path: &Path) {
 
     let mut fnnz: Vec<(String, usize)> = Vec::with_capacity(3);
     for (tag, m) in methods.iter() {
-        match symbolic_factorize_with_method(&csc, &params, *m) {
+        match symbolic_factorize_with_method(&csc, &params, m.clone()) {
             Ok(sym) => {
                 let raw = sym.col_counts.iter().sum::<usize>();
                 fnnz.push((tag.to_string(), raw));

--- a/crates/feral-diagnostics/src/bin/diag_issue50_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_inventory.rs
@@ -202,8 +202,8 @@ fn run_one_method(matrix: &CscMatrix, method: OrderingMethod) -> Result<(usize, 
         ..SupernodeParams::default()
     };
     let t = Instant::now();
-    let sym =
-        symbolic_factorize_with_method(matrix, &params, method).map_err(|e| format!("{e:?}"))?;
+    let sym = symbolic_factorize_with_method(matrix, &params, method.clone())
+        .map_err(|e| format!("{e:?}"))?;
     let us = t.elapsed().as_micros() as u64;
     Ok((sym.factor_nnz_estimate, us))
 }

--- a/crates/feral-diagnostics/src/bin/diag_issue50_symbolic.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_symbolic.rs
@@ -102,7 +102,7 @@ fn run(
         symbolic_profiler: Some(Arc::clone(&prof)),
         ..SupernodeParams::default()
     };
-    let sym = symbolic_factorize_with_method(matrix, &params, method)
+    let sym = symbolic_factorize_with_method(matrix, &params, method.clone())
         .map_err(|e| format!("symbolic_factorize_with_method({method:?}): {e:?}"))?;
     let report = prof
         .lock()
@@ -178,15 +178,15 @@ fn main() -> ExitCode {
     ];
 
     let mut any_failure = false;
-    for &(label, method) in cases {
+    for (label, method) in cases {
         let t = Instant::now();
-        match run(&matrix, method) {
+        match run(&matrix, method.clone()) {
             Ok((report, resolved, factor_nnz)) => {
                 eprintln!(
                     "[{label}] symbolic done in {:.2} s wall",
                     t.elapsed().as_secs_f64()
                 );
-                print_report(label, method, resolved, factor_nnz, &report);
+                print_report(label, method.clone(), resolved, factor_nnz, &report);
             }
             Err(e) => {
                 eprintln!("[{label}] FAILED: {e}");

--- a/crates/feral-diagnostics/src/bin/diag_ordering_panel.rs
+++ b/crates/feral-diagnostics/src/bin/diag_ordering_panel.rs
@@ -162,7 +162,7 @@ fn process_family(family: &str) {
             continue;
         };
         for (mi, (mname, method)) in METHODS.iter().enumerate() {
-            let sym = match symbolic_factorize_with_method(&csc, &snode_params, *method) {
+            let sym = match symbolic_factorize_with_method(&csc, &snode_params, method.clone()) {
                 Ok(s) => s,
                 Err(e) => {
                     println!("{label:>20}  {mname:>8}  symbolic FAIL: {e}");

--- a/crates/feral-diagnostics/src/bin/diag_ordering_race.rs
+++ b/crates/feral-diagnostics/src/bin/diag_ordering_race.rs
@@ -48,7 +48,7 @@ fn rel_residual_2norm(csc: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
 fn run(label: &str, csc: &CscMatrix, rhs: &[f64], oracle: &Inertia, method: OrderingMethod) {
     let snode = SupernodeParams::default();
     let t_sym = Instant::now();
-    let sym = match symbolic_factorize_with_method(csc, &snode, method) {
+    let sym = match symbolic_factorize_with_method(csc, &snode, method.clone()) {
         Ok(s) => s,
         Err(e) => {
             println!("  [{label:<10}]  symbolic FAILED: {e:?}");
@@ -57,7 +57,7 @@ fn run(label: &str, csc: &CscMatrix, rhs: &[f64], oracle: &Inertia, method: Orde
     };
     let sym_s = t_sym.elapsed().as_secs_f64();
     let nnz_l = sym.factor_nnz_estimate;
-    let resolved = sym.resolved_method;
+    let resolved = sym.resolved_method.clone();
 
     let params = NumericParams::default();
     let mut ws = FactorWorkspace::new();

--- a/crates/feral-diagnostics/src/bin/diag_pinene_amd.rs
+++ b/crates/feral-diagnostics/src/bin/diag_pinene_amd.rs
@@ -54,7 +54,7 @@ fn rel_residual_2norm(csc: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
 fn run(label: &str, csc: &CscMatrix, rhs: &[f64], oracle: &Inertia, method: OrderingMethod) {
     let snode = SupernodeParams::default();
     let t_sym = Instant::now();
-    let sym = match symbolic_factorize_with_method(csc, &snode, method) {
+    let sym = match symbolic_factorize_with_method(csc, &snode, method.clone()) {
         Ok(s) => s,
         Err(e) => {
             println!("  [{label}]  symbolic FAILED: {e:?}");

--- a/crates/feral-diagnostics/src/bin/diag_poisson_kkt.rs
+++ b/crates/feral-diagnostics/src/bin/diag_poisson_kkt.rs
@@ -235,7 +235,7 @@ fn main() {
         snode_params.nemin = n;
     }
     let t0 = Instant::now();
-    let symbolic = match symbolic_factorize_with_method(&csc, &snode_params, method) {
+    let symbolic = match symbolic_factorize_with_method(&csc, &snode_params, method.clone()) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("symbolic failed: {}", e);

--- a/crates/feral-diagnostics/src/bin/diag_qcqp_knobs.rs
+++ b/crates/feral-diagnostics/src/bin/diag_qcqp_knobs.rs
@@ -107,7 +107,7 @@ fn main() {
             ..SupernodeParams::default()
         };
         let t0 = Instant::now();
-        let sym = match symbolic_factorize_with_method(&csc, &snode, method) {
+        let sym = match symbolic_factorize_with_method(&csc, &snode, method.clone()) {
             Ok(s) => s,
             Err(e) => {
                 println!("{:<46} SYM_ERR {}", name, e);

--- a/crates/feral-diagnostics/src/bin/diag_qcqp_profile.rs
+++ b/crates/feral-diagnostics/src/bin/diag_qcqp_profile.rs
@@ -40,7 +40,7 @@ fn run(
         amalgamation_strategy: amalg,
         ..SupernodeParams::default()
     };
-    let sym = match symbolic_factorize_with_method(csc, &snode, method) {
+    let sym = match symbolic_factorize_with_method(csc, &snode, method.clone()) {
         Ok(s) => s,
         Err(e) => {
             println!("\n=== {} === SYM_ERR {}", label, e);

--- a/crates/feral-diagnostics/src/bin/probe_issue64_arrow.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue64_arrow.rs
@@ -53,7 +53,7 @@ fn arrow_stats(pat: &CscPattern) -> ArrowStats {
 
 fn nnz_l(m: &CscMatrix, method: OrderingMethod) -> usize {
     let sp = SupernodeParams::default();
-    match symbolic_factorize_with_method(m, &sp, method) {
+    match symbolic_factorize_with_method(m, &sp, method.clone()) {
         Ok(s) => s.col_counts.iter().sum(),
         Err(e) => {
             eprintln!("  {:?} FAILED: {:?}", method, e);

--- a/crates/feral-diagnostics/src/bin/probe_issue67_race.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue67_race.rs
@@ -37,7 +37,7 @@ fn sym_us(
     let mut t = Vec::with_capacity(reps);
     for _ in 0..reps.max(1) {
         let t0 = Instant::now();
-        symbolic_factorize_with_method(m, sp, method).ok()?;
+        symbolic_factorize_with_method(m, sp, method.clone()).ok()?;
         t.push(t0.elapsed().as_micros());
     }
     Some(median(t))

--- a/crates/feral-diagnostics/src/bin/probe_issue67_thin.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue67_thin.rs
@@ -43,10 +43,10 @@ fn measure(
     let mut factor_t = Vec::with_capacity(reps);
     let mut solve_t = Vec::with_capacity(reps);
     let mut nnz_l = 0usize;
-    let mut resolved = method;
+    let mut resolved = method.clone();
     let mut inertia_s = String::new();
     for _ in 0..reps.max(1) {
-        let mut s = Solver::new().with_ordering(method);
+        let mut s = Solver::new().with_ordering(method.clone());
         let t = Instant::now();
         let st = s.factor(m, None);
         factor_t.push(t.elapsed().as_micros());
@@ -58,7 +58,7 @@ fn measure(
         }
         let f = s.factors()?;
         nnz_l = f.factor_nnz();
-        resolved = f.resolved_method;
+        resolved = f.resolved_method.clone();
         if let Some(i) = s.inertia() {
             inertia_s = format!("({},{},{})", i.positive, i.negative, i.zero);
         }

--- a/crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue73_symbolic.rs
@@ -52,7 +52,7 @@ fn measure(
 ) -> Result<SymStats, feral::FeralError> {
     let params = SupernodeParams::default();
     let t = Instant::now();
-    let sym = symbolic_factorize_with_method(m, &params, method)?;
+    let sym = symbolic_factorize_with_method(m, &params, method.clone())?;
     let sym_ms = t.elapsed().as_secs_f64() * 1e3;
 
     let mut max_front = 0usize;

--- a/crates/feral-diagnostics/src/bin/vesuvio_diag.rs
+++ b/crates/feral-diagnostics/src/bin/vesuvio_diag.rs
@@ -145,7 +145,7 @@ fn run_one_method(csc: &CscMatrix, method: OrderingMethod, scaling: ScalingStrat
     };
 
     let t_sym = Instant::now();
-    let sym = match symbolic_factorize_with_method(csc, &snode_params, method) {
+    let sym = match symbolic_factorize_with_method(csc, &snode_params, method.clone()) {
         Ok(s) => s,
         Err(e) => {
             println!("  {:?}: symbolic FAILED: {:?}", method, e);

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,79 +1,79 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-01T01:38:26Z
+Generated: 2026-07-02T11:32:41Z
 
 ## Latest Session
-File: dev/sessions/2026-07-01-02.md
+File: dev/sessions/2026-07-02-01.md
 ```
-# Session 2026-07-01-02
+# Session 2026-07-02-01
 
 ## Goal
-
-Issue #95: enrich the LU rank-1 `update()` failure signal so a caller can tell an
-ill-conditioning failure (refine and retry) from a bookkeeping-budget trip (just
-refactor), and close the `should_refactor()` sparse/dense parity gap. discopt#364
-needs the *why* behind a `NeedsRefactor`, and discopt forces the dense LU for
-small bases (`m ≤ 256`).
+Implement issue #107: add `OrderingMethod::External(Vec<usize>)` so callers can
+inject a precomputed fill-reducing permutation into symbolic factorization,
+instead of only selecting an ordering *algorithm*. Mirror the existing
+`ScalingStrategy::External(Vec<f64>)`.
 
 ## Accomplished
+- **Research + plan first** (`dev/research/issue-107-external-ordering.md`,
+  `dev/plans/issue-107-external-ordering.md`), then tests, then implementation.
+- **`OrderingMethod::External(Vec<usize>)`**: a 0-based new-to-old permutation
+  of `0..n` (same convention as `SymbolicFactorization::perm`). Injected at the
+  single `run_external_ordering` point — for `External` it returns the user perm
+  directly instead of calling an ordering crate; the rest of the pipeline
+  (postorder → etree → column counts → supernodes) is byte-identical to any
+  other method.
+- **`Copy` → `Clone`.** A `Vec` field is not `Copy`, so `OrderingMethod` drops
+  `Copy` (kept `Clone`), matching `ScalingStrategy`. Hand-written `Debug` prints
+  `External { len: N }` so `NumericFactorization::summary` doesn't dump the perm.
+- **Validation up front** (`validate_external_perm`): wrong length /
+  out-of-range / duplicate → `FeralError::InvalidInput`, never a panic, no
+  `unwrap`.
+- **`External` forces `OrderingPreprocess::None`.** `LdltCompress` reorders a
+  compressed super-graph (dim `ncmp ≤ n`) and cannot consume a full-length user
+  perm; guarded so `External` also skips the preprocess-`Auto` fill race.
+- **`Copy`-removal fallout** (mechanical clones): `AutoRace` race loop,
+  preprocess-`Auto` `run` closure, `Solver::factor` (2), the three numeric
+  constructors, `src/bin/bench.rs` (3 match sites), `examples/bench_qap15.rs`,
+  `python/src/*` (`ordering_to_str` now takes `&OrderingMethod` + `External`
+  arm), and ~9 `feral-diagnostics` bins that reused a `method` binding.
+- **Tests** (oracles external/hand): `tests/issue107_external_ordering.rs` — 6
+  green. Saddle-point KKT inertia (2,1,0) by the saddle inertia theorem
+  (Nocedal & Wright Lemma 16.1); SPD tridiag inertia (n,0,0); RHS `b = K·x_true`
+  so the solution is known; identity and reversed external orderings both solve
+  to the oracle with identical inertia (ordering changes fill, not the answer);
+  validation rejects the three malformed inputs. `src/symbolic` units pin the
+  bijection perm + forced `None` preprocess, the validation rejections, and the
+  compact Debug.
+- **Suite green:** feral **395 lib** + all integration tests pass;
+  `cargo test -p feral-diagnostics` green; `cargo clippy --all-targets -- -D
+  warnings` clean on both feral and `feral-diagnostics`; `cargo fmt --check`
+  clean. Default (non-External) path unchanged.
 
-Chose the issue's **preferred additive (non-breaking)** design: keep the
-payload-free `Err(NeedsRefactor)`, record cause + magnitude alongside.
-
-- New public enum `RefactorCause { Growth, UpdateBudget, TinyPivot, Singular }`
-  (`src/lu/mod.rs`, re-exported from the crate root via `src/lib.rs`).
-- `last_refactor() -> Option<(RefactorCause, f64)>` on both `SparseLu` and
-  `DenseLu`. Set on **every** `NeedsRefactor` return path (update-count budget,
-  singular/empty-support, growth, tiny/zero/non-finite pivot). `None` after a
-  fresh factor/refactor; untouched by a successful update (read only after `Err`).
-- `growth()` getter on both (exposes the element-growth high-water monitor).
-- `should_refactor_growth()` on both: growth-aware recommendation firing once
-  `growth >= sqrt(max_growth)` (finite, > 1) — the geometric midpoint in log
-  space — so a caller can pre-empt a growth trip.
-- `should_refactor()` parity on `DenseLu` (cost-based: `updates_since_refactor >= m`;
-  dense update is O(m²), fresh factor O(m³)), mirroring the sparse cost-based
-  `should_refactor()`. `updates_since_refactor()` already existed on both.
-- Docs: `src/error.rs` `NeedsRefactor` variant now points at the accessor;
-  `CHANGELOG.md` Unreleased; design note `dev/research/refactor-signal-2026-07-01.md`.
-
-**Magnitude semantics** — Growth: the growth ratio that tripped (> max_growth);
-UpdateBudget: the update count that hit the cap (= max_updates); TinyPivot:
-|offending pivot| (≤ zero_pivot_tol·u_max0); Singular: 0.0.
-
-**Dense/sparse asymmetry (inherent, documented):** the dense path has no distinct
-`Singular` branch — a linearly dependent replacement drives the final `U` diagonal
-to ~0 and reports `TinyPivot`. Only the sparse path can cheaply detect the
-empty-support case (`h_rank < r_rank`) *before* eliminating, so `Singular` is
-sparse-only.
-
-### Evidence
-
-- 9 new unit tests (5 sparse, 4 dense): each cause reached via a deterministically
-  constructed input, plus the two recommendation getters. Assertions are
-  behavioral (which cause) and self-consistent (the magnitude relation the path
-  itself guarantees) — no external numerical oracle required.
-  - Note: the naive identity-basis update `update(0, e0/[1,1])` trips a
-    `TinyPivot` (after the cyclic shift `u[0,0]` = the identity's off-diagonal 0),
-    *not* a clean commit — so the budget/recommendation tests use the tridiagonal
+## Benchmark Results
+```
+cargo run --bin bench --release (built-in fixtures; no data/ corpus present)
+  KKT dense: Inertia match 1/1 (100%), Residual pass 1/1, worst 1.14e-15
+  vs MUMPS:  Inertia match 2/2 (100%), Residual pass 2/2, worst 1.26e-16
+  8 matrices benchmarked; no failures (dense or sparse).
 ```
 
 ## Git Status
 ```
-daa058f issue #95: richer update() instability signal + refactor recommendations
-f9398fd issue #94: one-norm condition estimate for the unsymmetric LU factor (#98)
-f114b5d issue #93: expose the LU element-growth factor via public getters (#96)
-f037285 release: feral v0.11.3
-a5c789f issue #89: FT update u_above reindex O(m³)→O(m²) + true per-update cost counter (#90)
+a1dd7b5 release: feral v0.12.0 (#106)
+1165d4d issue #102 follow-up: escalate ordering to LdltCompress on pivot growth (#105)
+d6fe546 issue #102: fix parallel dense-front re-entrant deadlock (0% CPU stall) (#104)
+bc24fc9 issue #99: packed BLAS-3 dense trailing update (byte-exact) + opt-in FMA-large-fronts gate (#103)
+f54b335 docs: session checkpoint 2026-07-01-03 (issue #91 dense-kernel follow-up) (#100)
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
@@ -86,80 +86,76 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 391 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.40s
+test result: ok. 395 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.95s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-01-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-02-01.md)
 
-
-Residual pass: 2/2 (100.0%)
-Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
-Dense ∩ Sparse failure overlap: 0 / 0 / 0
-(no oracle timings loaded in this environment; perf partitions N/A)
-
-Purely additive API + metadata on the error path (a single `Option` write only on
-a `NeedsRefactor` return); no factorization or solve arithmetic changed.
+cargo run --bin bench --release (built-in fixtures; no data/ corpus present)
+  KKT dense: Inertia match 1/1 (100%), Residual pass 1/1, worst 1.14e-15
+  vs MUMPS:  Inertia match 2/2 (100%), Residual pass 2/2, worst 1.26e-16
+  8 matrices benchmarked; no failures (dense or sparse).
+No performance change expected or observed: `External` is a new opt-in ordering
+source; the default `Auto` path is byte-exact.
 
 ```
 
 ## Recent Decisions
-accessor, not a breaking error-variant change. `SparseLu::update`/`DenseLu::update`
-keep returning the payload-free `Err(FeralError::NeedsRefactor)`; the cause +
-magnitude are recorded on `self` and read back via
-`last_refactor() -> Option<(RefactorCause, f64)>`. New public enum
-`RefactorCause { Growth, UpdateBudget, TinyPivot, Singular }`.
+diverge from the scaling precedent. The `Copy` loss is mechanical (clone at the
+`AutoRace` race loop, the preprocess-`Auto` race, `Solver::factor`, the three
+numeric constructors, and the `feral-diagnostics` bins that reuse a `method`
+binding) and was absorbed.
 
-**Why.** discopt#364 needs to distinguish an ill-conditioning failure
-(Growth/TinyPivot/Singular → refine-and-retry) from a mere update-count budget
-trip (UpdateBudget → refactor). The additive route (the issue's stated
-preference) leaves every existing caller compiling unchanged.
+**Why `External` forces `OrderingPreprocess::None`.** `LdltCompress` reorders an
+MC64-compressed super-graph of dimension `ncmp ≤ n`; a full-length user permutation
+cannot be applied to it. So `External` bypasses the preprocess-`Auto` fill race and
+pins `resolved_preprocess = None`, regardless of the requested (or default `Auto`)
+preprocess. Scaling is unaffected — it is computed independently in the numeric
+phase from `ScalingStrategy`; only the MC64 *cache-reuse* symbolic-time shortcut is
+skipped, which is a performance optimization, not a correctness input.
 
-**Magnitude semantics.** Growth = growth ratio that tripped; UpdateBudget =
-update count that hit the cap (= max_updates); TinyPivot = |offending pivot|;
-Singular = 0.0. `last_refactor()` is `None` after factor/refactor, untouched by a
-successful update.
+**Soundness.** Numeric factorization, pivoting, and inertia are untouched — a
+factorization under any valid ordering is exact. A bad user ordering only costs
+fill/time. The permutation is validated as a bijection of `0..n` up front
+(`validate_external_perm`): wrong length, out-of-range index, or duplicate returns
+`FeralError::InvalidInput` (never a panic, no `unwrap`). Programmatic-only: no
+string parsing, matching scaling's `External`.
 
-**Dense/sparse asymmetry (accepted, not a gap).** The dense path has no distinct
-`Singular` cause — a dependent replacement drives the final `U` diagonal to ~0 and
-reports `TinyPivot`. Only the sparse path detects the empty-support case
-(`h_rank < r_rank`) before eliminating, so `Singular` is sparse-only.
-
-**Refactor recommendations.** `should_refactor_growth()` (both types) fires at
-`growth >= sqrt(max_growth)` — the log-space midpoint between the floor 1 and the
-cap — to pre-empt a growth trip. Dense `should_refactor()` (cost-based parity) =
-`updates_since_refactor() >= m` (O(m²) update vs O(m³) factor), the dense analogue
-of sparse's `update_work_total >= factor_nnz()`.
-
-**Evidence.** +9 unit tests (each cause + both recommendation getters), 381 lib
-tests green, fmt/clippy clean, no numerical change (bench: no failures). Design
-note: `dev/research/refactor-signal-2026-07-01.md`.
+**Evidence.** `tests/issue107_external_ordering.rs` (identity + reversed orderings
+solve to the hand oracle with saddle-point inertia (2,1,0) and SPD inertia (n,0,0);
+validation rejects the three malformed inputs); `src/symbolic` units
+(`symbolic_factorize_external_produces_valid_perm` pins the bijection + forced
+`None` preprocess; `external_perm_validation_rejects_bad_input`;
+`ordering_method_external_debug_is_compact`). Full suite green: feral 395 lib + all
+integration, `feral-diagnostics` builds/tests, clippy `--all-targets` clean on both,
+`cargo fmt --check` clean. Default (non-External) path unchanged. See
+`dev/research/issue-107-external-ordering.md` and
+`dev/plans/issue-107-external-ordering.md`.
 
 ## Recent Tried-and-Rejected
-more work.** Step 2's premise (dense-spike bump, contiguous SAXPY) does not hold
-for this workload; implementing it would **regress** casctanks, not speed it up.
++23% option but is a reproducibility-policy change (kept opt-in), not a
+bit-exact win.
 
-This also explains Step 1's 15.8×: the old O(bump²) **scan** probed ~731²/2 ≈ 267k
-cells per update to find the ~24 that needed work. Removing the scan (Step 1) was
-the correct and sufficient fix for the sparse-wide-bump regime; the residual
-elimination work is already near-minimal.
+## 2026-07-01 — UPDATE: packed micro-kernel succeeds where B-1a source-pack failed (issue #99)
 
-**Not generally rejected.** A dense path could still help a genuinely *dense*-spike
-basis (the journal's 2026-06-08 tridiagonal/`L⁻¹`-dense worst case). If such a
-workload appears, Step 2 should be width-AND-density gated (dense path only when
-block density exceeds a threshold), never width-only. For the McCormick LP regime
-that motivated discopt#229, Step 1 stands alone.
+The 2026-06-30 "B-1a panel packing" entry above rejected source-panel packing as a
+net slowdown and concluded the root front is DST-bandwidth-bound. That conclusion
+was **specific to the variant tried** — packing the source into a tighter stride
+but *feeding the same strided kernels*, which keep the per-`q` `as_simd` + strided
+access. It does **not** generalize to a proper packed micro-kernel.
 
-**Evidence.** `FERAL_BUMP_STATS` aggregate over
-`FERAL_LU_TRACE=.../casctanks_trace.txt` (full trace): avg_width=731.3,
-max_width=2157, avg_density=0.1346 (all bumps) / 0.0023 (width>500),
-avg_axpy=23.9, avg_merge_work=233.4. Step 1 end-to-end: casctanks LP solve
-82.4 s → 5.2 s debug (15.8×), optimum −167.751 unchanged. Journal:
-dev/journal/2026-06-18-01.org.
+A different design — pack the panel into `q`-contiguous MR=8×NR=4 micro-panels and
+run a register-tiled kernel with a **contiguous inner `q`-loop**
+(`apply_schur_panel_range_packed`) — is **22–26× faster in isolation and
+byte-exact** (`examples/bench_schur_micro`), and gives 8–10× on real dense fronts.
+So the bottleneck was strided-`q` cache latency, not DST bandwidth, on this
+hardware. Not a rejection — a correction of scope. See
+`dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
+2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
+rejected; the packed micro-kernel is the shipped design.
 
 ## Source Files
 ```
@@ -236,10 +232,15 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
 tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5859,3 +5859,49 @@ is a possible future refinement).
 qap15/cont5-iter0/dirichlet120 unchanged. Byte-exact non-escalated path; lib
 394/0, parallel_parity/issue91/issue65/ldlt_compress/symbolic_profiler green.
 Guard `tests/issue102_ordering_escalation.rs`.
+
+## 2026-07-02 — `OrderingMethod::External(Vec<usize>)`: user-supplied ordering (issue #107)
+
+**Decision.** Add `OrderingMethod::External(Vec<usize>)` carrying a caller-supplied
+0-based new-to-old fill-reducing permutation of `0..n`. It replaces the internal
+AMD/METIS/etc. pass at the single `run_external_ordering` injection point; the rest
+of the symbolic pipeline (postorder, etree, column counts, supernodes) is unchanged.
+`OrderingMethod` drops `Copy` and keeps `Clone` (a `Vec` field is not `Copy`),
+exactly as `ScalingStrategy` already does for its `External(Vec<f64>)` variant. A
+hand-written `Debug` prints the variant as `External { len: N }` so diagnostic
+one-liners (`NumericFactorization::summary`) don't dump the whole permutation.
+
+**Why an enum variant (not a side-channel field).** The issue asks for parity with
+`ScalingStrategy::External`, whose vector rides on the strategy enum and threads
+through `Solver::with_ordering`/`FeralConfig` as one value. A separate
+`SupernodeParams` field would split the "how to order" decision across two knobs and
+diverge from the scaling precedent. The `Copy` loss is mechanical (clone at the
+`AutoRace` race loop, the preprocess-`Auto` race, `Solver::factor`, the three
+numeric constructors, and the `feral-diagnostics` bins that reuse a `method`
+binding) and was absorbed.
+
+**Why `External` forces `OrderingPreprocess::None`.** `LdltCompress` reorders an
+MC64-compressed super-graph of dimension `ncmp ≤ n`; a full-length user permutation
+cannot be applied to it. So `External` bypasses the preprocess-`Auto` fill race and
+pins `resolved_preprocess = None`, regardless of the requested (or default `Auto`)
+preprocess. Scaling is unaffected — it is computed independently in the numeric
+phase from `ScalingStrategy`; only the MC64 *cache-reuse* symbolic-time shortcut is
+skipped, which is a performance optimization, not a correctness input.
+
+**Soundness.** Numeric factorization, pivoting, and inertia are untouched — a
+factorization under any valid ordering is exact. A bad user ordering only costs
+fill/time. The permutation is validated as a bijection of `0..n` up front
+(`validate_external_perm`): wrong length, out-of-range index, or duplicate returns
+`FeralError::InvalidInput` (never a panic, no `unwrap`). Programmatic-only: no
+string parsing, matching scaling's `External`.
+
+**Evidence.** `tests/issue107_external_ordering.rs` (identity + reversed orderings
+solve to the hand oracle with saddle-point inertia (2,1,0) and SPD inertia (n,0,0);
+validation rejects the three malformed inputs); `src/symbolic` units
+(`symbolic_factorize_external_produces_valid_perm` pins the bijection + forced
+`None` preprocess; `external_perm_validation_rejects_bad_input`;
+`ordering_method_external_debug_is_compact`). Full suite green: feral 395 lib + all
+integration, `feral-diagnostics` builds/tests, clippy `--all-targets` clean on both,
+`cargo fmt --check` clean. Default (non-External) path unchanged. See
+`dev/research/issue-107-external-ordering.md` and
+`dev/plans/issue-107-external-ordering.md`.

--- a/dev/journal/2026-07-02-01.org
+++ b/dev/journal/2026-07-02-01.org
@@ -1,0 +1,44 @@
+* 11:30 :issue-107:ordering:api:
+Implemented `OrderingMethod::External(Vec<usize>)` (issue #107): a caller-supplied
+0-based new-to-old fill-reducing permutation, mirroring the existing
+`ScalingStrategy::External(Vec<f64>)`. Injection point is the single
+`run_external_ordering` function — for `External` it returns the user perm
+directly instead of calling an ordering crate; the rest of the pipeline
+(postorder → etree → column counts → supernodes) is byte-identical to any
+other method.
+
+Design notes:
+- `OrderingMethod` had to drop `Copy` (a `Vec` field is not `Copy`), kept
+  `Clone` — same as `ScalingStrategy`. Added a hand-written `Debug` so
+  `External` prints as `External { len: N }` (not a full-perm dump) in
+  `NumericFactorization::summary`.
+- `External` forces `OrderingPreprocess::None`: `LdltCompress` reorders a
+  compressed super-graph (dim `ncmp ≤ n`) and cannot consume a full-length user
+  perm. Guarded so `External` skips the preprocess-`Auto` race entirely.
+- Validation up front (`validate_external_perm`): wrong length / out-of-range /
+  duplicate → `FeralError::InvalidInput`, never a panic.
+
+`Copy` removal fallout (all mechanical `.clone()`s): `AutoRace` race loop,
+preprocess-`Auto` `run` closure, `Solver::factor` (2 sites), three numeric
+constructors (`symbolic.resolved_method.clone()`), `src/bin/bench.rs` (3 match
+sites), `examples/bench_qap15.rs`, `python/src/*` (`ordering_to_str` now takes
+`&OrderingMethod`, +`External` arm), and ~9 `feral-diagnostics` bins that reused
+a `method` binding by value.
+
+Evidence: `tests/issue107_external_ordering.rs` — 6 tests green. Oracles are
+external (hand): saddle-point KKT inertia (2,1,0) by the saddle inertia theorem
+(Nocedal & Wright Lemma 16.1), SPD tridiag inertia (n,0,0), RHS `b = K·x_true`
+so the solution is known. Identity and reversed external orderings both solve to
+the oracle and report identical inertia — ordering changes fill, not the answer.
+Unit tests pin the bijection perm + forced `None` preprocess, the three
+validation rejections, and the compact Debug. Full suite: feral 395 lib + all
+integration green; `feral-diagnostics` builds + tests green; clippy
+`--all-targets -- -D warnings` clean on both packages; `cargo fmt --check` clean.
+Default (non-External) path unchanged.
+
+Notes for future work: `resolved_method` faithfully reports `External(perm)`,
+which duplicates the length-`n` perm already in `sym.perm`; this is negligible
+beside the `perm`/`perm_inv`/`node_factors` clones the numeric constructor
+already does, but if it ever matters a lighter marker could replace it. The
+companion `pounce`/`FeralConfig` plumbing (issue mentions it) is downstream and
+out of scope for the feral crate.

--- a/dev/plans/issue-107-external-ordering.md
+++ b/dev/plans/issue-107-external-ordering.md
@@ -1,0 +1,45 @@
+# Implementation Plan: External / user-supplied ordering (issue #107)
+
+**Date:** 2026-07-02
+**Research note:** dev/research/issue-107-external-ordering.md
+**Spec sections:** 5.1
+
+## Files to Create/Modify
+- `src/symbolic/mod.rs` — add `External(Vec<usize>)` variant, drop `Copy`,
+  manual `Debug`, `validate_external_perm`, wire `run_external_ordering` and
+  `symbolic_factorize_with_method`, unit tests.
+- `src/numeric/solver.rs` — clone `self.ordering` at the two factor sites.
+- `src/numeric/factorize.rs` — clone `symbolic.resolved_method` at the three
+  numeric constructors.
+- `python/src/common.rs` — `ordering_to_str` gains an `External` arm.
+- `crates/feral-diagnostics/**` — `.clone()` wherever a `method` binding is
+  reused by value (compiler-driven).
+- `tests/issue107_external_ordering.rs` — behavioral tests (oracle = hand
+  permutation).
+- `CHANGELOG.md`, `dev/decisions.md`, session + journal.
+
+## Implementation Steps
+1. Enum: drop `Copy`, add `External(Vec<usize>)`, hand-written `Debug`.
+2. `validate_external_perm(perm, n) -> Result<(), FeralError>`.
+3. `run_external_ordering(&CscPattern, &OrderingMethod)`: early-return the
+   user perm for `External`; `.clone()` the resolved method for other arms.
+4. `symbolic_factorize_with_method`: validate `External` up front; force
+   `resolved_preprocess = None`; skip the preprocess-`Auto` delegation.
+5. Fix `AutoRace` race loop + preprocess-`Auto` `run` closure to clone method.
+6. Fix solver / numeric / python / diagnostics fallout from `Copy` removal.
+
+## Tests (write first)
+- `tests/issue107_external_ordering.rs`: identity perm solve+inertia; fixed
+  non-trivial perm solve+inertia parity; `resolved_method == External` and
+  `resolved_preprocess == None`; validation rejects (len / range / dup);
+  `Solver::with_ordering(External)` end-to-end parity.
+- `src/symbolic/mod.rs` unit: `External` yields a valid bijection perm and
+  forces `None` preprocess.
+
+## Success Criteria
+- `cargo test` (feral) green; `cargo test -p feral-diagnostics` green.
+- `cargo clippy --all-targets -- -D warnings` and
+  `cargo clippy -p feral-diagnostics --all-targets -- -D warnings` clean.
+- `cargo fmt --check` clean.
+- No `unwrap`/`expect`/`unsafe` added in `src/`.
+- Byte-exact: default path (`Auto`, no External) unchanged.

--- a/dev/research/issue-107-external-ordering.md
+++ b/dev/research/issue-107-external-ordering.md
@@ -1,0 +1,114 @@
+# Research Note: External / user-supplied ordering (`OrderingMethod::External`)
+
+**Status:** Pre-implementation
+**Date:** 2026-07-02
+**Related spec sections:** 5.1 (feature lifecycle), symbolic factorization pipeline
+**Key references:** issue #107; Parker, Garcia & Bent, *Exploiting block
+triangular submatrices in KKT systems* (arXiv:2602.17968); Baharev et al.,
+*An exact method for the minimum feedback arc set problem*, ACM JEA 26 (2021);
+`ScalingStrategy::External(Vec<f64>)` (the scaling analogue already in tree).
+
+## Overview
+
+`OrderingMethod` today maps only to *ordering algorithms* (`Amd`, `Amf`,
+`MetisND`, `ScotchND`, `KahipND`, `Auto`, `AutoRace`). A caller that has
+computed a *better-than-generic fill-reducing permutation from problem
+structure* (block-triangular Schur KKT reuse, tearing orderings from
+equation-oriented decomposition) has no way to inject it — the ordering is
+always recomputed internally.
+
+This mirrors what FERAL already does for **scaling**: `ScalingStrategy` has an
+`External(Vec<f64>)` variant carrying a user-supplied vector that cannot be
+expressed as a string option. Ordering has no analogous path. This note adds
+`OrderingMethod::External(Vec<usize>)`.
+
+## Algorithm
+
+There is no numerical algorithm. The supplied permutation *replaces* the
+internal AMD/METIS/etc. pass and is fed to the existing downstream pipeline
+unchanged (postorder composition → etree → column counts → supernode
+amalgamation → memory plan). The permutation convention is identical to the
+one FERAL already returns from `run_external_ordering` and stores in
+`SymbolicFactorization::perm`:
+
+- **new-to-old**, 0-based: `perm[k]` is the original column that becomes
+  column `k`.
+- length exactly `n`.
+
+Injection point: `run_external_ordering` is the single function that produces
+the initial ordering (`amd_perm`) for every method. For `External(perm)` it
+returns a clone of `perm` directly instead of calling an ordering crate. From
+there the pipeline is byte-identical to any other method — the same postorder
+is composed on top, so `SymbolicFactorization::perm` is the postorder ∘ user
+ordering, exactly as for AMD's output.
+
+### Validation
+
+A user permutation must be a bijection of `0..n`. `validate_external_perm`
+checks:
+1. `perm.len() == n`,
+2. every entry `< n`,
+3. no duplicates (seen-bitset).
+
+Invalid input returns `FeralError::InvalidInput` — never a panic, never
+`unwrap`. A *valid but poor* ordering only costs fill/time, never correctness
+(a factorization with any valid ordering is exact), exactly as the issue
+states and as with `ScalingStrategy::External`.
+
+### Interaction with `OrderingPreprocess`
+
+`OrderingPreprocess::LdltCompress` reorders a *compressed super-graph*
+(MC64-matched supervariables), whose dimension `ncmp <= n`. A full-length
+user permutation cannot be applied to that compressed graph. Therefore
+`External` **forces `OrderingPreprocess::None`**, regardless of the requested
+preprocess (including the default `Auto`). This is the only semantic
+subtlety and is documented on the variant. Scaling is unaffected: it is
+computed independently in the numeric phase from `ScalingStrategy`; only the
+MC64 *cache reuse* optimization (a symbolic-time perf shortcut) is skipped,
+not any correctness-bearing scaling.
+
+### `Copy` removal
+
+`Vec<usize>` is not `Copy`, so `OrderingMethod` can no longer derive `Copy`
+(exactly as `ScalingStrategy`, which is `Clone` not `Copy`). This ripples to
+by-value uses: `run_external_ordering` takes `&OrderingMethod`; the
+`AutoRace` race loop and `Solver::factor` clone the method; the three numeric
+constructors clone `symbolic.resolved_method`; `feral-diagnostics` binaries
+that reuse a `method` binding get `.clone()`s. A hand-written `Debug` keeps
+the diagnostic `summary()` one-liner compact (`External { len: N }`) instead
+of dumping the whole permutation.
+
+## Design Decisions
+
+- **Faithful `resolved_method`.** `run_external_ordering` reports
+  `OrderingMethod::External(perm.clone())` as the resolved method, matching
+  the existing contract that `resolved_method` is a truthful record of what
+  ran. The extra length-`n` clone is negligible beside the `perm`/`perm_inv`
+  clones the numeric constructor already does.
+- **Programmatic-only.** No string parsing (`feral_ordering` / bench
+  `--ordering`), matching scaling's `External`. `Solver::with_ordering` and
+  `symbolic_factorize_with_method` are the entry points.
+- **Not a race/auto candidate.** `External` is concrete; it is never produced
+  by `choose_adaptive`, `pick_default_method`, or the `AutoRace` /
+  preprocess-`Auto` races, and those paths never receive it (guarded).
+
+## Test Strategy
+
+External-facing test (`tests/issue107_external_ordering.rs`) — oracle is the
+identity/known permutation, computed by hand, not by the solver:
+
+1. **Identity permutation** on a small KKT solves correctly and yields the
+   oracle inertia and a residual at the same tolerance as the default path.
+2. **Non-trivial fixed permutation** (a hand-written reversal / interleave)
+   solves to the same solution and inertia — ordering changes fill, not the
+   answer.
+3. **`resolved_method` reports `External`** and `resolved_preprocess` is
+   `None` even when the default `Auto` preprocess was requested.
+4. **Validation rejects** wrong length, out-of-range index, and duplicate
+   index with `InvalidInput` (no panic).
+5. **`Solver::with_ordering(External(..))`** end-to-end parity with the
+   default solve on the same matrix.
+
+Unit tests in `src/symbolic/mod.rs`: `External` produces a valid bijection
+perm through the pipeline (mirrors the per-method `..._produces_valid_perm`
+tests) and forces `resolved_preprocess == None`.

--- a/dev/sessions/2026-07-02-01.md
+++ b/dev/sessions/2026-07-02-01.md
@@ -1,0 +1,72 @@
+# Session 2026-07-02-01
+
+## Goal
+Implement issue #107: add `OrderingMethod::External(Vec<usize>)` so callers can
+inject a precomputed fill-reducing permutation into symbolic factorization,
+instead of only selecting an ordering *algorithm*. Mirror the existing
+`ScalingStrategy::External(Vec<f64>)`.
+
+## Accomplished
+- **Research + plan first** (`dev/research/issue-107-external-ordering.md`,
+  `dev/plans/issue-107-external-ordering.md`), then tests, then implementation.
+- **`OrderingMethod::External(Vec<usize>)`**: a 0-based new-to-old permutation
+  of `0..n` (same convention as `SymbolicFactorization::perm`). Injected at the
+  single `run_external_ordering` point — for `External` it returns the user perm
+  directly instead of calling an ordering crate; the rest of the pipeline
+  (postorder → etree → column counts → supernodes) is byte-identical to any
+  other method.
+- **`Copy` → `Clone`.** A `Vec` field is not `Copy`, so `OrderingMethod` drops
+  `Copy` (kept `Clone`), matching `ScalingStrategy`. Hand-written `Debug` prints
+  `External { len: N }` so `NumericFactorization::summary` doesn't dump the perm.
+- **Validation up front** (`validate_external_perm`): wrong length /
+  out-of-range / duplicate → `FeralError::InvalidInput`, never a panic, no
+  `unwrap`.
+- **`External` forces `OrderingPreprocess::None`.** `LdltCompress` reorders a
+  compressed super-graph (dim `ncmp ≤ n`) and cannot consume a full-length user
+  perm; guarded so `External` also skips the preprocess-`Auto` fill race.
+- **`Copy`-removal fallout** (mechanical clones): `AutoRace` race loop,
+  preprocess-`Auto` `run` closure, `Solver::factor` (2), the three numeric
+  constructors, `src/bin/bench.rs` (3 match sites), `examples/bench_qap15.rs`,
+  `python/src/*` (`ordering_to_str` now takes `&OrderingMethod` + `External`
+  arm), and ~9 `feral-diagnostics` bins that reused a `method` binding.
+- **Tests** (oracles external/hand): `tests/issue107_external_ordering.rs` — 6
+  green. Saddle-point KKT inertia (2,1,0) by the saddle inertia theorem
+  (Nocedal & Wright Lemma 16.1); SPD tridiag inertia (n,0,0); RHS `b = K·x_true`
+  so the solution is known; identity and reversed external orderings both solve
+  to the oracle with identical inertia (ordering changes fill, not the answer);
+  validation rejects the three malformed inputs. `src/symbolic` units pin the
+  bijection perm + forced `None` preprocess, the validation rejections, and the
+  compact Debug.
+- **Suite green:** feral **395 lib** + all integration tests pass;
+  `cargo test -p feral-diagnostics` green; `cargo clippy --all-targets -- -D
+  warnings` clean on both feral and `feral-diagnostics`; `cargo fmt --check`
+  clean. Default (non-External) path unchanged.
+
+## Benchmark Results
+```
+cargo run --bin bench --release (built-in fixtures; no data/ corpus present)
+  KKT dense: Inertia match 1/1 (100%), Residual pass 1/1, worst 1.14e-15
+  vs MUMPS:  Inertia match 2/2 (100%), Residual pass 2/2, worst 1.26e-16
+  8 matrices benchmarked; no failures (dense or sparse).
+```
+No performance change expected or observed: `External` is a new opt-in ordering
+source; the default `Auto` path is byte-exact.
+
+## Decisions Made
+- `OrderingMethod::External(Vec<usize>)` as an enum variant (not a side-channel
+  field), `Copy`→`Clone`, `External` forces `OrderingPreprocess::None`. Appended
+  to `dev/decisions.md` (2026-07-02).
+
+## Abandoned Approaches
+- None. (Considered but rejected in-note: keeping `Copy` via a unit `External`
+  variant + a side-channel `SupernodeParams` perm field — diverges from the
+  `ScalingStrategy::External` precedent the issue asks to mirror, and splits the
+  "how to order" decision across two knobs.)
+
+## Next Session Should
+- Optional: downstream `pounce`/`FeralConfig` plumbing to thread `External`
+  through the `Problem` API (the companion request in issue #107; out of scope
+  for the feral crate).
+- Optional: if the length-`n` `resolved_method` clone ever matters, replace the
+  faithful `External(perm)` record with a lighter marker (it duplicates
+  `sym.perm`; currently negligible beside `perm`/`node_factors` clones).

--- a/examples/bench_qap15.rs
+++ b/examples/bench_qap15.rs
@@ -54,7 +54,7 @@ fn symbolic_report(csc: &CscMatrix) {
                 },
             ),
         ] {
-            match symbolic_factorize_with_method(csc, &sn, method) {
+            match symbolic_factorize_with_method(csc, &sn, method.clone()) {
                 Ok(sym) => {
                     let simplicial = total_factor_nnz(&sym.col_counts);
                     println!(

--- a/python/src/common.rs
+++ b/python/src/common.rs
@@ -80,7 +80,9 @@ pub(crate) fn ordering_from_str(name: &str) -> PyResult<OrderingMethod> {
     }
 }
 
-pub(crate) fn ordering_to_str(m: OrderingMethod) -> &'static str {
+// Takes `&OrderingMethod` because the enum is no longer `Copy` (the
+// `External` variant carries a `Vec<usize>`, issue #107).
+pub(crate) fn ordering_to_str(m: &OrderingMethod) -> &'static str {
     match m {
         OrderingMethod::Amd => "amd",
         OrderingMethod::Amf => "amf",
@@ -89,6 +91,9 @@ pub(crate) fn ordering_to_str(m: OrderingMethod) -> &'static str {
         OrderingMethod::KahipND => "kahip",
         OrderingMethod::Auto => "auto",
         OrderingMethod::AutoRace => "auto_race",
+        // Programmatic-only ordering supplied via the Rust API; a Python
+        // string round-trip can only report it, not construct it.
+        OrderingMethod::External(_) => "external",
     }
 }
 

--- a/python/src/factors.rs
+++ b/python/src/factors.rs
@@ -54,7 +54,7 @@ impl Factors {
             perm_inv: f.perm_inv.clone(),
             scaling: f.scaling.clone(),
             needs_refinement: f.needs_refinement,
-            ordering: ordering_to_str(f.resolved_method),
+            ordering: ordering_to_str(&f.resolved_method),
             l_indptr: export.l_indptr,
             l_indices: export.l_indices,
             l_values: export.l_values,

--- a/python/src/solver.rs
+++ b/python/src/solver.rs
@@ -437,8 +437,8 @@ impl Solver {
     fn ordering(&self) -> Option<&'static str> {
         self.inner
             .symbolic()
-            .map(|s| s.resolved_method)
-            .or_else(|| self.inner.factors().map(|f| f.resolved_method))
+            .map(|s| &s.resolved_method)
+            .or_else(|| self.inner.factors().map(|f| &f.resolved_method))
             .map(ordering_to_str)
     }
 

--- a/python/src/symbolic.rs
+++ b/python/src/symbolic.rs
@@ -58,7 +58,7 @@ impl SymbolicAnalysis {
             peak_contrib_bytes: s.peak_contrib_bytes,
             col_counts: s.col_counts.clone(),
             etree_parent,
-            ordering: ordering_to_str(s.resolved_method),
+            ordering: ordering_to_str(&s.resolved_method),
         }
     }
 }

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1377,7 +1377,7 @@ fn scaling_strategy_from_str(s: &str) -> Option<ScalingStrategy> {
 fn main() {
     println!("FERAL benchmark harness");
     let ordering_override = ordering_method_from_env();
-    match ordering_override {
+    match &ordering_override {
         Some(m) => println!("  ordering: {:?} (forced via FERAL_ORDERING)", m),
         None => println!("  ordering: default (symbolic_factorize heuristic)"),
     }
@@ -1926,8 +1926,8 @@ fn main() {
         // the reported `factor_us` is apples-to-apples with the single
         // `factor_us` field MUMPS and SSIDS emit for their equivalent work.
         let tf = Instant::now();
-        let sym_result = match ordering_override {
-            Some(m) => symbolic_factorize_with_method(&csc, &snode_params, m),
+        let sym_result = match &ordering_override {
+            Some(m) => symbolic_factorize_with_method(&csc, &snode_params, m.clone()),
             None => symbolic_factorize(&csc, &snode_params),
         };
         let sym = match sym_result {
@@ -1983,8 +1983,8 @@ fn main() {
         let (sp_factor_us_final, sp_solve_us_final) = if should_resample(entry) {
             resample_or_fallback((sp_factor_us, sp_solve_us), || {
                 let tf = Instant::now();
-                let rs_sym = match ordering_override {
-                    Some(m) => symbolic_factorize_with_method(&csc, &snode_params, m),
+                let rs_sym = match &ordering_override {
+                    Some(m) => symbolic_factorize_with_method(&csc, &snode_params, m.clone()),
                     None => symbolic_factorize(&csc, &snode_params),
                 }?;
                 let (rs_factors, _) =

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -1892,7 +1892,7 @@ fn factorize_multifrontal_with_schur_inner(
         needs_refinement,
         scaling: scaling_user,
         scaling_info,
-        resolved_method: symbolic.resolved_method,
+        resolved_method: symbolic.resolved_method.clone(),
         resolved_amalgamation: symbolic.resolved_amalgamation,
         resolved_preprocess: symbolic.resolved_preprocess,
     };
@@ -2226,7 +2226,7 @@ pub fn factorize_multifrontal_supernodal_with_workspace(
             // at assembly time.
             scaling: scaling_user,
             scaling_info,
-            resolved_method: symbolic.resolved_method,
+            resolved_method: symbolic.resolved_method.clone(),
             resolved_amalgamation: symbolic.resolved_amalgamation,
             resolved_preprocess: symbolic.resolved_preprocess,
         },
@@ -3199,7 +3199,7 @@ pub fn factorize_multifrontal_supernodal_parallel(
             needs_refinement,
             scaling: scaling_user,
             scaling_info,
-            resolved_method: symbolic.resolved_method,
+            resolved_method: symbolic.resolved_method.clone(),
             resolved_amalgamation: symbolic.resolved_amalgamation,
             resolved_preprocess: symbolic.resolved_preprocess,
         },

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -923,9 +923,11 @@ impl Solver {
                 if escalated {
                     sp.preprocess = crate::symbolic::OrderingPreprocess::LdltCompress;
                 }
-                symbolic_factorize_with_method(matrix, &sp, self.ordering)
+                // `OrderingMethod` is no longer `Copy` (the `External`
+                // variant carries a `Vec`); clone the configured ordering.
+                symbolic_factorize_with_method(matrix, &sp, self.ordering.clone())
             } else {
-                symbolic_factorize_with_method(matrix, &self.snode_params, self.ordering)
+                symbolic_factorize_with_method(matrix, &self.snode_params, self.ordering.clone())
             };
             match result {
                 Ok(sym) => {

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -24,7 +24,11 @@ pub use supernode::{
 /// All methods produce a permutation; the downstream postorder
 /// composition, etree construction, column counts, supernode detection,
 /// and memory planning are identical regardless of method.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// Note: this enum is `Clone` but **not** `Copy` — the `External` variant
+/// carries a `Vec<usize>`. This mirrors [`crate::scaling::ScalingStrategy`],
+/// whose `External(Vec<f64>)` variant is likewise `Clone`-only. Callers that
+/// previously relied on implicit copies now `.clone()` explicitly.
+#[derive(Default, Clone, PartialEq, Eq)]
 pub enum OrderingMethod {
     /// Approximate Minimum Degree (`feral-amd` crate: approximate
     /// external degree with aggressive element absorption and
@@ -121,6 +125,88 @@ pub enum OrderingMethod {
     /// produces a valid symbolic factorization. `resolved_method` on
     /// the returned `SymbolicFactorization` records the actual winner.
     AutoRace,
+    /// Caller-supplied fill-reducing permutation (issue #107). The vector
+    /// is a **0-based, new-to-old permutation of `0..n`** — the same
+    /// convention FERAL returns in [`SymbolicFactorization::perm`]:
+    /// `perm[k]` is the original column that becomes column `k`. Length
+    /// must equal the matrix dimension.
+    ///
+    /// Use this to inject an ordering that a generic algorithm cannot see —
+    /// block-triangular / Schur KKT reuse (Parker, Garcia & Bent,
+    /// arXiv:2602.17968) or tearing orderings from equation-oriented
+    /// decomposition (Baharev et al., ACM JEA 26, 2021). The supplied
+    /// permutation replaces the internal AMD/METIS/etc. pass; the downstream
+    /// postorder composition, etree, column counts, and supernode detection
+    /// are identical to every other method, so a *valid but poor* ordering
+    /// only costs fill/time, never correctness.
+    ///
+    /// The permutation is validated as a bijection of `0..n` at the top of
+    /// [`symbolic_factorize_with_method`]; a wrong length, out-of-range
+    /// index, or duplicate returns [`FeralError::InvalidInput`] (never a
+    /// panic).
+    ///
+    /// **Programmatic-only** — the string option `feral_ordering` cannot
+    /// express a vector, exactly as with `ScalingStrategy::External`.
+    ///
+    /// **Forces [`OrderingPreprocess::None`].** The `LdltCompress`
+    /// preprocessor reorders an MC64-compressed super-graph of dimension
+    /// `ncmp ≤ n`, which cannot consume a full-length user permutation, so
+    /// `External` always runs the ordering directly on the full pattern
+    /// regardless of the requested (or default `Auto`) preprocess. Scaling
+    /// is unaffected — it is computed independently in the numeric phase.
+    External(Vec<usize>),
+}
+
+impl core::fmt::Debug for OrderingMethod {
+    /// Hand-written so the `External` arm prints compactly
+    /// (`External { len: N }`) instead of dumping the whole permutation into
+    /// diagnostic one-liners such as `NumericFactorization::summary`. The
+    /// unit variants match the names `#[derive(Debug)]` would produce.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OrderingMethod::Amd => f.write_str("Amd"),
+            OrderingMethod::Amf => f.write_str("Amf"),
+            OrderingMethod::MetisND => f.write_str("MetisND"),
+            OrderingMethod::ScotchND => f.write_str("ScotchND"),
+            OrderingMethod::KahipND => f.write_str("KahipND"),
+            OrderingMethod::Auto => f.write_str("Auto"),
+            OrderingMethod::AutoRace => f.write_str("AutoRace"),
+            OrderingMethod::External(perm) => {
+                write!(f, "External {{ len: {} }}", perm.len())
+            }
+        }
+    }
+}
+
+/// Validate that `perm` is a bijection of `0..n` (a valid permutation).
+/// Used by [`symbolic_factorize_with_method`] for
+/// [`OrderingMethod::External`]. Returns [`FeralError::InvalidInput`] on any
+/// violation — never panics.
+fn validate_external_perm(perm: &[usize], n: usize) -> Result<(), FeralError> {
+    if perm.len() != n {
+        return Err(FeralError::InvalidInput(format!(
+            "external ordering has length {} but matrix has n={}",
+            perm.len(),
+            n
+        )));
+    }
+    let mut seen = vec![false; n];
+    for &p in perm {
+        if p >= n {
+            return Err(FeralError::InvalidInput(format!(
+                "external ordering index {} out of range for n={}",
+                p, n
+            )));
+        }
+        if seen[p] {
+            return Err(FeralError::InvalidInput(format!(
+                "external ordering is not a permutation: index {} repeated",
+                p
+            )));
+        }
+        seen[p] = true;
+    }
+    Ok(())
 }
 
 /// Resolve an `Auto` ordering to a concrete method from cheap pattern
@@ -551,20 +637,35 @@ fn to_contract_pattern_bufs(pattern: &CscPattern) -> Result<(Vec<i32>, Vec<i32>)
 /// when `method == Auto` is resolved adaptively).
 fn run_external_ordering(
     pattern: &CscPattern,
-    method: OrderingMethod,
+    method: &OrderingMethod,
 ) -> Result<(Vec<usize>, OrderingMethod), FeralError> {
+    // Caller-supplied ordering (issue #107): no ordering-crate call. The
+    // permutation is validated as a bijection of `0..n` by
+    // `symbolic_factorize_with_method` before it reaches here; re-check the
+    // length defensively (it must match the pattern being ordered, which for
+    // `External` is always the full uncompressed pattern).
+    if let OrderingMethod::External(perm) = method {
+        if perm.len() != pattern.n {
+            return Err(FeralError::InvalidInput(format!(
+                "external ordering has length {} but pattern has n={}",
+                perm.len(),
+                pattern.n
+            )));
+        }
+        return Ok((perm.clone(), OrderingMethod::External(perm.clone())));
+    }
     let (col_buf, row_buf) = to_contract_pattern_bufs(pattern)?;
     let pat = feral_ordering_core::CscPattern::new(pattern.n, &col_buf, &row_buf)
         .ok_or_else(|| FeralError::InvalidInput("malformed CSC pattern".to_string()))?;
     // `method` is expected to be concrete here — `Auto` is resolved
     // upstream by `symbolic_factorize_with_method` against the
     // original matrix's pattern, before any preprocessing.
-    debug_assert_ne!(method, OrderingMethod::Auto);
+    debug_assert!(!matches!(method, OrderingMethod::Auto));
     // `actual` diverges from `method` only when ScotchND silently
     // falls back to amd_leaf for every recursion (issue #3): the
     // returned permutation is bit-identical to AMD's, so the
     // `resolved_method` field must report Amd, not ScotchND.
-    let mut actual = method;
+    let mut actual = method.clone();
     let perm_i32 = match method {
         OrderingMethod::Amd => feral_amd::amd_order(&pat),
         OrderingMethod::Amf => feral_amf::amf_order(&pat),
@@ -579,6 +680,9 @@ fn run_external_ordering(
             })
         }
         OrderingMethod::KahipND => feral_kahip::kahip_order(&pat),
+        OrderingMethod::External(_) => {
+            unreachable!("External is returned before this match")
+        }
         OrderingMethod::Auto => {
             unreachable!("Auto is resolved by symbolic_factorize_with_method")
         }
@@ -641,7 +745,7 @@ fn symbolic_factorize_race(
     // reflects exactly one ordering run.
     let mut best_prof: Option<SymbolicProfiler> = None;
     let mut last_err: Option<FeralError> = None;
-    for &cand in RACE_CANDIDATES {
+    for cand in RACE_CANDIDATES {
         let cand_prof = snode_params
             .symbolic_profiler
             .as_ref()
@@ -650,7 +754,10 @@ fn symbolic_factorize_race(
             symbolic_profiler: cand_prof.clone(),
             ..snode_params.clone()
         };
-        match symbolic_factorize_with_method(matrix, &cand_params, cand) {
+        // `cand: &OrderingMethod` — `OrderingMethod` is no longer `Copy`
+        // (the `External` variant carries a `Vec`); clone the concrete
+        // candidate (all `RACE_CANDIDATES` are payload-free unit variants).
+        match symbolic_factorize_with_method(matrix, &cand_params, cand.clone()) {
             Ok(sym) => {
                 let is_better = best
                     .as_ref()
@@ -722,7 +829,11 @@ fn symbolic_factorize_preprocess_auto(
             symbolic_profiler: cand_prof.clone(),
             ..snode_params.clone()
         };
-        let sym = symbolic_factorize_with_method(matrix, &cand_params, method)?;
+        // `method` is captured by this closure and used across up to two
+        // runs (None vs LdltCompress); `OrderingMethod` is no longer `Copy`,
+        // so clone. `External` never reaches here — it is guarded to
+        // `OrderingPreprocess::None` before the preprocess-`Auto` race.
+        let sym = symbolic_factorize_with_method(matrix, &cand_params, method.clone())?;
         let snap = cand_prof.and_then(|a| a.lock().ok().map(|g| g.clone()));
         Ok((sym, snap))
     };
@@ -799,6 +910,17 @@ pub fn symbolic_factorize_with_method(
     if method == OrderingMethod::AutoRace {
         return symbolic_factorize_race(matrix, snode_params);
     }
+    // Issue #107: a caller-supplied external ordering. Validate the
+    // permutation is a bijection of `0..n` up front (a wrong length /
+    // out-of-range / duplicate is `InvalidInput`, never a panic). `External`
+    // forces `OrderingPreprocess::None` (see the variant docs and the
+    // `resolved_preprocess` computation below), so it also bypasses the
+    // preprocess-`Auto` fill race — that race would reorder a compressed
+    // super-graph, which cannot consume a full-length user permutation.
+    let is_external = matches!(method, OrderingMethod::External(_));
+    if let OrderingMethod::External(perm) = &method {
+        validate_external_perm(perm, matrix.n)?;
+    }
     // `OrderingPreprocess::Auto` is resolved by *verifying* fill, not by
     // trusting the structural predicate alone. `pick_ordering_preprocess`
     // is a one-way proxy ("many low-degree columns ⇒ compression helps")
@@ -807,7 +929,7 @@ pub fn symbolic_factorize_with_method(
     // recommends `LdltCompress` exactly where MC64 compression *inflates*
     // fill (issue #91: qap15 conic KKT, 7.16M → 45.4M, 0.77s → 15.4s).
     // Race None vs LdltCompress on symbolic fill and keep the smaller.
-    if snode_params.preprocess == OrderingPreprocess::Auto {
+    if snode_params.preprocess == OrderingPreprocess::Auto && !is_external {
         return symbolic_factorize_preprocess_auto(matrix, snode_params, method);
     }
     let n = matrix.n;
@@ -856,9 +978,16 @@ pub fn symbolic_factorize_with_method(
     // dispatch. Keeps the match below exhaustive on the two concrete
     // variants and keeps the dispatcher logic in one testable place.
     let t_pick = prof.map(|_| std::time::Instant::now());
-    let resolved_preprocess = match snode_params.preprocess {
-        OrderingPreprocess::Auto => pick_ordering_preprocess(matrix),
-        other => other,
+    // Issue #107: `External` forces `None` — its full-length permutation
+    // cannot be applied to a compressed super-graph. Any other requested
+    // preprocess is honored; `Auto` resolves via the structural predicate.
+    let resolved_preprocess = if is_external {
+        OrderingPreprocess::None
+    } else {
+        match snode_params.preprocess {
+            OrderingPreprocess::Auto => pick_ordering_preprocess(matrix),
+            other => other,
+        }
     };
     if let Some(t) = t_pick {
         record_stage(prof, "pick_preprocess", t);
@@ -873,7 +1002,7 @@ pub fn symbolic_factorize_with_method(
     // `ordering` stage.
     let record_ordering = |pat: &CscPattern| -> Result<(Vec<usize>, OrderingMethod), FeralError> {
         let t_ord = prof.map(|_| std::time::Instant::now());
-        let r = run_external_ordering(pat, method)?;
+        let r = run_external_ordering(pat, &method)?;
         if let Some(t) = t_ord {
             record_stage(prof, "ordering", t);
         }
@@ -1914,6 +2043,55 @@ mod tests {
         for i in 0..25 {
             assert_eq!(sym.perm[sym.perm_inv[i]], i);
         }
+    }
+
+    #[test]
+    fn symbolic_factorize_external_produces_valid_perm() {
+        // Issue #107: a caller-supplied permutation must flow through the
+        // full pipeline (postorder composition, etree, column counts,
+        // supernodes) and yield a valid bijection perm, and must force
+        // `OrderingPreprocess::None` even though the default params request
+        // `Auto`.
+        let m = small_grid_5x5();
+        let params = SupernodeParams::default();
+        assert_eq!(params.preprocess, OrderingPreprocess::Auto);
+        // A non-identity valid permutation (reverse).
+        let rev: Vec<usize> = (0..25).rev().collect();
+        let sym =
+            symbolic_factorize_with_method(&m, &params, OrderingMethod::External(rev)).unwrap();
+        assert_eq!(sym.n, 25);
+        let mut sorted = sym.perm.clone();
+        sorted.sort();
+        assert_eq!(sorted, (0..25).collect::<Vec<_>>(), "perm is a bijection");
+        for i in 0..25 {
+            assert_eq!(sym.perm[sym.perm_inv[i]], i);
+        }
+        assert!(matches!(sym.resolved_method, OrderingMethod::External(_)));
+        assert_eq!(
+            sym.resolved_preprocess,
+            OrderingPreprocess::None,
+            "External must force preprocess None"
+        );
+    }
+
+    #[test]
+    fn external_perm_validation_rejects_bad_input() {
+        // Length mismatch, out-of-range, and duplicate are all InvalidInput.
+        assert!(validate_external_perm(&[0, 1], 3).is_err());
+        assert!(validate_external_perm(&[0, 1, 3], 3).is_err());
+        assert!(validate_external_perm(&[0, 1, 1], 3).is_err());
+        // A valid bijection passes.
+        assert!(validate_external_perm(&[2, 0, 1], 3).is_ok());
+        assert!(validate_external_perm(&[], 0).is_ok());
+    }
+
+    #[test]
+    fn ordering_method_external_debug_is_compact() {
+        // The hand-written Debug must not dump the whole permutation.
+        let m = OrderingMethod::External(vec![0; 1000]);
+        assert_eq!(format!("{:?}", m), "External { len: 1000 }");
+        // Unit variants still print their bare name.
+        assert_eq!(format!("{:?}", OrderingMethod::Amd), "Amd");
     }
 
     #[test]

--- a/tests/issue107_external_ordering.rs
+++ b/tests/issue107_external_ordering.rs
@@ -1,0 +1,241 @@
+//! Issue #107: `OrderingMethod::External(Vec<usize>)` lets a caller inject a
+//! precomputed fill-reducing permutation (block-triangular Schur reuse,
+//! tearing orderings) instead of selecting an internal ordering algorithm.
+//! This mirrors `ScalingStrategy::External(Vec<f64>)`.
+//!
+//! Oracles here are external to the solver:
+//!   - the saddle-point KKT `[[H, Aᵀ],[A, 0]]` with H SPD (n×n) and A (m×n)
+//!     full row rank has inertia `(n, m, 0)` by the standard saddle-point
+//!     inertia theorem (Nocedal & Wright, *Numerical Optimization*, Lemma
+//!     16.1 / Gould 1985) — a hand oracle, not the solver's own output;
+//!   - the right-hand sides are `b = K · x_true` for a chosen `x_true`, so
+//!     the recovered solution is known by construction;
+//!   - the tridiagonal `diag=2, offdiag=-1` matrix is SPD (irreducibly
+//!     diagonally dominant with positive diagonal), inertia `(n, 0, 0)`.
+//!
+//! A *valid but different* permutation must change fill/timing only, never
+//! the answer or the inertia — the property these tests pin.
+
+use feral::numeric::factorize::factorize_multifrontal;
+use feral::symbolic::{
+    symbolic_factorize_with_method, OrderingMethod, OrderingPreprocess, SupernodeParams,
+};
+use feral::{CscMatrix, FactorStatus, NumericParams, Solver};
+
+/// Saddle-point KKT `[[I₂, Aᵀ],[A, 0]]` with `A = [1, 1]` (m=1), stored as
+/// lower triangle CSC:
+///
+/// ```text
+///   [ 1  0  1 ]
+///   [ 0  1  1 ]
+///   [ 1  1  0 ]
+/// ```
+///
+/// H = I₂ is SPD, A = [1,1] has full row rank, so the saddle-point inertia
+/// theorem gives inertia `(2, 1, 0)`.
+fn saddle_kkt_3x3() -> CscMatrix {
+    // lower triangle (row >= col): (0,0)=1, (1,1)=1, (2,0)=1, (2,1)=1, (2,2)=0
+    // The (2,2) zero pivot is the saddle block; store it explicitly so the
+    // pattern includes the diagonal.
+    let rows = vec![0usize, 2, 1, 2, 2];
+    let cols = vec![0usize, 0, 1, 1, 2];
+    let vals = vec![1.0, 1.0, 1.0, 1.0, 0.0];
+    CscMatrix::from_triplets(3, &rows, &cols, &vals).unwrap()
+}
+
+/// Tridiagonal SPD of order `n` (`diag=2, offdiag=-1`), lower triangle CSC.
+/// Inertia `(n, 0, 0)`.
+fn tridiag_spd(n: usize) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..n {
+        rows.push(j);
+        cols.push(j);
+        vals.push(2.0);
+        if j + 1 < n {
+            rows.push(j + 1);
+            cols.push(j);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap()
+}
+
+/// `b = K · x` for the symmetric matrix `K` given as its full (symmetrized)
+/// dense action; here we hardcode the small saddle case.
+fn saddle_matvec(x: &[f64]) -> Vec<f64> {
+    // K = [[1,0,1],[0,1,1],[1,1,0]]
+    vec![x[0] + x[2], x[1] + x[2], x[0] + x[1]]
+}
+
+#[test]
+fn external_identity_ordering_solves_and_reports_inertia() {
+    let csc = saddle_kkt_3x3();
+    let params = SupernodeParams::default();
+
+    let perm = vec![0usize, 1, 2]; // identity
+    let sym =
+        symbolic_factorize_with_method(&csc, &params, OrderingMethod::External(perm)).unwrap();
+
+    // The supplied permutation IS the fill-reducing ordering; it is never
+    // routed through the compression preprocessor.
+    assert_eq!(sym.resolved_preprocess, OrderingPreprocess::None);
+    assert!(
+        matches!(sym.resolved_method, OrderingMethod::External(ref p) if p == &[0, 1, 2]),
+        "resolved_method should faithfully report External, got {:?}",
+        sym.resolved_method
+    );
+    // perm is a bijection of 0..3.
+    let mut sorted = sym.perm.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1, 2]);
+
+    let np = NumericParams::default();
+    let (_factors, inertia) = factorize_multifrontal(&csc, &sym, &np).unwrap();
+    // Saddle-point inertia theorem: (n_H, m_A, 0) = (2, 1, 0).
+    assert_eq!(
+        (inertia.positive, inertia.negative, inertia.zero),
+        (2, 1, 0)
+    );
+}
+
+#[test]
+fn external_nontrivial_ordering_gives_same_answer() {
+    // A valid but non-identity permutation must not change the inertia or the
+    // solution — only the fill. Compare identity vs a reversed ordering.
+    let csc = saddle_kkt_3x3();
+
+    let x_true = vec![1.0f64, -2.0, 3.0];
+    let b = saddle_matvec(&x_true);
+
+    let solve_with = |perm: Vec<usize>| -> (feral::Inertia, Vec<f64>) {
+        let mut solver = Solver::new().with_ordering(OrderingMethod::External(perm));
+        assert!(matches!(solver.factor(&csc, None), FactorStatus::Success));
+        let inertia = solver
+            .inertia()
+            .expect("inertia after successful factor")
+            .clone();
+        let x = solver.solve(&b).expect("solve after successful factor");
+        (inertia, x)
+    };
+
+    let (in_id, x_id) = solve_with(vec![0, 1, 2]);
+    let (in_rev, x_rev) = solve_with(vec![2, 1, 0]);
+
+    assert_eq!(
+        (in_id.positive, in_id.negative, in_id.zero),
+        (2, 1, 0),
+        "identity-ordering inertia"
+    );
+    assert_eq!(
+        (in_rev.positive, in_rev.negative, in_rev.zero),
+        (2, 1, 0),
+        "reversed-ordering inertia must match — ordering never changes inertia"
+    );
+    for i in 0..3 {
+        assert!(
+            (x_id[i] - x_true[i]).abs() < 1e-10,
+            "identity solve wrong at {i}: {} vs {}",
+            x_id[i],
+            x_true[i]
+        );
+        assert!(
+            (x_rev[i] - x_true[i]).abs() < 1e-10,
+            "reversed-ordering solve wrong at {i}: {} vs {}",
+            x_rev[i],
+            x_true[i]
+        );
+    }
+}
+
+#[test]
+fn external_ordering_matches_default_on_spd() {
+    // End-to-end parity: an External identity ordering must solve the SPD
+    // tridiagonal system as accurately as the default (Auto) ordering, and
+    // report the same inertia (n, 0, 0).
+    let n = 60;
+    let csc = tridiag_spd(n);
+
+    let x_true = vec![1.0; n];
+    let mut b = vec![0.0; n];
+    for j in 0..n {
+        b[j] += 2.0 * x_true[j];
+        if j + 1 < n {
+            b[j + 1] -= x_true[j];
+            b[j] -= x_true[j + 1];
+        }
+    }
+
+    let mut solver_default = Solver::new();
+    // A hand-built valid permutation (reverse) — exercises postorder on a
+    // non-identity external ordering.
+    let rev: Vec<usize> = (0..n).rev().collect();
+    let mut solver_ext = Solver::new().with_ordering(OrderingMethod::External(rev));
+
+    assert!(matches!(
+        solver_default.factor(&csc, None),
+        FactorStatus::Success
+    ));
+    assert!(matches!(
+        solver_ext.factor(&csc, None),
+        FactorStatus::Success
+    ));
+
+    assert_eq!(
+        solver_default.inertia().unwrap(),
+        solver_ext.inertia().unwrap(),
+        "SPD inertia must be (n,0,0) under any valid ordering"
+    );
+    let inertia = solver_ext.inertia().unwrap();
+    assert_eq!(
+        (inertia.positive, inertia.negative, inertia.zero),
+        (n, 0, 0)
+    );
+
+    let x_default = solver_default.solve(&b).unwrap();
+    let x_ext = solver_ext.solve(&b).unwrap();
+    for i in 0..n {
+        assert!(
+            (x_ext[i] - 1.0).abs() < 1e-10,
+            "external-ordering solve diverged at i={i}: {}",
+            x_ext[i]
+        );
+        // Both feral paths should agree closely on an SPD system.
+        assert!(
+            (x_ext[i] - x_default[i]).abs() < 1e-9,
+            "external vs default mismatch at i={i}: {} vs {}",
+            x_ext[i],
+            x_default[i]
+        );
+    }
+}
+
+#[test]
+fn external_ordering_rejects_wrong_length() {
+    let csc = saddle_kkt_3x3();
+    let params = SupernodeParams::default();
+    // length 2 != n=3
+    let err = symbolic_factorize_with_method(&csc, &params, OrderingMethod::External(vec![0, 1]));
+    assert!(err.is_err(), "wrong-length permutation must be rejected");
+}
+
+#[test]
+fn external_ordering_rejects_out_of_range_index() {
+    let csc = saddle_kkt_3x3();
+    let params = SupernodeParams::default();
+    // 3 is out of range for n=3 (valid indices 0..=2)
+    let err =
+        symbolic_factorize_with_method(&csc, &params, OrderingMethod::External(vec![0, 1, 3]));
+    assert!(err.is_err(), "out-of-range index must be rejected");
+}
+
+#[test]
+fn external_ordering_rejects_duplicate_index() {
+    let csc = saddle_kkt_3x3();
+    let params = SupernodeParams::default();
+    // 1 repeated, 2 missing — not a bijection
+    let err =
+        symbolic_factorize_with_method(&csc, &params, OrderingMethod::External(vec![0, 1, 1]));
+    assert!(err.is_err(), "non-bijective permutation must be rejected");
+}


### PR DESCRIPTION
## Summary

Implement `OrderingMethod::External(Vec<usize>)` to allow callers to inject precomputed fill-reducing permutations into symbolic factorization, mirroring the existing `ScalingStrategy::External(Vec<f64>)`. This enables use of problem-specific orderings (block-triangular Schur KKT reuse, tearing orderings from equation-oriented decomposition) instead of only selecting an ordering algorithm.

## Key Changes

- **New enum variant**: `OrderingMethod::External(Vec<usize>)` carries a 0-based new-to-old permutation of `0..n` (same convention as `SymbolicFactorization::perm`). Injected at the single `run_external_ordering` point; the rest of the pipeline (postorder → etree → column counts → supernodes) is byte-identical to any other method.

- **`Copy` → `Clone`**: `OrderingMethod` drops `Copy` (a `Vec` field is not `Copy`) but keeps `Clone`, matching `ScalingStrategy`. Hand-written `Debug` prints `External { len: N }` so diagnostic one-liners don't dump the full permutation.

- **Validation up front**: `validate_external_perm` checks that the supplied permutation is a bijection of `0..n` (correct length, no out-of-range indices, no duplicates). Invalid input returns `FeralError::InvalidInput`, never a panic.

- **`External` forces `OrderingPreprocess::None`**: `LdltCompress` reorders a compressed super-graph (dimension `ncmp ≤ n`) and cannot consume a full-length user permutation. `External` bypasses the preprocess-`Auto` fill race and pins `resolved_preprocess = None`.

- **Mechanical fallout from `Copy` removal**: `.clone()` calls added to `AutoRace` race loop, preprocess-`Auto` `run` closure, `Solver::factor` (2 sites), three numeric constructors, `src/bin/bench.rs` (3 match sites), `examples/bench_qap15.rs`, `python/src/*` (`ordering_to_str` now takes `&OrderingMethod` + `External` arm), and ~9 `feral-diagnostics` bins that reused a `method` binding.

## Tests

New test file `tests/issue107_external_ordering.rs` with 6 tests:
- Identity and non-trivial (reversed) external orderings both solve to oracle with identical inertia (2,1,0) on saddle-point KKT
- External ordering matches default on SPD tridiagonal (inertia n,0,0)
- Validation rejects wrong length, out-of-range index, and duplicate indices
- `resolved_method` faithfully reports `External` and `resolved_preprocess` is forced to `None`

## Evidence

- **Suite**: feral 395 lib tests + all integration tests pass; `cargo test -p feral-diagnostics` green; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- **Benchmark** (built-in fixtures): KKT dense inertia match 1/1 (100%), residual pass 1/1 (worst 1.14e-15); vs MUMPS inertia match 2/2 (100%), residual pass 2/2 (worst 1.26e-16); 8 matrices, no failures
- **Default path unchanged**: non-`External` orderings are byte-exact to prior behavior

https://claude.ai/code/session_01K2MWBuQNrxxU3JmbnyF27n