### PR TITLE
release: feral v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-02
+
 ### Added — user-supplied fill-reducing ordering: `OrderingMethod::External` (issue #107)
 
 `OrderingMethod` gains an `External(Vec<usize>)` variant so callers can inject a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/examples/notebooks/01_basic_factor_solve.ipynb
+++ b/python/examples/notebooks/01_basic_factor_solve.ipynb
@@ -16,10 +16,10 @@
    "id": "270ce56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.757073Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.757008Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.791420Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.790895Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.508896Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.508693Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.558568Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.558143Z"
     }
    },
    "outputs": [
@@ -27,7 +27,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feral 0.12.0\n"
+      "feral 0.13.0\n"
      ]
     }
    ],
@@ -54,10 +54,10 @@
    "id": "63028ad5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.792870Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.792759Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.795624Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.795221Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.559986Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.559876Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.562763Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.562405Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "d28ab23a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.796913Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.796851Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.800935Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.800616Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.563990Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.563924Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.567947Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.567590Z"
     }
    },
    "outputs": [
@@ -141,10 +141,10 @@
    "id": "7a65ecf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.801970Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.801918Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.803938Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.803574Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.568943Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.568886Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.570563Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.570288Z"
     }
    },
    "outputs": [
@@ -182,10 +182,10 @@
    "id": "e8622af1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.805184Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.805122Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.806955Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.806628Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.571476Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.571410Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.572998Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.572640Z"
     }
    },
    "outputs": [
@@ -219,10 +219,10 @@
    "id": "e35c9097",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:34.808056Z",
-     "iopub.status.busy": "2026-07-01T17:11:34.807964Z",
-     "iopub.status.idle": "2026-07-01T17:11:34.810035Z",
-     "shell.execute_reply": "2026-07-01T17:11:34.809739Z"
+     "iopub.execute_input": "2026-07-02T12:04:36.573994Z",
+     "iopub.status.busy": "2026-07-02T12:04:36.573930Z",
+     "iopub.status.idle": "2026-07-02T12:04:36.575766Z",
+     "shell.execute_reply": "2026-07-02T12:04:36.575525Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/02_multi_rhs_batched.ipynb
+++ b/python/examples/notebooks/02_multi_rhs_batched.ipynb
@@ -25,10 +25,10 @@
    "id": "f9d1eb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.283318Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.283259Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.389242Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.388698Z"
+     "iopub.execute_input": "2026-07-02T12:04:38.892907Z",
+     "iopub.status.busy": "2026-07-02T12:04:38.892423Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.019053Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.018639Z"
     }
    },
    "outputs": [],
@@ -59,10 +59,10 @@
    "id": "0bb21c5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.390973Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.390858Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.394875Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.394381Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.020575Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.020476Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.024243Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.023853Z"
     }
    },
    "outputs": [
@@ -104,10 +104,10 @@
    "id": "3970ca77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.396036Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.395974Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.400446Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.400008Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.025494Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.025417Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.029476Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.029087Z"
     }
    },
    "outputs": [
@@ -145,10 +145,10 @@
    "id": "d1ba172b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.401573Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.401512Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.407506Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.407197Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.030787Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.030714Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.035774Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.035430Z"
     }
    },
    "outputs": [
@@ -191,10 +191,10 @@
    "id": "1e6f555d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.408869Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.408815Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.416321Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.415974Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.036754Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.036690Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.044009Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.043728Z"
     }
    },
    "outputs": [
@@ -235,10 +235,10 @@
    "id": "66e9c41e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.417769Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.417675Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.721498Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.721057Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.045105Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.045034Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.313989Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.313448Z"
     }
    },
    "outputs": [
@@ -283,10 +283,10 @@
    "id": "623c8936",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.722839Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.722735Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.820054Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.819673Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.315577Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.315443Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.403444Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.403167Z"
     }
    },
    "outputs": [
@@ -295,8 +295,8 @@
      "output_type": "stream",
      "text": [
       " nrhs        looped       batched   speedup\n",
-      "   64      64.76 us      17.57 us    3.69x\n",
-      "  256      64.92 us      20.58 us    3.16x\n"
+      "   64      57.41 us      15.91 us    3.61x\n",
+      "  256      58.89 us      20.52 us    2.87x\n"
      ]
     }
    ],
@@ -354,10 +354,10 @@
    "id": "82f406d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.821718Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.821639Z",
-     "iopub.status.idle": "2026-07-01T17:11:37.832283Z",
-     "shell.execute_reply": "2026-07-01T17:11:37.831980Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.404795Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.404717Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.415376Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.414842Z"
     }
    },
    "outputs": [
@@ -398,10 +398,10 @@
    "id": "6c1b5120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:37.833779Z",
-     "iopub.status.busy": "2026-07-01T17:11:37.833688Z",
-     "iopub.status.idle": "2026-07-01T17:11:38.109764Z",
-     "shell.execute_reply": "2026-07-01T17:11:38.109431Z"
+     "iopub.execute_input": "2026-07-02T12:04:39.416746Z",
+     "iopub.status.busy": "2026-07-02T12:04:39.416675Z",
+     "iopub.status.idle": "2026-07-02T12:04:39.676393Z",
+     "shell.execute_reply": "2026-07-02T12:04:39.676037Z"
     }
    },
    "outputs": [
@@ -410,14 +410,14 @@
      "output_type": "stream",
      "text": [
       " nrhs     loop refined    batch refined   speedup\n",
-      "   64        170.58 us         86.95 us    1.96x\n"
+      "   64        173.62 us         86.94 us    2.00x\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  256        187.80 us         82.07 us    2.29x\n"
+      "  256        173.81 us         79.64 us    2.18x\n"
      ]
     }
    ],

--- a/python/examples/notebooks/03_kkt_saddle_inertia.ipynb
+++ b/python/examples/notebooks/03_kkt_saddle_inertia.ipynb
@@ -20,10 +20,10 @@
    "id": "b7b52a48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.667269Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.667167Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.775202Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.774378Z"
+     "iopub.execute_input": "2026-07-02T12:04:41.994780Z",
+     "iopub.status.busy": "2026-07-02T12:04:41.994677Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.074658Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.074257Z"
     }
    },
    "outputs": [],
@@ -49,10 +49,10 @@
    "id": "e60b30ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.776974Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.776811Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.780033Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.779473Z"
+     "iopub.execute_input": "2026-07-02T12:04:42.076069Z",
+     "iopub.status.busy": "2026-07-02T12:04:42.075979Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.078134Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.077880Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "d366d85e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.781330Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.781263Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.784264Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.783767Z"
+     "iopub.execute_input": "2026-07-02T12:04:42.079334Z",
+     "iopub.status.busy": "2026-07-02T12:04:42.079275Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.081754Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.081383Z"
     }
    },
    "outputs": [
@@ -138,10 +138,10 @@
    "id": "d76cca73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.785400Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.785320Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.787644Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.787150Z"
+     "iopub.execute_input": "2026-07-02T12:04:42.082933Z",
+     "iopub.status.busy": "2026-07-02T12:04:42.082862Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.084701Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.084434Z"
     }
    },
    "outputs": [
@@ -176,10 +176,10 @@
    "id": "d6e873c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.788833Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.788762Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.791064Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.790482Z"
+     "iopub.execute_input": "2026-07-02T12:04:42.085751Z",
+     "iopub.status.busy": "2026-07-02T12:04:42.085694Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.087295Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.087014Z"
     }
    },
    "outputs": [
@@ -215,10 +215,10 @@
    "id": "f195548b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:40.792207Z",
-     "iopub.status.busy": "2026-07-01T17:11:40.792066Z",
-     "iopub.status.idle": "2026-07-01T17:11:40.794359Z",
-     "shell.execute_reply": "2026-07-01T17:11:40.793902Z"
+     "iopub.execute_input": "2026-07-02T12:04:42.088238Z",
+     "iopub.status.busy": "2026-07-02T12:04:42.088179Z",
+     "iopub.status.idle": "2026-07-02T12:04:42.089968Z",
+     "shell.execute_reply": "2026-07-02T12:04:42.089634Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/04_scipy_numpy_interop.ipynb
+++ b/python/examples/notebooks/04_scipy_numpy_interop.ipynb
@@ -16,10 +16,10 @@
    "id": "4b506150",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.307241Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.307159Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.438347Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.437883Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.150622Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.150535Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.269446Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.269037Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "id": "0354d27d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.440138Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.439972Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.456189Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.455812Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.270918Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.270817Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.273886Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.273548Z"
     }
    },
    "outputs": [
@@ -96,10 +96,10 @@
    "id": "cba4c504",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.457557Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.457475Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.459887Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.459452Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.274913Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.274860Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.276768Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.276426Z"
     }
    },
    "outputs": [
@@ -130,10 +130,10 @@
    "id": "691ea839",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.461314Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.461206Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.463916Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.463451Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.277798Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.277740Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.280081Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.279736Z"
     }
    },
    "outputs": [
@@ -170,10 +170,10 @@
    "id": "6a749326",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.465107Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.465033Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.467567Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.467275Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.281037Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.280976Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.283183Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.282838Z"
     }
    },
    "outputs": [
@@ -209,10 +209,10 @@
    "id": "18a4b721",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:43.468851Z",
-     "iopub.status.busy": "2026-07-01T17:11:43.468784Z",
-     "iopub.status.idle": "2026-07-01T17:11:43.471202Z",
-     "shell.execute_reply": "2026-07-01T17:11:43.470836Z"
+     "iopub.execute_input": "2026-07-02T12:04:44.284237Z",
+     "iopub.status.busy": "2026-07-02T12:04:44.284178Z",
+     "iopub.status.idle": "2026-07-02T12:04:44.286410Z",
+     "shell.execute_reply": "2026-07-02T12:04:44.286101Z"
     }
    },
    "outputs": [

--- a/python/examples/notebooks/05_lu_and_introspection.ipynb
+++ b/python/examples/notebooks/05_lu_and_introspection.ipynb
@@ -22,10 +22,10 @@
    "id": "489e8170",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.924830Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.924687Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.953333Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.952756Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.572481Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.572257Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.611398Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.610925Z"
     }
    },
    "outputs": [
@@ -33,7 +33,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feral 0.12.0\n"
+      "feral 0.13.0\n"
      ]
     }
    ],
@@ -60,10 +60,10 @@
    "id": "dbc3a512",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.954845Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.954655Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.957696Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.957298Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.613121Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.612980Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.616094Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.615669Z"
     }
    },
    "outputs": [
@@ -109,10 +109,10 @@
    "id": "7dc29790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.958996Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.958913Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.961474Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.961082Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.617426Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.617353Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.619666Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.619244Z"
     }
    },
    "outputs": [
@@ -156,10 +156,10 @@
    "id": "77052fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.962631Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.962570Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.964432Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.964030Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.620786Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.620706Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.622325Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.622042Z"
     }
    },
    "outputs": [
@@ -200,10 +200,10 @@
    "id": "d1a3c98f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.965499Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.965422Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.967839Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.967545Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.623508Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.623447Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.625687Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.625328Z"
     }
    },
    "outputs": [
@@ -238,10 +238,10 @@
    "id": "fddf8140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.968980Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.968928Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.972050Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.971741Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.626658Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.626600Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.629130Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.628812Z"
     }
    },
    "outputs": [
@@ -294,10 +294,10 @@
    "id": "ce141edc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.973235Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.973138Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.983159Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.982883Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.630186Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.630128Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.638571Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.638208Z"
     }
    },
    "outputs": [
@@ -345,10 +345,10 @@
    "id": "be37da55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.984372Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.984292Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.987443Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.987206Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.639828Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.639748Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.642562Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.642257Z"
     }
    },
    "outputs": [
@@ -381,10 +381,10 @@
    "id": "365fdf14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T17:11:45.988710Z",
-     "iopub.status.busy": "2026-07-01T17:11:45.988652Z",
-     "iopub.status.idle": "2026-07-01T17:11:45.991244Z",
-     "shell.execute_reply": "2026-07-01T17:11:45.990821Z"
+     "iopub.execute_input": "2026-07-02T12:04:46.643554Z",
+     "iopub.status.busy": "2026-07-02T12:04:46.643499Z",
+     "iopub.status.idle": "2026-07-02T12:04:46.645679Z",
+     "shell.execute_reply": "2026-07-02T12:04:46.645305Z"
     }
    },
    "outputs": [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.12.0"
+version = "0.13.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts the **v0.13.0** release.

## What
- Bump all six version strings (root `Cargo.toml`/lock, `python/Cargo.toml`/`pyproject.toml`/lock) `0.12.0` → `0.13.0` via `scripts/release-checklist.sh bump 0.13.0`.
- Cut `CHANGELOG.md` `## [0.13.0] - 2026-07-02` from `[Unreleased]`.
- Re-execute all five example notebooks against the 0.13.0 build (version output `0.12.0` → `0.13.0`).

## Why
Ship the user-supplied fill-reducing ordering work landed since v0.12.0:
- **#107** — `OrderingMethod::External(Vec<usize>)` lets callers inject a precomputed new-to-old fill-reducing permutation (block-triangular / Schur KKT reuse, tearing orderings) instead of only selecting an ordering *algorithm*. Validated as a bijection up front (bad input → `FeralError::InvalidInput`, never a panic) and forced onto `OrderingPreprocess::None`. Additive public API; `OrderingMethod` is now `Clone` but no longer `Copy` (pre-1.0, minor bump).

## Evidence
- `scripts/release-checklist.sh check`: all six strings agree on 0.13.0; no ordering crate stale (all unchanged since v0.12.0 at v0.2.1); CHANGELOG has a `[0.13.0]` section.
- Root `cargo test --release` green (all binaries 0 failed).
- `maturin build --release` → `feral_solver-0.13.0` (abi3); five notebooks re-execute clean (0 error outputs) reporting feral 0.13.0.

## After merge (irreversible publish)
Tag `v0.13.0` on `main` + publish the GitHub release → fires `release.yml` (7 crates to crates.io, permanent) and `python-wheels.yml` (PyPI, non-re-uploadable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
