### PR TITLE
Audit correctness fixes: LU update/solve + dense LDLᵀ rook (issues #114–#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,34 @@ interchanges: every multiplier is bounded by 1, keeping element growth
 bounded across long update chains. New `SparseLu::pivot_search_swaps()`
 exposes how often the interchanges deviated from the plain FT order.
 
+### Fixed — audit correctness fixes across the LU and LDLᵀ engines (issues #114–#119)
+
+- **#114** `SparseLu::update` / `DenseLu::update` now reject a non-finite
+  entering column with `InvalidInput` (matching the factor path) instead of
+  silently committing a NaN into `U` and returning `Ok` with a NaN solution.
+- **#115** The dense LU column-replacement update is reworked as an eta-based
+  Bartels–Golub update with partial pivoting: it no longer fails
+  `NeedsRefactor(TinyPivot, 0.0)` on trivially valid updates over
+  slack/triangular bases (the old column-shift scheme pivoted on a
+  structurally-zero superdiagonal). The base `L` is unchanged; the solves
+  replay the update etas.
+- **#116** The symmetric-indefinite D-block solve now divides by any *live*
+  small-but-nonzero 1×1 pivot (rook rescue / static floor / rank-deficiency
+  band) and skips only *force-zeroed* pivots, fixing a silent `O(1/d)` error
+  in the affected solution component; such rook pivots also set
+  `needs_refinement`.
+- **#117** The blocked and scalar dense-LDLᵀ frontal kernels no longer certify
+  different inertia: the blocked panel defers a rook-eligible below-threshold
+  1×1 pivot to the scalar (rook-capable) path instead of zero-counting it.
+- **#118** The LU update's tiny-pivot tolerance is anchored to the factored
+  matrix magnitude `max|A|` rather than `max|U|`, so a healthy pivot on a
+  high-growth (but well-conditioned) basis is no longer spuriously rejected —
+  removing an update→refactor livelock.
+- **#119** Knight–Ruiz ∞-norm equilibration (`ScalingStrategy::InfNorm`, the
+  LU-side equilibration, and the dense fast path) no longer returns
+  `NaN`/`Inf`/`0.0` scale factors on finite input with extreme or subnormal
+  couplings; the guarded update is bit-identical on well-scaled matrices.
+
 ## [0.13.0] - 2026-07-02
 
 ### Added — user-supplied fill-reducing ordering: `OrderingMethod::External` (issue #107)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T03:55:16Z
+Generated: 2026-07-10T10:32:51Z
 
 ## Latest Session
-File: dev/sessions/2026-07-10-01.md
+File: dev/sessions/2026-07-10-03.md
 ```
-# Session 2026-07-10-01
+# Session 2026-07-10-03
 
 ## Goal
-Issue #112: the sparse LU Forrest–Tomlin update fails with
-`RefactorCause::TinyPivot` at magnitude exactly `0.0` on provably nonsingular,
-well-conditioned bases (100% of FT failures in discopt's refactor storms).
-Requested: a pivot-searching (Bartels–Golub/Suhl–Suhl) update variant.
+Fix the six audit-confirmed correctness bugs #114–#119 (from the 2026-07-10
+six-agent audit), one at a time, each as its own tested commit.
 
 ## Accomplished
-- Research note `dev/research/issue-112-bg-update.md` + plan
-  `dev/plans/issue-112-bg-update.md` (branch `claude/issue-112-0885lr`).
-- **Disproof of the requested rescue design** (implemented first, then
-  removed on proof): any within-bump row-interchange order's working row is
-  exactly proportional to the fixed order's (`W'_k = λ_k·W_k`, λ resets to
-  `−piv/vrc` per swap), so the true final pivot is `λ·t_FT` (determinant
-  identity), skip patterns coincide, and FP absorption is scale-invariant —
-  a pivot the fixed order computed as exactly 0.0 by summation absorption is
-  unrecoverable by ANY pivot re-ordering. Verified numerically (float +
-  exact-Fraction sweep replays; on the regression basis the swap path's
-  final diag is `1.39e-17 = λ·2⁻³⁵`, correctly sub-ztol).
-- **Shipped the actual fix: Neumaier-compensated accumulation** in the bump
-  elimination's working-row scatter (always on; pooled `ft_rw_comp`;
-  branch-free two-sum). On the hand-traced m=4 regression basis the plain
-  sweep commits `0.0` exactly, the compensated sweep commits the true
-  diagonal `2⁻³⁵` **bit-for-bit** (oracle: hand calculation verified offline
-  in exact rational arithmetic; scipy's fresh LU sees only ε-noise). Classic
-  Kahan verified insufficient (its `y = v − c` re-absorbs the compensation).
-- **Shipped the pivot search as an opt-in always-on variant**:
-  `LuParams::update_pivot_search` (default `false`), Bartels–Golub
-  interchanges as physical row-content swaps (`FtOp::Swap` etas — symmetric
-  `uperm` invariant, diagonal-first storage, and prior etas untouched;
-  forward/transpose/spike replays; wholesale `u_above` rebuild and
-  swapped-row rollback snapshots on that path; `pivot_search_swaps()`
-  telemetry). Python bindings expose the keyword.
-- Tests: `tests/issue112_bg_update.rs` (5 tests) — bit-exact recovered
-  diagonal, backward-stable ftran/btran residuals (2.9e-11 vs bound
-  3.7e-10), genuine-singular rejection + clean rollback in both modes,
-  swap-mode factor validity incl. chained updates replaying Swap etas,
-  default path never swaps. Full suite green (395 lib + all integration),
-  clippy `--all-targets -D warnings` clean, fmt clean.
-- Test-design finding (documented): any single-shot absorption reproducer
-  has `σ_min(B') ⪅ δ·∏(retained diags)` — numerically singular to a
-  from-scratch factorization — so the issue's "residual ≤ refactor's"
-  acceptance can only be validated on discopt's captured corpus (whose
-  imbalance lives in chain-built factorization state, not in B').
+All six fixed, committed, full-suite + clippy green after each. Empirical
+reproduction confirmed before encoding every fix (issue-112 discipline).
+
+- **#114** (`90cb4fe`): finiteness validation in `update_sparse` +
+  `DenseLu::update`. NaN was silently committed → `Ok(NaN)` solve.
+- **#118** (`373264f`): store factor `a_max`; anchor update ztol to
+  `zero_pivot_tol·a_max`, not `u_max0`. Fixes spurious `TinyPivot` +
+  update→refactor **livelock** on high-growth bases.
+- **#115** (`ae13f27`): reworked `DenseLu::update` to an eta-based
+  Bartels–Golub update. **The issue's suggested "swap rows in U + fix L" does
+  not work** — a row swap of U forces a column swap of L that breaks its
+  unit-lower-triangular structure (worked the algebra). Correct fix mirrors
+  the sparse path: base `L` fixed, eliminations+interchanges recorded as
+  `DenseFtOp` etas replayed between the L- and U-solves; `ftran_partial` now
+  returns `G⁻¹L⁻¹Pa`. Partial pivoting bounds multipliers by 1 (growth `O(m)`
+  on the Hessenberg), superseding the sparse path's Neumaier need. New
+  `tests/lu_dense_update_bg.rs` (bump chains, slack bases, ftran+btran parity
+  vs fresh factor); all 10 adversarial tests now pass (0 ignored).
+- **#119** (`d7aafea`): `scaling::kr_guarded_update` applied to all 7
+  Knight–Ruiz update sites. Bit-identical on healthy matrices (KR
+  dense/sparse parity preserved); guards the `Inf→NaN→0` cascade on subnormal
+  couplings (confirmed the unguarded loop yields `[NaN, 0.0]`).
+- **#116** (`e5b6d4b`): chose the **solve-side** fix (skip iff
+  `d_diag == 0.0` exactly) over the audit's separate mask — safer for the hard
+  inertia rule because it changes **no** factorization (the force-accept-zero
+  path already sets `d = 0.0` exactly and is the only skip outcome). The
+  skip-iff-exactly-0.0 invariant was verified **empirically**: the whole
+  corpus (inertia oracles + threshold suites) stays green with the gate
+  change. Rook sub-floor accepts now set `needs_refinement`/`n_tiny`.
+- **#117** (`4a1d163`): blocked panel bails a rook-eligible below-threshold
+  1×1 pivot to the scalar (rook) path (the panel can't rook itself — its
+  trailing submatrix isn't Schur-updated yet). The 1×1-no-swap gate
+  (`akk ≥ α·gamma0`) means the bail only fires for near-zero columns (the
+  audit's case). `remaining==1` scalar site also routed through the rook
+  wrapper. Parity test: EPS-scale near-zero panel column → scalar==blocked
+  byte-identical with `n_rook_rescues > 0` (impossible pre-fix). Rook-disabled
+  default path byte-unchanged.
 
 ## Benchmark Results
 ```
-(this container has no oracle-timed corpus; the bench harness ran its
-in-tree matrices only — correctness gates, no perf partition)
+Dense KKT:  inertia match 1/1, residual pass 1/1, worst 1.14e-15
+Sparse KKT: inertia vs MUMPS 2/2, residual pass 2/2, worst 1.26e-16
+```
 ```
 
 ## Git Status
 ```
-82a81bd issue #112: compensated FT sweep + opt-in Bartels-Golub pivot search
-5794f0e issue #112: research note + plan for Bartels-Golub pivot-searching update
-9596472 docs: session checkpoint 2026-07-02-02 (v0.13.0 release)
-36da100 release: feral v0.13.0 (#109)
-9d05f75 issue #107: add OrderingMethod::External for user-supplied orderings (#108)
+4a1d163 issue #117: blocked/scalar rook parity — panel bails rook-eligible 1x1 to scalar
+e5b6d4b issue #116: divide by live tiny LDLT pivots at solve (rook factor/solve contract)
+d7aafea issue #119: guard Knight-Ruiz equilibration against non-finite scale factors
+ae13f27 issue #115: eta-based Bartels-Golub dense LU update (fix zero-superdiagonal landmine)
+373264f issue #118: anchor LU update ztol to a_max, not u_max0
 ```
 
 ## Test Status
@@ -86,24 +86,19 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 395 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.89s
+test result: ok. 398 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.55s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-10-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-10-03.md)
 
-(this container has no oracle-timed corpus; the bench harness ran its
-in-tree matrices only — correctness gates, no perf partition)
-KKT summary: 2 matrices — inertia match 1/1, residual pass 1/1,
-  worst residual 1.14e-15
-Sparse solver: 2/2 — inertia vs MUMPS 2/2, residual pass 2/2,
-  worst residual 1.26e-16
-Dense/Sparse exit partition: 0 matrices (corpus absent) — N/A
-No solver-perf-relevant kernels changed on the default path except the
-compensated scatter (~4 flops per scatter add in the update only; factor
-and solve paths untouched).
+Dense KKT:  inertia match 1/1, residual pass 1/1, worst 1.14e-15
+Sparse KKT: inertia vs MUMPS 2/2, residual pass 2/2, worst 1.26e-16
+No inertia or residual regression. (No perf-partition corpus in-container.)
+Full suite: **769 passed / 0 failed**; clippy `--all-targets -D warnings`
+clean; `cargo fmt --check` clean.
 
 ```
 
@@ -258,7 +253,9 @@ tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
+tests/lu_adversarial_inputs.rs
 tests/lu_dense.rs
+tests/lu_dense_update_bg.rs
 tests/lu_ft_widebump.rs
 tests/lu_scaling.rs
 tests/lu_sparse.rs

--- a/dev/journal/2026-07-10-02.org
+++ b/dev/journal/2026-07-10-02.org
@@ -37,3 +37,52 @@ Full suite 0 failures; clippy --test -D warnings clean; fmt clean.
 #116/#117 (rook factor/solve contract, blocked/scalar inertia divergence)
 deliberately NOT in this file: they are frontal-kernel-internal, not black-box
 update/solve inputs; noted in the module header and their own issues.
+
+* 10:31 :lu:ldlt:scaling:issue-114:issue-115:issue-116:issue-117:issue-118:issue-119:fixes:
+Fixed all six audit-confirmed correctness bugs #114-#119, one commit each,
+each with tests + full-suite + clippy gate. Empirical-before-encoding
+discipline throughout (issue-112 lesson).
+
+#114 (90cb4fe): validate entering-column finiteness in update_sparse +
+  DenseLu::update. NaN was committed silently -> Ok(NaN) solve.
+#118 (373264f): store factor a_max on SparseLu/DenseLu; anchor update ztol
+  to zero_pivot_tol*a_max not u_max0. u_max0 >> a_max on growth bases caused
+  spurious TinyPivot + update->refactor livelock. Corpus 760 green.
+#115 (ae13f27): BIG. Reworked DenseLu::update to eta-based Bartels-Golub.
+  KEY FINDING: the issue's suggested "swap rows in U + fix L" does NOT work
+  - a row swap of U forces a column swap of L that breaks unit-lower-tri
+  (worked the algebra: L[k,k] becomes old L[k,k+1]=0). Correct fix mirrors
+  sparse: keep base L fixed, record eliminations+swaps as DenseFtOp etas,
+  replay between L-solve and U-solve (added etas to solves incl.
+  ftran_partial -> spike is G^-1 L^-1 P a). Partial pivoting bounds
+  multipliers by 1 (growth O(m) on Hessenberg) -> supersedes Neumaier need.
+  New tests/lu_dense_update_bg.rs: bump chains, slack bases, ftran+btran
+  parity vs fresh factor. All 10 adversarial tests now pass (0 ignored).
+#119 (d7aafea): scaling::kr_guarded_update applied to all 7 KR update sites
+  (infnorm sparse+dense, lu/scaling x4, dense/equilibrate). d/=sqrt(m) could
+  go Inf->NaN->0 on subnormal coupling. Guard is bit-identical on healthy
+  matrices (dense/sparse KR parity preserved). Confirmed unguarded produces
+  [nan,0.0] via Python replay.
+
+#116 (e5b6d4b): rook factor/solve contract. Chose the SOLVE-side fix (skip
+  iff d_diag==0.0 exactly) over the audit's separate mask - SAFER for the
+  inertia rule because it changes NO factorization (the force-accept-zero
+  path already sets d=0.0 exactly, line 4453, and it's the only skip
+  outcome). Verified the skip-iff-exactly-0.0 invariant EMPIRICALLY: full
+  corpus (768 incl. all inertia oracles + threshold suites) green with the
+  gate change. + needs_refinement/n_tiny on rook sub-floor accepts. Updated
+  now-vestigial zero_tol field doc.
+#117 (4a1d163): blocked/scalar rook parity. Panel's 1x1 no-swap path bails
+  ScalarFallback when pivot_threshold>0 && |d|<=threshold, so scalar
+  re-decides with rook (panel can't rook itself - trailing submatrix not yet
+  Schur-updated). KEY math: 1x1-no-swap requires akk>=alpha*gamma0, so the
+  bail only fires when gamma0 tiny (threshold floored by null_pivot_tol=EPS)
+  - i.e. near-zero columns, the audit's exact case. Also routed remaining==1
+  scalar site through the rook wrapper (its "rook can't fire" comment was
+  wrong). Test builds an EPS-scale near-zero panel column: scalar==blocked
+  byte-identical with n_rook_rescues>0 (a rescue the pre-fix blocked panel
+  literally could not produce). Rook-disabled default path byte-unchanged.
+
+End-of-session bench: inertia 100% (1/1 dense, 2/2 sparse vs MUMPS), worst
+residual 1.14e-15/1.26e-16 - no regression. Full suite 769 passed / 0 failed,
+clippy --all-targets -D warnings clean, fmt clean.

--- a/dev/journal/2026-07-10-02.org
+++ b/dev/journal/2026-07-10-02.org
@@ -1,0 +1,39 @@
+* 09:20 :audit:lu:tests:issue-114:issue-115:issue-118:
+Built the shared adversarial-input test file (tests/lu_adversarial_inputs.rs)
+requested after the 2026-07-10 six-agent audit, covering the class "inputs the
+factor path validates/handles but the update()/solve paths do not guard."
+
+Verified each reproduction empirically before encoding (issue-112 discipline:
+plausible != confirmed). Scratch-probe findings:
+- #114 sparse: update(1,[NaN,1]) -> Ok, ftran -> Ok with x=[NaN,1.0].
+  SILENT wrong answer confirmed. Factor path rejects the same NaN column
+  (InvalidInput). Note: +Inf currently returns NeedsRefactor (not silent),
+  but wrong error type -> still needs the fix (correct = InvalidInput).
+- #114 dense: update(1,[NaN,1]) on 2x2 identity -> Ok (commits NaN input).
+  Confirmed. (3x3 variants: some positions error, some commit clean-looking;
+  the 2x2 slot-1 case is the clean silent-commit repro.)
+- #115 dense: identity self-replace col0 -> Err(TinyPivot,0.0). Confirmed;
+  sparse commits the same update fine.
+- #118: CONFIRMED genuine livelock. m=60 update(e0+e1) -> Err(TinyPivot,0.25)
+  three times with constant u_max0=5.765e17; fresh factor of B' succeeds.
+  ztol = 1e-13*u_max0 dwarfs the healthy 0.25 pivot.
+
+Test-vehicle sizing (measured residual of fresh factor of B' vs m):
+  m=24..50 residual EXACTLY 0.0 (growth < 2^53, +-1/integer arithmetic exact);
+  m=60 residual 59.0 (growth 1.44e17 > 2^53, genuine backward error).
+  Chose m=50: u_max0=1.4e14 -> ztol~14 (dwarfs 0.25 pivot, triggers bug) AND
+  residual 0 (tight accuracy oracle stays valid). Verified m=50 triggers the
+  spurious rejection on both paths (sparse TinyPivot 0.25, dense TinyPivot 0.0).
+
+File design: 6 desired-behavior tests #[ignore]'d with issue refs (executable
+acceptance criteria; delete #[ignore] when the fix lands) + 4 non-ignored
+tests that pass today and establish the setup is sound (factor rejects
+non-finite; B' nonsingular via independent fresh factor; sparse already
+handles the slack self-replace dense cannot; genuinely singular replacement
+stays rejected -- the over-correction guard). Confirmed all 6 ignored tests
+fail on their INTENDED assertion (checked panic messages), not setup errors.
+Full suite 0 failures; clippy --test -D warnings clean; fmt clean.
+
+#116/#117 (rook factor/solve contract, blocked/scalar inertia divergence)
+deliberately NOT in this file: they are frontal-kernel-internal, not black-box
+update/solve inputs; noted in the module header and their own issues.

--- a/dev/sessions/2026-07-10-02.md
+++ b/dev/sessions/2026-07-10-02.md
@@ -1,0 +1,60 @@
+# Session 2026-07-10-02
+
+## Goal
+After the six-agent correctness/perf audit of the dense+sparse LDLᵀ and LU
+paths (which filed issues #114–#134), build the shared **adversarial-input
+test file** the audit recommended as the starting point for the confirmed LU
+bugs — the class "inputs the factor path validates/handles but the
+`update()`/solve paths do not guard."
+
+## Accomplished
+- `tests/lu_adversarial_inputs.rs`: 10 tests covering issues #114 (non-finite
+  entering columns), #115 (dense update zero-superdiagonal landmine), #118
+  (update ztol anchored to `u_max0` → spurious `TinyPivot` + refactor
+  livelock).
+  - 6 `#[ignore]`d desired-behavior tests = executable acceptance criteria
+    (delete the `#[ignore]` line when the fix lands). All 6 confirmed to fail
+    on their **intended** assertion against `main` (panic messages checked),
+    not on setup/compile errors.
+  - 4 non-ignored tests pass today: factor-path rejects non-finite; Wilkinson
+    replacement basis nonsingular via independent fresh factor; sparse update
+    already handles the slack self-replacement the dense path cannot; a
+    genuinely singular replacement stays rejected (over-correction guard).
+- Every reproduction empirically confirmed via scratch probe before encoding
+  (issue-112 discipline). #118 livelock reproduced directly (3 identical
+  `TinyPivot(0.25)` failures with constant `u_max0`, fresh factor of B'
+  succeeds).
+- Test vehicle sized deliberately: Wilkinson growth matrix at **m=50** — large
+  enough that `u_max0=1.4e14` makes `ztol≈14` (dwarfs the healthy 0.25 pivot,
+  triggering the bug on both paths) yet growth `<2^53` so the ±1/integer solve
+  is exact (residual 0), keeping the accuracy oracle tight. Measured the
+  residual-vs-m curve to pick this (m=60 residual = 59.0 from genuine
+  backward error would have confounded the test).
+
+## Benchmark Results
+Not re-run: this session adds only a test file (no `src/` change), so solver
+performance is unchanged from 2026-07-02 (per protocol, non-source commits are
+exempt from the bench/test re-run when CI on the last code commit was green;
+`main`@660224d CI was green). End-of-session `cargo test`: 0 failures across
+all suites; clippy `--test lu_adversarial_inputs -D warnings` clean; fmt clean.
+
+## Decisions Made
+- None architectural. Convention choice (recorded in the test file header):
+  desired-behavior regression tests for open bugs are `#[ignore]`d with an
+  issue ref rather than asserting current buggy behavior, so the suite stays
+  green and each test flips to passing exactly when its fix lands.
+
+## Abandoned Approaches
+- Wilkinson at m=60 (the audit's stated size): rejected because growth `>2^53`
+  gives a genuine backward-error residual of ~59, which would make the accuracy
+  oracle meaningless. m=50 preserves the trigger with an exact solve.
+
+## Next Session Should
+- (Opus) Start the confirmed-bug fixes using this file as the acceptance
+  harness — un-ignore each test as its fix lands. Suggested order per the
+  audit: #114 (finiteness validation, smallest) → #118 (ztol anchor to a
+  stored `a_max`) → #115 (dense update FT-scheme port + Neumaier compensation;
+  also flips the dense #118 test). #116/#117 need separate frontal-kernel
+  tests (not in this black-box file).
+- The #114/#115/#118 fixes touch neighboring lines in `dense_update.rs`;
+  coordinate as noted in the issues.

--- a/dev/sessions/2026-07-10-03.md
+++ b/dev/sessions/2026-07-10-03.md
@@ -1,0 +1,75 @@
+# Session 2026-07-10-03
+
+## Goal
+Fix the six audit-confirmed correctness bugs #114–#119 (from the 2026-07-10
+six-agent audit), one at a time, each as its own tested commit.
+
+## Accomplished
+All six fixed, committed, full-suite + clippy green after each. Empirical
+reproduction confirmed before encoding every fix (issue-112 discipline).
+
+- **#114** (`90cb4fe`): finiteness validation in `update_sparse` +
+  `DenseLu::update`. NaN was silently committed → `Ok(NaN)` solve.
+- **#118** (`373264f`): store factor `a_max`; anchor update ztol to
+  `zero_pivot_tol·a_max`, not `u_max0`. Fixes spurious `TinyPivot` +
+  update→refactor **livelock** on high-growth bases.
+- **#115** (`ae13f27`): reworked `DenseLu::update` to an eta-based
+  Bartels–Golub update. **The issue's suggested "swap rows in U + fix L" does
+  not work** — a row swap of U forces a column swap of L that breaks its
+  unit-lower-triangular structure (worked the algebra). Correct fix mirrors
+  the sparse path: base `L` fixed, eliminations+interchanges recorded as
+  `DenseFtOp` etas replayed between the L- and U-solves; `ftran_partial` now
+  returns `G⁻¹L⁻¹Pa`. Partial pivoting bounds multipliers by 1 (growth `O(m)`
+  on the Hessenberg), superseding the sparse path's Neumaier need. New
+  `tests/lu_dense_update_bg.rs` (bump chains, slack bases, ftran+btran parity
+  vs fresh factor); all 10 adversarial tests now pass (0 ignored).
+- **#119** (`d7aafea`): `scaling::kr_guarded_update` applied to all 7
+  Knight–Ruiz update sites. Bit-identical on healthy matrices (KR
+  dense/sparse parity preserved); guards the `Inf→NaN→0` cascade on subnormal
+  couplings (confirmed the unguarded loop yields `[NaN, 0.0]`).
+- **#116** (`e5b6d4b`): chose the **solve-side** fix (skip iff
+  `d_diag == 0.0` exactly) over the audit's separate mask — safer for the hard
+  inertia rule because it changes **no** factorization (the force-accept-zero
+  path already sets `d = 0.0` exactly and is the only skip outcome). The
+  skip-iff-exactly-0.0 invariant was verified **empirically**: the whole
+  corpus (inertia oracles + threshold suites) stays green with the gate
+  change. Rook sub-floor accepts now set `needs_refinement`/`n_tiny`.
+- **#117** (`4a1d163`): blocked panel bails a rook-eligible below-threshold
+  1×1 pivot to the scalar (rook) path (the panel can't rook itself — its
+  trailing submatrix isn't Schur-updated yet). The 1×1-no-swap gate
+  (`akk ≥ α·gamma0`) means the bail only fires for near-zero columns (the
+  audit's case). `remaining==1` scalar site also routed through the rook
+  wrapper. Parity test: EPS-scale near-zero panel column → scalar==blocked
+  byte-identical with `n_rook_rescues > 0` (impossible pre-fix). Rook-disabled
+  default path byte-unchanged.
+
+## Benchmark Results
+```
+Dense KKT:  inertia match 1/1, residual pass 1/1, worst 1.14e-15
+Sparse KKT: inertia vs MUMPS 2/2, residual pass 2/2, worst 1.26e-16
+```
+No inertia or residual regression. (No perf-partition corpus in-container.)
+Full suite: **769 passed / 0 failed**; clippy `--all-targets -D warnings`
+clean; `cargo fmt --check` clean.
+
+## Decisions Made
+- #116 fixed solve-side (no factorization change) rather than via a new
+  force-zeroed mask — preserves inertia exactly. Recorded here; not an
+  architectural change to `decisions.md`.
+- #115 dense update adopts the sparse eta model (`DenseFtOp`, base L fixed).
+  Worth a `decisions.md` note if the LU family is revisited.
+
+## Abandoned Approaches
+- #115: the issue's "swap rows in U and fix L" — a row swap of U cannot be
+  absorbed into an explicit unit-lower-triangular L (proven by the block
+  algebra); the eta model is required. (Not added to tried-and-rejected.md as
+  a standalone entry since it was resolved within the same fix; the reasoning
+  is in the journal and the `dense_update.rs` module header.)
+
+## Next Session Should
+- Consider the audit's remaining open items (#120–#134: perf + SOTA gaps),
+  starting with #124 (numeric-factor prologue) and #126 (fused single-RHS
+  solve) — the highest-leverage IPM-loop perf items.
+- If revisiting LU: a `decisions.md` entry for the dense eta-based update, and
+  the Schork–Gondzio permute-only fast path (#132) now composes cleanly with
+  both the sparse and dense eta machinery.

--- a/src/dense/equilibrate.rs
+++ b/src/dense/equilibrate.rs
@@ -27,7 +27,7 @@ pub fn equilibrate_scaling(matrix: &SymmetricMatrix) -> Vec<f64> {
             }
 
             if max_entry > 0.0 {
-                d[i] /= max_entry.sqrt();
+                d[i] = crate::scaling::kr_guarded_update(d[i], max_entry);
                 let deviation = (1.0 - max_entry).abs();
                 if deviation > max_deviation {
                     max_deviation = deviation;

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -2979,7 +2979,28 @@ fn lblt_panel_frontal(
             continue;
         }
 
-        // 1×1 pivot at col, no swap. Try the column-relative threshold.
+        // 1×1 pivot at col, no swap.
+        //
+        // Issue #117: when rook rescue is enabled (`pivot_threshold > 0`, e.g.
+        // the multifrontal default `1e-8`), a below-threshold pivot is exactly
+        // where `scalar_pivot_step` would attempt a rook rescue and sign-count
+        // the pivot *live*, whereas the panel's non-rook `try_reject_1x1_frontal`
+        // would zero-count or delay it — so the blocked and scalar kernels can
+        // certify different inertia on the same front. The panel cannot run
+        // `rook_rescue` itself (its trailing submatrix is not yet Schur-updated,
+        // so the search would read stale entries), so it bails to the scalar
+        // path, which re-decides the pivot from up-to-date state. Column `col`
+        // is only read here (it is peek-ahead'd — pivots `0..c` applied — and
+        // unmutated), so bailing before `try_reject_1x1_frontal` mutates it
+        // preserves the `ScalarFallback` contract (`j_start = k+n_elim+1`, same
+        // as the `Delayed` return below). When rook is disabled the panel keeps
+        // its inline handling, so the default dense path is byte-unchanged.
+        let threshold = (params.pivot_threshold * gamma0).max(params.null_pivot_tol);
+        if params.pivot_threshold > 0.0 && a[col * nrow + col].abs() <= threshold {
+            return Ok((c, PanelStatus::ScalarFallback));
+        }
+
+        // Try the column-relative threshold.
         let outcome = try_reject_1x1_frontal(
             a,
             nrow,
@@ -3903,8 +3924,12 @@ fn scalar_pivot_step(
     if remaining == 1 {
         // Last eliminated pivot: always 1×1. Compute the column max
         // over rows (k+1..nrow) for the column-relative threshold.
-        // Rook rescue cannot fire here (needs ncol-k >= 2), so call
-        // the rejection routine directly.
+        // Issue #117: rook rescue CAN fire here — `rook_rescue` only requires
+        // `k < ncol` and can accept the 1×1 at `k` itself (`arr >= u*gamma_r`,
+        // no swap). Routing through the rook wrapper (like every other scalar
+        // 1×1 site) keeps the last pivot's accept/sign-count consistent with
+        // the rest of the front; the old direct `try_reject_1x1_frontal` call
+        // could zero-count or delay a pivot the wrapper would rook-accept.
         let col_max = if let Some(mf) = cached {
             mf
         } else {
@@ -3917,28 +3942,25 @@ fn scalar_pivot_step(
             }
             m
         };
-        let outcome = try_reject_1x1_frontal(
+        let outcome = try_reject_1x1_with_rook_rescue(
             a,
             nrow,
+            ncol,
             k,
             col_max,
             may_delay,
             params,
+            perm,
             pos,
             neg,
             zero,
             needs_refinement,
+            n_rook_rescues,
             n_tiny,
         )?;
-        match outcome {
-            PivotOutcome::Accepted => do_1x1_update(a, nrow, k, params.fma),
-            PivotOutcome::Rejected => {}
-            PivotOutcome::Delayed => return Ok(PivotStepResult::Delayed),
-            PivotOutcome::AcceptedRook2x2 { .. } => {
-                unreachable!("remaining==1 never triggers rook rescue")
-            }
-        }
-        return Ok(PivotStepResult::Advanced(1));
+        return Ok(finish_1x1_outcome(
+            outcome, a, nrow, k, subdiag, pos, neg, zero, params.fma, None,
+        ));
     }
 
     // MAXFROMM short-circuit: if the previous 1×1 stash gives a

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -905,12 +905,16 @@ pub struct Factors {
     /// growth flagging (`|L_ij| > L_GROWTH_THRESHOLD`). (D9,
     /// repo-review-2026-06-09.md: previously documented as ForceAccept-only.)
     pub needs_refinement: bool,
-    /// 1×1 pivot threshold copied from BunchKaufmanParams at factor time.
-    /// `solve` consults this to decide whether to divide by `d_diag[k]`:
-    /// pivots `|d| <= zero_tol` were force-accepted as numerically zero
-    /// during factorization and must be skipped (left as-is) by the
-    /// D-block solve. Otherwise dividing by a tiny pivot produces
-    /// catastrophic error. See dev/plans/threshold-mismatch-fix.md.
+    /// 1×1 pivot floor copied from BunchKaufmanParams at factor time.
+    ///
+    /// No longer gates the D-block solve (issue #116): the solve divides by
+    /// any nonzero `d_diag[k]` and skips only force-zeroed pivots, which the
+    /// factor marks by setting `d_diag[k]` to exactly `0.0` (and clearing the
+    /// L column). The old `|d| <= zero_tol` skip wrongly dropped *live*
+    /// small-but-nonzero pivots (rook rescue, static/PerturbToEps floor, F-01
+    /// band) whose L column is intact and which must be divided by. Retained
+    /// as an informational field for callers. See
+    /// dev/plans/threshold-mismatch-fix.md for the original (superseded) gate.
     pub zero_tol: f64,
     /// 2×2 pivot block threshold (matches BunchKaufmanParams::zero_tol_2x2).
     pub zero_tol_2x2: f64,
@@ -4579,6 +4583,16 @@ fn try_reject_1x1_with_rook_rescue(
         match pivot.kind {
             RookKind::Pivot1x1 => {
                 let d_new = a[k * nrow + k];
+                // A rook-accepted pivot below the rank-deficiency floor is
+                // *live* (its L column is kept and the solve now divides by it,
+                // issue #116) but ill-conditioned: flag iterative refinement
+                // and count it as a tiny pivot, matching the static-floor and
+                // F-01 accept paths (the rook path previously set neither).
+                // Inertia is unchanged — still counted by sign.
+                if d_new.abs() <= params.null_pivot_tol {
+                    *needs_refinement = true;
+                    *n_tiny += 1;
+                }
                 if d_new > 0.0 {
                     *pos += 1;
                 } else {

--- a/src/dense/solve.rs
+++ b/src/dense/solve.rs
@@ -175,22 +175,26 @@ fn backward_substitute(factors: &Factors, v: &mut [f64]) {
 /// D-block solve: solve D_bk · w = z.
 /// Handles both 1×1 and 2×2 blocks using the normalized formulation.
 ///
-/// Pivots that were force-accepted as numerically zero during factorization
-/// are skipped — `w[k]` is left untouched, producing a least-squares-like
-/// solution where the corresponding row was rank-deficient. Dividing by such
-/// pivots produces catastrophic error; see dev/plans/threshold-mismatch-fix.md.
+/// The skip decision must match the factor side exactly, otherwise a pivot the
+/// factorization validly accepted and stored is silently skipped at solve time
+/// (wrong solution, no error, no flag).
 ///
-/// **Finding D4:** the skip decision must match the factor side exactly,
-/// otherwise a 2×2 block the factorization validly accepted and stored can be
-/// silently skipped at solve time (wrong solution, no error, no flag). For
-/// 1×1 pivots the `|d| <= zero_tol` floor matches the scalar acceptance gate.
-/// For 2×2 pivots the gate previously used the *naive* `a*c - b*b` against the
-/// *absolute* `zero_tol_2x2 ≈ EPS²`, while the factor side accepts via the
-/// *scale-invariant* SSIDS floor (`ssids_det_floor_fail`) — so a
-/// well-conditioned block at small absolute scale (true `|det|` below `EPS²`)
-/// was accepted by the factor but skipped by the solve. Both sides now call
-/// the shared `ssids_det_floor_fail`, so a block the factor inverts the solve
-/// inverts. (`zero_tol_2x2` is retained on `Factors` for the legacy
+/// **1×1 pivots (issue #116):** skip iff the pivot was *force-zeroed* — the
+/// factor sets `d_diag[k]` to exactly `0.0` and clears the L column, the only
+/// path that produces a pivot the solve must leave untouched. Every other
+/// accepted pivot is *live* (its L column participates in the elimination) and
+/// must be divided by, including small-but-nonzero ones from rook rescue, the
+/// static/PerturbToEps floor, or the F-01 rank-deficiency band. The previous
+/// `|d| > zero_tol` gate skipped those live tiny pivots too, silently dropping
+/// an O(1/d) term (`needs_refinement` is set so refinement can recover it).
+///
+/// **Finding D4 (2×2 pivots):** the gate previously used the *naive*
+/// `a*c - b*b` against the *absolute* `zero_tol_2x2 ≈ EPS²`, while the factor
+/// side accepts via the *scale-invariant* SSIDS floor (`ssids_det_floor_fail`)
+/// — so a well-conditioned block at small absolute scale (true `|det|` below
+/// `EPS²`) was accepted by the factor but skipped by the solve. Both sides now
+/// call the shared `ssids_det_floor_fail`, so a block the factor inverts the
+/// solve inverts. (`zero_tol_2x2` is retained on `Factors` for the legacy
 /// `count_2x2_inertia` accounting but no longer gates the solve.)
 fn d_block_solve(factors: &Factors, w: &mut [f64]) {
     let n = factors.n;
@@ -218,12 +222,17 @@ fn d_block_solve(factors: &Factors, w: &mut [f64]) {
             // w[k], w[k+1] untouched.
             k += 2;
         } else {
-            // 1×1 block
+            // 1×1 block. Skip iff the pivot was force-zeroed (its L column
+            // cleared and `d_diag` set to exactly 0.0 — the only skip outcome
+            // the factor produces). A small-but-nonzero *live* pivot (rook
+            // rescue, static/PerturbToEps floor, F-01 band) keeps its L column
+            // and MUST be divided by — the old `|d| > zero_tol` gate wrongly
+            // skipped rook-accepted pivots with `|d| ≤ zero_tol`, silently
+            // dropping an O(1/d) term from the solution (issue #116).
             let d = factors.d_diag[k];
-            if d.abs() > factors.zero_tol {
+            if d != 0.0 {
                 w[k] /= d;
             }
-            // else: pivot was force-accepted as zero; leave w[k] alone
             k += 1;
         }
     }
@@ -232,4 +241,41 @@ fn d_block_solve(factors: &Factors, w: &mut [f64]) {
 /// L2 norm of a vector.
 fn norm2(v: &[f64]) -> f64 {
     v.iter().map(|x| x * x).sum::<f64>().sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #116: the D-block solve must divide by a *live* small-but-nonzero
+    /// 1×1 pivot (rook rescue / static floor / F-01 band keep the L column and
+    /// can leave `d_diag` below `zero_tol`), and skip only a *force-zeroed*
+    /// pivot (`d_diag == 0.0` exactly, L cleared). The old `|d| > zero_tol`
+    /// gate skipped the live tiny pivot too, silently dropping an O(1/d) term
+    /// from the solution.
+    #[test]
+    fn d_block_solve_divides_live_tiny_pivot_skips_forced_zero() {
+        // Position 0: live tiny pivot d = 1e-16 (< zero_tol = 1e-13) → divide.
+        // Position 1: force-zeroed d = 0.0 → skip (leave w unchanged).
+        let factors = Factors {
+            n: 2,
+            l: vec![1.0, 0.0, 0.0, 1.0], // d_block_solve ignores L
+            d_diag: vec![1e-16, 0.0],
+            d_subdiag: vec![0.0, 0.0],
+            perm: vec![0, 1],
+            perm_inv: vec![0, 1],
+            d_eq: vec![1.0, 1.0],
+            needs_refinement: true,
+            zero_tol: 1e-13,
+            zero_tol_2x2: 1e-26,
+        };
+        let mut w = vec![2.0, 5.0];
+        d_block_solve(&factors, &mut w);
+        assert_eq!(
+            w[0],
+            2.0 / 1e-16,
+            "live tiny pivot must be divided, not skipped"
+        );
+        assert_eq!(w[1], 5.0, "force-zeroed pivot (d == 0) must be skipped");
+    }
 }

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -1,12 +1,21 @@
 //! Dense unsymmetric LU factorization with threshold partial pivoting.
 //!
-//! Maintains the invariant `P B Q = L U`, where `P` is the row permutation
+//! Maintains the invariant `P B Q = L G U`, where `P` is the row permutation
 //! from partial pivoting, `Q` is a column permutation (identity after a fresh
-//! factorization; a rank-1 update may permute columns), `L` is unit lower
-//! triangular, and `U` is upper triangular. `L` and `U` are stored as separate
-//! dense `m`×`m` column-major buffers so that the rank-1
-//! column-replacement update ([`super::dense_update`]) has a clean home for the
-//! spike column and the Hessenberg bump it eliminates.
+//! factorization; a rank-1 update permutes columns), `L` is unit lower
+//! triangular, `U` is upper triangular, and `G = E₁⁻¹…Eₜ⁻¹` is the product of
+//! the rank-1 updates' Hessenberg-reduction eliminations. `G` is identity after
+//! a fresh factorization (`etas` empty), so all one-shot factor/solve behavior
+//! is unchanged. `L` and `U` are stored as separate dense `m`×`m` column-major
+//! buffers.
+//!
+//! The update ([`super::dense_update`]) records its eliminations as `etas`
+//! rather than folding them into `L`: a Bartels–Golub row interchange (needed
+//! to dodge the zero-superdiagonal landmine and bound element growth) is an
+//! *unsymmetric* row permutation of `U` that cannot be absorbed into an
+//! explicit unit-lower-triangular `L`, so — exactly as on the sparse path
+//! ([`super::sparse_update`]) — the base `L` stays fixed and the solves replay
+//! the etas between the `L`-solve and the `U`-solve.
 //!
 //! The factorization kernel itself works in a packed buffer (the classic
 //! right-looking LAPACK layout) and is split into `L`/`U` at the end.
@@ -15,6 +24,44 @@ use super::scaling::{compute_lu_scale, LuScale};
 use super::sparse_matrix::SparseColMatrix;
 use super::{LuParams, LuScaling, LuSingularAction, RefactorCause};
 use crate::error::FeralError;
+
+/// One elementary operation of a dense rank-1 update's Hessenberg reduction,
+/// recorded so it can be replayed on a solve vector (and transposed for btran).
+/// Mirrors the sparse [`super::sparse_factor::FtOp`]; the base `L`, `P`, and the
+/// prior etas are never relabeled.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum DenseFtOp {
+    /// `s[target] -= mult · s[src]` (elimination of one Hessenberg subdiagonal).
+    Axpy {
+        target: usize,
+        src: usize,
+        mult: f64,
+    },
+    /// Rows `a` and `b` exchanged (a Bartels–Golub interchange); the matching
+    /// solve-vector entries swap with them. A transposition is its own
+    /// transpose, so btran replays the same swap in the reversed op walk.
+    Swap { a: usize, b: usize },
+}
+
+impl DenseFtOp {
+    /// Apply forward (`s ← Eᵢ s`): the row op exactly as performed on `U`.
+    #[inline]
+    pub(super) fn apply_forward(&self, s: &mut [f64]) {
+        match *self {
+            DenseFtOp::Axpy { target, src, mult } => s[target] -= mult * s[src],
+            DenseFtOp::Swap { a, b } => s.swap(a, b),
+        }
+    }
+
+    /// Apply transpose (`s ← Eᵢᵀ s`): axpy flips target/src; swap is unchanged.
+    #[inline]
+    pub(super) fn apply_transpose(&self, s: &mut [f64]) {
+        match *self {
+            DenseFtOp::Axpy { target, src, mult } => s[src] -= mult * s[target],
+            DenseFtOp::Swap { a, b } => s.swap(a, b),
+        }
+    }
+}
 
 /// Dense LU factorization of a square basis, with rank-1 update support.
 #[derive(Debug, Clone)]
@@ -34,6 +81,11 @@ pub struct DenseLu {
     pub(super) qcol: Vec<usize>,
     /// Inverse of `qcol`: `qcol_inv[slot] = column_position`.
     pub(super) qcol_inv: Vec<usize>,
+    /// Rank-1 update eliminations since the last factor/refactor (the `G`
+    /// factor of `P B Q = L G U`). Empty after a fresh factor; the solves
+    /// replay them between the `L`-solve and the `U`-solve so the base `L`
+    /// never needs the unsymmetric relabeling a row interchange would force.
+    pub(super) etas: Vec<DenseFtOp>,
     /// Updates applied since the last `factor`/`refactor`.
     pub(super) updates_since_refactor: usize,
     /// Running growth monitor; tripping `params.max_growth` forces a refactor.
@@ -96,6 +148,7 @@ impl DenseLu {
             perm_inv,
             qcol: (0..m).collect(),
             qcol_inv: (0..m).collect(),
+            etas: Vec::new(),
             updates_since_refactor: 0,
             growth: 1.0,
             u_max0,
@@ -140,6 +193,7 @@ impl DenseLu {
             *q = k;
             *qi = k;
         }
+        self.etas.clear();
         self.updates_since_refactor = 0;
         self.growth = 1.0;
         self.last_refactor = None;

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -44,6 +44,11 @@ pub struct DenseLu {
     /// `max|U|` immediately after the last factor/refactor — the denominator of
     /// the element-growth monitor. Floored away from zero.
     pub(super) u_max0: f64,
+    /// `max|A|` of the (scaled) factored matrix — the singularity-tolerance
+    /// reference the factor uses. The update anchors its bump-pivot ztol here,
+    /// not to `u_max0`, so healthy `O(a_max)` pivots on high-growth bases are
+    /// not spuriously rejected (issue #118).
+    pub(super) a_max: f64,
     /// Cause + magnitude of the most recent [`Self::update`] that returned
     /// [`FeralError::NeedsRefactor`]. `None` after a fresh factor/refactor;
     /// untouched by a successful update (read only after an `Err`). See issue #95.
@@ -73,6 +78,8 @@ impl DenseLu {
         let factor_cols: &[Vec<f64>] = scaled.as_deref().unwrap_or(cols);
         let mut packed = vec![0.0; m * m];
         copy_columns_into(&mut packed, factor_cols, m)?;
+        // `max|A|` before `factorize_packed` overwrites `packed` in place.
+        let a_max = packed.iter().fold(0.0_f64, |a, &x| a.max(x.abs()));
         let mut perm: Vec<usize> = (0..m).collect();
         factorize_packed(&mut packed, &mut perm, m, &params)?;
         let (l, u) = split_packed(&packed, m);
@@ -92,6 +99,7 @@ impl DenseLu {
             updates_since_refactor: 0,
             growth: 1.0,
             u_max0,
+            a_max,
             last_refactor: None,
             params,
             scale,
@@ -111,6 +119,7 @@ impl DenseLu {
         let factor_cols: &[Vec<f64>] = scaled.as_deref().unwrap_or(cols);
         let mut packed = vec![0.0; m * m];
         copy_columns_into(&mut packed, factor_cols, m)?;
+        self.a_max = packed.iter().fold(0.0_f64, |a, &x| a.max(x.abs()));
         for (k, p) in self.perm.iter_mut().enumerate() {
             *p = k;
         }

--- a/src/lu/dense_solve.rs
+++ b/src/lu/dense_solve.rs
@@ -110,6 +110,11 @@ impl DenseLu {
             *sk = rhs[self.perm[k]];
         }
         lsolve(&self.l, m, &mut s);
+        // Replay the update etas forward (G⁻¹) between the L-solve and the
+        // U-solve; identity when no update has run (`etas` empty).
+        for op in self.etas.iter() {
+            op.apply_forward(&mut s);
+        }
         // Restore the scratch buffer on every path (it was `mem::take`n, so an
         // early `?` would otherwise leave `self.scratch_a` empty and panic the
         // next call). Only write `rhs` on success.
@@ -134,6 +139,11 @@ impl DenseLu {
         // Restore scratch on every path; only finish + write `rhs` on success.
         let res = ut_solve(&self.u, m, &mut s); // Uᵀ z = g
         if res.is_ok() {
+            // Replay the etas transposed, in reverse — `Gᵀ⁻¹` between the
+            // Uᵀ-solve and the Lᵀ-solve (the transpose of `ftran_core`).
+            for op in self.etas.iter().rev() {
+                op.apply_transpose(&mut s);
+            }
             lt_solve(&self.l, m, &mut s); // Lᵀ v = z
             for (k, &vk) in s.iter().enumerate() {
                 rhs[self.perm[k]] = vk;
@@ -143,9 +153,12 @@ impl DenseLu {
         res
     }
 
-    /// Compute the spike `L⁻¹ P a`, overwriting `rhs` (= `a`). This is `ftran`
-    /// stopped before the `U`-solve and column permutation; it is the input to
-    /// [`DenseLu::update`](crate::lu::DenseLu::update).
+    /// Compute the spike `G⁻¹ L⁻¹ P a`, overwriting `rhs` (= `a`). This is
+    /// `ftran` stopped before the `U`-solve and column permutation; it is the
+    /// input to [`DenseLu::update`](crate::lu::DenseLu::update). The eta replay
+    /// is essential: the spike is inserted into the *current* `U`'s column
+    /// space, which is `G⁻¹ L⁻¹ P a`, not merely `L⁻¹ P a` (they coincide only
+    /// before the first update, when `etas` is empty).
     pub fn ftran_partial(&mut self, rhs: &mut [f64]) -> Result<(), FeralError> {
         let m = self.m;
         check_len(rhs.len(), m)?;
@@ -154,6 +167,9 @@ impl DenseLu {
             *sk = rhs[self.perm[k]];
         }
         lsolve(&self.l, m, &mut s);
+        for op in self.etas.iter() {
+            op.apply_forward(&mut s);
+        }
         rhs.copy_from_slice(&s);
         self.scratch_a = s;
         Ok(())

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -1,23 +1,35 @@
 //! Dense rank-1 column-replacement update (Bartels–Golub).
 //!
 //! Replacing basis slot `leaving_slot` by a new column whose spike is
-//! `s = L⁻¹ P aₙₑw` (from [`DenseLu::ftran_partial`]) maintains the invariant
-//! `P B Q = L U` in three steps.
+//! `s = G⁻¹ L⁻¹ P aₙₑw` (from [`DenseLu::ftran_partial`]) maintains the
+//! invariant `P B Q = L G U` in three steps.
 //!
 //! Step one overwrites column `q = qcol_inv[leaving_slot]` of `U` with the
 //! spike `s`; `U` is then upper triangular except column `q`, which has a spike
 //! below the diagonal. Step two cyclically shifts columns `q..m-1` of `U` left
 //! by one and moves the spike column to position `m-1` (updating `Q`), turning
 //! `U` into upper-Hessenberg with a single subdiagonal on positions `q..m-2`.
-//! Step three eliminates that subdiagonal with a Gauss sweep (no in-bump
-//! pivoting; the growth monitor and `NeedsRefactor` handle instability): each
-//! elimination is a row operation on `U` and the corresponding column operation
-//! on `L`, so `L` stays unit lower triangular and `U` upper triangular.
+//! Step three reduces that Hessenberg back to upper triangular by **Bartels–
+//! Golub elimination with partial pivoting**: at each subdiagonal it pivots on
+//! the larger of the diagonal and the subdiagonal, interchanging the two rows
+//! when the subdiagonal wins.
 //!
-//! The work is done on clones of `L`, `U`, and `Q`, committed only on success,
-//! so a `NeedsRefactor` return leaves `self` unchanged and recoverable.
+//! Each elimination (and interchange) is recorded as a [`DenseFtOp`] eta rather
+//! than folded into `L`: a row interchange is an *unsymmetric* row permutation
+//! of `U`, and absorbing it into `L` would require a column swap that destroys
+//! `L`'s unit-lower-triangular structure. So — exactly as on the sparse path —
+//! the base `L`, `P`, and prior etas stay fixed, and the solves replay the etas
+//! between the `L`-solve and the `U`-solve. Partial pivoting is what makes this
+//! robust: it dodges the zero-superdiagonal landmine of the old fixed-order
+//! sweep (which pivoted on the shifted-in old superdiagonal — structurally zero
+//! for slack/triangular bases, so it refactored on trivially valid updates,
+//! issue #115) and bounds every multiplier by 1, so element growth stays `O(m)`
+//! on the Hessenberg and no compensated accumulation is needed.
+//!
+//! The work is done on clones of `U` and `Q` plus a local eta list, committed
+//! only on success, so a `NeedsRefactor` return leaves `self` unchanged.
 
-use super::dense_factor::DenseLu;
+use super::dense_factor::{DenseFtOp, DenseLu};
 use super::RefactorCause;
 use crate::error::FeralError;
 
@@ -84,17 +96,23 @@ impl DenseLu {
         let ztol = self.params.zero_pivot_tol * self.a_max;
         let max_growth = self.params.max_growth;
 
-        // Work on clones; commit only on success.
+        // Work on clones of U and Q, and accumulate new eliminations in a local
+        // eta list; the base L, P, and the prior etas are never touched, so
+        // rollback is simply *not committing*. (Unlike the old scheme, L is not
+        // modified: a Bartels–Golub row interchange is an unsymmetric row
+        // permutation of U that cannot be absorbed into an explicit
+        // unit-lower-triangular L — see the module header.)
         let mut u = self.u.clone();
-        let mut l = self.l.clone();
         let mut qcol = self.qcol.clone();
+        let mut new_etas: Vec<DenseFtOp> = Vec::new();
 
-        // 1. Overwrite column q of U with the spike.
+        // 1. Overwrite column q of U with the spike (`G⁻¹ L⁻¹ P aₙₑw`).
         for i in 0..m {
             u[i + q * m] = spike[i];
         }
 
-        // 2. Cyclic column shift q..m-1: spike column moves to position m-1.
+        // 2. Cyclic column shift q..m-1: spike column moves to position m-1,
+        //    turning U into upper-Hessenberg with one subdiagonal on q..m-2.
         cyclic_shift_columns(&mut u, m, q);
         let leaving = qcol[q];
         for j in q..m - 1 {
@@ -102,27 +120,49 @@ impl DenseLu {
         }
         qcol[m - 1] = leaving;
 
-        // 3. Eliminate the Hessenberg subdiagonal on positions q..m-2.
+        // 3. Reduce the Hessenberg U to triangular by Bartels–Golub elimination
+        //    with partial pivoting: pivot on the larger of the diagonal and the
+        //    subdiagonal, interchanging the two rows when the subdiagonal wins.
+        //    This both dodges the zero-superdiagonal landmine (the old
+        //    fixed-order sweep pivoted on the shifted-in old superdiagonal,
+        //    structurally zero for slack/triangular bases → spurious
+        //    TinyPivot(0.0)) and bounds every multiplier by 1, keeping element
+        //    growth O(m) on the Hessenberg (issue #115). Each elimination is
+        //    recorded as an eta; the base L is untouched.
         for k in q..m.saturating_sub(1) {
-            let piv = u[k + k * m];
+            let mut piv = u[k + k * m];
+            let sub = u[k + 1 + k * m];
+            if sub.abs() > piv.abs() {
+                // Interchange rows k and k+1 of U (all columns; both rows are
+                // zero left of column k, so this only reorders columns ≥ k) and
+                // record the swap so the base L/P stay fixed.
+                for j in 0..m {
+                    u.swap(k + j * m, k + 1 + j * m);
+                }
+                new_etas.push(DenseFtOp::Swap { a: k, b: k + 1 });
+                piv = u[k + k * m];
+            }
             if piv.abs() <= ztol {
+                // Both diagonal and subdiagonal vanish ⇒ column k is negligible
+                // ⇒ singular replacement (reported as TinyPivot, as on the
+                // sparse path; the authoritative verdict is a fresh factor).
                 self.last_refactor = Some((RefactorCause::TinyPivot, piv.abs()));
                 return Err(FeralError::NeedsRefactor);
             }
             let sub = u[k + 1 + k * m];
             if sub == 0.0 {
-                continue;
+                continue; // subdiagonal already zero (no elimination needed)
             }
-            let mult = sub / piv;
-            // Row op on U: row_{k+1} -= mult · row_k, columns k..m-1.
+            let mult = sub / piv; // |mult| ≤ 1 by the interchange
             for j in k..m {
                 u[k + 1 + j * m] -= mult * u[k + j * m];
             }
             u[k + 1 + k * m] = 0.0; // enforce exact zero
-                                    // Column op on L: col_k += mult · col_{k+1} (keeps L unit lower).
-            for i in 0..m {
-                l[i + k * m] += mult * l[i + (k + 1) * m];
-            }
+            new_etas.push(DenseFtOp::Axpy {
+                target: k + 1,
+                src: k,
+                mult,
+            });
         }
 
         // L5 (dev/research/repo-review-2026-06-09.md): monitor element growth,
@@ -149,13 +189,13 @@ impl DenseLu {
             return Err(FeralError::NeedsRefactor);
         }
 
-        // Commit.
+        // Commit. The base L is unchanged; the new eliminations extend G.
         self.u = u;
-        self.l = l;
         self.qcol = qcol;
         for (k, &slot) in self.qcol.iter().enumerate() {
             self.qcol_inv[slot] = k;
         }
+        self.etas.extend(new_etas);
         self.growth = growth;
         self.updates_since_refactor += 1;
         Ok(())

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -47,6 +47,15 @@ impl DenseLu {
                 leaving_slot, m
             )));
         }
+        // Reject non-finite entries up front, matching the factor path
+        // (`dense_factor.rs`): a NaN pivot passes `piv.abs() <= ztol` (NaN
+        // comparisons are false) and the `umax` fold ignores it, committing a
+        // corrupted factor after `Ok` (issue #114).
+        if entering_col.iter().any(|x| !x.is_finite()) {
+            return Err(FeralError::InvalidInput(
+                "LU entering column contains non-finite entries".to_string(),
+            ));
+        }
         // Update-count budget (checked before doing any work).
         if self.updates_since_refactor + 1 > self.params.max_updates {
             self.last_refactor =

--- a/src/lu/dense_update.rs
+++ b/src/lu/dense_update.rs
@@ -77,10 +77,11 @@ impl DenseLu {
         let q = self.qcol_inv[leaving_slot];
         // L6 (dev/research/repo-review-2026-06-09.md): the bump-pivot and
         // final-pivot zero tests must be relative to the basis magnitude, not an
-        // absolute 1e-13. `u_max0` (max|U| at the last factor, already floored
-        // away from zero for L5) is the natural scale reference, consistent with
-        // the factor path's `zero_pivot_tol · max|A|`.
-        let ztol = self.params.zero_pivot_tol * self.u_max0;
+        // absolute 1e-13. The reference is `max|A|` — matching the factor path's
+        // `zero_pivot_tol · max|A|`. Anchoring to `u_max0` instead (as before)
+        // rejected healthy `O(a_max)` pivots on high-growth bases where
+        // `u_max0 ≫ a_max`, livelocking update→refactor→retry (issue #118).
+        let ztol = self.params.zero_pivot_tol * self.a_max;
         let max_growth = self.params.max_growth;
 
         // Work on clones; commit only on success.

--- a/src/lu/scaling.rs
+++ b/src/lu/scaling.rs
@@ -123,12 +123,12 @@ pub fn equilibrate_infnorm(b: &SparseColMatrix, iters: usize) -> LuScale {
         }
         for (dr, &rm) in d_row.iter_mut().zip(row_max.iter()) {
             if rm > 0.0 {
-                *dr /= rm.sqrt();
+                *dr = crate::scaling::kr_guarded_update(*dr, rm);
             }
         }
         for (dc, &cm) in d_col.iter_mut().zip(col_max.iter()) {
             if cm > 0.0 {
-                *dc /= cm.sqrt();
+                *dc = crate::scaling::kr_guarded_update(*dc, cm);
             }
         }
     }
@@ -199,12 +199,12 @@ fn compose_with_infnorm(b: &SparseColMatrix, mut scale: LuScale) -> LuScale {
         }
         for (dr, &rm) in scale.d_row.iter_mut().zip(row_max.iter()) {
             if rm > 0.0 {
-                *dr /= rm.sqrt();
+                *dr = crate::scaling::kr_guarded_update(*dr, rm);
             }
         }
         for (dc, &cm) in scale.d_col.iter_mut().zip(col_max.iter()) {
             if cm > 0.0 {
-                *dc /= cm.sqrt();
+                *dc = crate::scaling::kr_guarded_update(*dc, cm);
             }
         }
     }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -124,6 +124,13 @@ pub struct SparseLu {
     /// `max|U|` immediately after factor — denominator of the element-growth
     /// monitor. Floored away from zero.
     pub(super) u_max0: f64,
+    /// `max|A|` of the (scaled) factored matrix — the same singularity-tolerance
+    /// reference the factor uses (`zero_pivot_tol · a_max`). The update anchors
+    /// its bump-pivot ztol here, **not** to `u_max0`: on high-growth bases
+    /// `u_max0 ≫ a_max`, so a `u_max0`-anchored ztol spuriously rejects healthy
+    /// `O(a_max)` bump pivots — and since `refactor()` reproduces the same
+    /// high-growth factor, update→refactor→retry livelocks (issue #118).
+    pub(super) a_max: f64,
     /// Total Gilbert–Peierls reach nodes visited during the factor — a
     /// structural scalability witness (`O(nnz(U))`, not `O(n²)`).
     pub(super) reach_visits: usize,
@@ -516,6 +523,7 @@ impl SparseLu {
             etas: Vec::new(),
             growth: 1.0,
             u_max0,
+            a_max,
             reach_visits,
             params,
             scale,

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -503,7 +503,11 @@ impl SparseLu {
         saved: &mut Vec<(usize, Vec<(usize, f64)>)>,
         presaved: &[usize],
     ) -> Result<(Vec<FtOp>, Vec<usize>), FeralError> {
-        let ztol = self.params.zero_pivot_tol * self.u_max0;
+        // Anchor the bump-pivot floor to the matrix magnitude `a_max` (as the
+        // factor does), not `u_max0`: on high-growth bases `u_max0 ≫ a_max`
+        // would reject healthy `O(a_max)` pivots and livelock the caller's
+        // update→refactor→retry loop (issue #118).
+        let ztol = self.params.zero_pivot_tol * self.a_max;
         let mut ops: Vec<FtOp> = Vec::new();
         let mut swapped: Vec<usize> = Vec::new();
 

--- a/src/lu/sparse_update.rs
+++ b/src/lu/sparse_update.rs
@@ -100,12 +100,22 @@ impl SparseLu {
                 leaving_slot, m
             )));
         }
-        for &(row, _) in entering.iter() {
+        for &(row, val) in entering.iter() {
             if row >= m {
                 return Err(FeralError::InvalidInput(format!(
                     "entering-column row {} out of range for dimension {}",
                     row, m
                 )));
+            }
+            // Reject non-finite entries up front, matching the factor path
+            // (`sparse_matrix.rs`): a NaN passes the `v != 0.0` scan in
+            // `update` and would otherwise be committed into `U` — where the
+            // growth scan's `f64::max` ignores it and the solves guard only
+            // the diagonal — yielding a silent NaN solution (issue #114).
+            if !val.is_finite() {
+                return Err(FeralError::InvalidInput(
+                    "LU entering column contains non-finite entries".to_string(),
+                ));
             }
         }
         if self.updates_since_refactor() + 1 > self.params.max_updates {

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -323,10 +323,14 @@ fn solve_sparse_core_into(
                 // leave w[k], w[k + 1] untouched.
                 k += 2;
             } else {
-                if ff.d_diag[k].abs() > ff.zero_tol {
+                // Skip iff force-zeroed (`d_diag == 0.0` exactly, L cleared);
+                // divide by any live pivot, including a small-but-nonzero one
+                // from rook rescue / static floor / F-01 band (issue #116 — the
+                // old `|d| > zero_tol` gate silently dropped rook-accepted
+                // sub-`zero_tol` pivots from the solution).
+                if ff.d_diag[k] != 0.0 {
                     w[k] /= ff.d_diag[k];
                 }
-                // else: pivot force-accepted as zero; leave w[k] alone
                 k += 1;
             }
         }
@@ -831,7 +835,10 @@ fn dsolve_node(
                 // else: rejected by the shared SSIDS floor; leave as-is.
                 k += 2;
             } else {
-                if ff.d_diag[k].abs() > ff.zero_tol {
+                // Skip iff force-zeroed (`d_diag == 0.0` exactly); divide by
+                // any live pivot, including rook/static/F-01 sub-`zero_tol`
+                // ones (issue #116). Mirrors the single-RHS gate above.
+                if ff.d_diag[k] != 0.0 {
                     w[k * nrhs + c] /= ff.d_diag[k];
                 }
                 // else: pivot force-accepted as zero; leave as-is.

--- a/src/scaling/infnorm.rs
+++ b/src/scaling/infnorm.rs
@@ -95,7 +95,7 @@ pub fn compute_infnorm(matrix: &CscMatrix) -> (Vec<f64>, ScalingInfo) {
         for i in 0..n {
             let m = row_max[i];
             if m > 0.0 {
-                d[i] /= m.sqrt();
+                d[i] = crate::scaling::kr_guarded_update(d[i], m);
                 let dev = (m - 1.0).abs();
                 if dev > max_dev {
                     max_dev = dev;
@@ -199,7 +199,7 @@ pub fn compute_infnorm_dense(sym: &SymmetricMatrix) -> (Vec<f64>, ScalingInfo) {
         for i in 0..n {
             let m = row_max[i];
             if m > 0.0 {
-                d[i] /= m.sqrt();
+                d[i] = crate::scaling::kr_guarded_update(d[i], m);
                 let dev = (m - 1.0).abs();
                 if dev > max_dev {
                     max_dev = dev;
@@ -302,6 +302,45 @@ fn scan_offdiag_simd(d_off: &[f64], data_off: &[f64], dj: f64, row_max_off: &mut
 mod tests {
     use super::*;
     use crate::sparse::csc::CscMatrix;
+
+    /// Issue #119: the guarded Knight–Ruiz step applies `d/√m` only when it
+    /// stays finite and positive, else holds `d`. Healthy inputs are unchanged;
+    /// overflow (`d/√m → Inf`), underflow-to-zero (`m = Inf`), and `NaN` inputs
+    /// all return the input `d` instead of poisoning it.
+    #[test]
+    fn kr_guarded_update_guards_extremes() {
+        // Healthy: exact bare division.
+        assert_eq!(crate::scaling::kr_guarded_update(1.0, 4.0), 0.5);
+        assert_eq!(crate::scaling::kr_guarded_update(6.0, 9.0), 2.0);
+        // Overflow: 1e300/√(1e-40) = 1e320 → Inf → held.
+        assert_eq!(crate::scaling::kr_guarded_update(1e300, 1e-40), 1e300);
+        // m = Inf ⇒ d/Inf = 0 (not > 0) → held.
+        assert_eq!(crate::scaling::kr_guarded_update(1.0, f64::INFINITY), 1.0);
+        // m = NaN ⇒ NaN (not finite) → held.
+        assert_eq!(crate::scaling::kr_guarded_update(1.0, f64::NAN), 1.0);
+    }
+
+    /// Issue #119: a subnormal off-diagonal coupling with no diagonal in row 0
+    /// drives the unguarded iteration to `d = [NaN, 0.0]` on a finite input
+    /// (reproduced offline). The guarded iteration must return all-finite,
+    /// strictly-positive factors (no silent NaN/0 poisoning the factorization),
+    /// and the scaled entry must stay finite.
+    #[test]
+    fn kr_subnormal_coupling_stays_finite() {
+        // Lower triangle: (1,0) = 1e-320 (subnormal), (1,1) = 1; no (0,0), so
+        // row 0's only entry is the subnormal coupling.
+        let m = CscMatrix::from_triplets(2, &[1, 1], &[0, 1], &[1e-320, 1.0]).unwrap();
+        let (d, info) = compute_infnorm(&m);
+        assert!(matches!(info, ScalingInfo::Applied));
+        for (i, &di) in d.iter().enumerate() {
+            assert!(
+                di.is_finite() && di > 0.0,
+                "d[{i}] = {di} must be finite and strictly positive"
+            );
+        }
+        let scaled = (d[1] * 1e-320 * d[0]).abs();
+        assert!(scaled.is_finite(), "scaled entry {scaled} must be finite");
+    }
 
     /// Diagonal matrix diag(2, 3, 5). The oracle scaling is
     /// d = [1/sqrt(2), 1/sqrt(3), 1/sqrt(5)], so that

--- a/src/scaling/mod.rs
+++ b/src/scaling/mod.rs
@@ -56,6 +56,32 @@ pub fn mc64_matching(matrix: &CscMatrix) -> Result<(Vec<usize>, usize), FeralErr
     mc64::matching_perm(matrix)
 }
 
+/// One Knight–Ruiz equilibration step `d ← d / √m`, guarded against
+/// overflow/underflow (issue #119). Applies the update only when the result
+/// stays finite and strictly positive; otherwise `d` is held at its last good
+/// value. `m` is the row/column ∞-norm and is assumed `> 0` (the caller's
+/// existing `m > 0` guard).
+///
+/// On well-scaled matrices `d / √m` is always finite and positive, so this is
+/// **bit-identical** to the bare division — the guard bites only on extreme or
+/// subnormal couplings, where the unguarded `d` would reach `±Inf` (then `NaN`
+/// on the next sweep) or `0`. Such a value silently poisons every coupled row
+/// and the downstream factorization; the MC64 scaling path already rewrites
+/// non-finite/zero factors defensively (`scaling::mc64`), and this brings the
+/// Knight–Ruiz paths (`scaling::infnorm`, `lu::scaling`, `dense::equilibrate`)
+/// to the same safety. Keeping `d` finite each sweep — rather than only
+/// sanitizing at the end — also stops one overflowing row from dragging its
+/// neighbours to zero.
+#[inline]
+pub(crate) fn kr_guarded_update(d: f64, m: f64) -> f64 {
+    let cand = d / m.sqrt();
+    if cand.is_finite() && cand > 0.0 {
+        cand
+    } else {
+        d
+    }
+}
+
 /// Cached MC64 output: everything needed to both drive ordering
 /// compression (`perm`) and derive the symmetric scaling vector
 /// (`u`, `v`, `cmax`) without rerunning the expensive Hungarian

--- a/tests/blocked_ldlt.rs
+++ b/tests/blocked_ldlt.rs
@@ -255,6 +255,46 @@ fn test_rejection_fallback() {
     assert_frontals_byte_identical(&scalar, &blocked, "rejection_fallback");
 }
 
+/// Issue #117 — blocked/scalar rook parity. A near-zero column in the panel
+/// region (`gamma0` tiny, so `threshold` floored by `null_pivot_tol`) reaches
+/// the 1×1 no-swap path below threshold, where `scalar_pivot_step` rook-rescues
+/// and sign-counts the pivot *live*. Pre-fix the blocked panel's non-rook
+/// `try_reject_1x1_frontal` zero-counted or delayed it instead, so the two
+/// kernels certified different inertia. The panel now bails to the scalar path
+/// for such pivots, so both must be byte-identical — and the rook rescue must
+/// actually fire (`n_rook_rescues > 0`), which the pre-fix blocked panel could
+/// never do.
+#[test]
+fn test_issue117_blocked_scalar_rook_parity() {
+    let params = default_params(); // pivot_threshold = 0.01 → rook enabled
+    let n = 40;
+    let mut data = vec![0.0f64; n * n];
+    // Well-conditioned diagonal front, so max|A| ≈ 1 and null_pivot_tol ≈ 1e-13.
+    for j in 0..n {
+        data[j * n + j] = 1.0 + j as f64 * 0.01;
+    }
+    // Column 6 (inside the panel) is near-zero at the EPS scale: the diagonal
+    // dominates its (tinier) off-diagonals so it reaches the 1×1 no-swap path
+    // (akk ≥ α·gamma0), yet sits below `threshold = null_pivot_tol = EPS ≈
+    // 2.22e-16` — the rook-rescue zone. `factor_frontal` does not couple this
+    // column to earlier pivots, so the Schur updates leave it untouched.
+    let c0 = 6usize;
+    data[c0 * n + c0] = 1e-16; // α·gamma0 = 0.64·5e-17 ≈ 3.2e-17 ≤ 1e-16 ≤ EPS
+    for i in (c0 + 1)..n {
+        data[c0 * n + i] = 5e-17; // gamma0 = 5e-17 (symmetric column-c0 entries)
+    }
+    let mat = SymmetricMatrix { n, data };
+
+    let scalar = factor_frontal(&mat, n, false, &params).unwrap();
+    let blocked = factor_frontal_blocked(&mat, n, false, &params).unwrap();
+    assert_frontals_byte_identical(&scalar, &blocked, "issue117_rook_parity");
+    assert!(
+        scalar.n_rook_rescues > 0,
+        "test must exercise a rook rescue (got {})",
+        scalar.n_rook_rescues
+    );
+}
+
 /// Plan §6 — KKT regression spot-checks. We synthesize two tiny KKT
 /// blocks styled after the triage canaries (`ERRINBAR`, `ACOPP30`)
 /// and verify scalar/blocked byte-parity. These are not the literal

--- a/tests/lu_adversarial_inputs.rs
+++ b/tests/lu_adversarial_inputs.rs
@@ -1,0 +1,369 @@
+//! Shared adversarial-input tests for the LU basis engine — the class the
+//! 2026-07-10 audit flagged: **inputs the factor path validates or handles,
+//! but the `update()` / solve paths do not guard.** Each such input is a
+//! silent-wrong-answer or spurious-failure hazard that the existing update
+//! tests (dense/tridiagonal bases replacing the last slot) never exercise.
+//!
+//! Three families, one per open issue:
+//! - #114 non-finite entering columns (factor rejects; update commits NaN).
+//! - #115 dense update's zero-superdiagonal landmine (structural zeros the
+//!   sparse redesign dodges but the dense column-shift does not).
+//! - #118 update ztol anchored to `u_max0` not `max|A|` (healthy pivots on
+//!   high-growth bases spuriously rejected → refactor livelock).
+//!
+//! ## Convention for the pending fixes
+//!
+//! Tests that assert the **correct** post-fix behavior are `#[ignore]`d with
+//! their issue number, so `cargo test` stays green while the bug is open. They
+//! are executable acceptance criteria: run `cargo test --test
+//! lu_adversarial_inputs -- --ignored` to see them fail against `main`, and
+//! delete the `#[ignore]` line when the corresponding fix lands. Tests **not**
+//! ignored assert facts that are correct today (the factor-path rejection, the
+//! nonsingularity of the replacement basis via an independent fresh factor,
+//! the sparse path already handling what the dense path cannot, and that
+//! genuinely singular replacements stay rejected) — they establish the
+//! adversarial setup is sound and guard against a fix that over-corrects.
+//!
+//! Oracles are external and oracle-free: NaN-must-be-rejected is a contract,
+//! nonsingularity is verified by an independent from-scratch factorization,
+//! and accuracy is the equation-residual identity `‖B'x − b‖`.
+//!
+//! Not covered here (they are frontal-kernel-internal, not black-box
+//! update/solve inputs): the rook factor/solve contract (#116) and the
+//! blocked/scalar rook inertia divergence (#117) — those need dense-LDLᵀ
+//! frontal-level tests, tracked in their own issues.
+
+use feral::lu::sparse_matrix::SparseColMatrix;
+use feral::lu::{DenseLu, LuParams, RefactorCause, SparseLu, SparseLuSymbolic};
+use feral::FeralError;
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+/// `‖B x − b‖∞` for a basis given as dense columns (column-major `cols[j][i]`).
+fn residual(cols: &[Vec<f64>], x: &[f64], b: &[f64]) -> f64 {
+    let m = b.len();
+    let mut r = b.to_vec();
+    for (j, col) in cols.iter().enumerate() {
+        for i in 0..m {
+            r[i] -= col[i] * x[j];
+        }
+    }
+    inf_norm(&r)
+}
+
+// ===========================================================================
+// #114 — non-finite entering columns
+// ===========================================================================
+
+/// The factor path rejects a non-finite basis column loudly (sparse and
+/// dense). This is the asymmetry the update path violates; it is correct today
+/// and must stay correct.
+#[test]
+fn factor_rejects_nonfinite_columns() {
+    let bad = vec![vec![f64::NAN, 0.0], vec![0.0, 1.0]];
+    assert!(
+        matches!(
+            SparseLu::factor_dense_columns(2, &bad, LuParams::default()),
+            Err(FeralError::InvalidInput(_))
+        ),
+        "sparse factor must reject a NaN column"
+    );
+    assert!(
+        matches!(
+            DenseLu::factor(&bad, 2, LuParams::default()),
+            Err(FeralError::InvalidInput(_))
+        ),
+        "dense factor must reject a NaN column"
+    );
+    let inf = vec![vec![f64::INFINITY, 0.0], vec![0.0, 1.0]];
+    assert!(SparseLu::factor_dense_columns(2, &inf, LuParams::default()).is_err());
+    assert!(DenseLu::factor(&inf, 2, LuParams::default()).is_err());
+}
+
+/// #114 (sparse): `update` with a NaN entering column must be rejected as
+/// invalid input, leaving the factorization unchanged — matching the factor
+/// path. Currently the NaN is committed into `U` and a later `ftran` returns
+/// `Ok` with a NaN solution (confirmed: `x = [NaN, 1.0]`), a silent wrong
+/// answer.
+#[test]
+#[ignore = "issue #114 — sparse update commits NaN silently; fix pending"]
+fn sparse_update_rejects_nonfinite_column() {
+    let cols = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+    let mut lu = SparseLu::factor_dense_columns(2, &cols, LuParams::default()).unwrap();
+
+    for bad in [
+        vec![f64::NAN, 1.0],
+        vec![1.0, f64::NAN],
+        vec![f64::INFINITY, 1.0],
+    ] {
+        let err = lu.update(1, &bad);
+        assert!(
+            matches!(err, Err(FeralError::InvalidInput(_))),
+            "update must reject non-finite column {bad:?}, got {err:?}"
+        );
+        assert_eq!(
+            lu.updates_since_refactor(),
+            0,
+            "a rejected update must leave the factorization unchanged"
+        );
+    }
+
+    // Unchanged-on-failure: the original identity basis still solves exactly.
+    let mut x = vec![3.0, 5.0];
+    lu.ftran(&mut x).unwrap();
+    assert!((x[0] - 3.0).abs() < 1e-12 && (x[1] - 5.0).abs() < 1e-12);
+}
+
+/// #114 (dense): same contract on the dense path. Currently
+/// `update(1, [NaN, 1.0])` on a 2×2 identity returns `Ok(())`, committing a
+/// NaN into `U`.
+#[test]
+#[ignore = "issue #114 — dense update commits NaN; fix pending"]
+fn dense_update_rejects_nonfinite_column() {
+    let cols = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+    let mut lu = DenseLu::factor(&cols, 2, LuParams::default()).unwrap();
+    for bad in [vec![f64::NAN, 1.0], vec![f64::INFINITY, 1.0]] {
+        let err = lu.update(1, &bad);
+        assert!(
+            matches!(err, Err(FeralError::InvalidInput(_))),
+            "dense update must reject non-finite column {bad:?}, got {err:?}"
+        );
+        assert_eq!(lu.updates_since_refactor(), 0);
+    }
+}
+
+// ===========================================================================
+// #115 — dense update zero-superdiagonal landmine
+// ===========================================================================
+
+/// The sparse update already commits a slack-basis self-replacement (the
+/// Forrest–Tomlin symmetric permutation dodges the zero-superdiagonal
+/// landmine). Correct today; the contrast that shows the dense failure is a
+/// path defect, not an ill-posed input.
+#[test]
+fn sparse_update_handles_slack_basis_self_replacement() {
+    let cols = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+    let mut lu = SparseLu::factor_dense_columns(2, &cols, LuParams::default()).unwrap();
+    lu.update(0, &[1.0, 0.0])
+        .expect("sparse update must commit an identity self-replacement");
+    assert_eq!(lu.updates_since_refactor(), 1);
+    // Still solves the (unchanged) basis exactly.
+    let mut x = vec![2.0, 7.0];
+    lu.ftran(&mut x).unwrap();
+    assert!((x[0] - 2.0).abs() < 1e-12 && (x[1] - 7.0).abs() < 1e-12);
+}
+
+/// #115: the dense update must commit a trivially valid replacement on a
+/// slack/triangular basis. Currently the column-shift scheme pivots on the old
+/// (zero) superdiagonal and returns `NeedsRefactor(TinyPivot, 0.0)` even for an
+/// identity column replaced with itself.
+#[test]
+#[ignore = "issue #115 — dense update zero-superdiagonal landmine; fix pending"]
+fn dense_update_commits_on_slack_basis() {
+    // Identity self-replacement at every slot must be a no-op commit.
+    for slot in 0..3 {
+        let cols = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ];
+        let mut lu = DenseLu::factor(&cols, 3, LuParams::default()).unwrap();
+        let mut col = vec![0.0; 3];
+        col[slot] = 1.0;
+        lu.update(slot, &col)
+            .unwrap_or_else(|e| panic!("dense self-replace slot {slot} must commit: {e:?}"));
+    }
+
+    // A genuine slack-basis pivot: replace column 0 of I₃ with e₀ + e₁ (a valid
+    // nonsingular replacement). Must commit and solve.
+    let cols = vec![
+        vec![1.0, 0.0, 0.0],
+        vec![0.0, 1.0, 0.0],
+        vec![0.0, 0.0, 1.0],
+    ];
+    let mut lu = DenseLu::factor(&cols, 3, LuParams::default()).unwrap();
+    let new_col = vec![1.0, 1.0, 0.0];
+    lu.update(0, &new_col)
+        .expect("valid slack replacement must commit");
+    let mut bp = cols.clone();
+    bp[0] = new_col;
+    let xt = [1.0, 2.0, 3.0];
+    let mut b = vec![0.0; 3];
+    for i in 0..3 {
+        for (j, col) in bp.iter().enumerate() {
+            b[i] += col[i] * xt[j];
+        }
+    }
+    let mut x = b.clone();
+    lu.ftran(&mut x).unwrap();
+    assert!(residual(&bp, &x, &b) <= 1e-12 * inf_norm(&b).max(1.0));
+}
+
+// ===========================================================================
+// #118 — update ztol anchored to u_max0 (growth livelock)
+// ===========================================================================
+
+/// Wilkinson growth matrix: unit diagonal, −1 strictly below, last column all
+/// +1. Well-conditioned with `max|A| = 1`, but LU growth makes
+/// `u_max0 = 2^(m-1)`, so the update's `ztol = zero_pivot_tol · u_max0` climbs
+/// to ≈ 14 at m = 50 — dwarfing the healthy O(1) bump pivot (magnitude 0.25).
+/// m = 50 is deliberate: growth `≈ 1.4e14 < 2^53`, so the ±1/integer solve
+/// arithmetic stays exact (residual 0), keeping the accuracy oracle tight;
+/// beyond m ≈ 53 the growth exceeds the f64 mantissa and the residual blows up
+/// for genuine (backward-error) reasons, which would confound this test.
+fn wilkinson(m: usize) -> Vec<Vec<f64>> {
+    let mut cols = vec![vec![0.0; m]; m];
+    for (j, col) in cols.iter_mut().enumerate() {
+        col[j] = 1.0;
+        for row in col.iter_mut().skip(j + 1) {
+            *row = -1.0;
+        }
+    }
+    for row in cols[m - 1].iter_mut() {
+        *row = 1.0;
+    }
+    cols
+}
+
+/// The replacement basis is genuinely nonsingular: an independent from-scratch
+/// factorization of `B'` succeeds. Correct today; establishes that the update's
+/// rejection (below) is spurious, not a real singularity.
+#[test]
+fn wilkinson_replacement_basis_is_nonsingular() {
+    let m = 50;
+    let cols = wilkinson(m);
+    let mut bp = cols.clone();
+    bp[0] = {
+        let mut c = vec![0.0; m];
+        c[0] = 1.0;
+        c[1] = 1.0;
+        c
+    };
+    let a = SparseColMatrix::from_dense_columns(m, &bp).unwrap();
+    let sym = SparseLuSymbolic::analyze(&a).unwrap();
+    let mut fresh = SparseLu::factor(&a, &sym, LuParams::default())
+        .expect("B' is nonsingular: fresh factor must succeed");
+    // And it solves to small residual.
+    let xt: Vec<f64> = (0..m).map(|i| 1.0 + (i % 4) as f64).collect();
+    let mut b = vec![0.0; m];
+    a.matvec(&xt, &mut b);
+    let mut x = b.clone();
+    fresh.ftran(&mut x).unwrap();
+    assert!(residual(&bp, &x, &b) <= 1e-9 * inf_norm(&b).max(1.0));
+}
+
+/// #118 (sparse): replacing slot 0 of the Wilkinson basis with `e₀ + e₁` is a
+/// valid update whose true bump pivot is O(1) (magnitude 0.25), but the update
+/// rejects it as `TinyPivot` because `ztol ≈ 5.8e4`. Worse, `refactor()`
+/// reproduces the identical high-growth factor, so update→refactor→retry
+/// **livelocks**. Correct behavior: the update commits and solves.
+#[test]
+#[ignore = "issue #118 — update ztol anchored to u_max0; fix pending"]
+fn sparse_update_commits_on_high_growth_basis() {
+    let m = 50;
+    let cols = wilkinson(m);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).unwrap();
+    let sym = SparseLuSymbolic::analyze(&a).unwrap();
+    let mut lu = SparseLu::factor(&a, &sym, LuParams::default()).unwrap();
+
+    let mut col = vec![0.0; m];
+    col[0] = 1.0;
+    col[1] = 1.0;
+    lu.update(0, &col)
+        .expect("valid O(1)-pivot update on a well-conditioned basis must commit");
+
+    // Residual against B' with a non-trivial RHS.
+    let mut bp = cols.clone();
+    bp[0] = col;
+    let ba = SparseColMatrix::from_dense_columns(m, &bp).unwrap();
+    let xt: Vec<f64> = (0..m).map(|i| 1.0 + (i % 4) as f64).collect();
+    let mut b = vec![0.0; m];
+    ba.matvec(&xt, &mut b);
+    let mut x = b.clone();
+    lu.ftran(&mut x).unwrap();
+    assert!(
+        residual(&bp, &x, &b) <= 1e-8 * inf_norm(&b).max(1.0),
+        "committed update must solve B' accurately"
+    );
+}
+
+/// #118 (dense): the same on the dense path. (Also exercises the #115 landmine,
+/// since the Wilkinson basis has zero superdiagonals — both fixes are needed
+/// for this to pass.)
+#[test]
+#[ignore = "issue #118 (+#115) — dense update fails on high-growth basis; fix pending"]
+fn dense_update_commits_on_high_growth_basis() {
+    let m = 50;
+    let cols = wilkinson(m);
+    let mut lu = DenseLu::factor(&cols, m, LuParams::default()).unwrap();
+    let mut col = vec![0.0; m];
+    col[0] = 1.0;
+    col[1] = 1.0;
+    lu.update(0, &col)
+        .expect("dense update on a well-conditioned basis must commit");
+}
+
+/// #118: the livelock is the real cost — a rejected update followed by
+/// `refactor()` and retry never makes progress, because the refactor
+/// reproduces the identical high-growth factor. Correct behavior: the first
+/// update commits (loop exits at attempt 0).
+#[test]
+#[ignore = "issue #118 — update/refactor livelock; fix pending"]
+fn high_growth_update_does_not_livelock() {
+    let m = 50;
+    let cols = wilkinson(m);
+    let a = SparseColMatrix::from_dense_columns(m, &cols).unwrap();
+    let sym = SparseLuSymbolic::analyze(&a).unwrap();
+    let mut lu = SparseLu::factor(&a, &sym, LuParams::default()).unwrap();
+    let mut col = vec![0.0; m];
+    col[0] = 1.0;
+    col[1] = 1.0;
+
+    let mut committed = false;
+    for _ in 0..4 {
+        if lu.update(0, &col).is_ok() {
+            committed = true;
+            break;
+        }
+        lu.refactor(&a, &sym).unwrap();
+    }
+    assert!(
+        committed,
+        "update→refactor→retry must terminate productively, not livelock"
+    );
+}
+
+/// Guard against over-correcting #114/#115/#118: a genuinely singular
+/// replacement (a linearly dependent column — replacing slot 1 of I₃ with a
+/// duplicate of column 0) must still be rejected, on both paths. Correct today;
+/// must stay correct after the fixes loosen the update's rejection criteria.
+#[test]
+fn singular_replacement_still_rejected() {
+    let cols = vec![
+        vec![1.0, 0.0, 0.0],
+        vec![0.0, 1.0, 0.0],
+        vec![0.0, 0.0, 1.0],
+    ];
+    // Replace column 1 with a copy of column 0 (e₀): columns 0 and 1 identical
+    // ⇒ singular basis.
+    let dependent = vec![1.0, 0.0, 0.0];
+
+    let mut sp = SparseLu::factor_dense_columns(3, &cols, LuParams::default()).unwrap();
+    assert!(
+        matches!(sp.update(1, &dependent), Err(FeralError::NeedsRefactor)),
+        "sparse: dependent replacement must be rejected"
+    );
+
+    let mut dn = DenseLu::factor(&cols, 3, LuParams::default()).unwrap();
+    assert!(
+        matches!(dn.update(1, &dependent), Err(FeralError::NeedsRefactor)),
+        "dense: dependent replacement must be rejected"
+    );
+    // The recorded cause is a singularity/tiny-pivot signal, not a budget trip.
+    assert!(matches!(
+        dn.last_refactor(),
+        Some((RefactorCause::TinyPivot | RefactorCause::Singular, _))
+    ));
+}

--- a/tests/lu_adversarial_inputs.rs
+++ b/tests/lu_adversarial_inputs.rs
@@ -158,7 +158,6 @@ fn sparse_update_handles_slack_basis_self_replacement() {
 /// (zero) superdiagonal and returns `NeedsRefactor(TinyPivot, 0.0)` even for an
 /// identity column replaced with itself.
 #[test]
-#[ignore = "issue #115 — dense update zero-superdiagonal landmine; fix pending"]
 fn dense_update_commits_on_slack_basis() {
     // Identity self-replacement at every slot must be a no-op commit.
     for slot in 0..3 {
@@ -290,7 +289,6 @@ fn sparse_update_commits_on_high_growth_basis() {
 /// since the Wilkinson basis has zero superdiagonals — both fixes are needed
 /// for this to pass.)
 #[test]
-#[ignore = "issue #118 (+#115) — dense update fails on high-growth basis; fix pending"]
 fn dense_update_commits_on_high_growth_basis() {
     let m = 50;
     let cols = wilkinson(m);

--- a/tests/lu_adversarial_inputs.rs
+++ b/tests/lu_adversarial_inputs.rs
@@ -258,7 +258,6 @@ fn wilkinson_replacement_basis_is_nonsingular() {
 /// reproduces the identical high-growth factor, so update→refactor→retry
 /// **livelocks**. Correct behavior: the update commits and solves.
 #[test]
-#[ignore = "issue #118 — update ztol anchored to u_max0; fix pending"]
 fn sparse_update_commits_on_high_growth_basis() {
     let m = 50;
     let cols = wilkinson(m);
@@ -308,7 +307,6 @@ fn dense_update_commits_on_high_growth_basis() {
 /// reproduces the identical high-growth factor. Correct behavior: the first
 /// update commits (loop exits at attempt 0).
 #[test]
-#[ignore = "issue #118 — update/refactor livelock; fix pending"]
 fn high_growth_update_does_not_livelock() {
     let m = 50;
     let cols = wilkinson(m);

--- a/tests/lu_adversarial_inputs.rs
+++ b/tests/lu_adversarial_inputs.rs
@@ -88,7 +88,6 @@ fn factor_rejects_nonfinite_columns() {
 /// `Ok` with a NaN solution (confirmed: `x = [NaN, 1.0]`), a silent wrong
 /// answer.
 #[test]
-#[ignore = "issue #114 — sparse update commits NaN silently; fix pending"]
 fn sparse_update_rejects_nonfinite_column() {
     let cols = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
     let mut lu = SparseLu::factor_dense_columns(2, &cols, LuParams::default()).unwrap();
@@ -120,7 +119,6 @@ fn sparse_update_rejects_nonfinite_column() {
 /// `update(1, [NaN, 1.0])` on a 2×2 identity returns `Ok(())`, committing a
 /// NaN into `U`.
 #[test]
-#[ignore = "issue #114 — dense update commits NaN; fix pending"]
 fn dense_update_rejects_nonfinite_column() {
     let cols = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
     let mut lu = DenseLu::factor(&cols, 2, LuParams::default()).unwrap();

--- a/tests/lu_dense_update_bg.rs
+++ b/tests/lu_dense_update_bg.rs
@@ -1,0 +1,200 @@
+//! Dense LU Bartels–Golub update (issue #115): thorough exercise of the
+//! eta-based update path — bump-forming column replacements (which trigger the
+//! Hessenberg reduction and its row interchanges), update chains (multiple etas
+//! replayed per solve), and ftran/btran parity against an **independent**
+//! from-scratch factorization of the replaced basis.
+//!
+//! Oracles are external and oracle-free: the equation-residual identity
+//! `‖B'x − b‖` / `‖B'ᵀy − c‖`, and agreement with a fresh `DenseLu::factor`
+//! of the current basis (independent recomputation, not the update's own math).
+
+use feral::lu::{DenseLu, LuParams};
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()))
+}
+
+/// `B x` for a basis given column-major (`cols[j][i]`).
+fn matvec(cols: &[Vec<f64>], x: &[f64]) -> Vec<f64> {
+    let mut y = vec![0.0; x.len()];
+    for (col, &xj) in cols.iter().zip(x) {
+        for (yi, &cij) in y.iter_mut().zip(col) {
+            *yi += cij * xj;
+        }
+    }
+    y
+}
+
+/// `Bᵀ x`.
+fn matvec_t(cols: &[Vec<f64>], x: &[f64]) -> Vec<f64> {
+    cols.iter()
+        .map(|col| col.iter().zip(x).map(|(&cij, &xi)| cij * xi).sum())
+        .collect()
+}
+
+/// Verify a factorization solves the given basis for both ftran and btran to a
+/// backward-stable residual, cross-checked against a fresh factorization.
+fn assert_solves(lu: &mut DenseLu, cols: &[Vec<f64>], tag: &str) {
+    let m = cols.len();
+    let xt: Vec<f64> = (0..m).map(|i| 1.0 + (i % 5) as f64 * 0.5).collect();
+
+    // ftran: B x = b.
+    let b = matvec(cols, &xt);
+    let mut x = b.clone();
+    lu.ftran(&mut x)
+        .unwrap_or_else(|e| panic!("{tag}: ftran failed: {e:?}"));
+    let res = inf_norm(&sub(&matvec(cols, &x), &b));
+    assert!(
+        res <= 1e-8 * inf_norm(&b).max(1.0),
+        "{tag}: ftran residual {res:.3e} too large"
+    );
+
+    // btran: Bᵀ y = c.
+    let c = matvec_t(cols, &xt);
+    let mut y = c.clone();
+    lu.btran(&mut y)
+        .unwrap_or_else(|e| panic!("{tag}: btran failed: {e:?}"));
+    let rest = inf_norm(&sub(&matvec_t(cols, &y), &c));
+    assert!(
+        rest <= 1e-8 * inf_norm(&c).max(1.0),
+        "{tag}: btran residual {rest:.3e} too large"
+    );
+
+    // Cross-check ftran against an independent fresh factorization.
+    let mut fresh = DenseLu::factor(cols, m, LuParams::default())
+        .unwrap_or_else(|e| panic!("{tag}: fresh factor failed: {e:?}"));
+    let mut xf = b.clone();
+    fresh.ftran(&mut xf).expect("fresh ftran");
+    let diff = inf_norm(&sub(&x, &xf));
+    assert!(
+        diff <= 1e-7 * inf_norm(&xf).max(1.0),
+        "{tag}: updated ftran disagrees with fresh factor by {diff:.3e}"
+    );
+}
+
+fn sub(a: &[f64], b: &[f64]) -> Vec<f64> {
+    a.iter().zip(b).map(|(p, q)| p - q).collect()
+}
+
+/// A deterministic well-conditioned dense basis.
+fn dense_basis(m: usize, seed: u64) -> Vec<Vec<f64>> {
+    let mut s = seed;
+    let mut rng = || {
+        s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((s >> 33) as f64 / (1u64 << 31) as f64) - 1.0
+    };
+    let mut cols = vec![vec![0.0; m]; m];
+    for (j, col) in cols.iter_mut().enumerate() {
+        for cij in col.iter_mut() {
+            *cij = rng();
+        }
+        col[j] += m as f64; // diagonally dominant → well-conditioned
+    }
+    cols
+}
+
+/// Bump-forming updates: replacing an *early* column forces the Hessenberg
+/// reduction over the whole tail, exercising interchanges and multi-eta chains.
+/// After each committed update, both solves must be correct and agree with a
+/// fresh factor.
+#[test]
+fn dense_bg_update_chain_dense_basis() {
+    let m = 9;
+    let mut cols = dense_basis(m, 0xBEEF);
+    let params = LuParams {
+        max_updates: 64,
+        max_growth: 1e10,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(&cols, m, params.clone()).expect("factor");
+    assert_solves(&mut lu, &cols, "initial");
+
+    // Replace slots 0,1,2,... (early columns → wide bumps) with fresh columns.
+    let mut gen = dense_basis(m, 0xF00D);
+    for (step, slot) in [0usize, 1, 2, 0, 3, 1].into_iter().enumerate() {
+        let new_col = std::mem::take(&mut gen[step % m]);
+        match lu.update(slot, &new_col) {
+            Ok(()) => {
+                cols[slot] = new_col;
+                assert_solves(
+                    &mut lu,
+                    &cols,
+                    &format!("after update {step} (slot {slot})"),
+                );
+            }
+            Err(_) => {
+                // A legitimate growth/singular bail: refactor and continue.
+                cols[slot] = new_col;
+                lu.refactor(&cols).expect("refactor");
+                assert_solves(&mut lu, &cols, &format!("after refactor {step}"));
+            }
+        }
+    }
+}
+
+/// Slack/triangular bases are the landmine case (zero superdiagonals). Replacing
+/// early columns must commit via interchanges and stay correct across a chain.
+#[test]
+fn dense_bg_update_chain_slack_basis() {
+    let m = 6;
+    // Lower-bidiagonal "slack-like" basis: identity plus a subdiagonal.
+    let mut cols = vec![vec![0.0; m]; m];
+    for j in 0..m {
+        cols[j][j] = 1.0;
+        if j + 1 < m {
+            cols[j][j + 1] = 0.5;
+        }
+    }
+    let params = LuParams {
+        max_updates: 64,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(&cols, m, params).expect("factor");
+    assert_solves(&mut lu, &cols, "slack initial");
+
+    // Replace column 0 with a dense column (wide bump on a triangular base —
+    // the exact shape that tripped the old fixed-order sweep).
+    let replacements = [
+        (0usize, vec![1.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+        (1usize, vec![0.0, 2.0, 1.0, 1.0, 0.0, 0.0]),
+        (0usize, vec![3.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
+    ];
+    for (step, (slot, col)) in replacements.into_iter().enumerate() {
+        lu.update(slot, &col)
+            .unwrap_or_else(|e| panic!("slack update {step} (slot {slot}) must commit: {e:?}"));
+        cols[slot] = col;
+        assert_solves(&mut lu, &cols, &format!("slack after update {step}"));
+    }
+}
+
+/// Refinement (`ftran_refined`/`btran_refined`) must also work through the eta
+/// chain — it drives repeated ftran/btran calls internally.
+#[test]
+fn dense_bg_update_refined_solve() {
+    use feral::lu::GeneralMatrix;
+    let m = 7;
+    let mut cols = dense_basis(m, 0x1234);
+    let params = LuParams {
+        max_updates: 64,
+        refine_steps: 2,
+        ..LuParams::default()
+    };
+    let mut lu = DenseLu::factor(&cols, m, params).expect("factor");
+    // A bump-forming update.
+    let new_col: Vec<f64> = (0..m).map(|i| 1.0 + (i as f64) * 0.3).collect();
+    lu.update(0, &new_col).expect("update commits");
+    cols[0] = new_col;
+
+    let b = GeneralMatrix::from_columns(m, &cols).expect("matrix");
+    let xt: Vec<f64> = (0..m).map(|i| 2.0 - (i % 3) as f64).collect();
+    let rhs0 = matvec(&cols, &xt);
+    let mut x = rhs0.clone();
+    lu.ftran_refined(&b, &mut x).expect("ftran_refined");
+    let res = inf_norm(&sub(&matvec(&cols, &x), &rhs0));
+    assert!(
+        res <= 1e-10 * inf_norm(&rhs0).max(1.0),
+        "refined ftran residual {res:.3e}"
+    );
+}


### PR DESCRIPTION
Fixes the six correctness bugs confirmed in the 2026-07-10 audit. One branch/PR for the batch because the fixes share scaffolding (the adversarial-input harness, the `a_max` plumbing, the dense eta model) and each is an independent, tested commit.

Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119

## Fixes (one commit each)

- **#114** — `SparseLu::update` / `DenseLu::update` reject a non-finite entering column with `InvalidInput` (matching the factor path) instead of silently committing a NaN into `U` and returning `Ok` with a NaN solution.
- **#118** — the LU update's tiny-pivot tolerance is anchored to the factored matrix magnitude `max|A|` (stored as `a_max`) instead of `max|U|`, so a healthy `O(a_max)` pivot on a high-growth but well-conditioned basis is no longer spuriously rejected — removing an update→refactor **livelock**.
- **#115** — the dense LU column-replacement update is reworked as an **eta-based Bartels–Golub** update with partial pivoting. The old column-shift scheme pivoted on a structurally-zero superdiagonal and failed `NeedsRefactor(TinyPivot, 0.0)` on trivially valid updates over slack/triangular bases. Note: the issue's suggested "swap rows in U + fix L" does **not** work — a row swap of U forces a column swap of L that breaks its unit-lower-triangular structure — so, exactly as on the sparse path, the base `L` stays fixed and the solves replay the update etas (`ftran_partial` now returns `G⁻¹L⁻¹Pa`). Partial pivoting bounds multipliers by 1, superseding the sparse path's Neumaier need.
- **#119** — Knight–Ruiz ∞-norm equilibration (all seven update sites: sparse/dense infnorm, the four LU-side passes, `dense::equilibrate`) no longer returns `NaN`/`Inf`/`0.0` scale factors on finite input with extreme or subnormal couplings. The guarded update is bit-identical on well-scaled matrices (KR dense/sparse parity preserved).
- **#116** — the symmetric-indefinite D-block solve divides by any **live** small-but-nonzero 1×1 pivot (rook rescue / static floor / rank-deficiency band) and skips only **force-zeroed** pivots, fixing a silent `O(1/d)` error. Implemented solve-side (skip iff `d_diag == 0.0` exactly) so it changes **no factorization** — the safest option for the exact-inertia contract, verified by keeping the whole inertia-oracle corpus green. Rook sub-floor accepts now set `needs_refinement`.
- **#117** — the blocked and scalar dense-LDLᵀ frontal kernels no longer certify different inertia: the blocked panel defers a rook-eligible below-threshold 1×1 pivot to the scalar (rook-capable) path instead of zero-counting it.

## Testing

`tests/lu_adversarial_inputs.rs` (all 10 now pass, 0 ignored), `tests/lu_dense_update_bg.rs` (bump chains / slack bases / ftran+btran parity vs fresh factor), `tests/blocked_ldlt.rs::test_issue117_blocked_scalar_rook_parity`, and a D-block-solve gate-contract unit test. Full suite **769 passed / 0 failed**; clippy `--all-targets -D warnings` clean; `cargo fmt --check` clean. End-of-session bench: inertia 100% (dense 1/1, sparse 2/2 vs MUMPS), worst residual 1.14e-15 / 1.26e-16 — no regression.

Each behavior change is called out in `CHANGELOG.md` (Unreleased). The audit's remaining perf/SOTA items (#120–#134) are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH

---
_Generated by [Claude Code](https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH)_