### PR TITLE
Correctness-edge fixes: cascade-break scaling, symbolic-cache collision, guard bundle, MAXFROMM parity (#120–#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ exposes how often the interchanges deviated from the plain FT order.
   `NaN`/`Inf`/`0.0` scale factors on finite input with extreme or subnormal
   couplings; the guarded update is bit-identical on well-scaled matrices.
 
+### Fixed — audit correctness-edge fixes across the LDLᵀ engine (issues #120–#123)
+
+- **#120** The cascade-break supernode's `PerturbToEps` floor
+  (`cascade_break_eps`, default-armed at `1e-10`) is now scaled by the scaled
+  matrix ∞-norm `‖D·A·D‖∞`, matching the static-pivot floor. Previously it was
+  an *absolute* per-pivot floor while the kernel operates on `D·A·D`, so under
+  Identity scaling on a small-magnitude system (e.g. `γ·K`, `γ = 1e-12`) every
+  pivot was perturbed by `~1e2·‖A‖` and the returned inertia was that of
+  `A+Δ` with `‖Δ‖ ≫ ‖A‖`, silently.
+- **#121** The symbolic-factorization cache now confirms a fingerprint hit with
+  an exact `(col_ptr, row_idx)` compare before reuse. The fingerprint is a
+  64-bit hash; a collision between two distinct patterns sharing `(n, nnz)`
+  would previously reuse a stale symbolic ordering and corrupt the factor and
+  inertia with no error.
+- **#122** Guard-hardening bundle: (A) internal fill-reducing ordering results
+  are now bijectivity-checked (not just range-checked), closing a silent
+  pattern-corruption path on a malformed backend perm; (B) a non-finite 2×2
+  pivot block is rejected with `InvalidInput` instead of being certified as
+  inertia `(0,0,2)`; (C) `LuParams::validate` now rejects `max_growth`
+  (`NaN`/`≤ 1.0`) and `refine_tol` (non-finite/`≤ 0`) values that silently
+  disabled the growth guard or the refinement convergence check.
+- **#123** The MAXFROMM triangular-pivot acceleration now treats a cached
+  column-max of exactly `0.0` (an all-zero trailing column from floating-point
+  cancellation) as a cache miss, restoring the documented bit-for-bit parity
+  with the plain pivot path — previously such a column was routed through the
+  rook-rescue path instead of the dedicated zero-column branch, diverging in
+  delayed-pivot count and D under `may_delay`/`ForceAccept`.
+
 ## [0.13.0] - 2026-07-02
 
 ### Added — user-supplied fill-reducing ordering: `OrderingMethod::External` (issue #107)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T10:32:51Z
+Generated: 2026-07-10T11:05:54Z
 
 ## Latest Session
 File: dev/sessions/2026-07-10-03.md
@@ -59,15 +59,16 @@ Sparse KKT: inertia vs MUMPS 2/2, residual pass 2/2, worst 1.26e-16
 
 ## Git Status
 ```
-4a1d163 issue #117: blocked/scalar rook parity — panel bails rook-eligible 1x1 to scalar
-e5b6d4b issue #116: divide by live tiny LDLT pivots at solve (rook factor/solve contract)
-d7aafea issue #119: guard Knight-Ruiz equilibration against non-finite scale factors
-ae13f27 issue #115: eta-based Bartels-Golub dense LU update (fix zero-superdiagonal landmine)
-373264f issue #118: anchor LU update ztol to a_max, not u_max0
+8a980e4 Audit correctness fixes: LU update/solve + dense LDLᵀ rook (#135)
+660224d issue #112: compensated FT sweep + opt-in Bartels-Golub pivot search (#113)
+9596472 docs: session checkpoint 2026-07-02-02 (v0.13.0 release)
+36da100 release: feral v0.13.0 (#109)
+9d05f75 issue #107: add OrderingMethod::External for user-supplied orderings (#108)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
@@ -76,17 +77,16 @@ test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ...
 test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 398 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.55s
+test result: ok. 398 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
 
 ```
 

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T11:05:54Z
+Generated: 2026-07-10T11:40:42Z
 
 ## Latest Session
 File: dev/sessions/2026-07-10-03.md
@@ -59,16 +59,15 @@ Sparse KKT: inertia vs MUMPS 2/2, residual pass 2/2, worst 1.26e-16
 
 ## Git Status
 ```
+876cf72 issue #123: treat cached MAXFROMM mf == 0.0 as a cache miss (parity)
+cb96b6e issue #122: guard-hardening bundle (ordering bijectivity, NaN 2x2, LuParams)
+f8d5f8a issue #121: exact pattern compare on symbolic-cache hit, not hash-only
+d6f8ebd issue #120: scale cascade_break_eps by the scaled matrix norm
 8a980e4 Audit correctness fixes: LU update/solve + dense LDLᵀ rook (#135)
-660224d issue #112: compensated FT sweep + opt-in Bartels-Golub pivot search (#113)
-9596472 docs: session checkpoint 2026-07-02-02 (v0.13.0 release)
-36da100 release: feral v0.13.0 (#109)
-9d05f75 issue #107: add OrderingMethod::External for user-supplied orderings (#108)
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_supernodes_cover_n ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
@@ -77,16 +76,17 @@ test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ...
 test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 398 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.51s
+test result: ok. 403 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.45s
 
 ```
 

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5938,3 +5938,31 @@ rebuild on swap commits.
 `zero_pivot_tol·u_max0` is now trustworthy evidence of a genuinely dependent
 replacement (not a summation artifact), strengthening the existing
 `NeedsRefactor` semantics. No tolerances changed.
+
+## 2026-07-10 — Issue #122: propagate `Result` from `classify_2x2_inertia`; `max_growth` semantics
+
+Two small design choices made while closing the #122 guard-hardening bundle.
+
+**2×2 non-finite guard is a `Result`, not an inline per-site check.**
+`classify_2x2_inertia` previously returned `Inertia` and a NaN `det`/`tr` fell
+through every ordered comparison to the `(0,0,2)` arm — certifying a NaN block
+as two *zero* eigenvalues. The fix changes the signature to
+`Result<Inertia, FeralError>` (release-mode `!is_finite` → `InvalidInput`) and
+threads the `Result` through `count_2x2_inertia_val`, `finish_1x1_outcome`
+(now `Result<PivotStepResult>`), and all six call sites via `?`. Chosen over a
+per-call-site guard because it is DRY (one guard, impossible to forget at a
+future site) and every caller already sits in a `Result`-returning frame, so
+the ripple is mechanical. This backstops the debug-only finite entry-scan at
+`factor.rs:1749` in release without a full-column scan on the hot path (the
+guard is O(1) at the pivot-block level).
+
+**`LuParams::max_growth` is `> 1.0` with `+∞` an explicit disable.**
+`validate()` now rejects `max_growth` that is `NaN` or `≤ 1.0` and accepts any
+finite `> 1.0` plus `+∞`. `+∞` is the documented "never trigger a refactor on
+growth" opt-out (`growth > +∞` is always false); `NaN` is rejected because it
+silently disabled the growth guard in the update paths (which — unlike
+`should_refactor_growth` — do not defend with `is_finite`). `refine_tol` must
+be finite and `> 0`. No tolerances changed; all existing `LuParams` in the
+tree already satisfy the bounds (min `max_growth` `1.0 + 1e-9`, all
+`refine_tol > 0`), so this is pure input validation with no behavior change on
+valid inputs.

--- a/dev/journal/2026-07-10-04.org
+++ b/dev/journal/2026-07-10-04.org
@@ -40,3 +40,43 @@ Post-fix: symbolic_call_count 1->2 (fresh symbolic forced) and B's inertia
 guard reverted to hash-only the count stays at 1 (stale reuse) —
 "left: 1, right: 2". Full suite (75 test binaries) green,
 clippy --all-targets -D warnings clean, fmt clean.
+
+** 11:40 :issue-122:guard-hardening:ordering:inertia:lu-params:
+Bundle of three "bad values corrupt silently" guard gaps.
+
+A. Ordering bijectivity. run_external_ordering (symbolic/mod.rs) and
+schur::run_amd (ordering/schur.rs) range-checked each ordering-crate
+result element but never "no duplicates" — a dup/missing pair flows into
+permute_pattern's per-column count *assignment* and overwrites a column's
+counts -> wrong pattern/etree/inertia silently. Promoted
+validate_external_perm to pub(crate) and call it on the built perm in both
+sites (matches the full check user External perms already get). Its
+dup-rejection is already unit-tested (mod.rs:2091 [0,1,1] -> Err). Backends
+are trusted; this is one O(n) check on an O(nnz.a) path.
+
+B. NaN 2x2 -> (0,0,2). classify_2x2_inertia: a NaN det/tr failed every
+ordered comparison and fell through to the zero-zero arm — certifying a
+NaN block as two ZERO eigenvalues, the worst shape for a hard inertia
+contract. Added a release-mode !is_finite guard returning
+InvalidInput; threaded Result<Inertia> through count_2x2_inertia_val,
+finish_1x1_outcome (now Result<PivotStepResult>) and all six call sites
+(? at the Result-returning frames). Backstops the debug_assert!-only
+finite entry-scan at factor.rs:1749 (the only such gate on the inertia
+path — grep confirmed). Test classify_2x2_non_finite_block_errors_not_
+double_zero: 6 non-finite slots (incl inf-inf) -> Err, never (0,0,2);
+finite (0,0,0) still classifies (0,0,2).
+
+C. LuParams::validate missed max_growth/refine_tol. max_growth=NaN makes
+`growth > max_growth` always false -> growth guard silently disabled in
+the update paths (which don't defend with is_finite like
+should_refactor_growth). Now reject NaN or <=1.0 (accept finite>1 and the
++inf opt-out); refine_tol must be finite and >0 (NaN/<=0/+inf break the
+||r||/||a|| < tol convergence check). Both dense (dense_factor.rs:128,168)
+and sparse (sparse_factor.rs:227) entries call validate(). Test
+validate_max_growth_and_refine_tol covers boundaries + defaults-valid.
+All existing LuParams in tree have max_growth>1 (min 1.0+1e-9, 5.0) and
+refine_tol>0, so no regression.
+
+Full suite 75 binaries green, clippy --all-targets -D warnings clean
+(fixed needless-Ok-? on the finish_1x1_outcome callers and the
+neg_cmp_op_on_partial_ord on the max_growth check), fmt clean.

--- a/dev/journal/2026-07-10-04.org
+++ b/dev/journal/2026-07-10-04.org
@@ -80,3 +80,33 @@ refine_tol>0, so no regression.
 Full suite 75 binaries green, clippy --all-targets -D warnings clean
 (fixed needless-Ok-? on the finish_1x1_outcome callers and the
 neg_cmp_op_on_partial_ord on the max_growth check), fmt clean.
+
+** 12:05 :issue-123:maxfromm:parity:bit-identical:
+MAXFROMM short-circuit broke the documented Plain/Maxfromm bit-parity on
+exact-cancellation fronts. capture_maxfromm_col returns Some(0.0) for an
+all-zero trailing column; the short-circuit gate `akk >= alpha*mf` is
+unconditionally true at mf==0.0 (0>=0), so Maxfromm routed a zero column
+through try_reject_1x1_with_rook_rescue — but Plain's full scan hits
+gamma0==0.0 and takes the dedicated zero-column branch (count_1x1_inertia
++ set_l_column_identity, factor.rs:4035). Divergences: (i) may_delay=true
+delays the rook path's zero pivot (different nelim/n_delayed) where the
+zero-column branch counts in place; (ii) ForceAccept zeroes d_diag in the
+rook path vs the branch's own accounting.
+
+Fix: one guard — `if mf != 0.0 && akk >= alpha * mf` — so a cached 0.0 is
+a cache MISS and falls through to the full scan (cache only ever
+accelerates the nonzero case). The remaining==1 path is already parity-safe
+(both Plain and Maxfromm call rook_rescue with col_max; all-zero -> 0.0
+either way, no gamma0==0 special branch there).
+
+Repro: zero_tail_front(n) = all-ones symmetric matrix with a dominant head
+(A[0,0]=n+2). After pivot 0 the trailing block is uniform 1-1/head; after
+pivot 1 it cancels to exactly 0.0, so capture stashes mf=0.0 for pivot 2.
+New test maxfromm_zero_tail_cache_miss_parity asserts byte-identical
+FrontalFactors (nelim, n_delayed, inertia, perm, d_diag, d_subdiag, l,
+contrib) between Plain and Maxfromm for n in {4,5,8,16,33,64,65,100},
+may_delay in {false,true}, scalar and blocked. Verified pre-fix FAILS:
+"zero-tail scalar n=4 delay=true nelim" left!=right. Unit test
+capture_maxfromm_col_zero_column_is_some_zero pins Some(0.0) for a zero
+column (the precondition the fix relies on), Some(max) for nonzero, None
+for the last column. Full suite 75 binaries green, clippy/fmt clean.

--- a/dev/journal/2026-07-10-04.org
+++ b/dev/journal/2026-07-10-04.org
@@ -1,0 +1,42 @@
+#+TITLE: Session 2026-07-10-04 journal
+#+STARTUP: showall
+
+* Round: correctness-edge issues #120–#123
+
+** 11:11 :issue-120:cascade-break:scaling:
+Committed d6f8ebd. apply_post_scaling_overrides now multiplies
+cascade_break_eps by ||D.A.D||_inf (mirroring the N2 static_pivot_floor
+fix), so the cascade-break supernode's PerturbToEps floor is RELATIVE to
+the scaled matrix the BK kernel operates on. Root cause: default-armed
+1e-10 was an ABSOLUTE per-pivot floor, but kernels work on D.A.D; under
+Identity scaling on gamma*K (gamma=1e-12) every pivot ~gamma*||K|| << 1e-10
+was bent to +/-1e-10 (~1e2*||A|| perturbation), silently returning the
+inertia of A+Delta with ||Delta|| >> ||A||. Unit test
+cascade_break_eps_scaled_by_matrix_norm guards the None-in/None-out and
+norm-tracking cases. Full suite green.
+
+** 11:21 :issue-121:symbolic-cache:hash-collision:
+Symbolic-cache hit was gated on the PatternFingerprint only — a u64 hash.
+Two distinct patterns sharing (n, nnz) collide with probability 2^-64;
+a hash-only check would then scatter the new values through the OLD
+pattern's perm, silently corrupting the factor and inertia with no error
+(same failure mode REG-1 closed for the permute cache with a stored
+pattern). Fix in Solver::factor: added a `last_pattern:
+Option<(Vec<usize>, Vec<usize>)>` field kept in lockstep with
+last_pattern_fingerprint; `cache_valid` now requires the fingerprint match
+AND an exact O(n+nnz) (col_ptr, row_idx) compare. Fingerprint stays the
+fast reject; the exact compare confirms. Stored only on a cache miss
+(clone cost paid exactly when symbolic is (re)built), cleared everywhere
+the fingerprint is cleared (invalidate path + invalidate_symbolic_cache).
+
+Test f4_forged_fingerprint_collision_does_not_reuse_stale_symbolic:
+reproduces the 2^-64 event DETERMINISTICALLY — factor A (SPD tridiag,
+inertia (3,0,0)), overwrite last_pattern_fingerprint with B's while
+last_pattern still holds A's exact pattern, then factor B (3x3 arrow,
+same (n,nnz)=(3,5) and same col_ptr as A but different row_idx; hand
+oracle: eigvals {0.1, 0.1+-sqrt2} = {0.1, 1.514, -1.314} -> (2,1,0)).
+Post-fix: symbolic_call_count 1->2 (fresh symbolic forced) and B's inertia
+== untainted-Solver oracle (2,1,0). Verified pre-fix FAILS: with the
+guard reverted to hash-only the count stays at 1 (stale reuse) —
+"left: 1, right: 2". Full suite (75 test binaries) green,
+clippy --all-targets -D warnings clean, fmt clean.

--- a/dev/sessions/2026-07-10-04.md
+++ b/dev/sessions/2026-07-10-04.md
@@ -1,0 +1,84 @@
+# Session 2026-07-10-04
+
+## Goal
+Fix the four correctness-edge issues #120–#123 (from the 2026-07-10 six-agent
+audit), one at a time, each as its own tested commit with an empirical
+reproduction before encoding the fix. Then one PR for the batch.
+
+## Accomplished
+All four fixed, committed, full-suite (75 binaries) + clippy
+`--all-targets -D warnings` + fmt green after each. Every fix reproduced or
+guard-verified empirically before/after encoding (issue-112 discipline).
+
+- **#120** (`d6f8ebd`): `apply_post_scaling_overrides` now scales
+  `cascade_break_eps` by `‖D·A·D‖∞` (like the N2 `static_pivot_floor` fix), so
+  the cascade-break `PerturbToEps` floor is RELATIVE to the scaled matrix the
+  BK kernel operates on. Root cause: the default-armed `1e-10` was an ABSOLUTE
+  per-pivot floor; under Identity scaling on `γ·K` (γ=1e-12) every pivot was
+  bent to ±1e-10 (~1e2·‖A‖ perturbation), silently returning the inertia of
+  `A+Δ` with `‖Δ‖ ≫ ‖A‖`. Test `cascade_break_eps_scaled_by_matrix_norm`.
+- **#121** (`f8d5f8a`): symbolic-cache hit was gated on the `PatternFingerprint`
+  (a u64 hash) alone. Added a `last_pattern: Option<(Vec<usize>, Vec<usize>)>`
+  field kept in lockstep with the fingerprint; `cache_valid` now requires the
+  fingerprint match AND an exact O(n+nnz) `(col_ptr, row_idx)` compare, so a
+  2⁻⁶⁴ hash collision can never reuse a stale symbolic (which would scatter new
+  values through the old `perm` and corrupt factor/inertia). Test forges a
+  collision deterministically; verified it fails pre-fix (call_count 1 vs 2).
+- **#122** (`cb96b6e`): three-part guard-hardening bundle.
+  - **A** — ordering results (`run_external_ordering`, `schur::run_amd`) were
+    range-checked but never bijectivity-checked; a dup/missing perm corrupts
+    `permute_pattern`'s per-column count assignment. `validate_external_perm`
+    promoted to `pub(crate)` and called on both internal ordering results.
+  - **B** — `classify_2x2_inertia` mapped a NaN block to certified `(0,0,2)`.
+    Now returns `Result<Inertia, FeralError>` with a release-mode `!is_finite`
+    guard; Result threaded through `count_2x2_inertia_val`, `finish_1x1_outcome`
+    (now `Result<PivotStepResult>`), and all six call sites via `?`. Backstops
+    the debug-only finite entry-scan at `factor.rs:1749` (the only such gate on
+    the inertia path — grep confirmed).
+  - **C** — `LuParams::validate` now rejects `max_growth` NaN/≤1.0 (a NaN
+    silently disabled the growth guard in the update paths) and non-finite/≤0
+    `refine_tol`. Both dense and sparse factor entries call `validate()`.
+- **#123** (`876cf72`): the MAXFROMM short-circuit gate `akk >= alpha * mf` is
+  unconditionally true at `mf == 0.0` (`capture_maxfromm_col` returns `Some(0.0)`
+  for an all-zero trailing column), routing a zero column through rook-rescue —
+  where Plain's full scan hits `gamma0 == 0.0` and takes the dedicated
+  zero-column branch. Broke the documented Plain/Maxfromm bit-parity (delay/
+  inertia under `may_delay`, D under ForceAccept). Fix: `mf != 0.0 && …` treats
+  `Some(0.0)` as a cache miss. New `maxfromm_zero_tail_cache_miss_parity` (both
+  `may_delay` values, scalar + blocked) verified failing pre-fix; unit test
+  pins `capture_maxfromm_col`'s `Some(0.0)` precondition.
+
+## Benchmark Results
+No regression vs 2026-07-10-03 (inertia 100%, same worst residuals).
+```
+--- Dense solver validation ---
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+--- Sparse solver validation ---
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+Dense/Sparse failure analysis: no failures
+```
+
+## Decisions Made
+- #122B: chose to propagate `Result` from `classify_2x2_inertia` (threading
+  through `finish_1x1_outcome`) rather than an inline per-site guard — DRY, the
+  guard cannot be forgotten at a future call site, and all callers already sit
+  in `Result`-returning frames. Non-src-test `unwrap()` used in the affected
+  unit tests, consistent with existing test-module precedent in `factor.rs`.
+- #122C: `max_growth` semantics fixed as `> 1.0` with `+∞` an explicit
+  "never trigger on growth" opt-out; NaN and ≤1.0 rejected (documented on
+  `validate()`).
+
+## Abandoned Approaches
+None this session — all four fixes landed as first designed after empirical
+confirmation. (No new `dev/tried-and-rejected.md` entries.)
+
+## Next Session Should
+- Start the next audit issue batch (#124 onward — hardening/perf tier from the
+  2026-07-10 audit). Check `dev/context.md` "next session should" and the open
+  issue list.
+- The four correctness-edge fixes are on `claude/issue-112-0885lr`; open/merge
+  the batch PR and close #120–#123.

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -2952,7 +2952,7 @@ fn lblt_panel_frontal(
             if need_swap {
                 diag_inc(&panel_diag::INLINE_2X2_SWAP_OK);
             }
-            let pivot_inertia = count_2x2_inertia_val(d11, d21, d22);
+            let pivot_inertia = count_2x2_inertia_val(d11, d21, d22)?;
             *pos += pivot_inertia.positive;
             *neg += pivot_inertia.negative;
             *zero += pivot_inertia.zero;
@@ -3851,29 +3851,29 @@ fn finish_1x1_outcome(
     zero: &mut usize,
     fma: bool,
     maxfromm: Option<&mut Option<f64>>,
-) -> PivotStepResult {
+) -> Result<PivotStepResult, FeralError> {
     match outcome {
         PivotOutcome::Accepted => {
             do_1x1_update(a, nrow, k, fma);
             if let Some(slot) = maxfromm {
                 *slot = capture_maxfromm_col(a, nrow, k + 1);
             }
-            PivotStepResult::Advanced(1)
+            Ok(PivotStepResult::Advanced(1))
         }
         PivotOutcome::Rejected => {
             if let Some(slot) = maxfromm {
                 *slot = None;
             }
-            PivotStepResult::Advanced(1)
+            Ok(PivotStepResult::Advanced(1))
         }
         PivotOutcome::Delayed => {
             if let Some(slot) = maxfromm {
                 *slot = None;
             }
-            PivotStepResult::Delayed
+            Ok(PivotStepResult::Delayed)
         }
         PivotOutcome::AcceptedRook2x2 { d11, d21, d22 } => {
-            let inertia = count_2x2_inertia_val(d11, d21, d22);
+            let inertia = count_2x2_inertia_val(d11, d21, d22)?;
             *pos += inertia.positive;
             *neg += inertia.negative;
             *zero += inertia.zero;
@@ -3882,7 +3882,7 @@ fn finish_1x1_outcome(
             if let Some(slot) = maxfromm {
                 *slot = None;
             }
-            PivotStepResult::Advanced(2)
+            Ok(PivotStepResult::Advanced(2))
         }
     }
 }
@@ -3958,9 +3958,9 @@ fn scalar_pivot_step(
             n_rook_rescues,
             n_tiny,
         )?;
-        return Ok(finish_1x1_outcome(
+        return finish_1x1_outcome(
             outcome, a, nrow, k, subdiag, pos, neg, zero, params.fma, None,
-        ));
+        );
     }
 
     // MAXFROMM short-circuit: if the previous 1×1 stash gives a
@@ -3989,7 +3989,7 @@ fn scalar_pivot_step(
                     n_rook_rescues,
                     n_tiny,
                 )?;
-                return Ok(finish_1x1_outcome(
+                return finish_1x1_outcome(
                     outcome,
                     a,
                     nrow,
@@ -4000,7 +4000,7 @@ fn scalar_pivot_step(
                     zero,
                     params.fma,
                     Some(cached_maxfromm),
-                ));
+                );
             }
             // Diagonal too small relative to cached MAXFROMM — fall
             // through to full scan. `cached_maxfromm` is already
@@ -4058,7 +4058,7 @@ fn scalar_pivot_step(
             n_rook_rescues,
             n_tiny,
         )?;
-        return Ok(finish_1x1_outcome(
+        return finish_1x1_outcome(
             outcome,
             a,
             nrow,
@@ -4073,7 +4073,7 @@ fn scalar_pivot_step(
             } else {
                 None
             },
-        ));
+        );
     }
 
     // gamma_r: max off-diagonal in symmetric row r
@@ -4102,7 +4102,7 @@ fn scalar_pivot_step(
             n_rook_rescues,
             n_tiny,
         )?;
-        return Ok(finish_1x1_outcome(
+        return finish_1x1_outcome(
             outcome,
             a,
             nrow,
@@ -4117,7 +4117,7 @@ fn scalar_pivot_step(
             } else {
                 None
             },
-        ));
+        );
     }
 
     if akk * gamma_r >= alpha * gamma0 * gamma0 {
@@ -4138,7 +4138,7 @@ fn scalar_pivot_step(
             n_rook_rescues,
             n_tiny,
         )?;
-        return Ok(finish_1x1_outcome(
+        return finish_1x1_outcome(
             outcome,
             a,
             nrow,
@@ -4153,7 +4153,7 @@ fn scalar_pivot_step(
             } else {
                 None
             },
-        ));
+        );
     }
 
     // 2×2 partner selection (issue #46). BK's magnitude-argmax `r` is
@@ -4302,7 +4302,7 @@ fn scalar_pivot_step(
                 n_rook_rescues,
                 n_tiny,
             )?;
-            return Ok(finish_1x1_outcome(
+            return finish_1x1_outcome(
                 outcome,
                 a,
                 nrow,
@@ -4317,10 +4317,10 @@ fn scalar_pivot_step(
                 } else {
                     None
                 },
-            ));
+            );
         }
 
-        let pivot_inertia = count_2x2_inertia_val(d11, d21, d22);
+        let pivot_inertia = count_2x2_inertia_val(d11, d21, d22)?;
         *pos += pivot_inertia.positive;
         *neg += pivot_inertia.negative;
         *zero += pivot_inertia.zero;
@@ -4352,7 +4352,7 @@ fn scalar_pivot_step(
             n_rook_rescues,
             n_tiny,
         )?;
-        Ok(finish_1x1_outcome(
+        finish_1x1_outcome(
             outcome,
             a,
             nrow,
@@ -4367,7 +4367,7 @@ fn scalar_pivot_step(
             } else {
                 None
             },
-        ))
+        )
     }
 }
 
@@ -4739,8 +4739,9 @@ pub(crate) fn do_2x2_update(
 }
 
 /// Count inertia of a 2×2 D block `[[d11, d21], [d21, d22]]`, returning
-/// an `Inertia` struct. Thin wrapper over [`classify_2x2_inertia`].
-fn count_2x2_inertia_val(d11: f64, d21: f64, d22: f64) -> Inertia {
+/// an `Inertia` struct. Thin wrapper over [`classify_2x2_inertia`];
+/// propagates the non-finite-block error (issue #122B).
+fn count_2x2_inertia_val(d11: f64, d21: f64, d22: f64) -> Result<Inertia, FeralError> {
     classify_2x2_inertia(d11, d21, d22)
 }
 
@@ -4794,10 +4795,23 @@ fn det_sym2x2(d11: f64, d21: f64, d22: f64) -> f64 {
 /// rounds a non-zero sum across zero. See journal 2026-05-21-03 §18:05
 /// and `dev/plans/kkt-cascade-fix2-2x2-inertia-cancellation.md`.
 #[inline]
-fn classify_2x2_inertia(d11: f64, d21: f64, d22: f64) -> Inertia {
+fn classify_2x2_inertia(d11: f64, d21: f64, d22: f64) -> Result<Inertia, FeralError> {
+    // Non-finite guard (issue #122B): a NaN `det`/`tr` fails every ordered
+    // comparison below and would fall through to the `(0, 0, 2)` arm —
+    // certifying a NaN block as two *zero* eigenvalues, the worst possible
+    // failure shape for a solver with a hard inertia contract. Block inputs
+    // are validated finite at factor entry, but an intermediate `inf − inf`
+    // in a release-mode Schur update is not excluded, so reject here rather
+    // than launder it into a certified inertia.
+    if !d11.is_finite() || !d21.is_finite() || !d22.is_finite() {
+        return Err(FeralError::InvalidInput(format!(
+            "non-finite 2x2 pivot block: d11={}, d21={}, d22={}",
+            d11, d21, d22
+        )));
+    }
     let det = det_sym2x2(d11, d21, d22);
     let tr = d11 + d22;
-    if det < 0.0 {
+    let inertia = if det < 0.0 {
         Inertia::new(1, 1, 0)
     } else if det > 0.0 {
         if tr > 0.0 {
@@ -4815,7 +4829,8 @@ fn classify_2x2_inertia(d11: f64, d21: f64, d22: f64) -> Inertia {
         } else {
             Inertia::new(0, 0, 2)
         }
-    }
+    };
+    Ok(inertia)
 }
 
 /// Closed-form eigenvalues of the symmetric 2×2 matrix
@@ -5484,7 +5499,7 @@ fn count_2x2_inertia(
                 // which is out of scope; it gets the same sign
                 // accounting and relies on iterative refinement.
                 *needs_refinement = true;
-                let inertia = classify_2x2_inertia(a00, a10, a11);
+                let inertia = classify_2x2_inertia(a00, a10, a11)?;
                 *pos += inertia.positive;
                 *neg += inertia.negative + inertia.zero;
                 Ok(())
@@ -5507,7 +5522,7 @@ fn count_2x2_inertia(
         // `factors.zero_tol_2x2`. See `dev/decisions.md` and
         // `dev/research/f01-rankdef-underreporting.md`.
         *needs_refinement = true;
-        let inertia = classify_2x2_inertia(a00, a10, a11);
+        let inertia = classify_2x2_inertia(a00, a10, a11)?;
         *pos += inertia.positive;
         *neg += inertia.negative + inertia.zero;
         Ok(())
@@ -5518,7 +5533,7 @@ fn count_2x2_inertia(
         // A `zero` is surfaced here only on the (effectively
         // unreachable) genuine exact singularity, in which case
         // reporting it honestly is correct.
-        let inertia = classify_2x2_inertia(a00, a10, a11);
+        let inertia = classify_2x2_inertia(a00, a10, a11)?;
         let _ = det; // det used only for the singularity gates above
         *pos += inertia.positive;
         *neg += inertia.negative;
@@ -5657,7 +5672,7 @@ mod sym2_inertia_tests {
 
     #[test]
     fn count_2x2_inertia_val_positive_definite() {
-        let inertia = count_2x2_inertia_val(2.0, 1.0, 2.0);
+        let inertia = count_2x2_inertia_val(2.0, 1.0, 2.0).unwrap();
         assert_eq!(inertia.positive, 2);
         assert_eq!(inertia.negative, 0);
         assert_eq!(inertia.zero, 0);
@@ -5665,7 +5680,7 @@ mod sym2_inertia_tests {
 
     #[test]
     fn count_2x2_inertia_val_negative_definite() {
-        let inertia = count_2x2_inertia_val(-2.0, 1.0, -2.0);
+        let inertia = count_2x2_inertia_val(-2.0, 1.0, -2.0).unwrap();
         assert_eq!(inertia.positive, 0);
         assert_eq!(inertia.negative, 2);
         assert_eq!(inertia.zero, 0);
@@ -5674,7 +5689,7 @@ mod sym2_inertia_tests {
     #[test]
     fn count_2x2_inertia_val_indefinite() {
         // [[1, 2], [2, 1]] eigs are 3, -1.
-        let inertia = count_2x2_inertia_val(1.0, 2.0, 1.0);
+        let inertia = count_2x2_inertia_val(1.0, 2.0, 1.0).unwrap();
         assert_eq!(inertia.positive, 1);
         assert_eq!(inertia.negative, 1);
         assert_eq!(inertia.zero, 0);
@@ -5696,7 +5711,7 @@ mod sym2_inertia_tests {
         // Either way: must not report any negative eigenvalues for a
         // matrix whose true spectrum is (+, +).
         let a = 1.0 + f64::EPSILON;
-        let inertia = count_2x2_inertia_val(a, 1.0, a);
+        let inertia = count_2x2_inertia_val(a, 1.0, a).unwrap();
         assert_eq!(inertia.negative, 0, "must not over-report negatives");
     }
 
@@ -5717,7 +5732,7 @@ mod sym2_inertia_tests {
         let a = 1.0;
         let c = 1.0 + 4.0 * f64::EPSILON;
         let b = (1.0 - f64::EPSILON).sqrt(); // b*b ≈ 1 - eps mathematically
-        let inertia = count_2x2_inertia_val(a, b, c);
+        let inertia = count_2x2_inertia_val(a, b, c).unwrap();
         // True det = (1)(1 + 4eps) - (1 - eps) = 5 eps > 0; (+,+).
         assert_eq!(inertia.negative, 0, "must not over-report negatives");
     }
@@ -5742,7 +5757,7 @@ mod sym2_inertia_tests {
     fn count_2x2_inertia_val_diagonal_tiny_huge_positive() {
         // [[1e-30, 0], [0, 1e30]] — eigenvalues 1e-30 and 1e30, both
         // strictly positive ⇒ inertia (2, 0, 0). det = 1e-30·1e30 = 1.0.
-        let inertia = count_2x2_inertia_val(1e-30, 0.0, 1e30);
+        let inertia = count_2x2_inertia_val(1e-30, 0.0, 1e30).unwrap();
         assert_eq!(inertia, Inertia::new(2, 0, 0), "got {inertia}");
     }
 
@@ -5750,7 +5765,7 @@ mod sym2_inertia_tests {
     fn count_2x2_inertia_val_diagonal_tiny_neg_huge_pos() {
         // [[-1e-30, 0], [0, 1e30]] — eigenvalues -1e-30 and 1e30,
         // opposite signs ⇒ straddle ⇒ inertia (1, 1, 0).
-        let inertia = count_2x2_inertia_val(-1e-30, 0.0, 1e30);
+        let inertia = count_2x2_inertia_val(-1e-30, 0.0, 1e30).unwrap();
         assert_eq!(inertia, Inertia::new(1, 1, 0), "got {inertia}");
     }
 
@@ -5758,7 +5773,7 @@ mod sym2_inertia_tests {
     fn count_2x2_inertia_val_diagonal_both_negative() {
         // [[-1e-30, 0], [0, -1e30]] — eigenvalues -1e-30 and -1e30,
         // both strictly negative ⇒ inertia (0, 2, 0).
-        let inertia = count_2x2_inertia_val(-1e-30, 0.0, -1e30);
+        let inertia = count_2x2_inertia_val(-1e-30, 0.0, -1e30).unwrap();
         assert_eq!(inertia, Inertia::new(0, 2, 0), "got {inertia}");
     }
 
@@ -5766,36 +5781,71 @@ mod sym2_inertia_tests {
     fn count_2x2_inertia_val_genuine_singular_positive() {
         // [[0, 0], [0, 5]] — eigenvalues 0 and 5 ⇒ inertia (1, 0, 1).
         // A genuine exact zero must still be reported as `zero`.
-        let inertia = count_2x2_inertia_val(0.0, 0.0, 5.0);
+        let inertia = count_2x2_inertia_val(0.0, 0.0, 5.0).unwrap();
         assert_eq!(inertia, Inertia::new(1, 0, 1), "got {inertia}");
     }
 
     #[test]
     fn count_2x2_inertia_val_genuine_singular_negative() {
         // [[0, 0], [0, -5]] — eigenvalues 0 and -5 ⇒ inertia (0, 1, 1).
-        let inertia = count_2x2_inertia_val(0.0, 0.0, -5.0);
+        let inertia = count_2x2_inertia_val(0.0, 0.0, -5.0).unwrap();
         assert_eq!(inertia, Inertia::new(0, 1, 1), "got {inertia}");
     }
 
     #[test]
     fn count_2x2_inertia_val_genuine_double_zero() {
         // [[0, 0], [0, 0]] — both eigenvalues 0 ⇒ inertia (0, 0, 2).
-        let inertia = count_2x2_inertia_val(0.0, 0.0, 0.0);
+        let inertia = count_2x2_inertia_val(0.0, 0.0, 0.0).unwrap();
         assert_eq!(inertia, Inertia::new(0, 0, 2), "got {inertia}");
     }
 
     #[test]
     fn count_2x2_inertia_val_off_diagonal_straddle() {
         // [[0, 1], [1, 0]] — eigenvalues ±1 ⇒ inertia (1, 1, 0).
-        let inertia = count_2x2_inertia_val(0.0, 1.0, 0.0);
+        let inertia = count_2x2_inertia_val(0.0, 1.0, 0.0).unwrap();
         assert_eq!(inertia, Inertia::new(1, 1, 0), "got {inertia}");
     }
 
     #[test]
     fn count_2x2_inertia_val_well_separated_pd() {
         // [[2, 1], [1, 2]] — eigenvalues 3 and 1 ⇒ inertia (2, 0, 0).
-        let inertia = count_2x2_inertia_val(2.0, 1.0, 2.0);
+        let inertia = count_2x2_inertia_val(2.0, 1.0, 2.0).unwrap();
         assert_eq!(inertia, Inertia::new(2, 0, 0), "got {inertia}");
+    }
+
+    /// Issue #122B: a non-finite 2×2 block must be rejected, never
+    /// laundered into a certified `(0, 0, 2)` (two *zero* eigenvalues).
+    /// Pre-fix, NaN `det`/`tr` failed every ordered comparison and fell
+    /// through to the zero-zero arm — the worst failure shape for a hard
+    /// inertia contract. This tests every non-finite argument slot.
+    #[test]
+    fn classify_2x2_non_finite_block_errors_not_double_zero() {
+        for (d11, d21, d22) in [
+            (f64::NAN, 1.0, 2.0),
+            (2.0, f64::NAN, 1.0),
+            (1.0, 2.0, f64::NAN),
+            (f64::INFINITY, 1.0, 2.0),
+            (1.0, 2.0, f64::NEG_INFINITY),
+            (f64::INFINITY, 1.0, f64::NEG_INFINITY),
+        ] {
+            let got = classify_2x2_inertia(d11, d21, d22);
+            assert!(
+                matches!(got, Err(FeralError::InvalidInput(_))),
+                "non-finite block ({d11}, {d21}, {d22}) must error, got {got:?}"
+            );
+            // Belt-and-suspenders: it must never come back as any inertia,
+            // least of all the certified double-zero.
+            assert_ne!(
+                got.ok(),
+                Some(Inertia::new(0, 0, 2)),
+                "non-finite block laundered into certified (0,0,2)"
+            );
+        }
+        // The finite path is unchanged: a genuine double-zero still classifies.
+        assert_eq!(
+            classify_2x2_inertia(0.0, 0.0, 0.0).unwrap(),
+            Inertia::new(0, 0, 2)
+        );
     }
 
     #[test]

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -3972,7 +3972,18 @@ fn scalar_pivot_step(
     if use_maxfromm {
         if let Some(mf) = cached {
             let akk = a[k * nrow + k].abs();
-            if akk >= alpha * mf {
+            // Issue #123: a cached `mf == 0.0` (all-zero trailing column, e.g.
+            // exact fp cancellation from duplicate columns) is a cache MISS, not
+            // a hit. The gate `akk >= alpha * mf` is unconditionally true at
+            // `mf == 0.0` (`0 ≥ 0`), which would route a zero column through the
+            // rook-rescue path — but Plain's full scan hits `gamma0 == 0.0` and
+            // takes the dedicated zero-column branch (`count_1x1_inertia` +
+            // identity L column, below). Those differ under `may_delay` (Delayed
+            // vs counted-in-place) and `ForceAccept` (D zeroed vs tiny value
+            // kept), breaking the documented Plain/Maxfromm bit-parity. Falling
+            // through re-scans and lands in the same zero-column branch — the
+            // cache only ever accelerates the common nonzero case.
+            if mf != 0.0 && akk >= alpha * mf {
                 let outcome = try_reject_1x1_with_rook_rescue(
                     a,
                     nrow,
@@ -6045,6 +6056,39 @@ mod row_offdiag_tests {
             got, 7.0,
             "A(r, k) must be included in the row-r off-diagonal max (LAPACK ROWMAX)"
         );
+    }
+}
+
+#[cfg(test)]
+mod maxfromm_capture_tests {
+    use super::*;
+
+    /// Issue #123: `capture_maxfromm_col` returns `Some(0.0)` for an all-zero
+    /// trailing column (the exact-cancellation case). This is the value the
+    /// short-circuit consumer must treat as a cache MISS — pinning it here so
+    /// a refactor of the capture side can't silently change the precondition
+    /// the fix relies on. A nonzero column returns its off-diagonal max, and
+    /// the last-column case returns `None`.
+    #[test]
+    fn capture_maxfromm_col_zero_column_is_some_zero() {
+        let n = 4;
+        // Column 1's trailing rows (2, 3) are exactly zero → Some(0.0).
+        let mut a = vec![0.0f64; n * n];
+        // Column-major (row i, col j) lives at `j * n + i`.
+        // Leave column 1's tail (rows 2, 3) zero; put noise elsewhere to prove
+        // it is ignored: column 1's diagonal (n + 1) and column 0 row 3 (3).
+        a[n + 1] = 5.0; // col 1 diagonal — not scanned (scan starts at col+1)
+        a[3] = 9.0; // col 0 row 3 — a different column, not scanned
+        assert_eq!(capture_maxfromm_col(&a, n, 1), Some(0.0));
+
+        // Nonzero tail → its off-diagonal max. Column 1 rows 2 and 3.
+        let mut b = vec![0.0f64; n * n];
+        b[n + 2] = 3.0;
+        b[n + 3] = -7.0;
+        assert_eq!(capture_maxfromm_col(&b, n, 1), Some(7.0));
+
+        // Last column (no rows below) → None, never Some(0.0).
+        assert_eq!(capture_maxfromm_col(&a, n, n - 1), None);
     }
 }
 

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -150,8 +150,10 @@ impl LuParams {
     /// diagonal), `> 1` is meaningless, and `NaN` poisons every threshold
     /// comparison. `zero_pivot_tol` is a relative floor and must be finite and
     /// in `[0, 1)`: negative is nonsensical and `≥ 1` would declare every
-    /// pivot singular. Validating here keeps the dense and sparse factor paths
-    /// from drifting on the same bad input.
+    /// pivot singular. `max_growth` must be `> 1.0` (finite or `+∞`; `NaN` or
+    /// `≤ 1.0` rejected) and `refine_tol` finite and `> 0` — both otherwise
+    /// silently disable a guard (issue #122C). Validating here keeps the dense
+    /// and sparse factor paths from drifting on the same bad input.
     pub(crate) fn validate(&self) -> Result<(), crate::error::FeralError> {
         use crate::error::FeralError;
         if !(self.pivot_threshold > 0.0 && self.pivot_threshold <= 1.0) {
@@ -164,6 +166,30 @@ impl LuParams {
             return Err(FeralError::InvalidInput(format!(
                 "LuParams::zero_pivot_tol must be in [0, 1), got {}",
                 self.zero_pivot_tol
+            )));
+        }
+        // `max_growth` gates the update refactor trigger (`growth > max_growth`).
+        // A `NaN` makes that comparison always false, silently disabling the
+        // growth guard in the update paths (which — unlike `should_refactor_growth`
+        // — do not defend with `is_finite`); `≤ 1.0` rejects every update since
+        // the monitored growth is ≥ 1. `+∞` is the documented "never trigger on
+        // growth" opt-out and passes (`+∞ > 1.0`); `NaN` does not (`NaN > 1.0`
+        // is false). Issue #122C.
+        if self.max_growth.is_nan() || self.max_growth <= 1.0 {
+            return Err(FeralError::InvalidInput(format!(
+                "LuParams::max_growth must be > 1.0 (finite or +inf), got {}",
+                self.max_growth
+            )));
+        }
+        // `refine_tol` is the relative-residual stop for iterative refinement.
+        // `NaN` breaks the `‖r‖/‖a‖ < refine_tol` convergence check (always
+        // false → refinement runs to `refine_steps` doing no useful work or
+        // spinning); `≤ 0` can never be met; `+∞` would accept any residual.
+        // Require finite and strictly positive. Issue #122C.
+        if !self.refine_tol.is_finite() || self.refine_tol <= 0.0 {
+            return Err(FeralError::InvalidInput(format!(
+                "LuParams::refine_tol must be finite and > 0, got {}",
+                self.refine_tol
             )));
         }
         Ok(())
@@ -233,5 +259,50 @@ mod tests {
         // 64x64 = 4096 cells; dense iff nnz >= 1024.
         assert!(!should_use_dense_lu(64, 1023, &p));
         assert!(should_use_dense_lu(64, 1024, &p));
+    }
+
+    /// Issue #122C: `validate()` must reject `max_growth` and `refine_tol`
+    /// values that silently disable a guard, and accept the documented
+    /// boundary/opt-out values. The default is valid.
+    #[test]
+    fn validate_max_growth_and_refine_tol() {
+        use crate::error::FeralError;
+        assert!(LuParams::default().validate().is_ok());
+
+        let bad_growth = |g: f64| LuParams {
+            max_growth: g,
+            ..LuParams::default()
+        };
+        // NaN disables `growth > max_growth` silently → reject.
+        assert!(matches!(
+            bad_growth(f64::NAN).validate(),
+            Err(FeralError::InvalidInput(_))
+        ));
+        // ≤ 1.0 rejects every update (growth ≥ 1) → reject.
+        assert!(matches!(
+            bad_growth(1.0).validate(),
+            Err(FeralError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            bad_growth(0.5).validate(),
+            Err(FeralError::InvalidInput(_))
+        ));
+        // Just past 1.0 and the +∞ opt-out are both documented-valid.
+        assert!(bad_growth(1.0 + 1e-12).validate().is_ok());
+        assert!(bad_growth(f64::INFINITY).validate().is_ok());
+
+        let bad_tol = |t: f64| LuParams {
+            refine_tol: t,
+            ..LuParams::default()
+        };
+        // NaN / ≤ 0 / +∞ all break the convergence check → reject.
+        for t in [f64::NAN, 0.0, -1e-12, f64::INFINITY] {
+            assert!(
+                matches!(bad_tol(t).validate(), Err(FeralError::InvalidInput(_))),
+                "refine_tol {t} must be rejected"
+            );
+        }
+        // A small positive finite tol is valid.
+        assert!(bad_tol(1e-14).validate().is_ok());
     }
 }

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -157,20 +157,21 @@ pub struct NumericParams {
     /// `dev/research/issue-15-cascade-break-symbolic-arm.md`.
     pub cascade_break_ratio: Option<f64>,
 
-    /// Per-pivot perturbation floor for cascade-break supernodes.
-    /// When `cascade_break_ratio` fires AND this is `Some(eps)`, the
-    /// triggered supernode runs with
-    /// `on_zero_pivot = PerturbToEps { abs_floor: eps }`, replacing
-    /// each tiny pivot by `sign(d) * max(|d|, eps)` and counting it
-    /// by sign rather than zero. The factor then satisfies
-    /// `LDL^T = A + Δ` with `||Δ||_∞ <= eps` per perturbed pivot —
-    /// inertia is preserved provided every nonzero eigenvalue of
-    /// `A` exceeds the cumulative perturbation. Default `None`
-    /// keeps the legacy `ForceAccept` semantics (unbounded Δ,
-    /// counts perturbed pivots as zero). See
-    /// `dev/journal/2026-05-13-03.org` 01:15 for the matrix-specific
-    /// "sweet spot" pathology that motivates bounded-Δ
-    /// perturbation.
+    /// **Relative** per-pivot perturbation floor for cascade-break
+    /// supernodes. When `cascade_break_ratio` fires AND this is
+    /// `Some(eps)`, the triggered supernode runs with
+    /// `on_zero_pivot = PerturbToEps { abs_floor: eps · ‖D·A·D‖∞ }`
+    /// (the scaling is applied by `apply_post_scaling_overrides`, issue
+    /// #120), replacing each tiny pivot by `sign(d) · max(|d|, floor)`
+    /// and counting it by sign rather than zero. The factor then
+    /// satisfies `LDL^T = A + Δ` with `||Δ||_∞ <= eps · ‖D·A·D‖∞` per
+    /// perturbed pivot — inertia is preserved provided every nonzero
+    /// eigenvalue exceeds the cumulative perturbation. Because the floor
+    /// tracks the scaled matrix norm, the same `eps` behaves identically
+    /// on `A` and `γ·A`. Default `None` keeps the legacy `ForceAccept`
+    /// semantics (unbounded Δ, counts perturbed pivots as zero). See
+    /// `dev/journal/2026-05-13-03.org` 01:15 for the "sweet spot"
+    /// pathology that motivates bounded-Δ perturbation.
     pub cascade_break_eps: Option<f64>,
 
     /// Override the minimum estimated tree-flop count at which
@@ -2517,10 +2518,10 @@ fn factor_one_supernode(
     let bk_ref: &BunchKaufmanParams = if cascade_break {
         // When `cascade_break_eps` is set, use the bounded-Δ
         // perturbation path; otherwise fall back to the legacy
-        // unbounded `ForceAccept`. The eps is treated as an absolute
-        // floor per pivot — callers should pre-multiply by an
-        // estimate of `||A||_∞` when working with non-normalized
-        // matrices.
+        // unbounded `ForceAccept`. `cascade_break_eps` has already been
+        // scaled to `eps · ‖D·A·D‖∞` by `apply_post_scaling_overrides`
+        // (issue #120), so the floor here is relative to the scaled
+        // matrix the BK kernel operates on — no caller pre-multiply needed.
         let on_zero = match params.cascade_break_eps {
             Some(eps) => ZeroPivotAction::PerturbToEps { abs_floor: eps },
             None => ZeroPivotAction::ForceAccept,
@@ -3624,7 +3625,20 @@ fn apply_post_scaling_overrides(
         (floor > params.bk.null_pivot_tol).then_some(floor)
     };
 
-    if static_floor.is_none() && null_floor.is_none() {
+    // Issue #120: the cascade-break perturbation floor `cascade_break_eps` was
+    // fed to `ZeroPivotAction::PerturbToEps` as an *absolute* per-pivot floor,
+    // but the BK kernels operate on the scaled matrix `D·A·D`. So — exactly as
+    // N2 does for `static_pivot_floor` above — treat `cascade_break_eps` as a
+    // *relative* threshold and enforce `eps · ‖D·A·D‖∞`. Under Identity scaling
+    // this is `eps · ‖A‖∞`, so a matrix scaled by `γ` (e.g. ripopt's `γ·K`) gets
+    // a `γ`-scaled floor instead of a fixed `1e-10` that could be `10²·‖A‖`.
+    let cascade_floor = params
+        .cascade_break_eps
+        .filter(|e| *e > 0.0)
+        .map(|e| e * scaled_infnorm)
+        .filter(|f| f.is_finite() && *f > 0.0);
+
+    if static_floor.is_none() && null_floor.is_none() && cascade_floor.is_none() {
         return None;
     }
     let mut local = params.clone();
@@ -3634,6 +3648,9 @@ fn apply_post_scaling_overrides(
     if let Some(floor) = null_floor {
         local.bk.null_pivot_tol = floor;
         local.bk.null_pivot_tol_2x2 = (floor * scaled_infnorm).max(floor * floor);
+    }
+    if let Some(cf) = cascade_floor {
+        local.cascade_break_eps = Some(cf);
     }
     Some(local)
 }
@@ -4036,6 +4053,61 @@ mod tests {
             on_zero_pivot: ZeroPivotAction::ForceAccept,
             ..BunchKaufmanParams::default()
         })
+    }
+
+    /// Issue #120: `cascade_break_eps` is a *relative* floor —
+    /// `apply_post_scaling_overrides` must scale it by the scaled matrix
+    /// ∞-norm, so the same `eps` yields a floor that tracks the matrix scale
+    /// (identical behavior on `A` and `γ·A`). Pre-fix it was passed to
+    /// `PerturbToEps` as an absolute `1e-10`, so a `γ`-scaled matrix received a
+    /// floor that was `γ⁻¹`× too large/small relative to its own pivots.
+    #[test]
+    fn cascade_break_eps_scaled_by_matrix_norm() {
+        let mut params = make_params();
+        params.cascade_break_eps = Some(1e-10);
+
+        // Floor = eps · ‖D·A·D‖∞.
+        let f_hi = apply_post_scaling_overrides(&params, 1e6, 100)
+            .expect("override applied when cascade_break_eps set")
+            .cascade_break_eps
+            .unwrap();
+        assert!(
+            (f_hi - 1e-10 * 1e6).abs() <= 1e-20,
+            "floor must be eps·norm, got {f_hi}"
+        );
+
+        // Normalized matrix (‖·‖∞ = 1) leaves the raw eps as the floor.
+        let f_unit = apply_post_scaling_overrides(&params, 1.0, 100)
+            .unwrap()
+            .cascade_break_eps
+            .unwrap();
+        assert_eq!(f_unit, 1e-10);
+
+        // Scale invariance: the floor tracks the norm ratio exactly, so a
+        // `γ`-scaled matrix (norm `γ·base`) gets a `γ`× floor.
+        let base = apply_post_scaling_overrides(&params, 4.0, 100)
+            .unwrap()
+            .cascade_break_eps
+            .unwrap();
+        let scaled = apply_post_scaling_overrides(&params, 4.0e-6, 100)
+            .unwrap()
+            .cascade_break_eps
+            .unwrap();
+        assert!(
+            (scaled / base - 1e-6).abs() <= 1e-12,
+            "floor must scale with the matrix norm ratio: {scaled} / {base}"
+        );
+
+        // A `None` cascade_break_eps must never be invented by the override
+        // (other floors — e.g. the F-01 null-pivot floor — may still fire).
+        let mut off = make_params();
+        off.cascade_break_eps = None;
+        if let Some(local) = apply_post_scaling_overrides(&off, 1e6, 100) {
+            assert_eq!(
+                local.cascade_break_eps, None,
+                "override must not invent a cascade floor"
+            );
+        }
     }
 
     #[test]

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -192,6 +192,15 @@ pub struct Solver {
     last_factors: Option<SparseFactors>,
     last_inertia: Option<Inertia>,
     last_pattern_fingerprint: Option<PatternFingerprint>,
+    /// The exact `(col_ptr, row_idx)` of the pattern the cached symbolic was
+    /// built for, kept in lockstep with `last_pattern_fingerprint`. The
+    /// fingerprint is only a `u64` hash, so a collision between two distinct
+    /// patterns sharing `(n, nnz)` would silently reuse a stale symbolic —
+    /// its `perm` scatters the new values into fronts whose `row_map` lookups
+    /// miss, dropping entries and corrupting the factor/inertia with no error.
+    /// The exact `O(n + nnz)` compare on a fingerprint hit forecloses that
+    /// (issue #121), mirroring the permute-cache's REG-1 stored-pattern rule.
+    last_pattern: Option<(Vec<usize>, Vec<usize>)>,
     /// Diagnostic counter: number of times `symbolic_factorize` was
     /// called from this `Solver`. Used by integration tests to
     /// verify the cache-reuse property and by future telemetry.
@@ -411,6 +420,7 @@ impl Solver {
             last_factors: None,
             last_inertia: None,
             last_pattern_fingerprint: None,
+            last_pattern: None,
             symbolic_call_count: 0,
             mc64_fallback_count: 0,
             mc64_scaling_fallback_count: 0,
@@ -872,11 +882,20 @@ impl Solver {
         // reused on this call. Sampling at entry — rather than at the
         // success branch — keeps the signal honest even if downstream
         // work fails after the symbolic has already been reused.
-        let pattern_reused = self.last_pattern_fingerprint == Some(fp);
+        // The cache is valid only when the fingerprint matches AND the exact
+        // stored pattern matches (issue #121): the fingerprint is a fast
+        // reject; an equal fingerprint is confirmed by the O(n + nnz) compare
+        // so a hash collision can never reuse a stale symbolic.
+        let cache_valid = self.last_pattern_fingerprint == Some(fp)
+            && self.last_pattern.as_ref().is_some_and(|(cp, ri)| {
+                cp.as_slice() == matrix.col_ptr && ri.as_slice() == matrix.row_idx
+            });
+        let pattern_reused = cache_valid;
 
         // Step 2: invalidate cache on pattern change.
-        if self.last_pattern_fingerprint != Some(fp) {
+        if !cache_valid {
             self.last_symbolic = None;
+            self.last_pattern = None;
             self.last_factors = None;
             self.last_inertia = None;
             self.last_pattern_fingerprint = None;
@@ -934,6 +953,10 @@ impl Solver {
                     self.symbolic_call_count += 1;
                     self.last_symbolic = Some(sym);
                     self.last_pattern_fingerprint = Some(fp);
+                    // Store the exact pattern (issue #121) so a future
+                    // fingerprint hit is confirmed by an exact compare, never
+                    // reused on a hash collision. Cloned only on a cache miss.
+                    self.last_pattern = Some((matrix.col_ptr.clone(), matrix.row_idx.clone()));
                 }
                 Err(e) => return FactorStatus::FatalError(e),
             }
@@ -1910,6 +1933,7 @@ impl Solver {
     pub fn invalidate_symbolic_cache(&mut self) {
         self.last_symbolic = None;
         self.last_pattern_fingerprint = None;
+        self.last_pattern = None;
     }
 }
 
@@ -2678,6 +2702,86 @@ mod tests {
             PatternFingerprint::of(&a),
             PatternFingerprint::of(&b),
             "different col_ptr distribution must fingerprint differently"
+        );
+    }
+
+    /// F4 — issue #121: a forged fingerprint collision must NOT reuse the
+    /// stale symbolic. The fingerprint is a `u64`, so two distinct patterns
+    /// sharing `(n, nnz)` can (with probability 2⁻⁶⁴) collide; a hash-only
+    /// cache check would then scatter the new values through the old pattern's
+    /// `perm`, silently corrupting the factor and inertia. The exact
+    /// `(col_ptr, row_idx)` compare on a fingerprint hit closes that.
+    ///
+    /// We reproduce the 2⁻⁶⁴ event deterministically by overwriting the stored
+    /// fingerprint with B's while `last_pattern` still holds A's exact pattern.
+    #[test]
+    fn f4_forged_fingerprint_collision_does_not_reuse_stale_symbolic() {
+        // A: SPD tridiagonal → inertia (3,0,0). col_ptr=[0,2,4,5],
+        // row_idx=[0,1,1,2,2].
+        let a = tridiag(3, 10.0, 1.0);
+        // B: 3×3 arrow, small diagonal, indefinite. SAME (n, nnz)=(3,5) and
+        // SAME col_ptr as A, but a DIFFERENT row_idx (the arrow tail in cols
+        // 0/1 hits row 2, not the sub-diagonal). Hand oracle: (1,-1,0) gives
+        // λ=0.1; the orthogonal 2×2 block [[0.1,√2],[√2,0.1]] gives
+        // 0.1±√2 = {1.514, −1.314} → inertia (2,1,0).
+        let b = CscMatrix::from_triplets(
+            3,
+            &[0, 2, 1, 2, 2],
+            &[0, 0, 1, 1, 2],
+            &[0.1, 1.0, 0.1, 1.0, 0.1],
+        )
+        .expect("valid CSC");
+        // Precondition: A and B share (n, nnz) and col_ptr but differ in
+        // row_idx, so a stale-symbolic reuse would silently corrupt B.
+        assert_eq!(a.n, b.n);
+        assert_eq!(a.col_ptr, b.col_ptr, "same col_ptr — collision realistic");
+        assert_ne!(a.row_idx, b.row_idx, "different pattern — must not reuse");
+
+        // Oracle for B from an untainted Solver (no forged collision).
+        let mut fresh = Solver::new();
+        let st = fresh.factor(&b, None);
+        assert!(
+            matches!(st, FactorStatus::Success),
+            "fresh B factor: {:?}",
+            st
+        );
+        assert_eq!(
+            *fresh.inertia().expect("B inertia"),
+            Inertia::new(2, 1, 0),
+            "hand oracle: B is indefinite (2,1,0)"
+        );
+
+        // Collision scenario on a single Solver: factor A, then forge B's
+        // fingerprint over the stored one.
+        let mut s = Solver::new();
+        let st = s.factor(&a, Some(Inertia::new(3, 0, 0)));
+        assert!(matches!(st, FactorStatus::Success), "A factor: {:?}", st);
+        let calls_after_a = s.symbolic_call_count();
+        assert_eq!(calls_after_a, 1);
+
+        // Forge the collision: overwrite the stored fingerprint with B's so
+        // the fast-reject passes, while `last_pattern` still holds A's exact
+        // pattern.
+        s.last_pattern_fingerprint = Some(PatternFingerprint::of(&b));
+
+        let st = s.factor(&b, None);
+        assert!(
+            matches!(st, FactorStatus::Success),
+            "B factor after forged collision: {:?}",
+            st
+        );
+        // The exact-compare guard must reject the collision and rebuild the
+        // symbolic — a hash-only check would keep this at 1 and corrupt B.
+        assert_eq!(
+            s.symbolic_call_count(),
+            calls_after_a + 1,
+            "forged fingerprint collision must force a fresh symbolic (issue #121)"
+        );
+        // And B's inertia matches the untainted oracle — no silent corruption.
+        assert_eq!(
+            *s.inertia().expect("B inertia after collision"),
+            Inertia::new(2, 1, 0),
+            "B inertia must be correct despite the forged collision"
         );
     }
 

--- a/src/ordering/schur.rs
+++ b/src/ordering/schur.rs
@@ -210,6 +210,12 @@ fn run_amd(pattern: &CscPattern) -> Result<Vec<usize>, FeralError> {
         }
         out.push(u);
     }
+    // Bijectivity guard (issue #122A): the loop range-checks each element
+    // but not "no duplicates". A duplicate/missing pair would corrupt
+    // `permute_pattern`'s per-column count assignment silently. One O(n)
+    // check on this O(nnz·α) path closes it, matching the full check that
+    // user-supplied `External` perms already receive.
+    crate::symbolic::validate_external_perm(&out, pattern.n)?;
     Ok(out)
 }
 

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -180,9 +180,10 @@ impl core::fmt::Debug for OrderingMethod {
 
 /// Validate that `perm` is a bijection of `0..n` (a valid permutation).
 /// Used by [`symbolic_factorize_with_method`] for
-/// [`OrderingMethod::External`]. Returns [`FeralError::InvalidInput`] on any
-/// violation — never panics.
-fn validate_external_perm(perm: &[usize], n: usize) -> Result<(), FeralError> {
+/// [`OrderingMethod::External`], by [`run_external_ordering`] on every
+/// ordering-crate result (issue #122A), and by `ordering::schur::run_amd`.
+/// Returns [`FeralError::InvalidInput`] on any violation — never panics.
+pub(crate) fn validate_external_perm(perm: &[usize], n: usize) -> Result<(), FeralError> {
     if perm.len() != n {
         return Err(FeralError::InvalidInput(format!(
             "external ordering has length {} but matrix has n={}",
@@ -711,6 +712,14 @@ fn run_external_ordering(
         }
         out.push(u);
     }
+    // Bijectivity guard (issue #122A): the loop above range-checks each
+    // element but not "no duplicates". A duplicate/missing pair from a
+    // trusted ordering backend would flow into `permute_pattern`, whose
+    // count pass *assigns* per column, so one column's counts overwrite
+    // another's — a structurally wrong pattern, wrong etree, and possibly
+    // wrong inertia, silently. One O(n) seen-bitmap on an O(nnz·α) path
+    // closes it, matching the full check user-supplied `External` perms get.
+    validate_external_perm(&out, pattern.n)?;
     Ok((out, actual))
 }
 

--- a/tests/maxfromm_parity.rs
+++ b/tests/maxfromm_parity.rs
@@ -9,7 +9,7 @@
 //! Phase 2 corpus validation in a separate diag binary.
 
 use feral::dense::factor::{factor_frontal, factor_frontal_blocked, FrontalFactors, TppMethod};
-use feral::{BunchKaufmanParams, SymmetricMatrix};
+use feral::{BunchKaufmanParams, SymmetricMatrix, ZeroPivotAction};
 
 fn rng_scalar(state: &mut u64, idx: usize) -> f64 {
     *state = state
@@ -142,6 +142,69 @@ fn maxfromm_indefinite_blocked_parity() {
         let a = factor_frontal_blocked(&mat, n, false, &plain).unwrap();
         let b = factor_frontal_blocked(&mat, n, false, &mfm).unwrap();
         assert_byte_identical(&a, &b, &format!("blocked indef n={n}"));
+    }
+}
+
+/// A front that drives a trailing column to *exactly* zero mid-elimination,
+/// so `capture_maxfromm_col` stashes `mf = 0.0`. Columns 1..n are all
+/// identical to column 0's tail, so eliminating the dominant pivot 0 and
+/// then pivot 1 cancels the whole trailing block to zero in fp.
+///
+///   A = [[k, 1, 1, ...],
+///        [1, 1, 1, ...],
+///        [1, 1, 1, ...],  (every trailing entry = 1)
+///        ...            ]
+///
+/// After pivot 0 the trailing block is uniform `1 - 1/k`; after pivot 1 it
+/// is uniform `0.0`, and the cache captures `mf = 0.0` for the next pivot.
+fn zero_tail_front(n: usize) -> SymmetricMatrix {
+    assert!(n >= 3);
+    let mut data = vec![1.0f64; n * n];
+    // Dominant head so pivot 0 is a clean 1×1.
+    data[0] = n as f64 + 2.0;
+    SymmetricMatrix { n, data }
+}
+
+fn params_zero(tpp: TppMethod) -> BunchKaufmanParams {
+    BunchKaufmanParams {
+        tpp_method: tpp,
+        pivot_threshold: 0.01,
+        // The reproduction hinges on the zero-column pivot being *accepted*
+        // rather than erroring, so the two paths' divergence (delay/inertia/D)
+        // is observable. ForceAccept exercises issue #123 divergence (ii);
+        // may_delay exercises (i).
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        ..BunchKaufmanParams::default()
+    }
+}
+
+/// Issue #123: a cached `mf == 0.0` from an exact-cancellation trailing
+/// column must be treated as a cache MISS, so the Maxfromm short-circuit
+/// falls through to the same dedicated zero-column branch Plain's full scan
+/// takes. Pre-fix, `akk >= alpha * 0.0` is unconditionally true and Maxfromm
+/// routed a zero column through rook-rescue instead — diverging in
+/// `n_delayed` under `may_delay = true` and in `D.to_bits()` under
+/// `ForceAccept`. Asserts bit-identical `(nelim, n_delayed, inertia, L, D)`
+/// under both `may_delay` values, scalar and blocked.
+#[test]
+fn maxfromm_zero_tail_cache_miss_parity() {
+    let plain = params_zero(TppMethod::Plain);
+    let mfm = params_zero(TppMethod::Maxfromm);
+    for &n in &[4usize, 5, 8, 16, 33, 64, 65, 100] {
+        let mat = zero_tail_front(n);
+        for &may_delay in &[false, true] {
+            let a = factor_frontal(&mat, n, may_delay, &plain).unwrap();
+            let b = factor_frontal(&mat, n, may_delay, &mfm).unwrap();
+            assert_byte_identical(&a, &b, &format!("zero-tail scalar n={n} delay={may_delay}"));
+
+            let ab = factor_frontal_blocked(&mat, n, may_delay, &plain).unwrap();
+            let bb = factor_frontal_blocked(&mat, n, may_delay, &mfm).unwrap();
+            assert_byte_identical(
+                &ab,
+                &bb,
+                &format!("zero-tail blocked n={n} delay={may_delay}"),
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the four correctness-edge issues from the 2026-07-10 six-agent audit, one tested commit per issue. Each fix was reproduced or guard-verified empirically before and after encoding; the full suite (75 test binaries), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` are green on every commit. End-of-session bench shows no regression (inertia 100%: 1/1 dense, 2/2 sparse; worst residual 1.14e-15 / 1.26e-16).

## #120 — cascade-break floor scaled by ‖D·A·D‖∞ (`d6f8ebd`)
`apply_post_scaling_overrides` now multiplies `cascade_break_eps` by the scaled matrix ∞-norm, matching the static-pivot floor. It was an **absolute** per-pivot floor (default-armed at `1e-10`) while the BK kernel operates on `D·A·D`; under Identity scaling on a small-magnitude system (`γ·K`, `γ = 1e-12`) every pivot was perturbed by `~1e2·‖A‖`, so the returned inertia was that of `A+Δ` with `‖Δ‖ ≫ ‖A‖`, silently. Test `cascade_break_eps_scaled_by_matrix_norm`.

## #121 — exact pattern compare on symbolic-cache hit (`f8d5f8a`)
The symbolic cache was gated on a 64-bit `PatternFingerprint` alone. A collision between two distinct patterns sharing `(n, nnz)` would reuse a stale symbolic ordering and scatter new values through the old `perm`, corrupting factor and inertia with no error. Added a `last_pattern` field kept in lockstep with the fingerprint; a hit now requires the fingerprint match **and** an exact `O(n + nnz)` `(col_ptr, row_idx)` compare. The regression test forges a fingerprint collision deterministically (overwriting the stored hash while the stored pattern differs) and asserts a fresh symbolic is forced and inertia is correct; verified it fails pre-fix (symbolic call count stays 1 instead of 2).

## #122 — guard-hardening bundle (`cb96b6e`)
Three "bad values corrupt silently instead of erroring" gaps:
- **A** — internal fill-reducing ordering results (`run_external_ordering`, `schur::run_amd`) were range-checked but never bijectivity-checked; a duplicate/missing perm corrupts `permute_pattern`'s per-column count assignment. `validate_external_perm` is promoted to `pub(crate)` and now runs on both internal ordering results (matching the check user-supplied `External` perms already get; its duplicate rejection is unit-tested).
- **B** — `classify_2x2_inertia` mapped a NaN block to certified inertia `(0,0,2)`. It now returns `Result<Inertia, FeralError>` with a release-mode `!is_finite` guard, threaded through `count_2x2_inertia_val` and `finish_1x1_outcome` (now `Result<PivotStepResult>`). This backstops the debug-only finite entry-scan at `factor.rs:1749` — the only remaining `debug_assert!`-only finiteness gate on the inertia path (grep-confirmed). Test `classify_2x2_non_finite_block_errors_not_double_zero`.
- **C** — `LuParams::validate` now rejects `max_growth` (`NaN` or `≤ 1.0`; `+∞` allowed as the documented "never trigger" opt-out) and `refine_tol` (non-finite or `≤ 0`). A `NaN max_growth` silently disabled the growth guard in the update paths. Both dense and sparse factor entries call `validate()`. Test `validate_max_growth_and_refine_tol`.

## #123 — MAXFROMM cached `mf == 0.0` is a cache miss (`876cf72`)
The MAXFROMM short-circuit gate `akk >= alpha * mf` is unconditionally true at `mf == 0.0` (`capture_maxfromm_col` returns `Some(0.0)` for an all-zero trailing column from fp cancellation), routing a zero column through the rook-rescue path — where the plain path hits `gamma0 == 0.0` and takes the dedicated zero-column branch. That broke the documented Plain/Maxfromm bit-parity (delayed-pivot count under `may_delay`, D under `ForceAccept`). Fix: `mf != 0.0 && …` treats `Some(0.0)` as a cache miss and falls through to the full scan. New `maxfromm_zero_tail_cache_miss_parity` (both `may_delay` values, scalar + blocked) verified failing pre-fix; unit test `capture_maxfromm_col_zero_column_is_some_zero` pins the precondition.

## Notes
- Pure input-validation / defense-in-depth: no behavior change for valid inputs. All `LuParams` in the tree already satisfy the new bounds.
- Session checkpoint: `dev/sessions/2026-07-10-04.md`; decisions appended to `dev/decisions.md`; CHANGELOG Unreleased updated.

Closes #120, closes #121, closes #122, closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH

---
_Generated by [Claude Code](https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH)_