### PR TITLE
issue #112: compensated FT sweep + opt-in Bartels-Golub pivot search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — sparse LU update: exact-zero bump pivots on nonsingular bases (issue #112)
+
+The Forrest–Tomlin column-replacement update could fail with
+`RefactorCause::TinyPivot` at magnitude exactly `0.0` on provably nonsingular
+bases — plain summation in the bump elimination absorbed the true pivot's
+bits once an intermediate grew past `|true pivot|/ε`, forcing a full
+refactorization per pivot on dense-bump problems. The working-row scatter is
+now a Neumaier-compensated sum, so the true diagonal survives and such
+updates commit. Committed values can differ from previous releases only in
+situations where the old sum had already lost low-order bits.
+
+### Added — opt-in Bartels–Golub pivot search for the sparse LU update (issue #112)
+
+`LuParams::update_pivot_search` (default `false`; also a `LuFactor` keyword
+in the Python bindings) runs the bump elimination with Bartels–Golub row
+interchanges: every multiplier is bounded by 1, keeping element growth
+bounded across long update chains. New `SparseLu::pivot_search_swaps()`
+exposes how often the interchanges deviated from the plain FT order.
+
 ## [0.13.0] - 2026-07-02
 
 ### Added — user-supplied fill-reducing ordering: `OrderingMethod::External` (issue #107)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-02T12:19:04Z
+Generated: 2026-07-10T02:36:06Z
 
 ## Latest Session
 File: dev/sessions/2026-07-02-02.md
@@ -58,34 +58,34 @@ All exit-partition buckets PASS, unchanged from the prior session.
 
 ## Git Status
 ```
+9596472 docs: session checkpoint 2026-07-02-02 (v0.13.0 release)
 36da100 release: feral v0.13.0 (#109)
 9d05f75 issue #107: add OrderingMethod::External for user-supplied orderings (#108)
 a1dd7b5 release: feral v0.12.0 (#106)
 1165d4d issue #102 follow-up: escalate ordering to LdltCompress on pivot growth (#105)
-d6fe546 issue #102: fix parallel dense-front re-entrant deadlock (0% CPU stall) (#104)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 397 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.50s
+test result: ok. 395 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
 
 ```
 
@@ -224,8 +224,8 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -238,14 +238,6 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -255,6 +247,14 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
@@ -278,8 +278,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,68 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T02:36:06Z
+Generated: 2026-07-10T03:55:16Z
 
 ## Latest Session
-File: dev/sessions/2026-07-02-02.md
+File: dev/sessions/2026-07-10-01.md
 ```
-# Session 2026-07-02-02
+# Session 2026-07-10-01
 
 ## Goal
-Cut and publish the **v0.13.0** release, shipping issue #107
-(`OrderingMethod::External`) landed since v0.12.0.
+Issue #112: the sparse LU Forrest–Tomlin update fails with
+`RefactorCause::TinyPivot` at magnitude exactly `0.0` on provably nonsingular,
+well-conditioned bases (100% of FT failures in discopt's refactor storms).
+Requested: a pivot-searching (Bartels–Golub/Suhl–Suhl) update variant.
 
 ## Accomplished
-- Bumped all six version strings `0.12.0` → `0.13.0` via
-  `scripts/release-checklist.sh bump 0.13.0` (root `Cargo.toml`/lock,
-  `python/Cargo.toml`/`pyproject.toml`/lock). `check` reports all six agree on
-  0.13.0; no ordering crate stale (all unchanged since v0.12.0 at v0.2.1).
-- Cut `CHANGELOG.md` `## [0.13.0] - 2026-07-02` from `[Unreleased]` (contents:
-  #107 `OrderingMethod::External`).
-- Re-executed all five example notebooks against the 0.13.0 wheel
-  (`maturin build --release` → `feral_solver-0.13.0` abi3): 0 error outputs,
-  version output `feral 0.12.0` → `feral 0.13.0`.
-- Root `cargo test --release` green (all binaries 0 failed).
-- PR #109 opened, all CI green (check, stress-smoke, linux wheel tests
-  py3.10/3.12/3.13), squash-merged to main as `36da100`.
-- Tagged `v0.13.0`, published the GitHub release. `release.yml` (crates.io)
-  and `python-wheels.yml` (PyPI) both completed **success**.
-- Verified live: crates.io `feral` = **0.13.0**; PyPI `feral-solver` = **0.13.0**.
+- Research note `dev/research/issue-112-bg-update.md` + plan
+  `dev/plans/issue-112-bg-update.md` (branch `claude/issue-112-0885lr`).
+- **Disproof of the requested rescue design** (implemented first, then
+  removed on proof): any within-bump row-interchange order's working row is
+  exactly proportional to the fixed order's (`W'_k = λ_k·W_k`, λ resets to
+  `−piv/vrc` per swap), so the true final pivot is `λ·t_FT` (determinant
+  identity), skip patterns coincide, and FP absorption is scale-invariant —
+  a pivot the fixed order computed as exactly 0.0 by summation absorption is
+  unrecoverable by ANY pivot re-ordering. Verified numerically (float +
+  exact-Fraction sweep replays; on the regression basis the swap path's
+  final diag is `1.39e-17 = λ·2⁻³⁵`, correctly sub-ztol).
+- **Shipped the actual fix: Neumaier-compensated accumulation** in the bump
+  elimination's working-row scatter (always on; pooled `ft_rw_comp`;
+  branch-free two-sum). On the hand-traced m=4 regression basis the plain
+  sweep commits `0.0` exactly, the compensated sweep commits the true
+  diagonal `2⁻³⁵` **bit-for-bit** (oracle: hand calculation verified offline
+  in exact rational arithmetic; scipy's fresh LU sees only ε-noise). Classic
+  Kahan verified insufficient (its `y = v − c` re-absorbs the compensation).
+- **Shipped the pivot search as an opt-in always-on variant**:
+  `LuParams::update_pivot_search` (default `false`), Bartels–Golub
+  interchanges as physical row-content swaps (`FtOp::Swap` etas — symmetric
+  `uperm` invariant, diagonal-first storage, and prior etas untouched;
+  forward/transpose/spike replays; wholesale `u_above` rebuild and
+  swapped-row rollback snapshots on that path; `pivot_search_swaps()`
+  telemetry). Python bindings expose the keyword.
+- Tests: `tests/issue112_bg_update.rs` (5 tests) — bit-exact recovered
+  diagonal, backward-stable ftran/btran residuals (2.9e-11 vs bound
+  3.7e-10), genuine-singular rejection + clean rollback in both modes,
+  swap-mode factor validity incl. chained updates replaying Swap etas,
+  default path never swaps. Full suite green (395 lib + all integration),
+  clippy `--all-targets -D warnings` clean, fmt clean.
+- Test-design finding (documented): any single-shot absorption reproducer
+  has `σ_min(B') ⪅ δ·∏(retained diags)` — numerically singular to a
+  from-scratch factorization — so the issue's "residual ≤ refactor's"
+  acceptance can only be validated on discopt's captured corpus (whose
+  imbalance lives in chain-built factorization state, not in B').
 
 ## Benchmark Results
-No solver code changed this session (release-only: version strings, CHANGELOG,
-re-executed notebooks), so numbers are unchanged from 2026-07-02-01. End-of-session
-run for the record:
 ```
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.71     <= 2.0     PASS
-medium (<500)            152145     2.09     <= 3.0     PASS
-
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.52     <= 2.0     PASS
-medium (<500)            153560     1.52     <= 3.0     PASS
-```
-All exit-partition buckets PASS, unchanged from the prior session.
-
-## Decisions Made
-- None (release-only session).
-
-## Abandoned Approaches
-- None.
-
-## Next Session Should
-- Return to the open engineering backlog (LU / ordering / dense-kernel follow-ups);
-  no release-blocking items outstanding.
+(this container has no oracle-timed corpus; the bench harness ran its
+in-tree matrices only — correctness gates, no perf partition)
 ```
 
 ## Git Status
 ```
+82a81bd issue #112: compensated FT sweep + opt-in Bartels-Golub pivot search
+5794f0e issue #112: research note + plan for Bartels-Golub pivot-searching update
 9596472 docs: session checkpoint 2026-07-02-02 (v0.13.0 release)
 36da100 release: feral v0.13.0 (#109)
 9d05f75 issue #107: add OrderingMethod::External for user-supplied orderings (#108)
-a1dd7b5 release: feral v0.12.0 (#106)
-1165d4d issue #102 follow-up: escalate ordering to LdltCompress on pivot growth (#105)
 ```
 
 ## Test Status
@@ -85,83 +86,80 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 395 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
+test result: ok. 395 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.89s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-02-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-10-01.md)
 
-No solver code changed this session (release-only: version strings, CHANGELOG,
-re-executed notebooks), so numbers are unchanged from 2026-07-02-01. End-of-session
-run for the record:
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.71     <= 2.0     PASS
-medium (<500)            152145     2.09     <= 3.0     PASS
-
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.52     <= 2.0     PASS
-medium (<500)            153560     1.52     <= 3.0     PASS
-All exit-partition buckets PASS, unchanged from the prior session.
+(this container has no oracle-timed corpus; the bench harness ran its
+in-tree matrices only — correctness gates, no perf partition)
+KKT summary: 2 matrices — inertia match 1/1, residual pass 1/1,
+  worst residual 1.14e-15
+Sparse solver: 2/2 — inertia vs MUMPS 2/2, residual pass 2/2,
+  worst residual 1.26e-16
+Dense/Sparse exit partition: 0 matrices (corpus absent) — N/A
+No solver-perf-relevant kernels changed on the default path except the
+compensated scatter (~4 flops per scatter add in the update only; factor
+and solve paths untouched).
 
 ```
 
 ## Recent Decisions
-diverge from the scaling precedent. The `Copy` loss is mechanical (clone at the
-`AutoRace` race loop, the preprocess-`Auto` race, `Solver::factor`, the three
-numeric constructors, and the `feral-diagnostics` bins that reuse a `method`
-binding) and was absorbed.
+**Decision.** Fix the exact-`0.0` `TinyPivot` failures of `SparseLu`'s
+Forrest–Tomlin update (issue #112) with **Neumaier (Kahan–Babuška)
+compensated accumulation** in the bump elimination's working-row scatter,
+always on; and ship Bartels–Golub row interchanges as an **opt-in, always-on
+variant** (`LuParams::update_pivot_search`, default `false`) rather than the
+issue's requested rescue-after-failure.
 
-**Why `External` forces `OrderingPreprocess::None`.** `LdltCompress` reorders an
-MC64-compressed super-graph of dimension `ncmp ≤ n`; a full-length user permutation
-cannot be applied to it. So `External` bypasses the preprocess-`Auto` fill race and
-pins `resolved_preprocess = None`, regardless of the requested (or default `Auto`)
-preprocess. Scaling is unaffected — it is computed independently in the numeric
-phase from `ScalingStrategy`; only the MC64 *cache-reuse* symbolic-time shortcut is
-skipped, which is a performance optimization, not a correctness input.
+**Why.** The exact-`0.0` on a nonsingular basis is summation absorption: the
+fixed-order sweep grows an intermediate past `|true pivot|/ε` and one rounded
+add destroys the pivot's bits. Re-selecting pivots afterwards provably cannot
+recover them (any interchange order's working row is exactly proportional to
+the fixed order's — see `dev/research/issue-112-bg-update.md` §UPDATE and the
+tried-and-rejected entry), while the compensated sum retains them: on the
+regression basis (`tests/issue112_bg_update.rs`) the committed diagonal
+equals the hand-computed true value `2⁻³⁵` bit-for-bit where the plain sweep
+returned `0.0` and scipy's fresh LU returns ε-noise. Cost: ~4 flops per
+scatter add + one pooled length-m `f64` buffer; no allocation, no API change.
+Pivot search remains valuable as a *trajectory* choice (multipliers bounded
+by 1 keep U balanced over long update chains, preventing the imbalance that
+makes absorption possible) — but it changes committed factors/etas wherever a
+working-row entry dominates a retained diagonal, so it defaults off pending
+discopt A/B on the captured corpus. New machinery: `FtOp::Swap` (physical
+row-content swap preserves the symmetric `uperm` invariant, diagonal-first
+storage, prior etas), `pivot_search_swaps()` telemetry, wholesale `u_above`
+rebuild on swap commits.
 
-**Soundness.** Numeric factorization, pivoting, and inertia are untouched — a
-factorization under any valid ordering is exact. A bad user ordering only costs
-fill/time. The permutation is validated as a bijection of `0..n` up front
-(`validate_external_perm`): wrong length, out-of-range index, or duplicate returns
-`FeralError::InvalidInput` (never a panic, no `unwrap`). Programmatic-only: no
-string parsing, matching scaling's `External`.
-
-**Evidence.** `tests/issue107_external_ordering.rs` (identity + reversed orderings
-solve to the hand oracle with saddle-point inertia (2,1,0) and SPD inertia (n,0,0);
-validation rejects the three malformed inputs); `src/symbolic` units
-(`symbolic_factorize_external_produces_valid_perm` pins the bijection + forced
-`None` preprocess; `external_perm_validation_rejects_bad_input`;
-`ordering_method_external_debug_is_compact`). Full suite green: feral 395 lib + all
-integration, `feral-diagnostics` builds/tests, clippy `--all-targets` clean on both,
-`cargo fmt --check` clean. Default (non-External) path unchanged. See
-`dev/research/issue-107-external-ordering.md` and
-`dev/plans/issue-107-external-ordering.md`.
+**Contract note.** A compensated final diagonal at/below
+`zero_pivot_tol·u_max0` is now trustworthy evidence of a genuinely dependent
+replacement (not a summation artifact), strengthening the existing
+`NeedsRefactor` semantics. No tolerances changed.
 
 ## Recent Tried-and-Rejected
-+23% option but is a reproducibility-policy change (kept opt-in), not a
-bit-exact win.
+sweep replays across four hand constructions (journal 2026-07-10-01,
+research note §UPDATE).
 
-## 2026-07-01 — UPDATE: packed micro-kernel succeeds where B-1a source-pack failed (issue #99)
+Also rejected en route: classic **Kahan** compensation for the sweep
+accumulator (its `y = v − c` pre-subtraction re-absorbs the compensation
+into the next 2²⁰-scale addend — computed `0.0` again; verified
+numerically); the **Neumaier** two-sum variant works and shipped. And three
+regression-matrix constructions whose base or replacement was numerically
+singular for every path (±1 cascade to 2³⁴: `σ_min(B') = 1.5e-16`; diag-4
+cascade: rescue-true `4.5e-13 <` ztol; spike-poison m=6: fresh LU burns the
+4e6 spike entry and deflates its tail pivot to 0) — any single-shot
+absorption reproducer necessarily has `σ_min(B') ⪅ δ·∏retained`, so the
+"fresh factor succeeds" oracle is unsatisfiable without a multi-update
+imbalance history.
 
-The 2026-06-30 "B-1a panel packing" entry above rejected source-panel packing as a
-net slowdown and concluded the root front is DST-bandwidth-bound. That conclusion
-was **specific to the variant tried** — packing the source into a tighter stride
-but *feeding the same strided kernels*, which keep the per-`q` `as_simd` + strided
-access. It does **not** generalize to a proper packed micro-kernel.
-
-A different design — pack the panel into `q`-contiguous MR=8×NR=4 micro-panels and
-run a register-tiled kernel with a **contiguous inner `q`-loop**
-(`apply_schur_panel_range_packed`) — is **22–26× faster in isolation and
-byte-exact** (`examples/bench_schur_micro`), and gives 8–10× on real dense fronts.
-So the bottleneck was strided-`q` cache latency, not DST bandwidth, on this
-hardware. Not a rejection — a correction of scope. See
-`dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
-2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
-rejected; the packed micro-kernel is the shipped design.
+**Shipped instead.** Always-on Neumaier-compensated scatter (recovers the
+true pivot bit-for-bit on the regression basis) + `update_pivot_search` as an
+always-on opt-in trajectory variant (bounded multipliers across chains),
+default false. See `dev/research/issue-112-bg-update.md` §UPDATE and
+`dev/decisions.md` 2026-07-10.
 
 ## Source Files
 ```
@@ -241,6 +239,7 @@ tests/growth_flag.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
 tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5905,3 +5905,36 @@ integration, `feral-diagnostics` builds/tests, clippy `--all-targets` clean on b
 `cargo fmt --check` clean. Default (non-External) path unchanged. See
 `dev/research/issue-107-external-ordering.md` and
 `dev/plans/issue-107-external-ordering.md`.
+
+## 2026-07-10 — Issue #112: compensated FT sweep (always on) + opt-in BG pivot search
+
+**Decision.** Fix the exact-`0.0` `TinyPivot` failures of `SparseLu`'s
+Forrest–Tomlin update (issue #112) with **Neumaier (Kahan–Babuška)
+compensated accumulation** in the bump elimination's working-row scatter,
+always on; and ship Bartels–Golub row interchanges as an **opt-in, always-on
+variant** (`LuParams::update_pivot_search`, default `false`) rather than the
+issue's requested rescue-after-failure.
+
+**Why.** The exact-`0.0` on a nonsingular basis is summation absorption: the
+fixed-order sweep grows an intermediate past `|true pivot|/ε` and one rounded
+add destroys the pivot's bits. Re-selecting pivots afterwards provably cannot
+recover them (any interchange order's working row is exactly proportional to
+the fixed order's — see `dev/research/issue-112-bg-update.md` §UPDATE and the
+tried-and-rejected entry), while the compensated sum retains them: on the
+regression basis (`tests/issue112_bg_update.rs`) the committed diagonal
+equals the hand-computed true value `2⁻³⁵` bit-for-bit where the plain sweep
+returned `0.0` and scipy's fresh LU returns ε-noise. Cost: ~4 flops per
+scatter add + one pooled length-m `f64` buffer; no allocation, no API change.
+Pivot search remains valuable as a *trajectory* choice (multipliers bounded
+by 1 keep U balanced over long update chains, preventing the imbalance that
+makes absorption possible) — but it changes committed factors/etas wherever a
+working-row entry dominates a retained diagonal, so it defaults off pending
+discopt A/B on the captured corpus. New machinery: `FtOp::Swap` (physical
+row-content swap preserves the symmetric `uperm` invariant, diagonal-first
+storage, prior etas), `pivot_search_swaps()` telemetry, wholesale `u_above`
+rebuild on swap commits.
+
+**Contract note.** A compensated final diagonal at/below
+`zero_pivot_tol·u_max0` is now trustworthy evidence of a genuinely dependent
+replacement (not a summation artifact), strengthening the existing
+`NeedsRefactor` semantics. No tolerances changed.

--- a/dev/journal/2026-07-10-01.org
+++ b/dev/journal/2026-07-10-01.org
@@ -1,0 +1,28 @@
+* 02:48 :lu:ft-update:issue-112:orientation:
+Oriented on issue #112: the FT bump update (src/lu/sparse_update.rs,
+eliminate_pivot_row) returns RefactorCause::TinyPivot with magnitude exactly
+0.0 on provably nonsingular, well-conditioned bases (discopt evidence: 11714
+events on st_e36, 100% of FT failures; 120/120 captured bases full-rank,
+cond <= 3.4e6; refactor with partial pivoting always succeeds). Request: a
+pivot-searching (Bartels-Golub/Suhl-Suhl) update variant.
+
+Key code findings:
+- The zero pivot fires at the *final* diagonal check (sparse_update.rs:498):
+  diag = rw[r] after the fixed-order sweep. Intermediate pivots are old U
+  diagonals, all nonzero (checked at factor/commit), so line 458 rarely fires.
+- Determinant argument: the bump block M is nonsingular whenever B' is
+  (spiked U is block upper triangular around M), and the final diagonal is
+  mathematically det(M)/prod(old bump diags) != 0. So an exact-0.0 computed
+  value on a nonsingular basis is *floating-point cancellation* driven by
+  element growth in the fixed pivot order - exactly the instability
+  threshold row-interchanges (Bartels-Golub) bound (|mult| <= 1 per step).
+- ft-row-elimination-design-2026-06-21.md already lists "in-bump stability
+  pivoting" as future work. Nothing in dev/tried-and-rejected.md rejects it.
+
+Design insight for keeping the symmetric uperm invariant: implement the BG
+row interchange as a *physical* row-content swap between u_rows[c] and the
+working row (destined for u_rows[r]), recorded as a new FtOp::Swap{a,b}
+eta op (solve vectors swap s[a],s[b]). Column ranks never change, the
+diagonal-first storage convention survives (the working row placed at
+position c has its diagonal at column c), and uperm/uperm_inv are untouched
+beyond the existing cyclic shift. L, P, Q stay fixed; G absorbs the swap.

--- a/dev/journal/2026-07-10-01.org
+++ b/dev/journal/2026-07-10-01.org
@@ -26,3 +26,73 @@ eta op (solve vectors swap s[a],s[b]). Column ranks never change, the
 diagonal-first storage convention survives (the working row placed at
 position c has its diagonal at column c), and uperm/uperm_inv are untouched
 beyond the existing cyclic shift. L, P, Q stay fixed; G absorbs the swap.
+
+* 03:20 :lu:issue-112:analysis:finding:
+Three failed hand constructions for the regression matrix (2^34 unit
+cascade; diag-4 cascade; spike-poison v5) exposed a structural constraint
+worth recording:
+
+1. Determinant identity: any in-bump elimination's pivots satisfy
+   prod(pivots) * final_diag = det(bump block M), so the final diagonal of
+   ANY row-interchange order is det(M)/prod(pivots).
+2. Proportionality theorem: in the single-working-row (row-spike) form,
+   the carried row of a swapped path is exactly lambda_k times the
+   fixed-order carried row (lambda resets to -piv/vrc at each swap;
+   induction over Axpy/Swap steps). Hence the TRUE final diagonal of the
+   pivot-searching pass equals lambda_final * t_FT - pivot search cannot
+   manufacture a larger true pivot, only compute the (rescaled) value
+   accurately, because its own intermediates are lambda_k-modulated to
+   stay O(u) while FT's blow up.
+3. Consequence: a rescue after an FT exact-0.0 commits only when the
+   absorbed true value t_FT (and its lambda-multiple) still clears
+   ztol = zero_pivot_tol * u_max0. Since exact-0.0 requires
+   |t_FT| <= eps * I (I = FT's intermediate growth), rescuable cases need
+   I/u >> ztol/(eps*u) ~ 450 with tau=1 swaps; a tau < 1 threshold rule
+   (swap preferred when |vrc| >= tau*|piv|) lets lambda rebalance by 1/tau
+   per swap - the classic reason Reid/Suhl-Suhl use tau in (0.01, 0.5),
+   not strict-larger. Switching the rescue to tau = 0.5.
+4. Any distilled test matrix with an FT exact-0.0 is necessarily within
+   ~t_FT of a singular matrix (sigma_min <= perturbation distance), so the
+   reproducer lives at sigma_min ~ 100x ztol by construction - the
+   evidence numbers in issue #112 (sigma_min >= 1.5e-4) cannot be matched
+   by a small hand matrix at default zero_pivot_tol; the test documents
+   this and pins the mechanism instead.
+
+Evidence: numpy/scipy + exact-Fraction replays of the FT and BG sweeps on
+the three constructions (v1: base cascade cond 2.5e7 but sigma_min(B')
+1.5e-16, fresh LU min pivot 2.8e-17; v3: BG true final 4.5e-13 < ztol
+because prod(BG pivots) inflated by the swapped-in doubled values; v5:
+det(B') = 0 in float, fresh LU burns the 4e6 spike value as a pivot and
+deflates the tail to 0).
+
+* 04:55 :lu:issue-112:implementation:finding:
+Implemented, tested, and landed the reworked fix:
+
+1. Neumaier-compensated working-row scatter in eliminate_pivot_row (always
+   on; new pooled ft_rw_comp buffer; two_sum_add is branch-free two-sum).
+   Regression basis (tests/issue112_bg_update.rs, m=4, hand-traced and
+   verified in exact rational arithmetic offline): plain sweep final diag
+   computed 0.0 exactly; compensated sweep = 2^-35 exactly = true value.
+   Classic Kahan verified NOT to work (y = v - c re-absorbs the
+   compensation into the next 2^20-scale addend).
+2. Rescue-after-TinyPivot retry REMOVED before commit (proportionality
+   theorem, see 03:20 entry + tried-and-rejected 2026-07-10). Empirical
+   confirmation: on the regression basis the swap path's final diag is
+   1.39e-17 = lambda*2^-35 with lambda ~ 2^-20 - genuinely sub-ztol,
+   correctly refused. update_pivot_search is now an always-on opt-in
+   variant (default false), single pass, telemetry pivot_search_swaps().
+3. FtOp::Swap machinery kept exactly per the research note 4.1 (physical
+   row-content swap; symmetric uperm untouched; forward/transpose/spike
+   replay handled; u_above rebuilt wholesale on swap commits; displaced
+   rows snapshotted for rollback, deduped against the pre-update saved set).
+4. Test-design finding: any single-shot absorption reproducer has
+   sigma_min(B') <= delta*prod(retained diags) - numerically singular for a
+   from-scratch factorization - so the issue's "residual <= refactor's"
+   oracle is unsatisfiable on a distilled matrix (fresh factor returns
+   SingularBasis; scipy returns eps-noise pivots 3e-18..5e-17 across all
+   four constructions tried). The test asserts bit-exact committed diagonal
+   + backward-stable solve residuals (measured 2.9e-11 vs bound 3.7e-10)
+   instead; corpus validation stays discopt-side.
+
+Full suite green (395 lib + all integration incl. 5 new issue112 tests),
+clippy --all-targets -D warnings clean, fmt clean.

--- a/dev/plans/issue-112-bg-update.md
+++ b/dev/plans/issue-112-bg-update.md
@@ -1,0 +1,75 @@
+# Plan: issue #112 — Bartels–Golub pivot-searching rescue for the FT update
+
+Research: `dev/research/issue-112-bg-update.md`. Branch: `claude/issue-112-0885lr`.
+
+## Scope
+
+Sparse path only (`src/lu/sparse_update.rs`, `sparse_factor.rs`). The dense
+update is out of scope (issue targets `update_sparse`); its behavior is
+unchanged.
+
+## Steps (tests first)
+
+1. **Tests** (`tests/issue112_bg_update.rs`), written before the
+   implementation, red on the current code:
+   - `ft_fixed_order_cancels_to_exact_zero_on_nonsingular_basis`: hand-built
+     m≈40 basis (construction in research note §4.4: upper-triangular base,
+     ±1 cascade doubling the working row to 2³⁴, seed diagonal `8 + 2⁻²⁰`).
+     With `update_pivot_search: false` the update must return
+     `NeedsRefactor` with `last_refactor() == Some((TinyPivot, 0.0))`, while
+     the replacement basis is verifiably nonsingular (fresh `SparseLu::factor`
+     on B' succeeds; dense-LU oracle solves it).
+   - `bg_rescue_commits_where_ft_cancels`: same basis, param on (default):
+     update returns `Ok`, `pivot_search_rescues() == 1`, and for a spread of
+     RHS the update-path solution residual `‖B'x − a‖∞` is ≤ the from-scratch
+     refactor's residual on the same RHS (acceptance criterion from the
+     issue), with ftran AND btran checked.
+   - `bg_rescue_preserves_invariants_and_chains`: after the rescue, run
+     further updates/solves; check uperm bijection, diagonal-first, rank
+     triangularity (mirror of `uperm_triangular_invariant_holds_after_wide_bump_chain`).
+   - `bg_swap_eta_roundtrip`: small (m=3..6) matrices where the rescue path is
+     forced; ftran/btran against dense-LU oracle to pin `FtOp::Swap` replay
+     (forward, transpose, and `compute_spike`) exactly.
+   - Param off ⇒ bit-identical legacy behavior (existing suite already covers
+     the legacy path; add an explicit `update_pivot_search: false` assertion in
+     the regression test).
+2. **`FtOp::Swap`** in `sparse_factor.rs`: variant + `apply_forward`
+   (`y.swap`), `apply_transpose` (same swap; reversed walk already exists).
+3. **`LuParams::update_pivot_search: bool`** (default `true`) + doc fix for
+   the stale "always uses strict partial pivoting" sentence on
+   `pivot_threshold`; `pivot_search_rescues: usize` counter + accessor on
+   `SparseLu` (reset by factor/refactor).
+4. **`eliminate_pivot_row(…, allow_swaps: bool, saved, changed_sorted)`**:
+   - dedicated touched-mark pooled buffer (`ft_rw_mark: Vec<bool>`) so
+     `rw_touched` is duplicate-free; drop the final-gather `dedup_by_key`.
+   - swap branch (allow_swaps && `|piv| < |vrc|`): snapshot old row `c` into
+     `saved` (dedup vs sorted prefix), gather `rw` into the new `u_rows[c]`
+     (diagonal `(c, vrc)` first, tail column-sorted), push
+     `Swap{a:c,b:r}` + `Axpy{target:r,src:c,mult:piv/vrc}`, transform
+     `rw ← old_c − mult·rw` in place (scale gathered support by `−mult`,
+     `rw[c] = 0` exactly, scatter old row `c` skipping its diagonal),
+     return swapped positions alongside ops.
+5. **`update_sparse` orchestration**: capture `diag0 = w[r]` and
+   `last_refactor` before elimination; pass 1 FT (allow_swaps=false); on
+   `TinyPivot` + param on: restore `u_rows[r]` from the snapshot, re-run with
+   allow_swaps=true; on rescue success restore prior `last_refactor`, bump the
+   rescue counter; extend `changed` with swapped rows before the growth scan;
+   commit path rebuilds `u_above` wholesale when swaps occurred (helper
+   `rebuild_u_above`), incremental otherwise.
+6. **`compute_spike`**: replay `Swap` (swap + mark/touch both positions).
+7. Docs: module header (`sparse_update.rs`), CHANGELOG Unreleased entry.
+8. Full suite + clippy + fmt; run `lu`-relevant benches; session-end protocol.
+
+## Risks / checks
+
+- Swap must not re-enqueue the swap column (exact-zero clearing, same
+  landmine as 2026-06-21 bring-up) — covered by the chain test looping.
+- `last_refactor` must stay `None`-equivalent after a successful rescue
+  (existing `should_refactor_growth_preempts_trip` asserts `is_none()`).
+- Rollback correctness when the BG pass itself fails (growth trip or still
+  tiny): all swapped rows restored — covered by asserting the factors solve
+  identically to pre-update after a forced BG failure (growth cap 1.0… or
+  reuse existing rollback tests with param on).
+- Oracle discipline: the regression matrix is a hand calculation (documented
+  in-test), the residual oracle is the pre-existing refactor path and the
+  dense LU — no same-session self-oracle.

--- a/dev/research/issue-112-bg-update.md
+++ b/dev/research/issue-112-bg-update.md
@@ -200,3 +200,79 @@ residual matching the refactor's.
 `citep:reid1982sparsity`, `citep:suhl1990computing`,
 `citep:huangfu2015novel`, `citep:schork2017permuting` — all in
 `dev/references.bib`. BASICLU (GPL) not consulted; clean-room from papers.
+
+---
+
+## UPDATE 2026-07-10 (same session): the rescue design is impossible; the fix is compensated accumulation
+
+The plan above (§4.2, FT-first + BG-retry-on-TinyPivot) was implemented and
+then **rejected on proof**, before commit. Three findings, each verified
+numerically (float + exact-rational replays of the sweep on candidate
+matrices):
+
+### 1. Proportionality theorem: pivot re-ordering cannot recover an absorbed pivot
+
+In the row-spike form, let `W_k` be the fixed-order (FT) working row before
+step `k` and `W'_k` the working row of *any* interchange variant of the same
+sweep. Induction over the two step types gives `W'_k = λ_k·W_k` **exactly (in
+exact arithmetic)**: a no-swap step preserves `λ`, a swap at column `c`
+resets `λ ← −U[c,c]/W_k[c]`. Consequences:
+
+- the swapped path's **true** final diagonal is `λ_final · t_FT`, and under
+  domination-triggered swaps `|λ| ≤ 1` monotonically — pivot search can only
+  *shrink* the true final pivot (`∏(pivots)·final = det(bump)` makes this a
+  determinant identity);
+- both paths skip exactly the same columns (proportional zeros), so no
+  interchange schedule can "route around" a poisoned column;
+- FP absorption is **scale-invariant** (ulp is relative), so a λ-scaled
+  recomputation absorbs the same bit at the same step. The absorbed
+  information exists nowhere any within-bump row-operation order can reach.
+
+Hence a rescue pass run *after* the FT sweep produced an exact-`0.0` can
+never soundly commit: if the computed zero was absorption
+(`|t_FT| ≤ ε·I`, `I` = intermediate growth), every interchange order's
+signal-to-noise is the same `t_FT/(ε·I) ≤ 1`. The retry implementation was
+removed; `dev/tried-and-rejected.md` has the entry.
+
+### 2. The actual fix: Neumaier-compensated accumulation in the sweep
+
+The exact-`0.0` is a *summation* artifact: `rw[·]` accumulates hits whose
+intermediate magnitude exceeds `|true|/ε`, and one rounded add drops the true
+value's bits. Making every scatter add a Neumaier (Kahan–Babuška) two-sum —
+value carried as `rw[c] + comp[c]`, error of each add banked in `comp[c]`,
+collapsed once at each read — retains those bits: on the m=4 regression
+matrix the compensated sweep's final diagonal equals the true value `2⁻³⁵`
+**bit-for-bit** where the plain sweep returns `0.0` (and scipy's fresh LU
+returns ε-noise). The classic Kahan form does **not** work here: its
+`y = v − c` pre-subtraction re-absorbs the compensation into the next large
+addend (verified numerically). Cost: ~4 extra flops per scatter add,
+`O(bump)` extra memory (one pooled `f64` array), no allocation.
+
+This is always-on. It also sharpens the singular case: a compensated final
+diagonal of `0.0`/sub-ztol is now trustworthy evidence of a genuinely
+dependent replacement, not an artifact.
+
+### 3. What pivot search is still for — and the limits of a distilled reproducer
+
+`update_pivot_search` (default off) now runs the whole sweep with
+Bartels–Golub interchanges from the start: every multiplier bounded by 1,
+growth bounded across update chains — a *trajectory* choice that prevents the
+imbalance (`∏(retained diagonals) ≫ det`) from building up over long update
+chains, which is where the issue #112 storms come from in vivo. It is not,
+and provably cannot be, a cure after the fact (finding 1). The `FtOp::Swap`
+eta machinery (physical row-content swap keeps the symmetric `uperm`
+invariant, diagonal-first storage, and all prior etas intact) is exactly as
+designed in §4.1.
+
+Distillation limit (test design): any *single-shot* reproducer of an
+exact-absorption failure necessarily satisfies
+`σ_min(B') ⪅ δ·∏(retained diagonals)` with `δ ≤ ε·I` — the replacement basis
+is within `δ` of singular, so a from-scratch factorization of it sees an
+ε-relative pivot and cannot serve as the residual oracle. The discopt
+captures' healthy `σ_min ≥ 1.5e-4` coexists with the exact-`0.0` only because
+their retained-`U` imbalance was built by a long *chain* of updates (the
+`∏retained ≫ det` split lives in the factorization state, not in `B'`).
+The regression test therefore asserts (a) the committed diagonal equals the
+hand-computed true value exactly, and (b) backward-stable solve residuals —
+and validation on the real captures (issue acceptance) remains a discopt-side
+step, now with the compensated sweep expected to commit them.

--- a/dev/research/issue-112-bg-update.md
+++ b/dev/research/issue-112-bg-update.md
@@ -1,0 +1,202 @@
+# Issue #112: pivot-searching (Bartels–Golub) bump update for `SparseLu`
+
+Date: 2026-07-10
+Status: research → plan (`dev/plans/issue-112-bg-update.md`)
+Prior art in-tree: `dev/research/ft-row-elimination-design-2026-06-21.md`
+(which explicitly left "in-bump stability pivoting" as future work).
+
+## 1. Problem
+
+`SparseLu::update_sparse` restores triangularity after a column replacement by
+the Forrest–Tomlin scheme: a symmetric cyclic `uperm` shift moves the leaving
+column/row to the bottom of the bump, then the single pivotal row `r` is
+eliminated in **fixed rank order** against the (unchanged) bump rows
+(`eliminate_pivot_row`). The pivots of that sweep are the *retained* `U`
+diagonals; the update never re-selects a pivot.
+
+Issue #112 (measured downstream in discopt): on dense McCormick-lifted node
+LPs this fails with `RefactorCause::TinyPivot` at magnitude **exactly 0.0** on
+~every pivot (`st_e36`: 11 714 events, 100% of FT failures; `Growth` and
+`Singular` never fire), forcing an O(m²) refactor per pivot. 120/120 captured
+bases are full-rank and well-conditioned (cond ≤ 3.4e6, σ_min ≥ 1.5e-4); a
+from-scratch refactor (partial pivoting) always succeeds.
+
+## 2. Where the zero comes from
+
+The failing check is the **final diagonal** of the rebuilt row `r`
+(`sparse_update.rs:498`, `diag = rw[r]`). The intermediate pivots
+(`sparse_update.rs:449-461`) are old `U` diagonals — nonzero by the factor's
+`ztol` gate and every prior commit's final-diagonal gate — so they essentially
+never fire; the mid-sweep `TinyPivot` sites are corruption guards, not the
+observed failure.
+
+Two facts pin down the mechanism:
+
+1. **The bump block is nonsingular whenever the replacement basis is.** In
+   rank coordinates the spiked matrix is block upper triangular
+   `[[T₁, ·, ·], [0, M, ·], [0, 0, T₃]]` around the bump block `M` (every bump
+   row has support only at ranks ≥ its own; rows outside the bump are
+   untouched). So `det(spiked U) = det(T₁)·det(M)·det(T₃)`, and `B'`
+   nonsingular ⇒ `M` nonsingular.
+2. **The final diagonal is mathematically `det(M) / ∏(retained bump
+   diagonals)`** — the Schur complement of the upper-triangular part of `M` —
+   and the retained diagonals are all nonzero. Hence on a nonsingular `B'` the
+   true value is **never** zero.
+
+So a computed value of exactly `0.0` is floating-point **cancellation**: the
+fixed-order sweep can grow the working row unboundedly (its multipliers
+`rw[c]/U[c,c]` are unbounded — nothing constrains the retained diagonal to
+dominate the spike-row entry), and when intermediate terms reach magnitude
+`~|true| / ε`, the final subtraction returns 0.0 (or garbage). This matches
+the issue's offline analysis: "cancellation-to-zero in the retained pivot
+order on a nonsingular basis". No threshold tweak fixes it — the computed
+pivot is literally `0.0`, and the information needed to recover it is already
+rounded away. The fix must **change the elimination order**, i.e. pivot.
+
+## 3. Literature
+
+- **Bartels & Golub 1969** (`citep:bartels1969stable`): the original stable
+  simplex update — re-triangularize the spiked factor with **row
+  interchanges** chosen by magnitude at each elimination step. Growth per step
+  bounded (|mult| ≤ 1 with full interchanges); backward stable like partial
+  pivoting.
+- **Reid 1982** (`citep:reid1982sparsity`, LA05): sparsity-exploiting BG —
+  threshold pivoting between the two candidate rows (diagonal row vs spike
+  row) so the sparser choice is kept when stability permits.
+- **Forrest & Tomlin 1972** (`citep:forrest1972updated`): drop the interchange
+  freedom entirely, keep the retained diagonals as pivots — cheapest update
+  (one row eta, no fill in other rows) but **unstable in exactly the way
+  observed here**; production codes pair it with a bail-to-refactor, which is
+  feral's current design.
+- **Suhl & Suhl 1990** (`citep:suhl1990computing`): the modern LU kernel these
+  updates sit on; threshold partial pivoting with sparsity bias.
+- **Huangfu & Hall 2015** (`citep:huangfu2015novel`): surveys FT vs PFI/BG
+  variants in a modern dual simplex (HiGHS); FT preferred *when it commits*,
+  robustness comes from the fallback chain.
+- **Schork & Gondzio 2017** (`citep:schork2017permuting`): permute-first FT
+  variant (paper only — BASICLU is GPL, not consulted).
+
+Mainstream sparse-LP codes all provide a pivot-searching update precisely for
+this robustness (issue text); FT-then-refactor alone is the outlier.
+
+## 4. Design
+
+### 4.1 Constraint: keep the symmetric `uperm` invariant
+
+The 2026-06-21 FT design hinges on `U` being upper triangular under a single
+symmetric permutation `uperm` (rows and columns ranked identically, diagonal
+of row `i` stored at column `i`, `usolve`/`ut_solve`/`compute_spike` all walk
+`uperm`). A textbook BG row interchange is an *unsymmetric* permutation — it
+would force separate row/column rank maps through every solve and invariant.
+
+**Key idea: implement the interchange as a physical row-content swap.** At
+elimination step `k` (pivot column `c = uperm_inv[k]`), the two candidate
+pivot rows are the retained row `u_rows[c]` (diagonal `piv = U[c,c]`) and the
+working row `W` (the dense scatter `rw`, destined for position `r`, entry
+`v = rw[c]`). To swap:
+
+- store `W` *as* `u_rows[c]` — its rank-`k` diagonal is its column-`c` entry
+  `v`, so the diagonal-first, diagonal-at-own-position convention is
+  preserved; every other entry of `W` has rank > `k`, so triangularity under
+  the **unchanged** `uperm` is preserved;
+- the displaced old row `c` becomes the new working row (destined for `r`),
+  and its column-`c` entry `piv` is eliminated against the new pivot:
+  `W' = old_row_c − (piv/v)·W`;
+- record two eta ops: a new **`FtOp::Swap{a: c, b: r}`** (rows of `U` and the
+  corresponding solve-vector entries permute together: `s[c] ↔ s[r]`),
+  followed by the usual `FtOp::Axpy{target: r, src: c, mult: piv/v}`.
+
+`L`, `P`, `Q`, `qcol`, and all prior etas stay fixed; `G` absorbs the swap
+exactly as it absorbs the axpys. `uperm` is untouched beyond the existing
+cyclic shift. `apply_forward` performs `y.swap(a,b)`; `apply_transpose` the
+same (a transposition is its own transpose) in the existing reversed op walk;
+`compute_spike`'s eta replay swaps `w[a]`, `w[b]` and marks both touched.
+
+The final step is unchanged: the last working row lands at position `r` (rank
+`h_rank`, diagonal column `r`), gated by the same `ztol` check.
+
+### 4.2 When to swap: FT first, BG as in-update fallback
+
+Per the issue ("FT = cheapest when it works; BG = robust when it doesn't"):
+
+- **Pass 1 (unchanged FT):** run the existing fixed-order sweep (never swap).
+  Zero behavior/cost change on every update that commits today.
+- **Pass 2 (BG rescue):** only if pass 1 fails with `TinyPivot`, roll the row
+  state back (the FT pass mutates nothing but `u_rows[r]`, already
+  snapshotted) and re-run the sweep with threshold row interchanges: swap when
+  `|piv| < |v|` (strict-larger candidate, τ = 1 — max stability; multipliers
+  then satisfy `|mult| ≤ 1`, the classic BG growth bound). If the final
+  diagonal still fails `ztol`, fall through to `NeedsRefactor` exactly as
+  today — the refactor remains the authoritative verdict, and accuracy is
+  never traded (growth monitor still gates the commit).
+
+This keeps the hot path byte-identical, bounds the rescue cost at ~2× one
+bump sweep (still ≪ the O(m²) refactor it replaces), and needs no tuning
+parameter for the common case. Gated by a new `LuParams::update_pivot_search:
+bool`, default **true** (opt-out restores bit-exact legacy behavior);
+rescues are counted and exposed (`pivot_search_rescues()`) so drivers like
+discopt can split the cause telemetry.
+
+### 4.3 Bookkeeping consequences (BG pass only)
+
+- **Rollback:** each row swapped into gets snapshotted (pre-update content)
+  before being rewritten, deduped against the rows already saved at update
+  start (`changed` is sorted then, so a binary search suffices; a position can
+  be swapped at most once — each rank is popped once). Rollback and the
+  growth-monitor scan then work unchanged over the extended saved/changed set.
+- **`u_above`:** swapped rows change their column sets wholesale (they take
+  the working row's full support, including a column-`r` entry), so the
+  incremental issue-#89 refresh is wrong for them. The BG commit path rebuilds
+  `u_above` from scratch — O(nnz(U)), acceptable because the alternative this
+  path replaces is a full refactor (strictly more work). The FT commit path
+  keeps the incremental refresh, untouched.
+- **Scatter hygiene:** the swap gathers the working row out of `rw` — the
+  existing duplicate-tolerant `rw_touched` makes that ambiguous, so the sweep
+  gains a dedicated touched-mark buffer (pooled, like the others) making
+  `rw_touched` duplicate-free; this also deletes the `dedup_by_key` wart in
+  the final gather. The eliminated entry at the swap column is cleared exactly
+  (`rw[c] = 0.0`, skip the displaced diagonal in the scatter) — same
+  re-enqueue landmine as the 2026-06-21 bring-up (journal 2026-06-21).
+
+### 4.4 Why the rescue actually fixes the observed failure
+
+The cancellation requires intermediate working-row entries of magnitude
+`~|true pivot| / ε` — i.e. unbounded multipliers. With τ = 1 interchanges
+every multiplier is ≤ 1 in magnitude, so the sweep's growth is bounded by
+2 per step (Wilkinson bound restricted to the two-row choice), the same
+guarantee the refactor's partial pivoting provides — and the refactor
+demonstrably succeeds on all 120 captured bases. A regression test encodes
+the mechanism directly (see plan §tests): a hand-built basis whose fixed-order
+sweep doubles the working row each step (Wilkinson-style ±1 cascade) until an
+engineered rounding absorbs the true diagonal (`8 + 2⁻²⁰` against a `2³⁴`
+intermediate) and the final subtraction returns exactly `0.0` — while the
+matrix stays modest-entried and nonsingular (true diagonal `2⁻²⁰ ≫ ztol`),
+and the BG pass (which swaps on the first dominated pivot) commits with a
+residual matching the refactor's.
+
+## 5. Alternatives considered
+
+- **Unsymmetric rank maps (separate row/column `uperm`s):** the textbook
+  formulation; rejected — it threads a second permutation through `usolve`,
+  `ut_solve`, `compute_spike`, the invariant checker, and every triangularity
+  argument, for zero benefit over the content-swap formulation, which is
+  mathematically the same interchange.
+- **Always-on threshold pivoting (Reid/Suhl–Suhl style, τ ≈ 0.1..0.5) in the
+  single pass:** changes eta streams and fill on updates that commit fine
+  today; harder to A/B, no benefit for the failing class (the rescue engages
+  regardless), and contradicts "FT when it works". Possible later as a tuning
+  knob on top of the same machinery (τ becomes a parameter).
+- **Second symmetric shift to a deeper rank when the final diagonal is zero:**
+  useless — a symmetric permutation preserves diagonal values; the zero
+  diagonal just moves.
+- **Extending `zero_pivot_tol` / retry with perturbation:** the issue measured
+  the pivots at exactly `0.0` with the tolerance already at `1e-13`; a
+  perturbed pivot would silently poison the factor (cf. the PerturbToEps
+  lesson in `dev/tried-and-rejected.md` 2026-05-02).
+
+## 6. References
+
+`citep:bartels1969stable`, `citep:forrest1972updated`,
+`citep:reid1982sparsity`, `citep:suhl1990computing`,
+`citep:huangfu2015novel`, `citep:schork2017permuting` — all in
+`dev/references.bib`. BASICLU (GPL) not consulted; clean-room from papers.

--- a/dev/sessions/2026-07-10-01.md
+++ b/dev/sessions/2026-07-10-01.md
@@ -1,0 +1,80 @@
+# Session 2026-07-10-01
+
+## Goal
+Issue #112: the sparse LU Forrest–Tomlin update fails with
+`RefactorCause::TinyPivot` at magnitude exactly `0.0` on provably nonsingular,
+well-conditioned bases (100% of FT failures in discopt's refactor storms).
+Requested: a pivot-searching (Bartels–Golub/Suhl–Suhl) update variant.
+
+## Accomplished
+- Research note `dev/research/issue-112-bg-update.md` + plan
+  `dev/plans/issue-112-bg-update.md` (branch `claude/issue-112-0885lr`).
+- **Disproof of the requested rescue design** (implemented first, then
+  removed on proof): any within-bump row-interchange order's working row is
+  exactly proportional to the fixed order's (`W'_k = λ_k·W_k`, λ resets to
+  `−piv/vrc` per swap), so the true final pivot is `λ·t_FT` (determinant
+  identity), skip patterns coincide, and FP absorption is scale-invariant —
+  a pivot the fixed order computed as exactly 0.0 by summation absorption is
+  unrecoverable by ANY pivot re-ordering. Verified numerically (float +
+  exact-Fraction sweep replays; on the regression basis the swap path's
+  final diag is `1.39e-17 = λ·2⁻³⁵`, correctly sub-ztol).
+- **Shipped the actual fix: Neumaier-compensated accumulation** in the bump
+  elimination's working-row scatter (always on; pooled `ft_rw_comp`;
+  branch-free two-sum). On the hand-traced m=4 regression basis the plain
+  sweep commits `0.0` exactly, the compensated sweep commits the true
+  diagonal `2⁻³⁵` **bit-for-bit** (oracle: hand calculation verified offline
+  in exact rational arithmetic; scipy's fresh LU sees only ε-noise). Classic
+  Kahan verified insufficient (its `y = v − c` re-absorbs the compensation).
+- **Shipped the pivot search as an opt-in always-on variant**:
+  `LuParams::update_pivot_search` (default `false`), Bartels–Golub
+  interchanges as physical row-content swaps (`FtOp::Swap` etas — symmetric
+  `uperm` invariant, diagonal-first storage, and prior etas untouched;
+  forward/transpose/spike replays; wholesale `u_above` rebuild and
+  swapped-row rollback snapshots on that path; `pivot_search_swaps()`
+  telemetry). Python bindings expose the keyword.
+- Tests: `tests/issue112_bg_update.rs` (5 tests) — bit-exact recovered
+  diagonal, backward-stable ftran/btran residuals (2.9e-11 vs bound
+  3.7e-10), genuine-singular rejection + clean rollback in both modes,
+  swap-mode factor validity incl. chained updates replaying Swap etas,
+  default path never swaps. Full suite green (395 lib + all integration),
+  clippy `--all-targets -D warnings` clean, fmt clean.
+- Test-design finding (documented): any single-shot absorption reproducer
+  has `σ_min(B') ⪅ δ·∏(retained diags)` — numerically singular to a
+  from-scratch factorization — so the issue's "residual ≤ refactor's"
+  acceptance can only be validated on discopt's captured corpus (whose
+  imbalance lives in chain-built factorization state, not in B').
+
+## Benchmark Results
+```
+(this container has no oracle-timed corpus; the bench harness ran its
+in-tree matrices only — correctness gates, no perf partition)
+KKT summary: 2 matrices — inertia match 1/1, residual pass 1/1,
+  worst residual 1.14e-15
+Sparse solver: 2/2 — inertia vs MUMPS 2/2, residual pass 2/2,
+  worst residual 1.26e-16
+Dense/Sparse exit partition: 0 matrices (corpus absent) — N/A
+```
+No solver-perf-relevant kernels changed on the default path except the
+compensated scatter (~4 flops per scatter add in the update only; factor
+and solve paths untouched).
+
+## Decisions Made
+- Compensated (Neumaier) accumulation always-on in the FT sweep; BG pivot
+  search opt-in default-false (appended to `dev/decisions.md` 2026-07-10).
+
+## Abandoned Approaches
+- The rescue-after-TinyPivot retry design (issue's literal request), classic
+  Kahan compensation, and three regression-matrix constructions — appended
+  to `dev/tried-and-rejected.md` 2026-07-10 with the proportionality proof.
+
+## Next Session Should
+- Ask discopt to validate the compensated update on the 120 captured
+  zero-pivot bases (expected: the storms dissolve; `RefacFtTinyPivot`
+  events become commits) and A/B `update_pivot_search: true` on the
+  McCormick corpus for chain-length effects — then follow up on issue #112
+  with the findings (the issue's acceptance runs on their captures).
+- If captures still fail: instrument whether the absorption happens in the
+  spike solve (`compute_spike`) rather than the sweep — compensation can be
+  extended there.
+- Consider a Suhl–Suhl-style threshold (τ < 1) for the pivot-search variant
+  once A/B data exists (currently strict domination, τ = 1).

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4928,3 +4928,47 @@ hardware. Not a rejection — a correction of scope. See
 `dev/research/issue-99-dense-front-fma-gate.md` UPDATE 3 and `dev/decisions.md`
 2026-07-01 (packed BLAS-3). The B-1a *source-into-strided-kernel* variant remains
 rejected; the packed micro-kernel is the shipped design.
+
+## 2026-07-10 — BG rescue-after-TinyPivot for the FT update (issue #112)
+
+**Tried.** Implemented issue #112's requested design literally: run the plain
+Forrest–Tomlin bump sweep first; on `TinyPivot` (the exact-`0.0` class), roll
+back row `r` and re-run the sweep with Bartels–Golub row interchanges
+(`FtOp::Swap` physical row-content swaps; retry gated by
+`update_pivot_search`, default true), expecting the re-selected pivot order
+to commit where the fixed order cancelled.
+
+**Symptoms / why it cannot work.** Every candidate regression matrix had the
+rescue fail exactly like FT (computed `0.0` or sub-ztol), e.g. the m=4
+absorption basis: rescue's final diag `1.39e-17` = `λ·2⁻³⁵` with `λ ~ 2⁻²⁰`
+from the dominated-diagonal swaps. Root cause is a proved identity, not a
+bug: any interchange variant's working row is **exactly proportional**
+(`W'_k = λ_k·W_k`) to the fixed-order one — swaps only rescale the carried
+row (`λ` resets to `−piv/vrc` per swap, `|λ| ≤ 1` under domination swaps) —
+so (a) the true final pivot is `λ·t_FT ≤ t_FT` (determinant identity
+`∏pivots·final = det(bump)`), (b) skip patterns coincide (proportional
+zeros), and (c) FP absorption is scale-invariant (ulp is relative), so a
+rescue re-computation absorbs the same bit. A pivot the fixed order computed
+as exactly `0.0` by absorption is unrecoverable by ANY within-bump
+row-operation reordering; retry-commit values would be noise (signal/noise
+= `t_FT/(ε·I) ≤ 1` on every path). Numeric evidence: float + exact-Fraction
+sweep replays across four hand constructions (journal 2026-07-10-01,
+research note §UPDATE).
+
+Also rejected en route: classic **Kahan** compensation for the sweep
+accumulator (its `y = v − c` pre-subtraction re-absorbs the compensation
+into the next 2²⁰-scale addend — computed `0.0` again; verified
+numerically); the **Neumaier** two-sum variant works and shipped. And three
+regression-matrix constructions whose base or replacement was numerically
+singular for every path (±1 cascade to 2³⁴: `σ_min(B') = 1.5e-16`; diag-4
+cascade: rescue-true `4.5e-13 <` ztol; spike-poison m=6: fresh LU burns the
+4e6 spike entry and deflates its tail pivot to 0) — any single-shot
+absorption reproducer necessarily has `σ_min(B') ⪅ δ·∏retained`, so the
+"fresh factor succeeds" oracle is unsatisfiable without a multi-update
+imbalance history.
+
+**Shipped instead.** Always-on Neumaier-compensated scatter (recovers the
+true pivot bit-for-bit on the regression basis) + `update_pivot_search` as an
+always-on opt-in trajectory variant (bounded multipliers across chains),
+default false. See `dev/research/issue-112-bg-update.md` §UPDATE and
+`dev/decisions.md` 2026-07-10.

--- a/python/src/lu.rs
+++ b/python/src/lu.rs
@@ -251,6 +251,7 @@ impl LuFactor {
         scaling: &str,
         refine_steps: usize,
         refine_tol: f64,
+        update_pivot_search: bool,
     ) -> PyResult<LuParams> {
         let on_singular = match on_singular {
             "fail" => LuSingularAction::Fail,
@@ -273,6 +274,7 @@ impl LuFactor {
             scaling: pick_lu_scaling(scaling)?,
             refine_steps,
             refine_tol,
+            update_pivot_search,
         })
     }
 }
@@ -296,6 +298,7 @@ impl LuFactor {
         scaling = "none",
         refine_steps = 0,
         refine_tol = 1e-12,
+        update_pivot_search = false,
         force_dense = None,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -312,6 +315,7 @@ impl LuFactor {
         scaling: &str,
         refine_steps: usize,
         refine_tol: f64,
+        update_pivot_search: bool,
         force_dense: Option<bool>,
     ) -> PyResult<Self> {
         let params = Self::build_params(
@@ -325,6 +329,7 @@ impl LuFactor {
             scaling,
             refine_steps,
             refine_tol,
+            update_pivot_search,
         )?;
         let a = &matrix.inner;
         let m = a.m;

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -103,9 +103,10 @@ pub struct LuParams {
     /// Governs the **initial factorization** (both the dense and sparse paths
     /// honor it: the sparse path prefers the within-threshold diagonal row,
     /// matching CSparse `cs_lu`). The Forrest–Tomlin bump elimination in
-    /// `update()` always uses strict partial pivoting (`u = 1`) for stability —
-    /// the bump's structure is already fixed there, so a relaxed threshold buys
-    /// no fill reduction and only trades away stability.
+    /// `update()` does not consult it: the default FT sweep keeps the retained
+    /// pivot order (there is no pivot choice to threshold), and the opt-in
+    /// pivot-searching variant ([`LuParams::update_pivot_search`]) uses
+    /// strict-larger interchanges (`u = 1`) for maximum stability.
     pub pivot_threshold: f64,
     /// A pivot column with all candidates `≤ zero_pivot_tol` is singular.
     pub zero_pivot_tol: f64,
@@ -124,6 +125,22 @@ pub struct LuParams {
     pub refine_steps: usize,
     /// Stop refinement when `‖r‖/‖a‖ < refine_tol`.
     pub refine_tol: f64,
+    /// Run the sparse `update()` bump elimination with Bartels–Golub row
+    /// interchanges (strict-larger pivot search) instead of the fixed
+    /// Forrest–Tomlin pivot order (issue #112). With it on, every elimination
+    /// multiplier is bounded by 1 (the classic BG stability guarantee), which
+    /// keeps element growth bounded across long update chains at the cost of
+    /// extra fill in the rows the interchanges rewrite. Off (the default),
+    /// updates keep the plain FT order — cheapest, and already protected
+    /// against the issue #112 cancellation-to-exact-zero by the always-on
+    /// compensated accumulation in the sweep. Note a pivot search can only
+    /// *prevent* instability from building up; it cannot recover a pivot the
+    /// fixed order has already cancelled (any interchange order's working row
+    /// is exactly proportional to the fixed order's — see
+    /// `dev/research/issue-112-bg-update.md`), which is why this is a
+    /// trajectory choice rather than a failure rescue. Sparse path only; the
+    /// dense update is unaffected.
+    pub update_pivot_search: bool,
 }
 
 impl LuParams {
@@ -165,6 +182,7 @@ impl Default for LuParams {
             scaling: LuScaling::None,
             refine_steps: 0,
             refine_tol: 1e-12,
+            update_pivot_search: false,
         }
     }
 }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -20,8 +20,9 @@ use crate::lu::sparse_matrix::SparseColMatrix;
 
 /// One elementary operation of a Forrest–Tomlin update's row elimination,
 /// recorded so it can be replayed on a solve vector (and transposed for btran).
-/// The logical permutation lives in `uperm`, not here, so the only operation is
-/// the row axpy that clears one sub-diagonal of the pivotal row.
+/// The logical permutation lives in `uperm`, not here. The plain FT pass emits
+/// only `Axpy`s; the pivot-searching rescue pass (issue #112) additionally
+/// emits `Swap`s for its Bartels–Golub row interchanges.
 #[derive(Debug, Clone)]
 pub(super) enum FtOp {
     /// `target_row -= mult · src_row` (Gauss elimination of a sub-diagonal).
@@ -30,6 +31,11 @@ pub(super) enum FtOp {
         src: usize,
         mult: f64,
     },
+    /// Rows `a` and `b` of `U` exchanged contents (a Bartels–Golub
+    /// interchange): the matching solve-vector entries swap with them. A
+    /// transposition is its own transpose, so `apply_transpose` performs the
+    /// same swap (in the reversed op walk).
+    Swap { a: usize, b: usize },
 }
 
 /// One Forrest–Tomlin column-replacement update: the sequence of elementary row
@@ -49,6 +55,7 @@ impl FtEta {
         for op in self.ops.iter() {
             match *op {
                 FtOp::Axpy { target, src, mult } => y[target] -= mult * y[src],
+                FtOp::Swap { a, b } => y.swap(a, b),
             }
         }
     }
@@ -58,6 +65,7 @@ impl FtEta {
         for op in self.ops.iter().rev() {
             match *op {
                 FtOp::Axpy { target, src, mult } => y[src] -= mult * y[target],
+                FtOp::Swap { a, b } => y.swap(a, b),
             }
         }
     }
@@ -153,7 +161,21 @@ pub struct SparseLu {
     /// restored on every return path; contents are cleared and refilled, never
     /// read across calls.
     pub(super) ft_rw: Vec<f64>,
+    /// Neumaier (Kahan–Babuška) compensation terms for `ft_rw`: `ft_rw[c] +
+    /// ft_rw_comp[c]` is the working-row value. The FT sweep's fixed pivot
+    /// order can cancel the bump diagonal to exactly `0.0` on a nonsingular
+    /// basis when an intermediate grows past `|true value|/ε` — the absorbed
+    /// low-order bits are unrecoverable by any pivot re-ordering (issue #112,
+    /// `dev/research/issue-112-bg-update.md` §UPDATE), so the scatter adds are
+    /// compensated instead. Kept zeroed between updates, like `ft_rw`.
+    pub(super) ft_rw_comp: Vec<f64>,
     pub(super) targets_scratch: Vec<usize>,
+    /// Length-`m` membership marker for `targets_scratch` (the `ft_rw` touched
+    /// list), keeping that list duplicate-free — the pivot-searching rescue
+    /// gathers the working row straight out of `ft_rw`, which a
+    /// duplicate-tolerant touched list would make ambiguous. All-false between
+    /// updates, like `scratch_mark`.
+    pub(super) ft_touch_mark: Vec<bool>,
     pub(super) row_pool: Vec<Vec<(usize, f64)>>,
     /// FT-update rollback/reindex snapshot pools. `saved_scratch` is the reused
     /// outer `(row, old_content)` vec; `saved_pool` is a free-list of the inner
@@ -181,6 +203,11 @@ pub struct SparseLu {
     /// untouched by a successful update (read only after an `Err`). The magnitude
     /// is a growth ratio, update count, or `|pivot|` per the cause. See issue #95.
     pub(super) last_refactor: Option<(RefactorCause, f64)>,
+    /// Total Bartels–Golub row interchanges performed by committed updates
+    /// since the last factor/refactor (only nonzero when
+    /// [`LuParams::update_pivot_search`] is enabled; issue #112). Zero after
+    /// factor/refactor.
+    pub(super) pivot_search_swaps: usize,
 }
 
 impl SparseLu {
@@ -500,13 +527,16 @@ impl SparseLu {
             scratch_c: vec![0.0; m],
             scratch_d: vec![0.0; m],
             ft_rw: vec![0.0; m],
+            ft_rw_comp: vec![0.0; m],
             targets_scratch: Vec::new(),
+            ft_touch_mark: vec![false; m],
             row_pool: Vec::new(),
             saved_scratch: Vec::new(),
             saved_pool: Vec::new(),
             last_update_work: 0,
             update_work_total: 0,
             last_refactor: None,
+            pivot_search_swaps: 0,
         })
     }
 
@@ -600,6 +630,17 @@ impl SparseLu {
     #[inline]
     pub fn last_refactor(&self) -> Option<(RefactorCause, f64)> {
         self.last_refactor
+    }
+
+    /// Total Bartels–Golub row interchanges performed by committed updates
+    /// since the last factor/refactor — the telemetry counterpart of
+    /// [`LuParams::update_pivot_search`] (issue #112). Always zero with the
+    /// pivot search disabled (the default) and after a fresh factor/refactor.
+    /// Lets a driver observe how often the threshold interchanges actually
+    /// deviate from the plain Forrest–Tomlin order.
+    #[inline]
+    pub fn pivot_search_swaps(&self) -> usize {
+        self.pivot_search_swaps
     }
 
     /// Advisory (growth-aware): is the element-growth high-water close enough to

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -16,6 +16,23 @@
 //! records an `O(bump)` eta, not the `O(bump²)` of a full bump re-triangularization
 //! (`dev/research/ft-row-elimination-design-2026-06-21.md`, issue #87).
 //!
+//! FT never re-selects a pivot, and its fixed order can cancel the final bump
+//! diagonal to exactly `0.0` on a **nonsingular** basis when an intermediate
+//! grows past `|true pivot|/ε` (issue #112). Two defenses:
+//!
+//! - **Compensated accumulation (always on):** the working-row scatter is a
+//!   Neumaier (Kahan–Babuška) compensated sum ([`two_sum_add`]), so the bits a
+//!   plain sum would absorb survive to the final diagonal check. This is the
+//!   fix for the issue #112 exact-`0.0` class — re-ordering pivots cannot be,
+//!   because any interchange order's working row is exactly proportional to
+//!   the fixed order's (`dev/research/issue-112-bg-update.md` §UPDATE).
+//! - **Bartels–Golub interchanges (opt-in, [`super::LuParams::update_pivot_search`]):**
+//!   whenever the working row's entry strictly dominates the retained
+//!   diagonal, the two rows swap contents (recorded as an `FtOp::Swap` in the
+//!   eta, so `uperm`, `L`, `P`, `Q`, and prior etas still never change),
+//!   bounding every multiplier by 1 — the classic BG growth guarantee, which
+//!   keeps the factor balanced across long update chains.
+//!
 //! The work is otherwise bump-local: the spike is computed by a Gilbert–Peierls
 //! depth-first reach, and the "unchanged on failure" guarantee saves/restores only
 //! the changed rows and the bump's `uperm` range (no `O(nnz)` clone of `U`).
@@ -160,14 +177,37 @@ impl SparseLu {
         // row `r` to the bottom of the bump). Pure index bookkeeping, O(bump).
         self.shift_uperm(r, r_rank, h_rank);
 
-        // Eliminate the single pivotal row `r` (now at rank `h_rank`).
-        let result = self.eliminate_pivot_row(r, h_rank, w[r], &mut work);
+        // Eliminate the single pivotal row `r` (now at rank `h_rank`). With
+        // `update_pivot_search` off (the default) this is the plain fixed-order
+        // Forrest–Tomlin sweep, byte-identical to the pre-#112 behavior; with
+        // it on, the sweep performs Bartels–Golub row interchanges wherever the
+        // working row strictly dominates the retained diagonal. A retry-only
+        // rescue was tried and rejected: any interchange order's working row is
+        // exactly proportional to the fixed order's, so a pivot the FT sweep
+        // has already cancelled to zero is unrecoverable by re-ordering
+        // (dev/tried-and-rejected.md 2026-07-10); robustness must be always-on
+        // (bounded multipliers from the first update), not curative.
+        let diag0 = w[r];
+        let allow_swaps = self.params.update_pivot_search;
+        let result = self.eliminate_pivot_row(
+            r,
+            h_rank,
+            diag0,
+            &mut work,
+            allow_swaps,
+            &mut saved,
+            &changed,
+        );
 
         clear(&mut w, &touched);
         self.ft_work = w;
 
         match result {
-            Ok(ops) => {
+            Ok((ops, swapped)) => {
+                // Rows the pivot search displaced were rewritten wholesale:
+                // include them in the growth scan (duplicates with `changed`
+                // are harmless for a max) and rebuild the column index below.
+                changed.extend(swapped.iter().copied());
                 // Element-growth high-water over the changed rows (L5): only row
                 // `r` and the spike rows changed values, so this stays O(changed).
                 let mut changed_max = 0.0_f64;
@@ -182,37 +222,49 @@ impl SparseLu {
                     self.last_refactor = Some((RefactorCause::Growth, growth));
                     return Err(FeralError::NeedsRefactor);
                 }
-                // Commit: refresh the `u_above` column index *incrementally*. Only
-                // two things changed structurally (issue #89): `set_column_r`
-                // rewrote column `r` (its holders are now exactly the spike
-                // support), and `eliminate_pivot_row` rebuilt row `r`. Every other
-                // "changed" row only gained or lost its single column-`r` entry —
-                // already captured by column `r`'s holder list — so its membership
-                // in *other* columns is untouched and must NOT be re-indexed. The
-                // old code re-indexed every changed row wholesale, an
-                // `O(bump · rowlen · shift)` (≈ `O(m³)` on a dense bump) churn that
-                // dwarfed the elimination's `O(factor_nnz)` arithmetic.
-                //
-                // (a) Column `r`'s holders = spike support minus `r`. `supp` is
-                //     already sorted+deduped and `p != r` preserves order, so the
-                //     list stays sorted.
-                self.u_above[r].clear();
-                self.u_above[r].extend(supp.iter().copied().filter(|&p| p != r));
-                // (b) Row `r` changed its column set: drop `r` from its old
-                //     columns' holder lists and add it to the new ones. (Both skip
-                //     column `r` itself — that is the diagonal, not a `u_above`
-                //     entry — so this never touches the list rebuilt in (a).)
-                //     `saved` is a local moved out of `self`, so borrowing the
-                //     snapshot while mutating `self` is sound (no clone needed).
-                let old_row_r: &[(usize, f64)] = saved
-                    .iter()
-                    .find(|(i, _)| *i == r)
-                    .map(|(_, b)| b.as_slice())
-                    .unwrap_or(&[]);
-                self.unindex_above(r, old_row_r);
-                let new_row_r = std::mem::take(&mut self.u_rows[r]);
-                self.index_above(r, &new_row_r);
-                self.u_rows[r] = new_row_r;
+                if swapped.is_empty() {
+                    // Commit: refresh the `u_above` column index *incrementally*.
+                    // Only two things changed structurally (issue #89):
+                    // `set_column_r` rewrote column `r` (its holders are now
+                    // exactly the spike support), and `eliminate_pivot_row`
+                    // rebuilt row `r`. Every other "changed" row only gained or
+                    // lost its single column-`r` entry — already captured by
+                    // column `r`'s holder list — so its membership in *other*
+                    // columns is untouched and must NOT be re-indexed. The old
+                    // code re-indexed every changed row wholesale, an
+                    // `O(bump · rowlen · shift)` (≈ `O(m³)` on a dense bump)
+                    // churn that dwarfed the elimination's `O(factor_nnz)`
+                    // arithmetic.
+                    //
+                    // (a) Column `r`'s holders = spike support minus `r`. `supp`
+                    //     is already sorted+deduped and `p != r` preserves order,
+                    //     so the list stays sorted.
+                    self.u_above[r].clear();
+                    self.u_above[r].extend(supp.iter().copied().filter(|&p| p != r));
+                    // (b) Row `r` changed its column set: drop `r` from its old
+                    //     columns' holder lists and add it to the new ones. (Both
+                    //     skip column `r` itself — that is the diagonal, not a
+                    //     `u_above` entry — so this never touches the list
+                    //     rebuilt in (a).) `saved` is a local moved out of
+                    //     `self`, so borrowing the snapshot while mutating `self`
+                    //     is sound (no clone needed).
+                    let old_row_r: &[(usize, f64)] = saved
+                        .iter()
+                        .find(|(i, _)| *i == r)
+                        .map(|(_, b)| b.as_slice())
+                        .unwrap_or(&[]);
+                    self.unindex_above(r, old_row_r);
+                    let new_row_r = std::mem::take(&mut self.u_rows[r]);
+                    self.index_above(r, &new_row_r);
+                    self.u_rows[r] = new_row_r;
+                } else {
+                    // The pivot search rewrote the displaced rows' column sets
+                    // wholesale (each took the working row's full support), so
+                    // the incremental refresh above would leave stale holders.
+                    // Rebuild the index from `U` — O(nnz(U)); never taken on
+                    // the default (plain-FT) path.
+                    self.rebuild_u_above();
+                }
                 for (_, buf) in saved.drain(..) {
                     self.saved_pool.push(buf);
                 }
@@ -221,6 +273,7 @@ impl SparseLu {
                 self.growth = growth;
                 self.last_update_work = work;
                 self.update_work_total += work;
+                self.pivot_search_swaps += swapped.len();
                 #[cfg(feature = "lu-ft-invariant-check")]
                 self.debug_check_invariants();
                 Ok(())
@@ -340,6 +393,17 @@ impl SparseLu {
                             touched.push(target);
                         }
                     }
+                    FtOp::Swap { a, b } => {
+                        w.swap(a, b);
+                        if !mark[a] {
+                            mark[a] = true;
+                            touched.push(a);
+                        }
+                        if !mark[b] {
+                            mark[b] = true;
+                            touched.push(b);
+                        }
+                    }
                 }
             }
         }
@@ -383,31 +447,62 @@ impl SparseLu {
         self.uperm[r] = h_rank;
     }
 
-    /// Forrest–Tomlin elimination of the single pivotal row `r` (now at rank
-    /// `h_rank`, the bottom of the bump after [`Self::shift_uperm`]). Its
-    /// sub-diagonal entries — columns whose new rank is `< h_rank` — are cleared by
-    /// a sparse forward sweep against the (unmodified) upper-triangular bump rows,
-    /// in increasing rank order. Each eliminated column contributes one
-    /// `FtOp::Axpy{target: r, ..}` to the returned eta. Only row `r` is rewritten;
-    /// `diag0 = w[r]` seeds its column-`r` value.
+    /// Elimination of the single pivotal row `r` (now at rank `h_rank`, the
+    /// bottom of the bump after [`Self::shift_uperm`]). The working row's
+    /// sub-diagonal entries — columns whose new rank is `< h_rank` — are cleared
+    /// by a sparse forward sweep against the upper-triangular bump rows, in
+    /// increasing rank order. `diag0 = w[r]` seeds its column-`r` value.
+    ///
+    /// With `allow_swaps == false` this is the plain **Forrest–Tomlin** sweep:
+    /// the pivot at each step is the retained diagonal `U[c,c]`, only row `r`
+    /// is rewritten, and each step contributes one `FtOp::Axpy{target: r, ..}`
+    /// to the eta.
+    ///
+    /// With `allow_swaps == true` ([`super::LuParams::update_pivot_search`],
+    /// issue #112) each step performs a **Bartels–Golub row interchange**
+    /// whenever the working row's entry strictly dominates the retained
+    /// diagonal (`|U[c,c]| < |rw[c]|`): the working row is installed as the
+    /// new `u_rows[c]` (its column-`c` entry is the new rank-`k` diagonal,
+    /// every other entry has rank `> k`, so triangularity under the
+    /// *unchanged* `uperm` is preserved), the displaced row becomes the new
+    /// working row, and the eta gains `FtOp::Swap{a: c, b: r}` + the
+    /// elimination `Axpy`. Multipliers then satisfy `|mult| ≤ 1` — the classic
+    /// BG growth bound. Each displaced row is snapshotted into `saved` for
+    /// rollback (unless its position is already in the sorted pre-update
+    /// snapshot list `presaved`); the rewritten positions are returned so the
+    /// caller can extend its growth scan and rebuild the column index.
+    ///
+    /// In both modes the working-row scatter is **Neumaier-compensated**
+    /// ([`two_sum_add`]): the fixed pivot order can drive an intermediate past
+    /// `|true pivot|/ε` and a plain sum then cancels the final bump diagonal
+    /// to exactly `0.0` on a nonsingular basis — the issue #112 failure. The
+    /// compensation retains those bits, so the final diagonal check sees the
+    /// true value.
     ///
     /// Returns [`FeralError::NeedsRefactor`] if the resulting diagonal pivot
-    /// vanishes (singular replacement). `touched` accumulates the dense-scatter
-    /// positions so the caller clears them.
+    /// vanishes (singular replacement) or a retained pivot row is structurally
+    /// broken.
+    #[allow(clippy::too_many_arguments)]
     fn eliminate_pivot_row(
         &mut self,
         r: usize,
         h_rank: usize,
         diag0: f64,
         work: &mut usize,
-    ) -> Result<Vec<FtOp>, FeralError> {
+        allow_swaps: bool,
+        saved: &mut Vec<(usize, Vec<(usize, f64)>)>,
+        presaved: &[usize],
+    ) -> Result<(Vec<FtOp>, Vec<usize>), FeralError> {
         let ztol = self.params.zero_pivot_tol * self.u_max0;
         let mut ops: Vec<FtOp> = Vec::new();
+        let mut swapped: Vec<usize> = Vec::new();
 
         let mut rw = std::mem::take(&mut self.ft_rw); // dense scatter, zero on entry
+        let mut comp = std::mem::take(&mut self.ft_rw_comp); // its compensation terms
         let mut rw_touched = std::mem::take(&mut self.targets_scratch);
         rw_touched.clear();
         let mut queued = std::mem::take(&mut self.scratch_mark); // all-false on entry
+        let mut touch_mark = std::mem::take(&mut self.ft_touch_mark); // all-false on entry
         let mut heap: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
 
         // Seed: row r off-diagonals (column `r` excluded — its value is `diag0`),
@@ -420,8 +515,10 @@ impl SparseLu {
             }
             scatter_into(
                 &mut rw,
+                &mut comp,
                 &mut rw_touched,
                 &mut queued,
+                &mut touch_mark,
                 &mut heap,
                 c,
                 v,
@@ -431,33 +528,112 @@ impl SparseLu {
         }
         // Column r is the bump diagonal (rank h_rank): never sub-diagonal, so it is
         // not pushed to the heap; just record its starting value.
-        if rw[r] == 0.0 {
+        if !touch_mark[r] {
+            touch_mark[r] = true;
             rw_touched.push(r);
         }
-        rw[r] += diag0;
+        two_sum_add(&mut rw, &mut comp, r, diag0);
         self.row_pool.push(row_r); // recycle the old row's buffer
 
-        // Sweep sub-diagonal columns of row r in increasing rank order.
+        // Sweep sub-diagonal columns of the working row in increasing rank order.
         while let Some(Reverse(rank)) = heap.pop() {
             let c = self.uperm_inv[rank];
             queued[c] = false;
-            let vrc = rw[c];
+            let vrc = rw[c] + comp[c];
             if vrc == 0.0 {
                 continue;
             }
-            let prow = &self.u_rows[c];
-            let &(dc, piv) = match prow.first() {
+            let &(dc, piv) = match self.u_rows[c].first() {
                 Some(p) => p,
                 None => {
-                    self.restore_elim_pools(rw, rw_touched, queued);
+                    self.restore_elim_pools(rw, comp, rw_touched, queued, touch_mark);
                     // No diagonal in the pivot column ⇒ effectively a zero pivot.
                     self.last_refactor = Some((RefactorCause::TinyPivot, 0.0));
                     return Err(FeralError::NeedsRefactor);
                 }
             };
-            if dc != c || piv == 0.0 || !piv.is_finite() {
-                self.restore_elim_pools(rw, rw_touched, queued);
+            if dc != c || !piv.is_finite() {
+                self.restore_elim_pools(rw, comp, rw_touched, queued, touch_mark);
                 self.last_refactor = Some((RefactorCause::TinyPivot, piv.abs()));
+                return Err(FeralError::NeedsRefactor);
+            }
+            if allow_swaps && piv.abs() < vrc.abs() {
+                // Bartels–Golub interchange: the working row strictly dominates
+                // the retained diagonal, so it becomes the pivot row for rank
+                // `rank`. Gather it out of the scatter as the new `u_rows[c]`:
+                // diagonal `(c, vrc)` first, then the column-sorted tail —
+                // every other entry has rank > `rank` (ranks below were
+                // eliminated exactly), so triangularity under `uperm` holds.
+                // `rw_touched` is duplicate-free (`touch_mark`), so the gather
+                // is exact.
+                let mut new_c = self.row_pool.pop().unwrap_or_default();
+                new_c.clear();
+                new_c.push((c, vrc));
+                for &cc in rw_touched.iter() {
+                    let val = rw[cc] + comp[cc];
+                    if cc != c && val != 0.0 {
+                        new_c.push((cc, val));
+                    }
+                }
+                new_c[1..].sort_unstable_by_key(|&(cc, _)| cc);
+                *work += new_c.len();
+
+                let mult = piv / vrc; // |mult| < 1 by the swap condition
+                ops.push(FtOp::Swap { a: c, b: r });
+                ops.push(FtOp::Axpy {
+                    target: r,
+                    src: c,
+                    mult,
+                });
+
+                // New working row = displaced_row_c − mult · W, formed in place
+                // in the scatter: scale W's support by −mult, clear column `c`
+                // exactly (`piv − mult·vrc` is 0 mathematically; the FP residual
+                // would re-enqueue `c` forever — the FT bring-up landmine), then
+                // scatter the displaced row, skipping its consumed diagonal. A
+                // scaled-to-zero entry (only possible when `piv == 0`) stays
+                // queued and is skipped on pop.
+                for &(cc, _) in new_c[1..].iter() {
+                    rw[cc] *= -mult;
+                    comp[cc] *= -mult;
+                }
+                rw[c] = 0.0;
+                comp[c] = 0.0;
+                let old_c = std::mem::replace(&mut self.u_rows[c], new_c);
+                *work += old_c.len();
+                for &(cc, v) in old_c.iter() {
+                    if cc == c {
+                        continue;
+                    }
+                    scatter_into(
+                        &mut rw,
+                        &mut comp,
+                        &mut rw_touched,
+                        &mut queued,
+                        &mut touch_mark,
+                        &mut heap,
+                        cc,
+                        v,
+                        &self.uperm,
+                        h_rank,
+                    );
+                }
+
+                // Snapshot the displaced row for rollback unless this position
+                // was already saved at update start (each rank pops once, so a
+                // position is displaced at most once; a later duplicate would
+                // shadow the true pre-update snapshot in `rollback`).
+                if presaved.binary_search(&c).is_err() {
+                    saved.push((c, old_c));
+                } else {
+                    self.saved_pool.push(old_c);
+                }
+                swapped.push(c);
+                continue;
+            }
+            if piv == 0.0 {
+                self.restore_elim_pools(rw, comp, rw_touched, queued, touch_mark);
+                self.last_refactor = Some((RefactorCause::TinyPivot, 0.0));
                 return Err(FeralError::NeedsRefactor);
             }
             let mult = vrc / piv;
@@ -472,6 +648,7 @@ impl SparseLu {
             // skip the pivot's own diagonal in the scatter accordingly. Fill at
             // strictly higher ranks may enqueue further sub-diagonal columns.
             rw[c] = 0.0;
+            comp[c] = 0.0;
             // One scatter per off-diagonal of the eliminated row — the
             // fill-proportional term that makes the update O(factor_nnz) on a
             // dense bump (issue #89).
@@ -482,8 +659,10 @@ impl SparseLu {
                 }
                 scatter_into(
                     &mut rw,
+                    &mut comp,
                     &mut rw_touched,
                     &mut queued,
+                    &mut touch_mark,
                     &mut heap,
                     cc,
                     -mult * v,
@@ -494,9 +673,10 @@ impl SparseLu {
         }
 
         // Diagonal pivot check, then gather the rebuilt row r (diagonal first).
-        let diag = rw[r];
+        // Reads collapse the compensated pair `(rw, comp)` with one rounding.
+        let diag = rw[r] + comp[r];
         if diag.abs() <= ztol || !diag.is_finite() {
-            self.restore_elim_pools(rw, rw_touched, queued);
+            self.restore_elim_pools(rw, comp, rw_touched, queued, touch_mark);
             self.last_refactor = Some((RefactorCause::TinyPivot, diag.abs()));
             return Err(FeralError::NeedsRefactor);
         }
@@ -505,41 +685,43 @@ impl SparseLu {
         new_row.push((r, diag));
         let mut offdiag: Vec<(usize, f64)> = rw_touched
             .iter()
-            .filter(|&&c| c != r && rw[c] != 0.0)
-            .map(|&c| (c, rw[c]))
+            .map(|&c| (c, rw[c] + comp[c]))
+            .filter(|&(c, v)| c != r && v != 0.0)
             .collect();
         offdiag.sort_unstable_by_key(|&(c, _)| c);
-        // `rw_touched` may list a column more than once (its scatter value crossed
-        // zero and back), so drop duplicate columns — each carries the same final
-        // `rw[c]`. Leaving them would put duplicate entries in the row and corrupt
-        // `U` / `u_above`.
-        offdiag.dedup_by_key(|&mut (c, _)| c);
         new_row.extend_from_slice(&offdiag);
         self.u_rows[r] = new_row;
 
         // Clear the dense scatter and hand the pools back.
-        self.restore_elim_pools(rw, rw_touched, queued);
-        Ok(ops)
+        self.restore_elim_pools(rw, comp, rw_touched, queued, touch_mark);
+        Ok((ops, swapped))
     }
 
-    /// Clear the dense scatter `rw` and the `queued` marker over their touched
-    /// positions (so both reach all-zero / all-false for the next update, on every
-    /// exit path — including a mid-sweep error where the heap still held columns)
-    /// and return the row-elimination churn buffers to their `SparseLu` pools.
+    /// Clear the dense scatter `rw` and the `queued`/`touch_mark` markers over
+    /// their touched positions (so all reach all-zero / all-false for the next
+    /// update, on every exit path — including a mid-sweep error where the heap
+    /// still held columns) and return the row-elimination churn buffers to
+    /// their `SparseLu` pools.
     fn restore_elim_pools(
         &mut self,
         mut rw: Vec<f64>,
+        mut comp: Vec<f64>,
         mut rw_touched: Vec<usize>,
         mut queued: Vec<bool>,
+        mut touch_mark: Vec<bool>,
     ) {
         for &c in rw_touched.iter() {
             rw[c] = 0.0;
+            comp[c] = 0.0;
             queued[c] = false;
+            touch_mark[c] = false;
         }
         rw_touched.clear();
         self.ft_rw = rw;
+        self.ft_rw_comp = comp;
         self.targets_scratch = rw_touched;
         self.scratch_mark = queued;
+        self.ft_touch_mark = touch_mark;
     }
 
     /// Structural self-check (opt-in via the `lu-ft-invariant-check` feature, off
@@ -601,6 +783,26 @@ impl SparseLu {
             }
         }
     }
+
+    /// Rebuild the `u_above` column index from `U` wholesale — used when a
+    /// pivot-searching rescue rewrote displaced rows' column sets, where the
+    /// incremental refresh would leave stale holders. Rows are walked in
+    /// ascending position, so each holder list comes out sorted (the
+    /// `unindex_above`/`index_above` binary-search invariant).
+    fn rebuild_u_above(&mut self) {
+        let mut above = std::mem::take(&mut self.u_above);
+        for col in above.iter_mut() {
+            col.clear();
+        }
+        for (i, row) in self.u_rows.iter().enumerate() {
+            for &(c, _) in row.iter() {
+                if c != i {
+                    above[c].push(i);
+                }
+            }
+        }
+        self.u_above = above;
+    }
 }
 
 fn clear(w: &mut [f64], touched: &[usize]) {
@@ -609,27 +811,51 @@ fn clear(w: &mut [f64], touched: &[usize]) {
     }
 }
 
-/// Add `v` to the dense scatter `rw[c]` of the pivotal row, recording `c` as
-/// touched on its first nonzero and enqueuing it (by triangular rank) when it is
-/// a not-yet-queued sub-diagonal column (`uperm[c] < h_rank`). `queued` dedups the
-/// heap; a column is re-enqueueable only after it is popped (rank order guarantees
-/// fill lands at strictly higher ranks, so no column is processed twice).
+/// Neumaier (Kahan–Babuška) compensated add into the working-row scatter:
+/// `(rw[c], comp[c]) += v`, with the rounding error of the add captured in
+/// `comp[c]` via a branch-free two-sum. The compensated value is
+/// `rw[c] + comp[c]`. This is what defeats the issue #112 cancellation: when
+/// an intermediate sum grows past `|true value|/ε`, a plain `+=` rounds the
+/// true value's bits away irrecoverably (the classic Kahan form fails here
+/// too — its `y = v − c` pre-subtraction re-absorbs the compensation into the
+/// next large addend), while the Neumaier form keeps them in `comp[c]` until
+/// the final read.
+#[inline]
+fn two_sum_add(rw: &mut [f64], comp: &mut [f64], c: usize, v: f64) {
+    let s = rw[c];
+    let t = s + v;
+    let z = t - s;
+    comp[c] += (s - (t - z)) + (v - z);
+    rw[c] = t;
+}
+
+/// Add `v` to the compensated dense scatter `(rw, comp)[c]` of the pivotal
+/// row, recording `c` as touched on first contact (`touch_mark` keeps
+/// `rw_touched` duplicate-free — the pivot-searching swap gathers the working
+/// row straight from the scatter) and enqueuing it (by triangular rank) when
+/// it is a not-yet-queued sub-diagonal column (`uperm[c] < h_rank`). `queued`
+/// dedups the heap; a column is re-enqueueable only after it is popped (rank
+/// order guarantees fill lands at strictly higher ranks, so no column is
+/// processed twice).
 #[allow(clippy::too_many_arguments)]
 fn scatter_into(
     rw: &mut [f64],
+    comp: &mut [f64],
     rw_touched: &mut Vec<usize>,
     queued: &mut [bool],
+    touch_mark: &mut [bool],
     heap: &mut BinaryHeap<Reverse<usize>>,
     c: usize,
     v: f64,
     uperm: &[usize],
     h_rank: usize,
 ) {
-    if rw[c] == 0.0 {
+    if !touch_mark[c] {
+        touch_mark[c] = true;
         rw_touched.push(c);
     }
-    rw[c] += v;
-    if uperm[c] < h_rank && !queued[c] && rw[c] != 0.0 {
+    two_sum_add(rw, comp, c, v);
+    if uperm[c] < h_rank && !queued[c] && rw[c] + comp[c] != 0.0 {
         queued[c] = true;
         heap.push(Reverse(uperm[c]));
     }

--- a/tests/issue112_bg_update.rs
+++ b/tests/issue112_bg_update.rs
@@ -1,0 +1,313 @@
+//! Issue #112: the Forrest–Tomlin bump update failed with `TinyPivot` at
+//! magnitude **exactly 0.0** on nonsingular bases — the fixed-order sweep's
+//! plain accumulation absorbed the true pivot's bits once an intermediate
+//! grew past `|true pivot|/ε`. The fix is Neumaier-compensated accumulation
+//! in the sweep (always on); the opt-in Bartels–Golub pivot search
+//! (`LuParams::update_pivot_search`) additionally bounds every multiplier by
+//! 1 so instability cannot build across update chains. These tests pin both.
+//!
+//! Oracles (no same-session self-oracle): the regression basis is a **hand
+//! calculation** (full arithmetic trace at `absorption_basis`, verified
+//! offline in exact rational arithmetic — the committed diagonal is asserted
+//! bit-for-bit against the hand value), and accuracy is measured by the
+//! oracle-free equation-residual identity `‖B'x − b‖` under the backward
+//! -stability bound (the issue's "accuracy preserved" acceptance).
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{LuParams, SparseLu, SparseLuSymbolic};
+use feral::FeralError;
+
+const M: usize = 4;
+/// Legal tiny retained diagonals that amplify the fixed-order sweep.
+const T: f64 = 9.5367431640625e-7; // 2^-20
+
+/// Hand-built m=4 basis whose fixed-order FT bump elimination drives the
+/// working row to `2²⁰`-scale intermediates and cancels the final diagonal to
+/// **exactly 0.0** under plain accumulation, while the true value is
+/// `2⁻³⁵ ≠ 0` (so the replacement basis is nonsingular). Upper triangular,
+/// entries in `[2⁻²⁰, 1]` (so under natural ordering `L = I`, `U = B`,
+/// `perm = qcol = id`, `u_max0 = 1`, `ztol = 1e-13`, and the tiny diagonals
+/// are forced legal pivots — each column's only unpivoted row is its own).
+///
+/// Replacing column 0 by `a = (2 + δ, 1, −(0.5 − 2⁻²¹), 1)` with `δ = 2⁻³⁵`
+/// gives spike = `a` (since `L = I`) and the sweep (hand trace, exact unless
+/// noted; verified offline in exact rational arithmetic):
+///
+/// - rank 0 (col 1): `vrc = B[0][1] = 1`, `piv = 2⁻²⁰` ⇒ `mult = 2²⁰`
+///   (exact power of two). Fill: `rw[2] −= 2²⁰·B[1][2] = −2²⁰·(−2⁻²⁰) = +1`
+///   ⇒ `rw[2] = 2`; spike hit: `rw[0] −= 2²⁰·a[1] = 2²⁰`:
+///   `fl(2 + 2⁻³⁵ − 2²⁰) = −(2²⁰ − 2)` — the true value needs a bit at
+///   `2⁻³⁵ = ulp/4` of that binade, so a plain round-to-nearest sum
+///   **absorbs the δ exactly** (the compensated sum keeps it);
+/// - rank 1 (col 2): `vrc = 2`, `piv = 2⁻²⁰` ⇒ `mult = 2²¹`; spike hit:
+///   `rw[0] −= 2²¹·(−(0.5 − 2⁻²¹)) = +(2²⁰ − 1)` (exact) ⇒ plain `rw[0] = 1`
+///   (exact);
+/// - rank 2 (col 3): `vrc = 1`, `piv = 1`; spike hit `rw[0] −= 1·1` ⇒
+///   plain-sum final diagonal = **0.0 exactly**; compensated = `2⁻³⁵` exactly.
+///
+/// Nonsingularity: `det(B') = ±(∏ retained diagonals)·2⁻³⁵ ≠ 0` in exact
+/// arithmetic (hand calculation). Numerically, `σ_min(B') ≈ δ·∏(tiny
+/// diagonals)` — inherent to *any* single-shot distilled absorption case —
+/// so a from-scratch factorization sees an ε-relative last pivot; see
+/// `updated_factors_solve_backward_stably` for how accuracy is asserted.
+fn absorption_basis() -> Vec<Vec<f64>> {
+    let mut cols = vec![vec![0.0; M]; M];
+    cols[0][0] = 1.0;
+    cols[1][0] = 1.0;
+    cols[1][1] = T;
+    cols[2][0] = 1.0;
+    cols[2][1] = -T;
+    cols[2][2] = T;
+    cols[3][0] = 1.0;
+    cols[3][3] = 1.0;
+    cols
+}
+
+/// True value of the bump's final diagonal after the replacement below.
+const TRUE_DIAG: f64 = 2.9103830456733704e-11; // 2^-35, the absorbed bit
+
+/// The entering column. `head_extra = 2⁻³⁵` gives the nonsingular
+/// cancellation case; `head_extra = 0.0` makes the same cancellation
+/// mathematically exact — a genuinely singular replacement.
+fn entering_column(head_extra: f64) -> Vec<f64> {
+    vec![2.0 + head_extra, 1.0, -(0.5 - 2f64.powi(-21)), 1.0]
+}
+
+fn replaced_cols(head_extra: f64) -> Vec<Vec<f64>> {
+    let mut cols = absorption_basis();
+    cols[0] = entering_column(head_extra);
+    cols
+}
+
+fn factor(cols: &[Vec<f64>], params: LuParams) -> SparseLu {
+    let a = SparseColMatrix::from_dense_columns(M, cols).expect("matrix");
+    SparseLu::factor(&a, &SparseLuSymbolic::natural(M), params).expect("factor")
+}
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |acc, &x| acc.max(x.abs()))
+}
+
+/// `‖B x − b‖∞` for dense columns.
+fn residual(cols: &[Vec<f64>], x: &[f64], b: &[f64]) -> f64 {
+    let mut r = b.to_vec();
+    for (j, col) in cols.iter().enumerate() {
+        for (i, &v) in col.iter().enumerate() {
+            r[i] -= v * x[j];
+        }
+    }
+    inf_norm(&r)
+}
+
+/// `‖Bᵀ x − b‖∞` for dense columns.
+fn residual_t(cols: &[Vec<f64>], x: &[f64], b: &[f64]) -> f64 {
+    let mut r = b.to_vec();
+    for (j, col) in cols.iter().enumerate() {
+        for (i, &v) in col.iter().enumerate() {
+            r[j] -= v * x[i];
+        }
+    }
+    inf_norm(&r)
+}
+
+/// The compensated sweep must commit the update the plain sweep cancelled to
+/// an exact-zero pivot (the issue #112 fingerprint), recovering the true
+/// final diagonal **exactly**, with no refactorization and no stale failure
+/// cause. Pre-fix this update returned `NeedsRefactor` with
+/// `last_refactor() == Some((TinyPivot, 0.0))`.
+#[test]
+fn compensated_sweep_recovers_exactly_cancelled_pivot() {
+    let mut lu = factor(&absorption_basis(), LuParams::default());
+    lu.update(0, &entering_column(TRUE_DIAG))
+        .expect("the compensated sweep must absorb the nonsingular replacement");
+    assert_eq!(lu.updates_since_refactor(), 1, "committed as an update");
+    assert_eq!(lu.last_refactor(), None, "no failure cause after a commit");
+    assert_eq!(
+        lu.pivot_search_swaps(),
+        0,
+        "the default path must not have used the pivot search"
+    );
+    // The committed bump diagonal is the hand-computed true value, exactly:
+    // the Neumaier compensation loses nothing here (all inputs are exact
+    // powers-of-two combinations).
+    let diag = lu.u_dense(0, 0);
+    assert_eq!(
+        diag, TRUE_DIAG,
+        "committed diagonal must be the true absorbed bit 2^-35"
+    );
+}
+
+/// Accuracy of the committed factors: ftran and btran on the updated
+/// factorization are **backward stable** — residual `≤ ε·m·‖B'‖∞·‖x‖∞` — on
+/// the replacement basis (the issue's "accuracy preserved" acceptance).
+///
+/// Note on the issue's literal "residual ≤ the from-scratch refactor's":
+/// a *single-shot* distilled absorption case is necessarily within `~δ` of a
+/// singular matrix (`σ_min(B') ≤ δ·∏retained`), so a from-scratch
+/// factorization of this B' sees an ε-relative last pivot and reports
+/// `SingularBasis` — there is no refactor residual to compare against; the
+/// updated factors here are in fact **exact** (every sweep value is an exact
+/// power-of-two combination, and the compensated diagonal equals the true
+/// `2⁻³⁵` bit-for-bit — asserted above). Matching the captures' healthy
+/// `σ_min` needs the multi-update imbalance history only the real corpus
+/// has; see `dev/research/issue-112-bg-update.md` §UPDATE.
+#[test]
+fn updated_factors_solve_backward_stably() {
+    let mut lu = factor(&absorption_basis(), LuParams::default());
+    lu.update(0, &entering_column(TRUE_DIAG)).expect("update");
+
+    let bp = replaced_cols(TRUE_DIAG);
+    let a = SparseColMatrix::from_dense_columns(M, &bp).expect("matrix");
+    let bnorm = 2.0; // ‖B'‖max
+    let xt = vec![1.0, 2.0, 3.0, 4.0];
+
+    let mut b = vec![0.0; M];
+    a.matvec(&xt, &mut b);
+    let mut x = b.clone();
+    lu.ftran(&mut x).expect("updated ftran");
+    let res = residual(&bp, &x, &b);
+    let bound = f64::EPSILON * (M as f64) * bnorm * inf_norm(&x);
+    assert!(
+        res <= bound,
+        "ftran must be backward stable: residual {res:.3e} > bound {bound:.3e}"
+    );
+
+    let mut bt = vec![0.0; M];
+    a.matvec_transpose(&xt, &mut bt);
+    let mut y = bt.clone();
+    lu.btran(&mut y).expect("updated btran");
+    let rest = residual_t(&bp, &y, &bt);
+    let bound_t = f64::EPSILON * (M as f64) * bnorm * inf_norm(&y);
+    assert!(
+        rest <= bound_t,
+        "btran must be backward stable: residual {rest:.3e} > bound {bound_t:.3e}"
+    );
+}
+
+/// With `head_extra = 0` the cancellation is mathematically exact — the
+/// replacement basis is genuinely singular — so the compensated sweep (whose
+/// final diagonal is now a true zero, not an artifact) must still reject the
+/// update, and the failed update must leave the factorization untouched —
+/// including under the pivot search, whose interchange path rewrites more
+/// rows before discovering the failure (the swapped rows must roll back).
+#[test]
+fn genuinely_singular_replacement_still_rejected_and_rolled_back() {
+    for pivot_search in [false, true] {
+        let params = LuParams {
+            update_pivot_search: pivot_search,
+            ..LuParams::default()
+        };
+        let mut lu = factor(&absorption_basis(), params);
+        let err = lu.update(0, &entering_column(0.0));
+        assert!(
+            matches!(err, Err(FeralError::NeedsRefactor)),
+            "a truly singular replacement must be rejected (pivot_search={pivot_search}): {err:?}"
+        );
+        assert_eq!(lu.updates_since_refactor(), 0, "nothing committed");
+
+        // The original basis must still solve exactly as before the failure.
+        let cols = absorption_basis();
+        let a = SparseColMatrix::from_dense_columns(M, &cols).expect("matrix");
+        let xt = vec![1.0, -1.0, 2.0, 0.5];
+        let mut b = vec![0.0; M];
+        a.matvec(&xt, &mut b);
+        let mut x = b.clone();
+        lu.ftran(&mut x)
+            .expect("ftran on the rolled-back factorization");
+        let res = residual(&cols, &x, &b);
+        assert!(
+            res <= 1e-12 * inf_norm(&b).max(1.0),
+            "rolled-back factors must solve the original basis (residual {res:.3e})"
+        );
+    }
+
+    // Engine stays usable after the rolled-back failure: the nonsingular
+    // variant commits — on the default path. (Under the pivot search the same
+    // replacement is *correctly* refused: its interchange order's true final
+    // pivot is λ·2⁻³⁵ with λ ~ 2⁻²⁰ from the dominated-diagonal swaps —
+    // genuinely below ztol. Pivot re-ordering cannot express this
+    // factorization; only the compensated fixed order can. See the
+    // proportionality analysis in dev/research/issue-112-bg-update.md.)
+    let mut lu = factor(&absorption_basis(), LuParams::default());
+    let _ = lu.update(0, &entering_column(0.0));
+    lu.update(0, &entering_column(TRUE_DIAG))
+        .expect("engine must remain usable after the rolled-back failure");
+    assert_eq!(lu.updates_since_refactor(), 1);
+}
+
+/// The opt-in Bartels–Golub pivot search: on a basis where the working row
+/// strictly dominates a retained diagonal, the update must perform
+/// interchanges (`FtOp::Swap` etas), commit valid factors, and keep solving —
+/// including a second update whose spike solve replays the Swap etas, and
+/// btran (the transposed replay). Oracle: the equation-residual identity on
+/// the exactly-known replacement bases.
+#[test]
+fn pivot_search_interchanges_produce_valid_factors_and_chain() {
+    let params = LuParams {
+        update_pivot_search: true,
+        ..LuParams::default()
+    };
+    let mut lu = factor(&absorption_basis(), params);
+
+    // Entering column whose sweep meets dominated retained diagonals
+    // (T = 2^-20 vs working-row entries of O(1)) — the pivot search must swap.
+    let v1 = vec![1.0, 1.0, 0.0, 0.25];
+    lu.update(0, &v1).expect("pivot-searching update commits");
+    assert!(
+        lu.pivot_search_swaps() >= 1,
+        "dominated retained diagonals must trigger interchanges, got {}",
+        lu.pivot_search_swaps()
+    );
+
+    let mut bp = absorption_basis();
+    bp[0] = v1.clone();
+    let a1 = SparseColMatrix::from_dense_columns(M, &bp).expect("matrix");
+    let xt = vec![0.5, 1.5, -2.0, 3.0];
+    let mut b = vec![0.0; M];
+    a1.matvec(&xt, &mut b);
+    let mut x = b.clone();
+    lu.ftran(&mut x).expect("ftran after swap update");
+    let res = residual(&bp, &x, &b);
+    assert!(
+        res <= 1e-9 * inf_norm(&b).max(1.0),
+        "ftran residual {res:.3e}"
+    );
+
+    // Second update: its spike computation must replay the Swap etas.
+    let v2 = vec![0.5, 0.0, 1.0, 2.0];
+    lu.update(3, &v2).expect("post-swap update commits");
+    bp[3] = v2;
+    let a2 = SparseColMatrix::from_dense_columns(M, &bp).expect("matrix");
+
+    let mut b2 = vec![0.0; M];
+    a2.matvec(&xt, &mut b2);
+    let mut x2 = b2.clone();
+    lu.ftran(&mut x2).expect("ftran after chained updates");
+    let res2 = residual(&bp, &x2, &b2);
+    assert!(
+        res2 <= 1e-9 * inf_norm(&b2).max(1.0),
+        "chained ftran residual {res2:.3e}"
+    );
+
+    let mut bt = vec![0.0; M];
+    a2.matvec_transpose(&xt, &mut bt);
+    let mut y = bt.clone();
+    lu.btran(&mut y).expect("btran after chained updates");
+    let rest = residual_t(&bp, &y, &bt);
+    assert!(
+        rest <= 1e-9 * inf_norm(&bt).max(1.0),
+        "chained btran residual {rest:.3e}"
+    );
+}
+
+/// With the pivot search off (the default), the same dominated-diagonal
+/// update must still commit via the plain FT order (its multipliers are large
+/// but the growth monitor arbitrates), and the swap counter must stay zero —
+/// the default path never deviates from the legacy pivot order.
+#[test]
+fn default_path_never_swaps() {
+    let mut lu = factor(&absorption_basis(), LuParams::default());
+    lu.update(0, &[1.0, 1.0, 0.0, 0.25])
+        .expect("plain FT update commits");
+    assert_eq!(lu.pivot_search_swaps(), 0, "default path must not swap");
+}


### PR DESCRIPTION
Fixes the issue #112 exact-`0.0` `TinyPivot` failures of `SparseLu`'s Forrest–Tomlin update and adds the requested pivot-searching variant. Full findings in the [issue comment](https://github.com/jkitchin/feral/issues/112#issuecomment-4931843771); research note, plan, journal, decisions, and tried-and-rejected entries are in the diff.

## What

- **Neumaier-compensated accumulation in the bump elimination (always on).** The exact-`0.0` pivots on nonsingular bases are summation absorption — the fixed-order sweep grows an intermediate past `|true pivot|/ε` and a rounded add destroys the pivot's bits. The working-row scatter now carries per-entry compensation terms (pooled `ft_rw_comp`, branch-free two-sum), so the true diagonal survives to the final check. On the hand-traced m=4 regression basis the plain sweep commits exactly `0.0` while the compensated sweep commits the true diagonal `2⁻³⁵` bit-for-bit.
- **`LuParams::update_pivot_search` (default `false`).** Runs the sweep with Bartels–Golub strict-larger row interchanges — every multiplier bounded by 1 — implemented as physical row-content swaps recorded as a new `FtOp::Swap` eta, so the symmetric `uperm` invariant, `L`, `P`, `Q`, and prior etas never change. `SparseLu::pivot_search_swaps()` exposes interchange telemetry; the Python bindings gain the keyword.
- **Rescue-after-failure design rejected on proof** (the issue's literal request): any within-bump interchange order's working row is exactly proportional to the fixed order's, so a pivot already absorbed to `0.0` is unrecoverable by re-ordering. Proof and numeric evidence in `dev/research/issue-112-bg-update.md` §UPDATE and `dev/tried-and-rejected.md` 2026-07-10.

## Tests

`tests/issue112_bg_update.rs` (5 tests): bit-exact recovered diagonal against the hand-calculated oracle (verified offline in exact rational arithmetic), backward-stable ftran/btran residuals, genuine-singular rejection + clean rollback in both modes (including swapped-row rollback), swap-mode factor validity with chained updates replaying `Swap` etas, and default-path-never-swaps. Full suite green (395 lib + all integration), clippy `--all-targets -D warnings` clean, fmt clean.

## Notes

- Committed update values can differ from previous releases only where the old sum had already lost low-order bits (CHANGELOG entry included).
- The issue's acceptance ("completes without refactoring on the captured bases, residual ≤ the refactor's") runs on discopt's 120 captures — a distilled single-shot reproducer is provably ε-singular to a fresh factorization, so that validation is a discopt-side step (details in the issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH