### PR TITLE
Tree-parallel sparse solve + analysis-time assembly maps (#131 Gap A, #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — tree-parallel sparse solve (issue #131 Gap A)
+
+- **`solve_sparse_cb(factors, rhs, parallel)`** — an opt-in contribution-block
+  single-RHS sparse solve. With `parallel = true` it runs forward and backward
+  substitution across the assembly tree on the rayon pool; forward assembles
+  each front's RHS from its children's contribution blocks in a fixed order
+  (mirroring the factor's `extend_add`), so a serial and a tree-parallel run
+  are **byte-identical**. A subtree-cost coarsening keeps rayon tasks coarse,
+  and a `worthwhile` gate falls back to the serial core on path-like /
+  single-front / small trees. Measured ~2.0× on a bushy grid (n=48400) at 4
+  threads; near-neutral on path-like trees. The default `solve_sparse` is
+  unchanged. The multi-RHS core remains serial (follow-up).
+
+### Performance — analysis-time assembly maps (issue #125)
+
+- **#125** Each supernode's static frontal row layout (`[own cols | sorted
+  trailing]`) is now precomputed at symbolic-analysis time and reused by the
+  numeric factorization on the no-delay fast path, instead of re-scanning the
+  pattern and re-sorting the trailing set every factorization. Bit-identical
+  factors (delayed-pivot fronts fall back to the dynamic path). Measured ~8%
+  off the per-supernode loop and ~4.5% off the warm factor on a bushy grid
+  (n=48400).
+
 ### Performance — warm-path prologue and solve speedups (issues #124, #126, #128)
 
 - **#124** The default (parallel) numeric driver now reuses the persistent

--- a/crates/feral-diagnostics/src/bin/diag_compress_costbenefit.rs
+++ b/crates/feral-diagnostics/src/bin/diag_compress_costbenefit.rs
@@ -86,6 +86,7 @@ fn ldlt_params() -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/diag_small_leaf.rs
+++ b/crates/feral-diagnostics/src/bin/diag_small_leaf.rs
@@ -89,6 +89,7 @@ fn params_off() -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/diag_small_leaf_gate.rs
+++ b/crates/feral-diagnostics/src/bin/diag_small_leaf_gate.rs
@@ -55,6 +55,7 @@ fn ldlt_params(gate: SmallLeafBatch, profiler: Arc<Mutex<Profiler>>) -> NumericP
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/diag_strategy_compare.rs
+++ b/crates/feral-diagnostics/src/bin/diag_strategy_compare.rs
@@ -57,6 +57,7 @@ fn ldlt_params(profiler: Arc<Mutex<Profiler>>) -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/polak6_diag.rs
+++ b/crates/feral-diagnostics/src/bin/polak6_diag.rs
@@ -136,6 +136,7 @@ fn try_factor_and_solve(
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     };
     let sym = match symbolic_factorize_with_method(csc, &snode_params, OrderingMethod::Amd) {
         Ok(s) => s,
@@ -376,6 +377,7 @@ fn main() {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     };
     let sym =
         symbolic_factorize_with_method(&csc, &snode_params, OrderingMethod::Amd).expect("symbolic");

--- a/crates/feral-diagnostics/src/bin/probe_deltac_sensitivity.rs
+++ b/crates/feral-diagnostics/src/bin/probe_deltac_sensitivity.rs
@@ -178,6 +178,7 @@ fn ldlt_params() -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/profile_supernode_distribution.rs
+++ b/crates/feral-diagnostics/src/bin/profile_supernode_distribution.rs
@@ -83,6 +83,7 @@ fn ldlt_params(profiler: Arc<Mutex<Profiler>>) -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/vesuvio_diag.rs
+++ b/crates/feral-diagnostics/src/bin/vesuvio_diag.rs
@@ -135,6 +135,7 @@ fn run_one_method(csc: &CscMatrix, method: OrderingMethod, scaling: ScalingStrat
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     };
     let scale_tag = match scaling {
         ScalingStrategy::InfNorm => "infnorm",

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T16:53:36Z
+Generated: 2026-07-10T17:13:00Z
 
 ## Latest Session
 File: dev/sessions/2026-07-10-06.md
@@ -54,39 +54,39 @@ first, then Gap B.
   (~2.0×); cb_serial 13.0 ms (no regression); arrow → serial fallback,
   near-neutral.**
 
-All commits: full suite green, `cargo fmt --check` + `clippy -D warnings` clean
+- **#131 Gap A (3/n) — pool the CB workspace + wire into `Solver`** (commit
 ```
 
 ## Git Status
 ```
+ab4b2fc #131 Gap A (3/n): pool the CB workspace and wire it into Solver
+3d91ffb session 2026-07-10-06 checkpoint: #125 + #131 Gap A/B
 d83ca3e #131 Gap A (2/n): contribution-block tree-parallel single-RHS solve
 c12a5d3 #131 Gap A (1/n): carry the assembly tree into SparseFactors
 93cf6ed research: #131 Gap B (parallel assembly) measured not justified
-efa1000 #125: precompute static assembly row maps at analysis time
-77df474 research+plan: #131 parallelism design and implementation plan
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_single_schur_index ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
 test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
 test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 405 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 3.01s
+test result: ok. 405 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.98s
 
 ```
 

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-10T12:42:23Z
+Generated: 2026-07-10T16:53:36Z
 
 ## Latest Session
-File: dev/sessions/2026-07-10-04.md
+File: dev/sessions/2026-07-10-06.md
 ```
-# Session 2026-07-10-04
+# Session 2026-07-10-06
 
 ## Goal
-Fix the four correctness-edge issues #120–#123 (from the 2026-07-10 six-agent
-audit), one at a time, each as its own tested commit with an empirical
-reproduction before encoding the fix. Then one PR for the batch.
+
+Implement issue #131 (parallelism gaps) after the session-05 measure-first pass
+found it — unlike #130/#132/#133 — has genuine headroom. User scope: solve gap
+(Gap A) → full contribution-block rewrite; assembly gap → #125 static maps
+first, then Gap B.
 
 ## Accomplished
-All four fixed, committed, full-suite (75 binaries) + clippy
-`--all-targets -D warnings` + fmt green after each. Every fix reproduced or
-guard-verified empirically before/after encoding (issue-112 discipline).
 
-- **#120** (`d6f8ebd`): `apply_post_scaling_overrides` now scales
-  `cascade_break_eps` by `‖D·A·D‖∞` (like the N2 `static_pivot_floor` fix), so
-  the cascade-break `PerturbToEps` floor is RELATIVE to the scaled matrix the
-  BK kernel operates on. Root cause: the default-armed `1e-10` was an ABSOLUTE
-  per-pivot floor; under Identity scaling on `γ·K` (γ=1e-12) every pivot was
-  bent to ±1e-10 (~1e2·‖A‖ perturbation), silently returning the inertia of
-  `A+Δ` with `‖Δ‖ ≫ ‖A‖`. Test `cascade_break_eps_scaled_by_matrix_norm`.
-- **#121** (`f8d5f8a`): symbolic-cache hit was gated on the `PatternFingerprint`
-  (a u64 hash) alone. Added a `last_pattern: Option<(Vec<usize>, Vec<usize>)>`
-  field kept in lockstep with the fingerprint; `cache_valid` now requires the
-  fingerprint match AND an exact O(n+nnz) `(col_ptr, row_idx)` compare, so a
-  2⁻⁶⁴ hash collision can never reuse a stale symbolic (which would scatter new
-  values through the old `perm` and corrupt factor/inertia). Test forges a
-  collision deterministically; verified it fails pre-fix (call_count 1 vs 2).
-- **#122** (`cb96b6e`): three-part guard-hardening bundle.
-  - **A** — ordering results (`run_external_ordering`, `schur::run_amd`) were
-    range-checked but never bijectivity-checked; a dup/missing perm corrupts
-    `permute_pattern`'s per-column count assignment. `validate_external_perm`
-    promoted to `pub(crate)` and called on both internal ordering results.
-  - **B** — `classify_2x2_inertia` mapped a NaN block to certified `(0,0,2)`.
-    Now returns `Result<Inertia, FeralError>` with a release-mode `!is_finite`
-    guard; Result threaded through `count_2x2_inertia_val`, `finish_1x1_outcome`
-    (now `Result<PivotStepResult>`), and all six call sites via `?`. Backstops
-    the debug-only finite entry-scan at `factor.rs:1749` (the only such gate on
-    the inertia path — grep confirmed).
-  - **C** — `LuParams::validate` now rejects `max_growth` NaN/≤1.0 (a NaN
-    silently disabled the growth guard in the update paths) and non-finite/≤0
-    `refine_tol`. Both dense and sparse factor entries call `validate()`.
-- **#123** (`876cf72`): the MAXFROMM short-circuit gate `akk >= alpha * mf` is
-  unconditionally true at `mf == 0.0` (`capture_maxfromm_col` returns `Some(0.0)`
-  for an all-zero trailing column), routing a zero column through rook-rescue —
-  where Plain's full scan hits `gamma0 == 0.0` and takes the dedicated
-  zero-column branch. Broke the documented Plain/Maxfromm bit-parity (delay/
-  inertia under `may_delay`, D under ForceAccept). Fix: `mf != 0.0 && …` treats
-  `Some(0.0)` as a cache miss. New `maxfromm_zero_tail_cache_miss_parity` (both
-  `may_delay` values, scalar + blocked) verified failing pre-fix; unit test
-  pins `capture_maxfromm_col`'s `Some(0.0)` precondition.
+- **#125 — analysis-time static assembly maps** (commit `efa1000`).
+  Precompute each supernode's `[own cols | sorted trailing]` frontal row layout
+  at symbolic time (`compute_static_row_indices`, one postorder pass, CSR-flat
+  on `SymbolicFactorization`); the numeric factor reads it on the no-delay fast
+  path (`n_delayed_in == 0`) instead of recomputing with `build_row_indices`.
+  Bit-identical (delayed fronts fall back). Tests (`tests/static_assembly_maps.rs`,
+  8): A/B factor byte-identical static-on vs -off incl. KKT-with-delays; an
+  independent BTreeSet oracle == `static_rows(i)`. **Bench: grid220 (n=48400)
+  per-supernode loop 164.8→151.6 ms (~8%), warm factor 176.0→168.1 ms (~4.5%);
+  arrow wash.**
 
+- **#131 Gap B — measured not justified, not built** (commit `93cf6ed`).
+  Assembly is 8.3% of factor on grid220 / 1.5% on dense1400, and independent
+  fronts' assembly already overlaps in the parallel driver; only the serial
+  root-front O(nrow²) remains, behind the already-parallel O(nrow³) factor.
+  <1–3% ceiling → skipped with evidence (user agreed).
+  `dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`.
+
+- **#131 Gap A (1/n) — carry the assembly tree into `SparseFactors`** (commit
+  `c12a5d3`). `node_parents: Vec<Option<usize>>` mirrored from symbolic in all
+  constructors. Behavior-neutral foundation for the tree-parallel solve.
+
+- **#131 Gap A (2/n) — contribution-block tree-parallel single-RHS solve**
+  (commit `d83ca3e`). Opt-in `solve_sparse_cb(factors, rhs, parallel)`; default
+  `solve_sparse` untouched (no rebaseline). Forward = contribution-block
+  (children summed in fixed ascending order → serial-CB == parallel-CB
+  byte-identical); backward = unchanged shared-vector arithmetic, root-down.
+  Global `y` written only at disjoint eliminated rows (concurrent via a
+  Send+Sync raw-pointer wrapper + disjointness safety comment). Subtree-cost
+  **coarsening** (`CbTaskPlan`) + a `worthwhile` gate (≥2 task roots, no
+  Amdahl-dominant front, total ≥ 1e6 flops) — per-node tasks were far too fine.
+  Tests (`tests/cb_solve_parity.rs`, 6, stable under RAYON_NUM_THREADS=8):
+  serial==parallel byte-identical incl. an n=9216 concurrent-path fixture,
+  KKT-with-delays, dense fast path; determinism; valid solve.
+  **Bench: grid220 default solve 13.5 ms → cb_parallel 6.6 ms at 4 threads
+  (~2.0×); cb_serial 13.0 ms (no regression); arrow → serial fallback,
+  near-neutral.**
+
+All commits: full suite green, `cargo fmt --check` + `clippy -D warnings` clean
 ```
 
 ## Git Status
 ```
-cafa023 issue #129: measure panel fragmentation — not justified, close with data
-fc4e9b8 issue #128: skip the bpack1 alloc+zero-fill on all-1x1 dense Schur panels
-4124faf issue #126: fuse the D-block solve into the forward pass (single-RHS)
-164d201 issue #124: thread the permute cache through the parallel driver
-d9d5e86 session 2026-07-10-04: checkpoint, CHANGELOG, decisions for #120–#123
+d83ca3e #131 Gap A (2/n): contribution-block tree-parallel single-RHS solve
+c12a5d3 #131 Gap A (1/n): carry the assembly tree into SparseFactors
+93cf6ed research: #131 Gap B (parallel assembly) measured not justified
+efa1000 #125: precompute static assembly row maps at analysis time
+77df474 research+plan: #131 parallelism design and implementation plan
 ```
 
 ## Test Status
@@ -86,58 +86,57 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 405 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.49s
+test result: ok. 405 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 3.01s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-10-04.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-10-06.md)
 
-No regression vs 2026-07-10-03 (inertia 100%, same worst residuals).
---- Dense solver validation ---
-  Inertia match: 1/1 (100.0%)
-  Residual pass: 1/1 (100.0%)
-  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
---- Sparse solver validation ---
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-Dense/Sparse failure analysis: no failures
+
+cargo run --bin bench --release: no matrices in this container (corpus absent,
+all buckets count 0). Perf evidence is from src/bin/perf_probe.rs (warm factor +
+solve, RAYON_NUM_THREADS-aware) and src/bin/probe_panel_frag.rs (phase timing):
+
+#125   grid220 loop 164.8→151.6 ms (~8%), warm factor 176.0→168.1 ms (~4.5%)
+Gap B  grid220 assembly 8.3% of factor; dense1400 1.5%  (skipped)
+Gap A  grid220 solve 13.5 ms (default) → 6.6 ms (cb_parallel, 4t) = ~2.0×
+       arrow (path) → worthwhile gate → serial fallback, near-neutral
 
 ```
 
 ## Recent Decisions
-replacement (not a summation artifact), strengthening the existing
-`NeedsRefactor` semantics. No tolerances changed.
 
-## 2026-07-10 — Issue #122: propagate `Result` from `classify_2x2_inertia`; `max_growth` semantics
+The tree-parallel single-RHS solve (`solve_sparse_cb`) is a **separate,
+opt-in** path, not a replacement of `solve_sparse`. Rationale: a bit-exact
+tree-parallel forward substitution must use a contribution-block reduction
+(sum tree, fixed child order) rather than the default core's shared-global-
+vector left-fold. Those two accumulation orders are not float-bit-identical, so
+converting the default path in place would shift every ~1e-15 residual baseline
+(and the single-vs-many-core bit-parity test). Keeping the CB solve as its own
+path leaves the default `solve_sparse` — and every existing test/baseline —
+untouched, and the #131 "serial == parallel byte-identical" contract is
+satisfied within the CB path itself (serial-CB == parallel-CB by construction:
+the child-reduction order is fixed regardless of thread scheduling). The
+backward substitution keeps the default arithmetic unchanged (separator rows
+are read-only, eliminated rows disjoint), so only forward is contribution-block.
+Coarsening (subtree-cost task roots) and a `worthwhile` gate are required for a
+net win — per-node rayon tasks are far too fine for the tiny per-front solve
+work. Evidence: `dev/research/issue-131-parallelism-design-2026-07-10.md`,
+`tests/cb_solve_parity.rs`, ~2.0× on grid220 (n=48400) at 4 threads.
 
-Two small design choices made while closing the #122 guard-hardening bundle.
+## 2026-07-10 — #131 Gap B (parallel assembly): measured not justified, not built
 
-**2×2 non-finite guard is a `Result`, not an inline per-site check.**
-`classify_2x2_inertia` previously returned `Inertia` and a NaN `det`/`tr` fell
-through every ordered comparison to the `(0,0,2)` arm — certifying a NaN block
-as two *zero* eigenvalues. The fix changes the signature to
-`Result<Inertia, FeralError>` (release-mode `!is_finite` → `InvalidInput`) and
-threads the `Result` through `count_2x2_inertia_val`, `finish_1x1_outcome`
-(now `Result<PivotStepResult>`), and all six call sites via `?`. Chosen over a
-per-call-site guard because it is DRY (one guard, impossible to forget at a
-future site) and every caller already sits in a `Result`-returning frame, so
-the ripple is mechanical. This backstops the debug-only finite entry-scan at
-`factor.rs:1749` in release without a full-column scan on the hot path (the
-guard is O(1) at the pivot-block level).
-
-**`LuParams::max_growth` is `> 1.0` with `+∞` an explicit disable.**
-`validate()` now rejects `max_growth` that is `NaN` or `≤ 1.0` and accepts any
-finite `> 1.0` plus `+∞`. `+∞` is the documented "never trigger a refactor on
-growth" opt-out (`growth > +∞` is always false); `NaN` is rejected because it
-silently disabled the growth guard in the update paths (which — unlike
-`should_refactor_growth` — do not defend with `is_finite`). `refine_tol` must
-be finite and `> 0`. No tolerances changed; all existing `LuParams` in the
-tree already satisfy the bounds (min `max_growth` `1.0 + 1e-9`, all
-`refine_tol > 0`), so this is pure input validation with no behavior change on
-valid inputs.
+Per-front assembly is 8.3% of the factor on grid220 / 1.5% on dense1400, and in
+the parallel driver independent fronts' assembly already overlaps across
+threads (each front's assembly is part of its own tree task). The only assembly
+left on the critical path is the root/near-root fronts' O(nrow²), behind the
+root's O(nrow³) dense factor that intra-front parallelism (Lever 1.1) already
+targets — so column-partitioned parallel assembly would chase <1–3% of the
+factor. #125 already captured the tractable, bit-exact assembly win
+(`build_row_indices`). Not built. Evidence:
+`dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`.
 
 ## Recent Tried-and-Rejected
 sweep replays across four hand constructions (journal 2026-07-10-01,
@@ -165,6 +164,8 @@ default false. See `dev/research/issue-112-bg-update.md` §UPDATE and
 ```
 src/bin/bench.rs
 src/bin/perf_probe.rs
+src/bin/probe_ft_eta.rs
+src/bin/probe_lu_phases.rs
 src/bin/probe_panel_frag.rs
 src/capi.rs
 src/dense/block_ldlt32.rs
@@ -224,6 +225,7 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
+tests/cb_solve_parity.rs
 tests/column_renumbering.rs
 tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
@@ -288,6 +290,7 @@ tests/solver_with_ordering.rs
 tests/sparse_postorder.rs
 tests/sparse_refined.rs
 tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
 tests/stress_tests.rs
 tests/symbolic_profiler.rs
 tests/threshold_consistency.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -5966,3 +5966,35 @@ be finite and `> 0`. No tolerances changed; all existing `LuParams` in the
 tree already satisfy the bounds (min `max_growth` `1.0 + 1e-9`, all
 `refine_tol > 0`), so this is pure input validation with no behavior change on
 valid inputs.
+
+## 2026-07-10 — #131 Gap A: opt-in contribution-block tree-parallel solve (not a rewrite of the default path)
+
+The tree-parallel single-RHS solve (`solve_sparse_cb`) is a **separate,
+opt-in** path, not a replacement of `solve_sparse`. Rationale: a bit-exact
+tree-parallel forward substitution must use a contribution-block reduction
+(sum tree, fixed child order) rather than the default core's shared-global-
+vector left-fold. Those two accumulation orders are not float-bit-identical, so
+converting the default path in place would shift every ~1e-15 residual baseline
+(and the single-vs-many-core bit-parity test). Keeping the CB solve as its own
+path leaves the default `solve_sparse` — and every existing test/baseline —
+untouched, and the #131 "serial == parallel byte-identical" contract is
+satisfied within the CB path itself (serial-CB == parallel-CB by construction:
+the child-reduction order is fixed regardless of thread scheduling). The
+backward substitution keeps the default arithmetic unchanged (separator rows
+are read-only, eliminated rows disjoint), so only forward is contribution-block.
+Coarsening (subtree-cost task roots) and a `worthwhile` gate are required for a
+net win — per-node rayon tasks are far too fine for the tiny per-front solve
+work. Evidence: `dev/research/issue-131-parallelism-design-2026-07-10.md`,
+`tests/cb_solve_parity.rs`, ~2.0× on grid220 (n=48400) at 4 threads.
+
+## 2026-07-10 — #131 Gap B (parallel assembly): measured not justified, not built
+
+Per-front assembly is 8.3% of the factor on grid220 / 1.5% on dense1400, and in
+the parallel driver independent fronts' assembly already overlaps across
+threads (each front's assembly is part of its own tree task). The only assembly
+left on the critical path is the root/near-root fronts' O(nrow²), behind the
+root's O(nrow³) dense factor that intra-front parallelism (Lever 1.1) already
+targets — so column-partitioned parallel assembly would chase <1–3% of the
+factor. #125 already captured the tractable, bit-exact assembly win
+(`build_row_indices`). Not built. Evidence:
+`dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`.

--- a/dev/journal/2026-07-10-05.org
+++ b/dev/journal/2026-07-10-05.org
@@ -249,3 +249,37 @@ negative like #130/#132/#133. Recorded
 dev/research/issue-131-gapb-assembly-measure-2026-07-10.md. User: skip Gap B,
 proceed to Gap A (the high-value solve rewrite). Kept the assembly breakdown
 addition to probe_panel_frag (useful diagnostic).
+
+* 18:30 :issue-131:gapa:solve:contribution-block:parallel:
+Implemented the #131 Gap A contribution-block tree-parallel single-RHS solve
+(opt-in solve_sparse_cb; default solve_sparse untouched → zero risk to existing
+tests, no rebaseline). Forward = contribution-block (assemble b at eliminated
+rows + children contributions summed in ascending child order, the same
+deterministic reduction as the factor's extend_add), leaves-up. Backward =
+unchanged shared-vector arithmetic (separator rows read-only, eliminated rows
+disjoint), root-down. Global y written only at eliminated rows (disjoint across
+fronts); concurrent writes via a Send+Sync raw-pointer wrapper (YPtr) with a
+disjointness safety comment.
+Coarsening (CbTaskPlan): per-node rayon tasks were far too fine (grid220 = 48400
+tiny tasks → spawn/lock overhead swamped the tiny per-front solve work: NO
+speedup, cb_parallel 14.6ms vs cb_serial 10.7ms at 1t). Cut the tree at a
+subtree-cost threshold into "task roots"; each task root runs its contiguous
+postorder block of light descendants serially (postorder ⇒ contiguous ⇒ no
+recursion), only the top of the tree spawns tasks. Bit-exact preserved
+(coarsening changes which thread runs a front, never the reduction order).
+`worthwhile` gate: skip parallel (run serial) when <2 independent task roots, or
+one task root's serial share >70% of total (Amdahl — e.g. arrow's huge root
+front), or total < 1e6 flops (scratch-setup not amortized).
+MEASURED (grid220 n=48400 bushy, 30-iter min, warm factor): default solve
+13.5ms; cb_serial 13.0ms (≈default, no regression); cb_parallel 6.6ms at 4t =
+~2.0x. arrow (path+big root): gate → serial fallback, near-neutral (0.51 vs
+0.46ms). Solve is ~6-13% of factor so absolute win is a few ms/solve; matters
+cumulatively for IPM hosts (several refined solves per factor).
+TESTS (tests/cb_solve_parity.rs, 6 pass incl. n=9216 concurrent path, stable
+under RAYON_NUM_THREADS=8): serial-CB == parallel-CB byte-identical (to_bits);
+determinism across parallel runs; valid solve (residual <= 10x default);
+CB≈default within reassociation; KKT-with-delays (data-flow risk area); dense
+fast-path (lone root). Full suite green; fmt + clippy -D warnings clean.
+Scope note: multi-RHS core (solve_sparse_core_many_into) still shared-vector
+serial — a documented follow-up; single-RHS is the IPM refinement/condition
+hot path #131 motivates.

--- a/dev/journal/2026-07-10-05.org
+++ b/dev/journal/2026-07-10-05.org
@@ -200,3 +200,37 @@ Combined discopt-simplex verdict (#130/#132/#133 all measured, all
 not-justified): the compute_spike L-solve over an already-well-ordered factor
 is near the achievable floor. Remaining wins are simplex-algorithmic
 (pivots/pricing) or refactor cadence, not the LU kernels. discopt left pristine.
+
+* 15:40 :issue-131:issue-125:parallelism:design:
+User scoped #131 full implementation. Wrote code-level design +
+bit-exactness analysis (dev/research/issue-131-parallelism-design-2026-07-10.md).
+KEY FINDING: the SOLVE gap (Gap A) cannot be made bit-exact vs today's serial
+solve — it uses a shared global vector where sibling subtrees read-modify-write
+the same ancestor separator entries; naive tree-parallel races, and
+private-accumulation-then-merge violates the byte-identical contract (float
+non-associativity). Real bit-exact tree-parallel solve needs a
+contribution-block rewrite of both solve cores (arithmetic reorder → residual
+re-baseline). Assembly gap (Gap B) IS bit-exact-safe (disjoint-column partition)
+but second-order (O(nrow^2) behind already-parallel O(nrow^3) factor). Both are
+tree-shape dependent (bushy only; path-like KKT gets ~0).
+User decisions: Gap A → full contribution-block rewrite (accept residual
+re-baseline, show diffs first); assembly → #125 static maps first, then Gap B.
+
+* 16:20 :issue-125:factorize:prologue:
+Implemented #125 (static assembly maps). build_row_indices' output is a pure
+function of static structure when n_delayed_in==0 (trailing set is a sorted
+seen-dedup, numeric-pivot-order independent). Precompute per-supernode
+[own cols | sorted trailing] at symbolic time (compute_static_row_indices, one
+postorder pass), store CSR-flat on SymbolicFactorization
+(static_row_offsets/static_row_flat + static_rows() accessor). Numeric
+factor_one_supernode uses the static slice when n_delayed_in==0 &&
+use_static_row_indices (new NumericParams flag, default true); delayed fronts
+fall back to build_row_indices. Both drivers covered (shared factor_one_supernode).
+Tests (tests/static_assembly_maps.rs, 8 pass): (1) A/B byte-identical factor
+static-on vs static-off incl. KKT-with-delays (proves static==build_row_indices
+bit-for-bit on real matrices); (2) independent BTreeSet oracle over public
+symbolic data == static_rows(i). Full suite green; fmt/clippy clean.
+BENCH (perf_probe A/B via FERAL_STATIC_ROWS, sequential driver, grid220 n=48400
+bushy): per-supernode loop 164.8ms→151.6ms (~8%), total warm factor
+176.0ms→168.1ms (~4.5%). arrow (few fronts, delayed root): wash (noise). Win is
+concentrated on bushy trees with many small no-delay fronts, as expected.

--- a/dev/journal/2026-07-10-05.org
+++ b/dev/journal/2026-07-10-05.org
@@ -283,3 +283,24 @@ fast-path (lone root). Full suite green; fmt + clippy -D warnings clean.
 Scope note: multi-RHS core (solve_sparse_core_many_into) still shared-vector
 serial — a documented follow-up; single-RHS is the IPM refinement/condition
 hot path #131 motivates.
+
+* 19:45 :issue-131:gapa:solve:pooling:solver-wiring:
+Wired the CB parallel solve into the Solver (follow-up 3/n). Refactored the CB
+cores to run against a pooled CbSolveWorkspace (caches RHS-independent children
+lists + coarsening plan + per-worker scratch + y; scaling fused into the
+entry-permute / exit-unpermute, dropped scaled_rhs). solve_sparse_refined_core
+gained a parallel_cb flag: when set AND the factor is worthwhile, it builds ONE
+CbSolveWorkspace and reuses it for the initial + up-to-10 correction solves
+(no per-solve alloc churn — the stated concern); else the proven shared-vector
+SolveWorkspace path runs bit-for-bit. New pub solve_sparse_refined_parallel.
+Solver::solve_refined + solve_many_refined (per-column) dispatch to it when
+use_parallel, installed on the solver's own rayon pool (same worker count as the
+factor, no oversubscription). Small/path trees self-gate to serial (exact
+current behavior); only bushy trees switch to CB.
+MEASURED end-to-end (perf_probe, grid220 n=48400, Solver::solve_refined, warm):
+serial 56.0ms → parallel 29.0ms = ~1.93x. Refinement runs ~11 solves; the
+pooled workspace parallelizes each with no churn.
+Tests: cb_solve_parity (6), sparse_refined (13), parity (21), multi_rhs (5) all
+green; full suite green; fmt + clippy -D warnings clean. No solve baseline
+changed (residual-based tests survive the CB reassociation; refinement
+converges either way). Remaining: multi-RHS CB core (4/n).

--- a/dev/journal/2026-07-10-05.org
+++ b/dev/journal/2026-07-10-05.org
@@ -234,3 +234,18 @@ BENCH (perf_probe A/B via FERAL_STATIC_ROWS, sequential driver, grid220 n=48400
 bushy): per-supernode loop 164.8ms→151.6ms (~8%), total warm factor
 176.0ms→168.1ms (~4.5%). arrow (few fronts, delayed root): wash (noise). Win is
 concentrated on bushy trees with many small no-delay fronts, as expected.
+
+* 16:55 :issue-131:gapb:assembly:measure:not-justified:
+Measured Gap B (parallel assembly) before building it. probe_panel_frag
+(phase_timing, sequential): grid220 assembly 14.0ms = 8.3% of assembly+densef
+(buildrow 1.0 [now cheap via #125] | scatter 1.3 | extendadd 7.5, summed over
+48400 fronts); dense1400 assembly 7.8ms = 1.5% (pure scatter, single front).
+DECISIVE: in the parallel driver, independent fronts' assembly already overlaps
+across threads (assembly is part of each front's tree task), so the only serial
+assembly on the critical path is the root/near-root fronts' O(nrow^2) — behind
+the root's O(nrow^3) dense factor that Lever 1.1 intra-front parallelism already
+targets. Column-partitioned assembly would chase <1-3% of factor. Measure-first
+negative like #130/#132/#133. Recorded
+dev/research/issue-131-gapb-assembly-measure-2026-07-10.md. User: skip Gap B,
+proceed to Gap A (the high-value solve rewrite). Kept the assembly breakdown
+addition to probe_panel_frag (useful diagnostic).

--- a/dev/plans/issue-131-parallel-assembly-solve.md
+++ b/dev/plans/issue-131-parallel-assembly-solve.md
@@ -1,0 +1,63 @@
+# Issue #131 implementation plan — 2026-07-10
+
+Design + bit-exactness analysis: `dev/research/issue-131-parallelism-design-2026-07-10.md`.
+User scope decisions (2026-07-10): solve gap → **full contribution-block
+rewrite** (accept residual re-baseline, show diffs before any tolerance change);
+assembly gap → **#125 static maps first, then column-partitioned parallel
+assembly**.
+
+Sequencing (bit-exact/autonomous track first, sign-off track last):
+
+## Part 1 — #125 static assembly maps (bit-exact, autonomous)
+
+Precompute per-supernode static row_indices at symbolic time; use them in the
+numeric path when `n_delayed_in == 0`.
+
+**Key fact (bit-exactness):** `build_row_indices`' output is a function of only
+static structure whenever the node's `n_delayed_in == 0` — the delayed set is
+empty, and the trailing set is `own-pattern-reach ∪ children's-contrib-trailing`,
+then **sorted** (so numeric pivot order `ff.perm` cannot affect it). A child's
+contrib-trailing equals its static separator iff the child eliminated all its
+columns (child `n_delayed == 0`), which is exactly the `n_delayed_in == 0`
+condition on the parent. So `static == build_row_indices` bit-for-bit under the
+gate; delayed-pivot fronts fall back to `build_row_indices`.
+
+Steps:
+1. Storage: flat `static_row_offsets: Vec<usize>` (len n_snodes+1) +
+   `static_row_indices_flat: Vec<usize>` on `SymbolicFactorization`.
+2. Compute in one postorder pass (supernodes are already child-before-parent):
+   for each node, trailing = sorted-dedup of (own-col pattern reach ≥ own_last) ∪
+   (each child's static separator ≥ own_last); layout `[own cols | trailing]`.
+   Mirror `build_row_indices` filters exactly.
+3. Numeric: in `factor_one_supernode` (both drivers), when `n_delayed_in == 0`
+   use the static slice; else `build_row_indices`.
+4. Tests first: `tests/static_assembly_maps.rs` — for a zero-delay matrix,
+   symbolic static slice == `build_row_indices` for every node; full suite green
+   (numeric output unchanged ⇒ existing parity tests pass).
+5. Bench: prologue (`BUILDROW_NS`) drop via perf_probe.
+
+## Part 2 — #131 Gap B: column-partitioned parallel assembly (bit-exact)
+
+On top of Part 1: partition a front's destination columns into disjoint chunks;
+each thread scatters original entries + extend-adds every child's entries whose
+destination column is in its chunk. Disjoint columns ⇒ disjoint `f_data` memory
+⇒ bit-exact (each cell keeps serial child-order `+=`). Gate on front area/flops
+and only under the parallel driver (`intrafront_parallel`). Tests: parity with
+3+ children, disjoint/overlapping ranges; determinism (repeat == identical bits).
+Bench: assembly-phase scaling on grid220.
+
+## Part 3 — #131 Gap A: contribution-block solve rewrite (needs sign-off)
+
+Rewrite both solve cores (`solve_sparse_core_into`,
+`solve_sparse_core_many_into`) to contribution-block form: each node produces a
+private contribution to its parent's RHS rows; parent sums children in fixed
+child-order (mirrors factor `extend_add`). Then siblings solve concurrently into
+private blocks; forward = leaves-up, backward = root-down; serial within small
+subtrees (flop threshold). Carry the assembly tree into `SparseFactors`.
+
+Bit-exactness: new-serial == new-parallel (byte-identical, the #131 contract).
+NOT bit-identical to the *old* serial solve (arithmetic reorder). **Before
+changing any residual-test tolerance, show the user the exact diffs** (hard
+rule). Tests: `tests/parallel_solve_parity.rs` (serial==parallel bits;
+post-delayed-pivot factors; determinism across repeats). Bench: solve-phase
+thread-scaling on grid220 (baseline 13.5 ms fully serial) + nuffield2.

--- a/dev/research/issue-131-gapb-assembly-measure-2026-07-10.md
+++ b/dev/research/issue-131-gapb-assembly-measure-2026-07-10.md
@@ -1,0 +1,61 @@
+# Issue #131 Gap B (parallel assembly) — measure-first — 2026-07-10
+
+**Verdict: not justified.** Per-front assembly is a single-digit percent of the
+factor, and — the decisive point — in the parallel driver the assembly of
+independent fronts **already overlaps across threads** (each front's assembly is
+part of its own tree task). The only assembly left on the critical path is the
+root / near-root fronts', which is `O(nrow²)` behind the root's `O(nrow³)` dense
+factor that intra-front parallelism (Lever 1.1) already targets. Column-
+partitioned parallel assembly would chase <1–3% of the factor. Recorded per the
+measure-first discipline (cf. #129/#130/#132/#133).
+
+## Measurement (`probe_panel_frag`, phase_timing, sequential driver)
+
+Assembly time and its split vs the dense factor it feeds:
+
+```
+grid220  (n=48400, bushy):   assembly 14.0 ms = 8.3% of assembly+densefactor
+                             (buildrow 1.0 | scatter 1.3 | extendadd 7.5 ms)
+                             densefactor 155.7 ms (schur 43.5% | panel 44.3%)
+dense1400 (single front):    assembly  7.8 ms = 1.5% of assembly+densefactor
+                             (buildrow 0.0 | scatter 3.2 | extendadd 0.0 ms)
+                             densefactor 502.7 ms (schur 72.1% | panel 26.5%)
+```
+
+`extendadd` is 0 on dense1400 because a single front has no children; its
+assembly is pure original-entry scatter. On grid220 the 7.5 ms of extend-add is
+summed over **all 48 400 fronts** of a bushy tree.
+
+## Why the parallel driver already hides most of it
+
+The `probe_panel_frag` numbers are the *sequential* sum. The production driver
+for these matrices is the rayon tree-parallel factor. There, each supernode's
+assembly (build_row_indices + scatter + extend-add of its children) runs inside
+that supernode's task, on whatever worker picks it up. Sibling fronts assemble
+concurrently. So the *serial* assembly on the critical path is only the
+root-path fronts' — dominated by the root, whose extend-add is `O(cdim²)` while
+its dense factor is `O(cdim³)`. That root factor is exactly what Lever 1.1's
+intra-front `par_chunks_mut` already parallelises. Column-partitioned assembly
+would parallelise the root's `O(cdim²)` assembly — one part in `cdim` of the
+work already being parallelised, i.e. deep in the noise.
+
+## Interaction with #125
+
+#125 (just landed) already removed the `build_row_indices` component of assembly
+on the no-delay fast path (grid220 buildrow is now ~1.0 ms, down from the
+pre-#125 scan+sort), for a measured ~8% per-supernode-loop / ~4.5% total warm
+factor win on grid220 — the tractable, bit-exact part of the assembly cost.
+What remains (scatter + extend-add) is the second-order part Gap B would target.
+
+## Decision
+
+Do not build column-partitioned parallel assembly. The bit-exact-safe machinery
+(disjoint-destination-column partition, loop restructure) is real work for a
+<1–3% ceiling that the parallel tree schedule already mostly captures. Re-open
+only if a workload appears whose factor is dominated by a **single enormous
+root front with many children** (so its serial extend-add is a large absolute
+cost) AND the root dense factor is already fully thread-saturated — a narrow
+corner not present in the current corpus.
+
+Effort redirects to Gap A (the solve rewrite), the high-value gap: the solve is
+100% serial today and IPM hosts run several solves per factor.

--- a/dev/research/issue-131-parallelism-design-2026-07-10.md
+++ b/dev/research/issue-131-parallelism-design-2026-07-10.md
@@ -1,0 +1,129 @@
+# Issue #131 — parallelism gaps: design + bit-exactness analysis — 2026-07-10
+
+Follows the measure-first investigation (session 05) that found #131 — unlike
+#130/#132/#133 — has **genuine measured headroom**: on a bushy nested-dissection
+tree (grid220, n=48400) factor scales only ~1.99× on 4 cores and the solve is
+**100% serial** (13.5 ms, 6–13% of factor); on a path-like tree (nuffield2)
+neither scales (1.11× factor, solve 0.3% of factor). This note takes the next
+step required by the protocol — code inspection + design — before any code.
+
+The headline finding: **the solve gap (Gap A) cannot be made bit-exact against
+today's serial solve without rewriting the solve core to a contribution-block
+formulation.** The assembly gap (Gap B) is bit-exact-safe but second-order. Both
+are strongly tree-shape-dependent, and the primary IPM/KKT workloads often have
+path-like trees where tree parallelism gives ~nothing. Details below.
+
+## Gap A — tree-parallel forward/backward solve
+
+### How the serial solve works today (`src/numeric/solve.rs:236`)
+
+`solve_sparse_core_into` is a shared-global-vector formulation:
+
+```
+for node in node_factors (postorder):        # forward
+    gather   w[i] = y[row_indices[perm[i]]]   for i in 0..nrow   # incl. separators
+    L-solve  w[i] -= L[j,i]*w[j]              for j<nelim, i>j    # updates separators too
+    D-solve  w[0..nelim] *= D^-1
+    scatter  y[row_indices[perm[i]]] = w[i]   for i in 0..nrow   # incl. separators
+```
+
+The gather/scatter covers **all** `nrow` rows, not just the `nelim` eliminated
+ones. The separator rows (`nelim..nrow`) are ancestor variables, and the
+scatter is a read-modify-write of `y` at those entries (`y[sep] = y[sep] -
+Σ L[j,i] w_j`).
+
+### Why naive subtree parallelism races
+
+A variable `v` eliminated at node `p` appears as a **separator row in every
+descendant of `p`** that reaches it. Two sibling subtrees `A`, `B` (children of
+some `q`) are both descendants of `q` and of every ancestor of `q`, so both
+contain nodes with `v ∈ separators` for every `v` eliminated at `q` or above.
+Running `A` and `B` on different threads means both do `y[v] -= …` via the
+gather/scatter — a lost-update race on shared `y` entries. This is **not** an
+edge case; the parent's pivot rows receive contributions from *all* children by
+construction. Confirmed by reading the gather/scatter at `solve.rs:270-323`.
+
+### Why it can't be made bit-exact by private accumulation
+
+The obvious fix — each subtree accumulates a private delta `dA` for shared
+entries, then `y[v] -= dA` — is **not bit-exact**. Serial computes
+`((y0 - a1) - a2) - b1 …` (individual subtractions in postorder). Lumping
+`dA = a1 + a2` and doing `y0 - dA` reorders the floating-point adds; by
+non-associativity `y0 - (a1+a2) ≠ (y0 - a1) - a2`. The established contract for
+#131 is *byte-identical* serial-vs-parallel, so any lumped reduction violates it.
+
+The only way to stay bit-exact with the current arithmetic is to apply each
+individual separator subtraction to `y` in the exact serial (postorder) order —
+which serializes precisely the shared-separator writes. Those writes are a large
+fraction of the total solve work (they are the `i>=nelim` half of every L-solve
+inner loop). So even a "compute in parallel, apply serially" scheme has a big
+serial fraction — Amdahl caps it low. The dominant root front is the *last*
+node (no tree parallelism there regardless).
+
+### What a real speedup would require
+
+Rewrite both solve cores to the **contribution-block formulation** MUMPS/SSIDS
+use: each node produces a private contribution to its parent's RHS rows; the
+parent sums children in fixed order (exactly mirroring the factor's `extend_add`,
+which is bit-exact because the child-order reduction is serial at the parent).
+Siblings then solve concurrently into private blocks. This is a genuine parallel
+win — but it **changes the arithmetic order versus today's serial solve**, so it
+is *not* bit-exact against the current serial path. To keep a bit-exactness
+contract we would rewrite the serial solve to the same formulation, then assert
+serial-new == parallel-new. That is real surgery on the bit-exact-tested numeric
+core (risks the ~1e-15 residual assertions in `tests/`), for a payoff that is
+~8 ms on grid220 and ~0 on path-like trees.
+
+## Gap B — parallel assembly (`extend_add`, `factorize.rs:4053`)
+
+`extend_add` does `f_data[col*fn_ + row] += val` with
+`(row,col)=(max(pi,pj),min(pi,pj))` — canonicalised to the parent's lower
+triangle. Bit-exact-safe parallelism **is** possible here: partition the
+destination frontal **columns** into disjoint chunks, one per thread; each
+thread scatters original entries + extend-adds every child's entries landing in
+its column range. Disjoint `col` ⇒ disjoint `f_data` memory ⇒ no race; the `+=`
+into each cell keeps its serial child-order. Bit-exact by construction.
+
+Caveats that make it second-order:
+- Assembly is `O(nrow²)` per front; the factor it feeds is `O(nrow³)` and is
+  **already** intra-front parallelised (Lever 1.1, `apply_blocked_schur_panel`).
+  So parallel assembly chases the smaller term.
+- The canonicalisation means "entries landing in column range `[c0,c1)`" is not
+  a contiguous slice of the child loop; efficient column-partitioned assembly
+  wants the per-front static assembly maps that **#125** (still open) proposes.
+  Building them on the fly each factor partly eats the gain.
+
+## Tree-shape dependence (applies to both gaps)
+
+Measured 4-core scaling (session 05):
+
+| matrix    | tree shape          | factor 1t→4t | solve fraction |
+|-----------|---------------------|--------------|----------------|
+| grid220   | bushy nested-diss.  | 205→103 ms (1.99×) | 6–13% (serial) |
+| nuffield2 | path-like           | 7.37→6.62 s (1.11×) | 0.3% (serial) |
+| dense1400 | single front        | flat (routes serial) | — |
+| arrow     | path + big root     | flat | — |
+
+Tree parallelism (both gaps) helps **only bushy trees**. Many KKT/optimization
+matrices — the primary consumer — factor to path-like or lightly-branched trees
+(nuffield2 is a KKT trap matrix). So #131's expected value is concentrated on a
+subset of the corpus and is near-zero on an important part of the target
+workload.
+
+## Recommendation
+
+Ordered by value-per-risk:
+
+1. **Gap B parallel assembly, column-partitioned** — bit-exact-safe, issue-first,
+   but second-order (chases `O(nrow²)` behind already-parallel `O(nrow³)`).
+   Cleanest with #125's static maps landed first.
+2. **Gap A tree-parallel solve** — needs the contribution-block rewrite of the
+   solve core to get real, bit-exact parallelism; larger and riskier (touches the
+   bit-exact numeric core), payoff ~8 ms on bushy trees / ~0 on path trees.
+3. **Panel parallelism** — the issue itself defers this last ("consider after
+   #129's measurement"); #129 measured *not justified*
+   (`panel-fragmentation-2026-07-10.md`), so the panel-tiling motivation is weak.
+
+This is recorded per the measure-first + correctness-before-performance rules so
+the scope decision is made on evidence, not on the optimistic headroom headline
+alone.

--- a/dev/sessions/2026-07-10-06.md
+++ b/dev/sessions/2026-07-10-06.md
@@ -1,0 +1,96 @@
+# Session 2026-07-10-06
+
+## Goal
+
+Implement issue #131 (parallelism gaps) after the session-05 measure-first pass
+found it — unlike #130/#132/#133 — has genuine headroom. User scope: solve gap
+(Gap A) → full contribution-block rewrite; assembly gap → #125 static maps
+first, then Gap B.
+
+## Accomplished
+
+- **#125 — analysis-time static assembly maps** (commit `efa1000`).
+  Precompute each supernode's `[own cols | sorted trailing]` frontal row layout
+  at symbolic time (`compute_static_row_indices`, one postorder pass, CSR-flat
+  on `SymbolicFactorization`); the numeric factor reads it on the no-delay fast
+  path (`n_delayed_in == 0`) instead of recomputing with `build_row_indices`.
+  Bit-identical (delayed fronts fall back). Tests (`tests/static_assembly_maps.rs`,
+  8): A/B factor byte-identical static-on vs -off incl. KKT-with-delays; an
+  independent BTreeSet oracle == `static_rows(i)`. **Bench: grid220 (n=48400)
+  per-supernode loop 164.8→151.6 ms (~8%), warm factor 176.0→168.1 ms (~4.5%);
+  arrow wash.**
+
+- **#131 Gap B — measured not justified, not built** (commit `93cf6ed`).
+  Assembly is 8.3% of factor on grid220 / 1.5% on dense1400, and independent
+  fronts' assembly already overlaps in the parallel driver; only the serial
+  root-front O(nrow²) remains, behind the already-parallel O(nrow³) factor.
+  <1–3% ceiling → skipped with evidence (user agreed).
+  `dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`.
+
+- **#131 Gap A (1/n) — carry the assembly tree into `SparseFactors`** (commit
+  `c12a5d3`). `node_parents: Vec<Option<usize>>` mirrored from symbolic in all
+  constructors. Behavior-neutral foundation for the tree-parallel solve.
+
+- **#131 Gap A (2/n) — contribution-block tree-parallel single-RHS solve**
+  (commit `d83ca3e`). Opt-in `solve_sparse_cb(factors, rhs, parallel)`; default
+  `solve_sparse` untouched (no rebaseline). Forward = contribution-block
+  (children summed in fixed ascending order → serial-CB == parallel-CB
+  byte-identical); backward = unchanged shared-vector arithmetic, root-down.
+  Global `y` written only at disjoint eliminated rows (concurrent via a
+  Send+Sync raw-pointer wrapper + disjointness safety comment). Subtree-cost
+  **coarsening** (`CbTaskPlan`) + a `worthwhile` gate (≥2 task roots, no
+  Amdahl-dominant front, total ≥ 1e6 flops) — per-node tasks were far too fine.
+  Tests (`tests/cb_solve_parity.rs`, 6, stable under RAYON_NUM_THREADS=8):
+  serial==parallel byte-identical incl. an n=9216 concurrent-path fixture,
+  KKT-with-delays, dense fast path; determinism; valid solve.
+  **Bench: grid220 default solve 13.5 ms → cb_parallel 6.6 ms at 4 threads
+  (~2.0×); cb_serial 13.0 ms (no regression); arrow → serial fallback,
+  near-neutral.**
+
+All commits: full suite green, `cargo fmt --check` + `clippy -D warnings` clean
+(via pre-commit). Pushed to `claude/issue-112-0885lr`.
+
+## Benchmark Results
+
+```
+cargo run --bin bench --release: no matrices in this container (corpus absent,
+all buckets count 0). Perf evidence is from src/bin/perf_probe.rs (warm factor +
+solve, RAYON_NUM_THREADS-aware) and src/bin/probe_panel_frag.rs (phase timing):
+
+#125   grid220 loop 164.8→151.6 ms (~8%), warm factor 176.0→168.1 ms (~4.5%)
+Gap B  grid220 assembly 8.3% of factor; dense1400 1.5%  (skipped)
+Gap A  grid220 solve 13.5 ms (default) → 6.6 ms (cb_parallel, 4t) = ~2.0×
+       arrow (path) → worthwhile gate → serial fallback, near-neutral
+```
+
+## Decisions Made
+
+(Appended to `dev/decisions.md`.)
+- #131 Gap A: CB tree-parallel solve is an **opt-in separate path**, not a
+  rewrite of the default `solve_sparse` — keeps every residual baseline and the
+  single-vs-many bit-parity test intact; the byte-identity contract holds within
+  the CB path (serial-CB == parallel-CB).
+- #131 Gap B: parallel assembly measured not justified (<1–3% ceiling, already
+  overlaps in the parallel driver); not built.
+
+## Abandoned Approaches
+
+- Per-node rayon tasks for the CB solve — far too fine (grid220 = 48400 tiny
+  tasks, no speedup, cb_parallel 14.6 ms vs cb_serial 10.7 ms at 1t). Replaced
+  by subtree-cost coarsening before landing. (Not a separate tried-and-rejected
+  entry — it was superseded within the same commit's development.)
+
+## Next Session Should
+
+1. **Wire `solve_sparse_cb` into the `Solver`** so consumers actually benefit:
+   route `Solver::solve`/`solve_refined` through the parallel CB path when the
+   `worthwhile` gate says so and `with_parallel(true)`. Needs a pooled
+   workspace for the CB path (the refinement loop does up to ~11 solves/call;
+   the current `solve_sparse_cb` allocates fresh each call — would churn).
+2. **Multi-RHS CB solve** (`solve_sparse_core_many_into`) — same
+   contribution-block treatment, to complete Gap A for the predictor-corrector
+   (nrhs=2) path. Keep single-vs-many bit-parity.
+3. Optionally tune the coarsening threshold / `worthwhile` gate against a
+   broader shape set (currently defaults: ~16 task roots/worker, Amdahl 0.7,
+   1e6-flop floor).
+4. Backlog still open: #127, #134.

--- a/dev/sessions/2026-07-10-06.md
+++ b/dev/sessions/2026-07-10-06.md
@@ -47,6 +47,20 @@ first, then Gap B.
   (~2.0×); cb_serial 13.0 ms (no regression); arrow → serial fallback,
   near-neutral.**
 
+- **#131 Gap A (3/n) — pool the CB workspace + wire into `Solver`** (commit
+  `ab4b2fc`). `CbSolveWorkspace` caches the RHS-independent state (child lists +
+  coarsening plan) + scratch, so `solve_refined`'s ~11 solves reuse one
+  workspace (no churn — the follow-up 2/n flagged). `Solver::solve_refined` and
+  the per-column `solve_many_refined` loop dispatch to
+  `solve_sparse_refined_parallel` when `use_parallel`, installed on the solver's
+  own rayon pool. Path-like / small trees self-gate to the serial core (exact
+  current behavior). **Bench: grid220 `Solver::solve_refined` 56.0 ms → 29.0 ms
+  at 4 threads = ~1.93× end-to-end.** cb_solve_parity/sparse_refined/parity/
+  multi_rhs all green.
+  NOTE: the predictor-corrector case (nrhs=2) goes through the per-column
+  refined loop (nrhs < 16), so it is **already covered** by this wiring. Only
+  the batched many-RHS path (nrhs ≥ 16) still lacks a CB core.
+
 All commits: full suite green, `cargo fmt --check` + `clippy -D warnings` clean
 (via pre-commit). Pushed to `claude/issue-112-0885lr`.
 
@@ -82,15 +96,17 @@ Gap A  grid220 solve 13.5 ms (default) → 6.6 ms (cb_parallel, 4t) = ~2.0×
 
 ## Next Session Should
 
-1. **Wire `solve_sparse_cb` into the `Solver`** so consumers actually benefit:
-   route `Solver::solve`/`solve_refined` through the parallel CB path when the
-   `worthwhile` gate says so and `with_parallel(true)`. Needs a pooled
-   workspace for the CB path (the refinement loop does up to ~11 solves/call;
-   the current `solve_sparse_cb` allocates fresh each call — would churn).
-2. **Multi-RHS CB solve** (`solve_sparse_core_many_into`) — same
-   contribution-block treatment, to complete Gap A for the predictor-corrector
-   (nrhs=2) path. Keep single-vs-many bit-parity.
-3. Optionally tune the coarsening threshold / `worthwhile` gate against a
+1. **Batched multi-RHS CB solve** (`solve_sparse_core_many_into`, nrhs ≥ 16) —
+   the remaining Gap A slice. The predictor-corrector (nrhs=2) is already
+   covered via the per-column refined wiring, so this is the lower-value case
+   (heavy many-RHS / block refinement). The tree machinery (`CbTaskPlan`,
+   children, tasks, coarsening) is nrhs-agnostic and reusable; generalize
+   `cb_forward_front` / `cb_backward_front` to row-major nrhs-wide `w` (the
+   existing multi-RHS front kernels `fwd_rank1`/`fwd_blas3`/`dsolve_node`/
+   `back_*` are bit-identical to the scalar path at nrhs=1, so a single
+   generalized implementation can serve both). Wire the batched
+   `solve_sparse_many_refined`.
+2. Optionally tune the coarsening threshold / `worthwhile` gate against a
    broader shape set (currently defaults: ~16 task roots/worker, Amdahl 0.7,
-   1e6-flop floor).
-4. Backlog still open: #127, #134.
+   1e6-flop floor). `FERAL_CB_THRESH` overrides.
+3. Backlog still open: #127, #134.

--- a/src/bin/perf_probe.rs
+++ b/src/bin/perf_probe.rs
@@ -24,7 +24,17 @@ fn median(mut v: Vec<u128>) -> u128 {
 }
 
 fn make_solver(sequential: bool, profiling: bool) -> Solver {
-    Solver::with_params(NumericParams::default(), Default::default())
+    // Issue #125 A/B: `FERAL_STATIC_ROWS=0` forces the `build_row_indices`
+    // path (static assembly map disabled) so the prologue win is
+    // measurable against the default (static map on).
+    let mut np = NumericParams::default();
+    if matches!(
+        std::env::var("FERAL_STATIC_ROWS").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("no")
+    ) {
+        np.use_static_row_indices = false;
+    }
+    Solver::with_params(np, Default::default())
         .with_parallel(!sequential)
         .with_profiling(profiling)
 }

--- a/src/bin/perf_probe.rs
+++ b/src/bin/perf_probe.rs
@@ -115,6 +115,30 @@ fn main() {
     let solve_med_ns = sv.get(sv.len() / 2).copied().unwrap_or(0);
     println!("  solve_min_ns={solve_min_ns} solve_median_ns={solve_med_ns}");
 
+    // Issue #131 Gap A: contribution-block solve A/B. Times the CB solve
+    // serial vs tree-parallel (rayon pool = RAYON_NUM_THREADS) on the warm
+    // factor. Enabled with FERAL_PROBE_CB=1.
+    if std::env::var("FERAL_PROBE_CB").is_ok() {
+        if let Some(factors) = solver.factors() {
+            let bench_cb = |parallel: bool| -> u128 {
+                let _ = feral::numeric::solve::solve_sparse_cb(factors, &rhs, parallel);
+                let mut walls = Vec::with_capacity(iters);
+                for _ in 0..iters {
+                    let t0 = Instant::now();
+                    let _ = feral::numeric::solve::solve_sparse_cb(factors, &rhs, parallel);
+                    walls.push(t0.elapsed().as_nanos());
+                }
+                walls.into_iter().min().unwrap_or(0)
+            };
+            let cb_ser = bench_cb(false);
+            let cb_par = bench_cb(true);
+            println!(
+                "  cb_serial_min_ns={cb_ser} cb_parallel_min_ns={cb_par} threads={}",
+                rayon::current_num_threads()
+            );
+        }
+    }
+
     // A separate profiled solver to attribute the prologue (profiling adds
     // overhead, so it is kept out of the timing number above).
     let mut prof = make_solver(sequential, true);

--- a/src/bin/perf_probe.rs
+++ b/src/bin/perf_probe.rs
@@ -137,6 +137,21 @@ fn main() {
                 rayon::current_num_threads()
             );
         }
+        // End-to-end refined solve via the wired Solver path
+        // (Solver::solve_refined dispatches to the parallel CB refinement
+        // when use_parallel). `sequential` selects the serial baseline.
+        let _ = solver.solve_refined(&csc, &rhs);
+        let mut rwalls = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            let t0 = Instant::now();
+            let _ = solver.solve_refined(&csc, &rhs);
+            rwalls.push(t0.elapsed().as_nanos());
+        }
+        println!(
+            "  solve_refined_min_ns={} driver={}",
+            rwalls.into_iter().min().unwrap_or(0),
+            if sequential { "serial" } else { "parallel" }
+        );
     }
 
     // A separate profiled solver to attribute the prologue (profiling adds

--- a/src/bin/probe_panel_frag.rs
+++ b/src/bin/probe_panel_frag.rs
@@ -42,6 +42,10 @@ fn main() {
     let mut agg_schur = 0u64;
     let mut agg_panelf = 0u64;
     let mut agg_scalartail = 0u64;
+    let mut agg_assembly = 0u64;
+    let mut agg_buildrow = 0u64;
+    let mut agg_scatter = 0u64;
+    let mut agg_extendadd = 0u64;
 
     println!(
         "{:<24} {:>8} {:>6} {:>6} {:>7} {:>7} {:>8} {:>8} {:>9}",
@@ -73,7 +77,9 @@ fn main() {
         let delayed = get("panel_delayed");
         let pin = get("pivots_inline");
         let psc = get("pivots_scalar");
-        let (_assembly, densef, panelf, schur, scalartail) = phase_timing::snapshot();
+        let (assembly, densef, panelf, schur, scalartail) = phase_timing::snapshot();
+        let (buildrow, scatter, extendadd, _lextract, _contribextract) =
+            phase_timing::snapshot_detail();
 
         let panels = (full + partial + delayed).max(1);
         let pivots = (pin + psc).max(1);
@@ -111,6 +117,10 @@ fn main() {
         agg_schur += schur;
         agg_panelf += panelf;
         agg_scalartail += scalartail;
+        agg_assembly += assembly;
+        agg_buildrow += buildrow;
+        agg_scatter += scatter;
+        agg_extendadd += extendadd;
     }
 
     let panels = (agg_full + agg_partial + agg_delayed).max(1);
@@ -134,4 +144,14 @@ fn main() {
             agg_densef / 1000,
         );
     }
+    // #131 Gap B scoping: assembly cost vs the dense factor it feeds.
+    let total = (agg_assembly + agg_densef).max(1);
+    println!(
+        "assembly: {} us ({:.1}% of assembly+densefactor)  | buildrow={} us scatter={} us extendadd={} us",
+        agg_assembly / 1000,
+        100.0 * agg_assembly as f64 / total as f64,
+        agg_buildrow / 1000,
+        agg_scatter / 1000,
+        agg_extendadd / 1000,
+    );
 }

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -895,6 +895,18 @@ pub struct SparseFactors {
     /// Concrete ordering preprocessor actually used. Mirrored
     /// from `SymbolicFactorization::resolved_preprocess`.
     pub resolved_preprocess: crate::symbolic::OrderingPreprocess,
+
+    /// Issue #131 Gap A: assembly-tree parent of each supernode, indexed
+    /// like `node_factors` (postorder). `node_parents[i] == Some(p)` iff
+    /// supernode `i`'s contribution block assembles into supernode `p`;
+    /// `None` for roots. Mirrored from `SymbolicFactorization` at factor
+    /// time (the symbolic analysis is not retained by `SparseFactors`).
+    /// The tree-parallel solve uses it to order forward substitution
+    /// (leaves-up: a node runs once all its children have) and backward
+    /// substitution (root-down: a node runs once its parent has). Empty
+    /// for ad-hoc `SparseFactors` built without a symbolic tree (the
+    /// serial postorder solve does not consult it).
+    pub node_parents: Vec<Option<usize>>,
 }
 
 /// A flat, factorization-order export of the LDLᵀ factors.
@@ -1637,6 +1649,8 @@ pub fn dense_fast_factor_with_workspace(
             resolved_method: crate::symbolic::OrderingMethod::Amd,
             resolved_amalgamation: crate::symbolic::AmalgamationStrategy::Adjacency,
             resolved_preprocess: crate::symbolic::OrderingPreprocess::None,
+            // Dense fast-path: a single supernode, no assembly tree.
+            node_parents: vec![None],
         },
         inertia,
     ))
@@ -1914,6 +1928,7 @@ fn factorize_multifrontal_with_schur_inner(
         resolved_method: symbolic.resolved_method.clone(),
         resolved_amalgamation: symbolic.resolved_amalgamation,
         resolved_preprocess: symbolic.resolved_preprocess,
+        node_parents: build_node_parents(symbolic),
     };
     let schur = SchurBlock {
         dim: n_schur,
@@ -2248,6 +2263,7 @@ pub fn factorize_multifrontal_supernodal_with_workspace(
             resolved_method: symbolic.resolved_method.clone(),
             resolved_amalgamation: symbolic.resolved_amalgamation,
             resolved_preprocess: symbolic.resolved_preprocess,
+            node_parents: build_node_parents(symbolic),
         },
         total_inertia,
     ));
@@ -3276,6 +3292,7 @@ pub fn factorize_multifrontal_supernodal_parallel_with_workspace(
             resolved_method: symbolic.resolved_method.clone(),
             resolved_amalgamation: symbolic.resolved_amalgamation,
             resolved_preprocess: symbolic.resolved_preprocess,
+            node_parents: build_node_parents(symbolic),
         },
         total_inertia,
     ))
@@ -3940,6 +3957,24 @@ fn build_permute_value_map(
 /// Trailing rows are deduplicated against the fully-summed set so a
 /// delayed column that also shows up as a pattern row of a parent
 /// column (via the full symmetric pattern) does not appear twice.
+/// Issue #131 Gap A: assembly-tree parent per supernode, indexed like
+/// `node_factors` (postorder). `parents[c] == Some(i)` iff supernode `i`
+/// lists `c` among its children. Mirrored into `SparseFactors` so the
+/// tree-parallel solve can order forward (leaves-up) and backward
+/// (root-down) substitution without retaining the symbolic analysis.
+fn build_node_parents(symbolic: &SymbolicFactorization) -> Vec<Option<usize>> {
+    let n_snodes = symbolic.supernodes.len();
+    let mut parents: Vec<Option<usize>> = vec![None; n_snodes];
+    for (i, snode) in symbolic.supernodes.iter().enumerate() {
+        for &c in &snode.children {
+            if c < n_snodes {
+                parents[c] = Some(i);
+            }
+        }
+    }
+    parents
+}
+
 fn build_row_indices(
     snode: &crate::symbolic::supernode::Supernode,
     full_pattern: &crate::sparse::csc::CscPattern,

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -272,6 +272,18 @@ pub struct NumericParams {
     /// `permute_csc_values`; closing that gap is the open N3 facet tracked
     /// in `dev/decisions.md`.
     pub pattern_reused_hint: bool,
+
+    /// Issue #125: when `true` (default), `factor_one_supernode` reads
+    /// each front's row layout from the symbolic-time
+    /// `SymbolicFactorization::static_rows` on the no-delay fast path
+    /// (`n_delayed_in == 0`) instead of recomputing it with
+    /// `build_row_indices`. The static layout is bit-for-bit identical
+    /// to `build_row_indices`' output in that case, so factors are
+    /// unchanged. Setting `false` forces the `build_row_indices` path
+    /// unconditionally — used only for A/B benchmarking of the prologue
+    /// win and by the equivalence test in
+    /// `tests/static_assembly_maps.rs`. Default `true`.
+    pub use_static_row_indices: bool,
 }
 
 /// Gate for Phase 2.9 small-leaf-subtree batching.
@@ -609,6 +621,10 @@ impl Default for NumericParams {
             // this on per-call when the symbolic cache reports
             // `pattern_reused`.
             pattern_reused_hint: false,
+            // Issue #125: use the symbolic-time static row layout on the
+            // no-delay fast path by default (bit-identical to
+            // `build_row_indices`). Only tests / A/B benches set false.
+            use_static_row_indices: true,
         }
     }
 }
@@ -640,6 +656,8 @@ impl NumericParams {
             warn_partial_singular: false,
             // Issue #56 Lever A.2: opt-in permute cache.
             pattern_reused_hint: false,
+            // Issue #125: static row layout on by default.
+            use_static_row_indices: true,
         }
     }
 }
@@ -2364,16 +2382,34 @@ fn factor_one_supernode(
 
     // Build the row indices for this frontal. The default layout is
     // [own native cols (own_ncol) | delayed cols from children (n_delayed_in) | trailing rows].
+    //
+    // Issue #125: on the no-delay fast path (`n_delayed_in == 0`, the
+    // common case) the layout is `[own cols | sorted trailing]` with no
+    // delayed block, which the symbolic phase already materialized in
+    // `symbolic.static_rows(snode_idx)` — bit-for-bit what
+    // `build_row_indices` would produce here (its trailing set is a
+    // sorted seen-dedup independent of numeric pivot order). Copy it
+    // directly and skip the pattern re-scan + sort. Delayed-pivot fronts
+    // (`n_delayed_in > 0`) still go through `build_row_indices`, which
+    // interleaves the child-order delayed columns. The static map may be
+    // absent for ad-hoc/stub `SymbolicFactorization`s (empty offsets);
+    // fall back to `build_row_indices` then.
     let _pt_asm = phase_timing::start();
     let _pt_br = phase_timing::start();
-    let mut row_indices = build_row_indices(
-        snode,
-        full_pattern,
-        contrib_blocks,
-        &mut ws.build_delayed,
-        &mut ws.build_trailing,
-        &mut ws.build_seen,
-    );
+    let static_rows = symbolic.static_rows(snode_idx);
+    let mut row_indices =
+        if params.use_static_row_indices && n_delayed_in == 0 && !static_rows.is_empty() {
+            static_rows.to_vec()
+        } else {
+            build_row_indices(
+                snode,
+                full_pattern,
+                contrib_blocks,
+                &mut ws.build_delayed,
+                &mut ws.build_trailing,
+                &mut ws.build_seen,
+            )
+        };
     phase_timing::stop(&phase_timing::BUILDROW_NS, _pt_br);
     let actual_nrow = row_indices.len();
     debug_assert!(
@@ -4363,6 +4399,7 @@ mod tests {
             static_pivot_threshold: None,
             warn_partial_singular: false,
             pattern_reused_hint: false,
+            use_static_row_indices: true,
         };
         let identity = NumericParams {
             bk: infnorm.bk.clone(),
@@ -4379,6 +4416,7 @@ mod tests {
             static_pivot_threshold: None,
             warn_partial_singular: false,
             pattern_reused_hint: false,
+            use_static_row_indices: true,
         };
 
         let (_, i_inf) = factorize_multifrontal(&m, &sym, &infnorm).unwrap();
@@ -4438,6 +4476,7 @@ mod tests {
             static_pivot_threshold: None,
             warn_partial_singular: false,
             pattern_reused_hint: false,
+            use_static_row_indices: true,
         };
         let infnorm = NumericParams {
             scaling: ScalingStrategy::InfNorm,
@@ -4945,6 +4984,7 @@ mod tests {
             static_pivot_threshold: None,
             warn_partial_singular: false,
             pattern_reused_hint: false,
+            use_static_row_indices: true,
         };
 
         let deltas = [0.0, 1e-4, 1e-2, 1.0, 1e2, 1e4, 1e6, 1e8, 1e10, 1e12];
@@ -5171,6 +5211,8 @@ mod tests {
             col_counts: Vec::new(),
             small_leaf_groups: Vec::new(),
             snode_group: Vec::new(),
+            static_row_offsets: Vec::new(),
+            static_row_flat: Vec::new(),
             cached_mc64: None,
             resolved_method: crate::symbolic::OrderingMethod::Amd,
             resolved_amalgamation: crate::symbolic::AmalgamationStrategy::Adjacency,

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -556,49 +556,38 @@ fn cb_backward_front(node: &NodeFactors, y: &mut [f64], w: &mut [f64]) {
 
 /// Serial contribution-block solve core (single RHS). Bit-identical to
 /// the parallel CB core; the default `solve_sparse` path is unaffected.
-fn solve_sparse_cb_core_serial(factors: &SparseFactors, rhs: &[f64], x_out: &mut [f64]) {
-    let n = factors.n;
-    let nodes = &factors.node_factors;
-    let n_nodes = nodes.len();
-
-    let mut y = vec![0.0f64; n];
-    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        y[new_idx] = rhs[old_idx];
-    }
-
-    let children = build_children(&factors.node_parents, n_nodes);
-    let max_nrow = nodes
-        .iter()
-        .map(|nd| nd.frontal_factors.nrow)
-        .max()
-        .unwrap_or(0);
-    let mut row_map = vec![usize::MAX; n];
-    let mut w = vec![0.0f64; max_nrow];
-    let mut contribs: Vec<Option<FwdContrib>> = (0..n_nodes).map(|_| None).collect();
-
-    // Forward: postorder (node_factors order) already lists children
-    // before parents, so every child's contribution is ready when its
-    // parent is reached — a serial linearisation of the leaves-up order.
-    for idx in 0..n_nodes {
+/// Serial contribution-block forward+backward over `y` in place (`y`
+/// holds the permuted RHS on entry, the permuted solution on exit),
+/// against caller-owned workspace buffers. `contribs` must be all-`None`
+/// and `row_map` all-`usize::MAX` on entry (both restored on exit —
+/// `row_map` by each front, `contribs` by the parent that drains each
+/// child; roots' contributions are left behind, so callers reset
+/// `contribs` between solves).
+fn cb_run_serial(
+    nodes: &[NodeFactors],
+    children: &[Vec<usize>],
+    y: &mut [f64],
+    row_map: &mut [usize],
+    w: &mut [f64],
+    contribs: &mut [Option<FwdContrib>],
+) {
+    // Forward: postorder (node_factors order lists children before
+    // parents), so every child's contribution is ready at its parent.
+    for idx in 0..nodes.len() {
         let contrib = cb_forward_front(
             &nodes[idx],
             &children[idx],
-            &mut y,
-            &mut row_map,
-            &mut w,
+            y,
+            row_map,
+            w,
             |c| contribs[c].take(),
             nodes,
         );
         contribs[idx] = contrib;
     }
-
     // Backward: reverse postorder (parents before children).
     for node in nodes.iter().rev() {
-        cb_backward_front(node, &mut y, &mut w);
-    }
-
-    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        x_out[old_idx] = y[new_idx];
+        cb_backward_front(node, y, w);
     }
 }
 
@@ -622,62 +611,27 @@ struct CbScratch {
     w: Vec<f64>,
 }
 
-/// Parallel contribution-block solve core (single RHS). Byte-identical to
-/// `solve_sparse_cb_core_serial`: the child-reduction order is fixed
-/// (ascending child index) regardless of thread scheduling.
-fn solve_sparse_cb_core_parallel(factors: &SparseFactors, rhs: &[f64], x_out: &mut [f64]) {
+/// Parallel contribution-block forward+backward over `y` in place,
+/// against caller-owned pooled buffers (`scratch` per worker, `contribs`
+/// shared). Byte-identical to `cb_run_serial`: the child-reduction order
+/// is fixed (ascending child index) regardless of thread scheduling. The
+/// caller resets `contribs` to all-`None` and provides `scratch` with
+/// `row_map` all-`usize::MAX`; both are left in that state on exit.
+#[allow(clippy::too_many_arguments)]
+fn cb_run_parallel(
+    nodes: &[NodeFactors],
+    children: &[Vec<usize>],
+    parents: &[Option<usize>],
+    plan: &CbTaskPlan,
+    scratch: &[std::sync::Mutex<CbScratch>],
+    contribs: &std::sync::Mutex<Vec<Option<FwdContrib>>>,
+    y: &mut [f64],
+    n: usize,
+) {
     use std::sync::atomic::AtomicUsize;
-    use std::sync::Mutex;
-
-    let n = factors.n;
-    let nodes = &factors.node_factors;
-    let n_nodes = nodes.len();
-
-    let mut y = vec![0.0f64; n];
-    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        y[new_idx] = rhs[old_idx];
-    }
-
-    let children = build_children(&factors.node_parents, n_nodes);
-    let parents = &factors.node_parents;
-    let max_nrow = nodes
-        .iter()
-        .map(|nd| nd.frontal_factors.nrow)
-        .max()
-        .unwrap_or(0);
-
-    // --- Coarsening: cut the assembly tree into subtrees at a cost
-    // threshold so each rayon task carries a whole light subtree serially
-    // (per-node tasks are far too fine — the solve work per front is tiny
-    // beside rayon's spawn/lock overhead). This changes only *which
-    // thread* runs a front, never the order contributions are summed into
-    // any parent, so it stays byte-identical to the serial CB core.
-    let plan = CbTaskPlan::build(&children, parents, nodes, n_nodes);
-
-    // When the tree offers too little independent work (path-like /
-    // single-front, or one front dominates by Amdahl, or the solve is too
-    // small to amortize scratch setup), the parallel machinery is pure
-    // overhead — run the byte-identical serial core instead.
-    if !plan.worthwhile {
-        solve_sparse_cb_core_serial(factors, rhs, x_out);
-        return;
-    }
-
-    // Per-worker scratch (one per rayon worker + one for the calling
-    // thread, whose `current_thread_index()` is `None`).
     let num_threads = rayon::current_num_threads().max(1);
-    let scratch: Vec<Mutex<CbScratch>> = (0..num_threads + 1)
-        .map(|_| {
-            Mutex::new(CbScratch {
-                row_map: vec![usize::MAX; n],
-                w: vec![0.0f64; max_nrow],
-            })
-        })
-        .collect();
 
-    let contribs: Mutex<Vec<Option<FwdContrib>>> = Mutex::new((0..n_nodes).map(|_| None).collect());
-
-    // ---- Forward: task-roots processed leaves-up ----
+    // ---- Forward: task roots processed leaves-up ----
     let pending_fwd: Vec<AtomicUsize> = plan
         .pending_fwd
         .iter()
@@ -687,11 +641,11 @@ fn solve_sparse_cb_core_parallel(factors: &SparseFactors, rhs: &[f64], x_out: &m
         let y_ptr = YPtr(y.as_mut_ptr());
         let ctx = CbCtx {
             nodes,
-            children: &children,
+            children,
             parents,
-            plan: &plan,
-            contribs: &contribs,
-            scratch: &scratch,
+            plan,
+            contribs,
+            scratch,
             y_ptr,
             n,
             num_threads,
@@ -703,16 +657,16 @@ fn solve_sparse_cb_core_parallel(factors: &SparseFactors, rhs: &[f64], x_out: &m
         });
     }
 
-    // ---- Backward: task-roots processed root-down ----
+    // ---- Backward: task roots processed root-down ----
     {
         let y_ptr = YPtr(y.as_mut_ptr());
         let ctx = CbCtx {
             nodes,
-            children: &children,
+            children,
             parents,
-            plan: &plan,
-            contribs: &contribs,
-            scratch: &scratch,
+            plan,
+            contribs,
+            scratch,
             y_ptr,
             n,
             num_threads,
@@ -722,10 +676,6 @@ fn solve_sparse_cb_core_parallel(factors: &SparseFactors, rhs: &[f64], x_out: &m
                 cb_bwd_task(scope, t, &ctx);
             }
         });
-    }
-
-    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        x_out[old_idx] = y[new_idx];
     }
 }
 
@@ -963,9 +913,149 @@ fn cb_bwd_task<'a>(scope: &rayon::Scope<'a>, t: usize, ctx: &CbCtx<'a>) {
     });
 }
 
+/// Pooled workspace for the contribution-block solve (issue #131 Gap A).
+/// Caches the RHS-independent state — the assembly-tree child lists and
+/// the coarsening plan — plus the per-solve scratch, so a caller doing
+/// several solves against one factor (iterative refinement runs up to
+/// ~11) pays the `O(threads·n)` scratch and `O(n_nodes)` plan setup once.
+/// Build with [`CbSolveWorkspace::for_factors`]; reuse across solves.
+pub(crate) struct CbSolveWorkspace {
+    n: usize,
+    max_nrow: usize,
+    scaled: bool,
+    children: Vec<Vec<usize>>,
+    plan: CbTaskPlan,
+    y: Vec<f64>,
+    // Serial scratch.
+    row_map: Vec<usize>,
+    w: Vec<f64>,
+    contribs: Vec<Option<FwdContrib>>,
+    // Parallel scratch, built lazily on first parallel solve and rebuilt
+    // only if the worker count changes.
+    par_scratch: Vec<std::sync::Mutex<CbScratch>>,
+    par_contribs: std::sync::Mutex<Vec<Option<FwdContrib>>>,
+}
+
+impl CbSolveWorkspace {
+    pub(crate) fn for_factors(factors: &SparseFactors) -> Self {
+        let n = factors.n;
+        let nodes = &factors.node_factors;
+        let n_nodes = nodes.len();
+        let children = build_children(&factors.node_parents, n_nodes);
+        let plan = CbTaskPlan::build(&children, &factors.node_parents, nodes, n_nodes);
+        let max_nrow = nodes
+            .iter()
+            .map(|nd| nd.frontal_factors.nrow)
+            .max()
+            .unwrap_or(0);
+        let scaled = !matches!(factors.scaling_info, ScalingInfo::NotApplied);
+        Self {
+            n,
+            max_nrow,
+            scaled,
+            children,
+            plan,
+            y: vec![0.0; n],
+            row_map: vec![usize::MAX; n],
+            w: vec![0.0; max_nrow],
+            contribs: (0..n_nodes).map(|_| None).collect(),
+            par_scratch: Vec::new(),
+            par_contribs: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Whether the tree-parallel path is expected to beat the serial core
+    /// on this factor (see `CbTaskPlan::worthwhile`).
+    pub(crate) fn worthwhile(&self) -> bool {
+        self.plan.worthwhile
+    }
+
+    /// Solve `A x = b` into `x_out` using this workspace. `parallel`
+    /// requests tree-parallel execution, honoured only when the plan is
+    /// `worthwhile`; otherwise the byte-identical serial core runs. MC64
+    /// pre/post scaling is fused into the entry permute and exit unpermute.
+    pub(crate) fn solve_into(
+        &mut self,
+        factors: &SparseFactors,
+        rhs: &[f64],
+        x_out: &mut [f64],
+        parallel: bool,
+    ) {
+        let n = self.n;
+        // Permute the RHS into `y`, fusing MC64 scaling: y[new] =
+        // b[old]·D[old] (the same congruence solve_sparse applies).
+        if self.scaled {
+            for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+                self.y[new_idx] = rhs[old_idx] * factors.scaling[old_idx];
+            }
+        } else {
+            for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+                self.y[new_idx] = rhs[old_idx];
+            }
+        }
+
+        if parallel && self.plan.worthwhile {
+            let num_threads = rayon::current_num_threads().max(1);
+            if self.par_scratch.len() != num_threads + 1 {
+                let max_nrow = self.max_nrow;
+                self.par_scratch = (0..num_threads + 1)
+                    .map(|_| {
+                        std::sync::Mutex::new(CbScratch {
+                            row_map: vec![usize::MAX; n],
+                            w: vec![0.0; max_nrow],
+                        })
+                    })
+                    .collect();
+            }
+            {
+                let mut pc = self.par_contribs.lock().unwrap_or_else(|p| p.into_inner());
+                pc.clear();
+                pc.resize_with(factors.node_factors.len(), || None);
+            }
+            cb_run_parallel(
+                &factors.node_factors,
+                &self.children,
+                &factors.node_parents,
+                &self.plan,
+                &self.par_scratch,
+                &self.par_contribs,
+                &mut self.y,
+                n,
+            );
+        } else {
+            // Roots' contributions are never drained, so reset.
+            for c in self.contribs.iter_mut() {
+                *c = None;
+            }
+            cb_run_serial(
+                &factors.node_factors,
+                &self.children,
+                &mut self.y,
+                &mut self.row_map,
+                &mut self.w,
+                &mut self.contribs,
+            );
+        }
+
+        // Unpermute, fusing the MC64 post-scale: x[old] = y[new]·D[old].
+        if self.scaled {
+            for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+                x_out[old_idx] = self.y[new_idx] * factors.scaling[old_idx];
+            }
+        } else {
+            for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+                x_out[old_idx] = self.y[new_idx];
+            }
+        }
+    }
+}
+
 /// Opt-in contribution-block sparse solve (issue #131 Gap A), single RHS.
 /// Applies the same MC64 pre/post scaling as `solve_sparse`. `parallel`
-/// selects the tree-parallel execution; both are byte-identical.
+/// selects the tree-parallel execution (honoured when the tree is
+/// `worthwhile`); serial and parallel are byte-identical. Allocates a
+/// one-shot [`CbSolveWorkspace`]; callers doing repeated solves against
+/// one factor should build and reuse a workspace instead.
 pub fn solve_sparse_cb(
     factors: &SparseFactors,
     rhs: &[f64],
@@ -981,28 +1071,9 @@ pub fn solve_sparse_cb(
     if n == 0 {
         return Ok(Vec::new());
     }
-
-    let needs_scaling = !matches!(factors.scaling_info, ScalingInfo::NotApplied);
-    let scaled: Vec<f64>;
-    let rhs_for_core: &[f64] = if needs_scaling {
-        scaled = (0..n).map(|i| rhs[i] * factors.scaling[i]).collect();
-        &scaled
-    } else {
-        rhs
-    };
-
+    let mut ws = CbSolveWorkspace::for_factors(factors);
     let mut x = vec![0.0f64; n];
-    if parallel {
-        solve_sparse_cb_core_parallel(factors, rhs_for_core, &mut x);
-    } else {
-        solve_sparse_cb_core_serial(factors, rhs_for_core, &mut x);
-    }
-
-    if needs_scaling {
-        for i in 0..n {
-            x[i] *= factors.scaling[i];
-        }
-    }
+    ws.solve_into(factors, rhs, &mut x, parallel);
     Ok(x)
 }
 
@@ -1620,7 +1691,24 @@ pub fn solve_sparse_refined(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<Vec<f64>, FeralError> {
-    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false)?;
+    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, false)?;
+    Ok(x)
+}
+
+/// Iterative refinement using the tree-parallel contribution-block solve
+/// (issue #131 Gap A) for the initial and correction solves, pooling one
+/// `CbSolveWorkspace` across them. Falls back per-solve to the serial
+/// path when the factor's assembly tree is not `worthwhile` (path-like /
+/// small trees), so it never regresses those; on bushy trees it runs the
+/// substitutions across the rayon pool. The refined result is a valid
+/// solution equal to `solve_sparse_refined`'s up to floating-point
+/// reassociation. Used by `Solver::solve_refined` when parallelism is on.
+pub fn solve_sparse_refined_parallel(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+) -> Result<Vec<f64>, FeralError> {
+    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, true)?;
     Ok(x)
 }
 
@@ -1694,7 +1782,7 @@ pub fn solve_sparse_refined_with_diagnostics(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<(Vec<f64>, RefinementDiagnostics), FeralError> {
-    let (x, diag) = solve_sparse_refined_core(matrix, factors, rhs, true)?;
+    let (x, diag) = solve_sparse_refined_core(matrix, factors, rhs, true, false)?;
     // `with_diagnostics = true` always yields `Some`; if it ever doesn't,
     // that's a logic bug — `expect` is fine in test code, but per CLAUDE.md
     // we use Result in src/. Return DimensionMismatch as a defensive
@@ -1711,6 +1799,7 @@ fn solve_sparse_refined_core(
     factors: &SparseFactors,
     rhs: &[f64],
     with_diagnostics: bool,
+    parallel_cb: bool,
 ) -> Result<(Vec<f64>, Option<RefinementDiagnostics>), FeralError> {
     let n = factors.n;
     if rhs.len() != n {
@@ -1732,9 +1821,28 @@ fn solve_sparse_refined_core(
         (0.0, 0.0)
     };
 
-    let mut ws = SolveWorkspace::for_factors(factors);
+    // Issue #131 Gap A: when the caller opts into the tree-parallel path
+    // and the factor's assembly tree is `worthwhile`, pool one
+    // contribution-block workspace across the initial + up-to-10
+    // correction solves (each reuses the plan + scratch). Otherwise keep
+    // the proven shared-vector `SolveWorkspace` path, bit-for-bit.
+    let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
+        let cb = CbSolveWorkspace::for_factors(factors);
+        cb.worthwhile().then_some(cb)
+    } else {
+        None
+    };
+    let mut ws: Option<SolveWorkspace> = if cb_ws.is_none() {
+        Some(SolveWorkspace::for_factors(factors))
+    } else {
+        None
+    };
     let mut x = vec![0.0; n];
-    solve_sparse_into_ws(factors, rhs, &mut x, &mut ws)?;
+    match (cb_ws.as_mut(), ws.as_mut()) {
+        (Some(cb), _) => cb.solve_into(factors, rhs, &mut x, true),
+        (None, Some(w)) => solve_sparse_into_ws(factors, rhs, &mut x, w)?,
+        (None, None) => unreachable!("exactly one solve workspace is built"),
+    }
 
     // Initial residual: compute A·x directly into r, then negate-add.
     let mut r = vec![0.0; n];
@@ -1800,7 +1908,11 @@ fn solve_sparse_refined_core(
             break;
         }
 
-        solve_sparse_into_ws(factors, &r, &mut dx, &mut ws)?;
+        match (cb_ws.as_mut(), ws.as_mut()) {
+            (Some(cb), _) => cb.solve_into(factors, &r, &mut dx, true),
+            (None, Some(w)) => solve_sparse_into_ws(factors, &r, &mut dx, w)?,
+            (None, None) => unreachable!("exactly one solve workspace is built"),
+        }
         for i in 0..n {
             x[i] += dx[i];
         }

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_range_loop)]
 use super::condition::{estimate_inverse_norm_1, matrix_norm_1};
-use super::factorize::SparseFactors;
+use super::factorize::{NodeFactors, SparseFactors};
 use crate::error::FeralError;
 use crate::scaling::ScalingInfo;
 use crate::sparse::csc::CscMatrix;
@@ -360,6 +360,650 @@ fn solve_sparse_core_into(
     for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
         x_out[old_idx] = y[new_idx];
     }
+}
+
+/// Single-RHS D-block solve on `w[0..nelim]` in place — the 1×1 / 2×2
+/// disposition extracted from `solve_sparse_core_into` so the
+/// contribution-block core (issue #131 Gap A) applies byte-identical
+/// arithmetic. Force-accepted zero pivots and SSIDS-floor-rejected 2×2
+/// blocks are left untouched, matching the shared-vector core.
+#[inline]
+fn dsolve_single(w: &mut [f64], ff: &crate::dense::factor::FrontalFactors, nelim: usize) {
+    let mut k = 0;
+    while k < nelim {
+        if k + 1 < nelim && ff.d_subdiag[k] != 0.0 {
+            let a = ff.d_diag[k];
+            let b = ff.d_subdiag[k];
+            let c = ff.d_diag[k + 1];
+            if let Some((x0, x1)) = solve_2x2_dblock(a, b, c, w[k], w[k + 1]) {
+                w[k] = x0;
+                w[k + 1] = x1;
+            }
+            k += 2;
+        } else {
+            if ff.d_diag[k] != 0.0 {
+                w[k] /= ff.d_diag[k];
+            }
+            k += 1;
+        }
+    }
+}
+
+// === Issue #131 Gap A: contribution-block (tree-parallel) sparse solve ==
+//
+// The shared-global-vector core (`solve_sparse_core_into`) accumulates
+// each front's separator updates directly into a global `y`, so sibling
+// subtrees read-modify-write the same ancestor entries — not
+// tree-parallelisable, and a private-accumulation merge would break bit
+// exactness (float non-associativity). The contribution-block core below
+// instead assembles each front's RHS from `b` (at its eliminated rows)
+// plus its children's contribution blocks, summed in a fixed child order
+// — exactly the deterministic reduction the factor's `extend_add` uses.
+// The reduction order is independent of thread scheduling, so a serial
+// run and a tree-parallel run are byte-identical (the #131 contract).
+//
+// Forward substitution is leaves-up (a front assembles once all children
+// have produced their contribution blocks); backward is root-down and
+// keeps the shared-vector arithmetic unchanged (separator rows are
+// read-only there, eliminated rows disjoint). Because the forward
+// reduction groups contributions by subtree (a sum tree) rather than the
+// flat postorder left-fold of `solve_sparse_core_into`, the result
+// differs from that path only by floating-point reassociation (~κ·eps):
+// a valid solve, offered as an opt-in path; the default `solve_sparse`
+// is unchanged.
+
+/// One front's forward contribution: the `nrow - nelim` separator-row
+/// values (in frontal separator order) it passes to its parent. Boxed
+/// per node in a slot vector consumed leaves-up.
+type FwdContrib = Vec<f64>;
+
+/// Build per-node child lists (ascending node index) from the parent
+/// table, for a deterministic child-reduction order in the CB forward.
+fn build_children(node_parents: &[Option<usize>], n_nodes: usize) -> Vec<Vec<usize>> {
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n_nodes];
+    for (c, p) in node_parents.iter().enumerate() {
+        if let Some(p) = p {
+            if *p < n_nodes {
+                children[*p].push(c);
+            }
+        }
+    }
+    // node_parents is filled by ascending child index, so each list is
+    // already ascending; make it explicit for the determinism contract.
+    for cs in &mut children {
+        cs.sort_unstable();
+    }
+    children
+}
+
+/// Assemble + eliminate one front for the CB forward pass, writing the
+/// eliminated finals into `y` (at the front's own eliminated global rows,
+/// disjoint across fronts) and returning its contribution block (or
+/// `None` if it has no separator rows). `row_map` is caller-owned scratch
+/// (length `n`, all `usize::MAX` on entry and restored on exit); `w` is
+/// caller-owned scratch (length ≥ `nrow`). `take_child` yields each
+/// child's already-computed contribution in ascending child order.
+#[allow(clippy::too_many_arguments)]
+fn cb_forward_front(
+    node: &NodeFactors,
+    children: &[usize],
+    y: &mut [f64],
+    row_map: &mut [usize],
+    w: &mut [f64],
+    mut take_child: impl FnMut(usize) -> Option<FwdContrib>,
+    child_nodes: &[NodeFactors],
+) -> Option<FwdContrib> {
+    let ff = &node.frontal_factors;
+    let nrow = ff.nrow;
+    let nelim = ff.nelim;
+    if nrow == 0 {
+        return None;
+    }
+
+    // global -> local frontal index for this front.
+    for i in 0..nrow {
+        row_map[node.row_indices[ff.perm[i]]] = i;
+    }
+
+    let w = &mut w[..nrow];
+    // b at eliminated rows (still intact in `y` — each global row is
+    // eliminated at exactly one front, written only here); separators 0.
+    for i in 0..nrow {
+        w[i] = 0.0;
+    }
+    for i in 0..nelim {
+        w[i] = y[node.row_indices[ff.perm[i]]];
+    }
+
+    // Extend-add each child's contribution block in ascending order.
+    for &child in children {
+        if let Some(cc) = take_child(child) {
+            let cff = &child_nodes[child].frontal_factors;
+            let cnelim = cff.nelim;
+            let cnrow = cff.nrow;
+            for i in cnelim..cnrow {
+                let g = child_nodes[child].row_indices[cff.perm[i]];
+                let local = row_map[g];
+                debug_assert!(
+                    local != usize::MAX && local < nrow,
+                    "CB forward: child separator row {g} not in parent frontal"
+                );
+                w[local] += cc[i - cnelim];
+            }
+        }
+    }
+
+    // L-solve over all rows (uses pre-D eliminated values), then D-solve
+    // on the eliminated rows only — mirrors solve_sparse_core_into.
+    for j in 0..nelim {
+        let w_j = w[j];
+        for i in (j + 1)..nrow {
+            w[i] -= ff.l[j * nrow + i] * w_j;
+        }
+    }
+    dsolve_single(w, ff, nelim);
+
+    // Eliminated finals -> y (disjoint rows across fronts).
+    for i in 0..nelim {
+        y[node.row_indices[ff.perm[i]]] = w[i];
+    }
+
+    // Contribution block = separator rows after the L-update.
+    let contrib = if nrow > nelim {
+        Some(w[nelim..nrow].to_vec())
+    } else {
+        None
+    };
+
+    // Restore row_map.
+    for i in 0..nrow {
+        row_map[node.row_indices[ff.perm[i]]] = usize::MAX;
+    }
+
+    contrib
+}
+
+/// Backward substitution for one front, shared-vector arithmetic
+/// (unchanged from `solve_sparse_core_into`): gather from `y`, Lᵀ-solve
+/// the eliminated rows, scatter the eliminated rows back. Separator rows
+/// are read-only here (they hold ancestors' final values, written by the
+/// ancestors' backward step which runs first in root-down order), so
+/// concurrent fronts touch disjoint `y` entries.
+fn cb_backward_front(node: &NodeFactors, y: &mut [f64], w: &mut [f64]) {
+    let ff = &node.frontal_factors;
+    let nelim = ff.nelim;
+    let nrow = ff.nrow;
+    if nelim == 0 {
+        return;
+    }
+    let w = &mut w[..nrow];
+    for i in 0..nrow {
+        w[i] = y[node.row_indices[ff.perm[i]]];
+    }
+    for j in (0..nelim).rev() {
+        let mut sum = 0.0;
+        for i in (j + 1)..nrow {
+            sum += ff.l[j * nrow + i] * w[i];
+        }
+        w[j] -= sum;
+    }
+    // Only the eliminated rows changed; scatter just those (separators are
+    // read-only, so this keeps concurrent fronts' writes disjoint).
+    for i in 0..nelim {
+        y[node.row_indices[ff.perm[i]]] = w[i];
+    }
+}
+
+/// Serial contribution-block solve core (single RHS). Bit-identical to
+/// the parallel CB core; the default `solve_sparse` path is unaffected.
+fn solve_sparse_cb_core_serial(factors: &SparseFactors, rhs: &[f64], x_out: &mut [f64]) {
+    let n = factors.n;
+    let nodes = &factors.node_factors;
+    let n_nodes = nodes.len();
+
+    let mut y = vec![0.0f64; n];
+    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+        y[new_idx] = rhs[old_idx];
+    }
+
+    let children = build_children(&factors.node_parents, n_nodes);
+    let max_nrow = nodes
+        .iter()
+        .map(|nd| nd.frontal_factors.nrow)
+        .max()
+        .unwrap_or(0);
+    let mut row_map = vec![usize::MAX; n];
+    let mut w = vec![0.0f64; max_nrow];
+    let mut contribs: Vec<Option<FwdContrib>> = (0..n_nodes).map(|_| None).collect();
+
+    // Forward: postorder (node_factors order) already lists children
+    // before parents, so every child's contribution is ready when its
+    // parent is reached — a serial linearisation of the leaves-up order.
+    for idx in 0..n_nodes {
+        let contrib = cb_forward_front(
+            &nodes[idx],
+            &children[idx],
+            &mut y,
+            &mut row_map,
+            &mut w,
+            |c| contribs[c].take(),
+            nodes,
+        );
+        contribs[idx] = contrib;
+    }
+
+    // Backward: reverse postorder (parents before children).
+    for node in nodes.iter().rev() {
+        cb_backward_front(node, &mut y, &mut w);
+    }
+
+    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+        x_out[old_idx] = y[new_idx];
+    }
+}
+
+/// `*mut f64` wrapper that is `Send`+`Sync` so rayon tasks can write the
+/// shared global solution vector `y` at **disjoint** indices. Safety is
+/// established by the callers below, not by this type.
+#[derive(Clone, Copy)]
+struct YPtr(*mut f64);
+// SAFETY: `YPtr` only ever hands out writes to disjoint `y` indices
+// (each global row is eliminated at exactly one front, and a front writes
+// only its own eliminated rows) and reads that are ordered after the
+// writing front by the task-dependency graph, so no two threads touch the
+// same element concurrently.
+unsafe impl Send for YPtr {}
+unsafe impl Sync for YPtr {}
+
+/// Per-worker forward scratch: `row_map` (length `n`, all `usize::MAX`
+/// between fronts) and `w` (length `max_nrow`).
+struct CbScratch {
+    row_map: Vec<usize>,
+    w: Vec<f64>,
+}
+
+/// Parallel contribution-block solve core (single RHS). Byte-identical to
+/// `solve_sparse_cb_core_serial`: the child-reduction order is fixed
+/// (ascending child index) regardless of thread scheduling.
+fn solve_sparse_cb_core_parallel(factors: &SparseFactors, rhs: &[f64], x_out: &mut [f64]) {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    let n = factors.n;
+    let nodes = &factors.node_factors;
+    let n_nodes = nodes.len();
+
+    let mut y = vec![0.0f64; n];
+    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+        y[new_idx] = rhs[old_idx];
+    }
+
+    let children = build_children(&factors.node_parents, n_nodes);
+    let parents = &factors.node_parents;
+    let max_nrow = nodes
+        .iter()
+        .map(|nd| nd.frontal_factors.nrow)
+        .max()
+        .unwrap_or(0);
+
+    // --- Coarsening: cut the assembly tree into subtrees at a cost
+    // threshold so each rayon task carries a whole light subtree serially
+    // (per-node tasks are far too fine — the solve work per front is tiny
+    // beside rayon's spawn/lock overhead). This changes only *which
+    // thread* runs a front, never the order contributions are summed into
+    // any parent, so it stays byte-identical to the serial CB core.
+    let plan = CbTaskPlan::build(&children, parents, nodes, n_nodes);
+
+    // When the tree offers too little independent work (path-like /
+    // single-front, or one front dominates by Amdahl, or the solve is too
+    // small to amortize scratch setup), the parallel machinery is pure
+    // overhead — run the byte-identical serial core instead.
+    if !plan.worthwhile {
+        solve_sparse_cb_core_serial(factors, rhs, x_out);
+        return;
+    }
+
+    // Per-worker scratch (one per rayon worker + one for the calling
+    // thread, whose `current_thread_index()` is `None`).
+    let num_threads = rayon::current_num_threads().max(1);
+    let scratch: Vec<Mutex<CbScratch>> = (0..num_threads + 1)
+        .map(|_| {
+            Mutex::new(CbScratch {
+                row_map: vec![usize::MAX; n],
+                w: vec![0.0f64; max_nrow],
+            })
+        })
+        .collect();
+
+    let contribs: Mutex<Vec<Option<FwdContrib>>> = Mutex::new((0..n_nodes).map(|_| None).collect());
+
+    // ---- Forward: task-roots processed leaves-up ----
+    let pending_fwd: Vec<AtomicUsize> = plan
+        .pending_fwd
+        .iter()
+        .map(|&c| AtomicUsize::new(c))
+        .collect();
+    {
+        let y_ptr = YPtr(y.as_mut_ptr());
+        let ctx = CbCtx {
+            nodes,
+            children: &children,
+            parents,
+            plan: &plan,
+            contribs: &contribs,
+            scratch: &scratch,
+            y_ptr,
+            n,
+            num_threads,
+        };
+        rayon::scope(|scope| {
+            for &t in &plan.fwd_seeds {
+                cb_fwd_task(scope, t, &ctx, &pending_fwd);
+            }
+        });
+    }
+
+    // ---- Backward: task-roots processed root-down ----
+    {
+        let y_ptr = YPtr(y.as_mut_ptr());
+        let ctx = CbCtx {
+            nodes,
+            children: &children,
+            parents,
+            plan: &plan,
+            contribs: &contribs,
+            scratch: &scratch,
+            y_ptr,
+            n,
+            num_threads,
+        };
+        rayon::scope(|scope| {
+            for &t in &plan.bwd_seeds {
+                cb_bwd_task(scope, t, &ctx);
+            }
+        });
+    }
+
+    for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
+        x_out[old_idx] = y[new_idx];
+    }
+}
+
+/// Coarsening plan: the top portion of the assembly tree is cut into
+/// "task roots"; each task root owns the contiguous postorder block of
+/// its light (below-threshold) descendants and runs them serially.
+struct CbTaskPlan {
+    /// `owned[t]` = node indices assigned to task root `t`, ascending
+    /// (postorder). Empty for non-task-root nodes.
+    owned: Vec<Vec<usize>>,
+    /// Task roots that have no task-root children (forward seeds).
+    fwd_seeds: Vec<usize>,
+    /// Task roots that have no parent (whole-tree roots; backward seeds).
+    bwd_seeds: Vec<usize>,
+    /// Direct task-root children of each task root (backward spawns).
+    tr_children: Vec<Vec<usize>>,
+    /// Forward pending count per task root = number of task-root children.
+    pending_fwd: Vec<usize>,
+    /// Whether each node is a task root.
+    is_task_root: Vec<bool>,
+    /// Whether tree-parallel execution is expected to beat the serial
+    /// core: at least two independent task roots, and no single task
+    /// root's serial share dominates (Amdahl), and enough total work to
+    /// amortize the O(threads·n) scratch setup. When false the caller
+    /// runs the serial core.
+    worthwhile: bool,
+}
+
+impl CbTaskPlan {
+    fn build(
+        children: &[Vec<usize>],
+        parents: &[Option<usize>],
+        nodes: &[NodeFactors],
+        n_nodes: usize,
+    ) -> Self {
+        // Per-front solve cost ~ nrow·(nelim+1) (forward L-solve +
+        // backward Lᵀ-solve are both O(nrow·nelim)); saturating.
+        let own_cost = |i: usize| -> u64 {
+            let ff = &nodes[i].frontal_factors;
+            (ff.nrow as u64).saturating_mul(ff.nelim as u64 + 1)
+        };
+        // Subtree cost bottom-up (node_factors is postorder ⇒ children
+        // precede parents).
+        let mut subtree_cost = vec![0u64; n_nodes];
+        let mut total = 0u64;
+        for i in 0..n_nodes {
+            let mut c = own_cost(i);
+            for &ch in &children[i] {
+                c = c.saturating_add(subtree_cost[ch]);
+            }
+            subtree_cost[i] = c;
+            total = total.saturating_add(own_cost(i));
+        }
+        // Threshold: aim for ~16 task roots per worker so the pool stays
+        // fed without per-node overhead. `FERAL_CB_THRESH` overrides.
+        let num_threads = rayon::current_num_threads().max(1);
+        let thresh: u64 = std::env::var("FERAL_CB_THRESH")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| (total / (num_threads as u64 * 16)).max(1));
+
+        let is_task_root: Vec<bool> = (0..n_nodes)
+            .map(|i| parents[i].is_none() || subtree_cost[i] >= thresh)
+            .collect();
+
+        // Owner = nearest task-root ancestor (self if task root). Process
+        // descending idx so each parent (higher idx) is set first.
+        let mut owner = vec![0usize; n_nodes];
+        for i in (0..n_nodes).rev() {
+            // A non-task-root always has a parent (roots are forced task
+            // roots), whose owner is already computed (higher idx). The
+            // `unwrap_or(i)` is an unreachable belt-and-braces fallback
+            // that keeps this `unwrap`-free.
+            owner[i] = match (is_task_root[i], parents[i]) {
+                (true, _) => i,
+                (false, Some(p)) => owner[p],
+                (false, None) => i,
+            };
+        }
+        let mut owned: Vec<Vec<usize>> = vec![Vec::new(); n_nodes];
+        for i in 0..n_nodes {
+            owned[owner[i]].push(i);
+        }
+
+        // Task-root children (a task root's parent is always a task root,
+        // by subtree-cost monotonicity, so these are direct children).
+        let mut tr_children: Vec<Vec<usize>> = vec![Vec::new(); n_nodes];
+        let mut pending_fwd = vec![0usize; n_nodes];
+        for i in 0..n_nodes {
+            if !is_task_root[i] {
+                continue;
+            }
+            for &ch in &children[i] {
+                if is_task_root[ch] {
+                    tr_children[i].push(ch);
+                    pending_fwd[i] += 1;
+                }
+            }
+        }
+        let fwd_seeds: Vec<usize> = (0..n_nodes)
+            .filter(|&i| is_task_root[i] && pending_fwd[i] == 0)
+            .collect();
+        let bwd_seeds: Vec<usize> = (0..n_nodes)
+            .filter(|&i| is_task_root[i] && parents[i].is_none())
+            .collect();
+
+        // Worthwhile gate. `local_cost[t] = subtree_cost[t] − Σ task-root
+        // children subtree_cost` is the serial work task root `t` runs
+        // itself; if the largest such share is most of the total, Amdahl
+        // caps the speedup and the parallel overhead dominates (e.g. an
+        // arrow front whose huge root front is one serial task). Also
+        // require enough total work to amortize the scratch setup.
+        let mut max_local = 0u64;
+        for t in 0..n_nodes {
+            if !is_task_root[t] {
+                continue;
+            }
+            let mut local = subtree_cost[t];
+            for &c in &tr_children[t] {
+                local = local.saturating_sub(subtree_cost[c]);
+            }
+            max_local = max_local.max(local);
+        }
+        // ~1e6 flops ≈ tens of µs of solve, the floor below which the
+        // O(threads·n) scratch alloc + rayon scope is not amortized.
+        const MIN_TOTAL_COST: u64 = 1_000_000;
+        let worthwhile = fwd_seeds.len() >= 2
+            && total >= MIN_TOTAL_COST
+            && (max_local as f64) < 0.7 * (total as f64);
+
+        CbTaskPlan {
+            owned,
+            fwd_seeds,
+            bwd_seeds,
+            tr_children,
+            pending_fwd,
+            is_task_root,
+            worthwhile,
+        }
+    }
+}
+
+/// Shared, read-only context threaded through the CB solve tasks.
+#[derive(Clone, Copy)]
+struct CbCtx<'a> {
+    nodes: &'a [NodeFactors],
+    children: &'a [Vec<usize>],
+    parents: &'a [Option<usize>],
+    plan: &'a CbTaskPlan,
+    contribs: &'a std::sync::Mutex<Vec<Option<FwdContrib>>>,
+    scratch: &'a [std::sync::Mutex<CbScratch>],
+    y_ptr: YPtr,
+    n: usize,
+    num_threads: usize,
+}
+
+/// Pick a per-worker scratch slot: the rayon worker index, or the extra
+/// slot `num_threads` for the calling thread (`current_thread_index() ==
+/// None`).
+#[inline]
+fn cb_scratch_slot(num_threads: usize) -> usize {
+    rayon::current_thread_index().unwrap_or(num_threads)
+}
+
+fn cb_fwd_task<'a>(
+    scope: &rayon::Scope<'a>,
+    t: usize,
+    ctx: &CbCtx<'a>,
+    pending_fwd: &'a [std::sync::atomic::AtomicUsize],
+) {
+    use std::sync::atomic::Ordering;
+    let ctx = *ctx;
+    scope.spawn(move |s| {
+        {
+            let slot = cb_scratch_slot(ctx.num_threads);
+            let mut sc = ctx.scratch[slot].lock().unwrap_or_else(|p| p.into_inner());
+            let CbScratch { row_map, w } = &mut *sc;
+            // SAFETY: every front in this task writes only its own
+            // eliminated global rows — disjoint across all fronts (each row
+            // is eliminated once) — and reads `b` only at those same rows,
+            // which no other live task touches. Length `n`; row indices are
+            // in `[0, n)`.
+            let y: &mut [f64] = unsafe { std::slice::from_raw_parts_mut(ctx.y_ptr.0, ctx.n) };
+            // Process this task root's owned subtree serially, leaves-up
+            // (owned is ascending = postorder), so every child's
+            // contribution — light (in `owned`, already processed) or a
+            // task-root child (done via the pending gate) — is ready.
+            for &j in &ctx.plan.owned[t] {
+                let contrib = cb_forward_front(
+                    &ctx.nodes[j],
+                    &ctx.children[j],
+                    y,
+                    row_map,
+                    w,
+                    |c| ctx.contribs.lock().unwrap_or_else(|p| p.into_inner())[c].take(),
+                    ctx.nodes,
+                );
+                ctx.contribs.lock().unwrap_or_else(|p| p.into_inner())[j] = contrib;
+            }
+        }
+        // Signal the parent task root; spawn it when all its task-root
+        // children are done.
+        if let Some(p) = ctx.parents[t] {
+            debug_assert!(ctx.plan.is_task_root[p]);
+            if pending_fwd[p].fetch_sub(1, Ordering::AcqRel) == 1 {
+                cb_fwd_task(s, p, &ctx, pending_fwd);
+            }
+        }
+    });
+}
+
+fn cb_bwd_task<'a>(scope: &rayon::Scope<'a>, t: usize, ctx: &CbCtx<'a>) {
+    let ctx = *ctx;
+    scope.spawn(move |s| {
+        {
+            let slot = cb_scratch_slot(ctx.num_threads);
+            let mut sc = ctx.scratch[slot].lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: every front writes only its own eliminated global
+            // rows (disjoint across fronts) and reads separator rows
+            // written by ancestor fronts — those in this task's owned set
+            // (processed earlier, this task) or in the parent task root
+            // (completed before this task was spawned, root-down
+            // dependency). Length `n`; row indices in `[0, n)`.
+            let y: &mut [f64] = unsafe { std::slice::from_raw_parts_mut(ctx.y_ptr.0, ctx.n) };
+            // Root-down within the owned subtree: descending idx = reverse
+            // postorder (parents before children).
+            for &j in ctx.plan.owned[t].iter().rev() {
+                cb_backward_front(&ctx.nodes[j], y, &mut sc.w);
+            }
+        }
+        // This task root is done ⇒ its task-root children may run.
+        for &c in &ctx.plan.tr_children[t] {
+            cb_bwd_task(s, c, &ctx);
+        }
+    });
+}
+
+/// Opt-in contribution-block sparse solve (issue #131 Gap A), single RHS.
+/// Applies the same MC64 pre/post scaling as `solve_sparse`. `parallel`
+/// selects the tree-parallel execution; both are byte-identical.
+pub fn solve_sparse_cb(
+    factors: &SparseFactors,
+    rhs: &[f64],
+    parallel: bool,
+) -> Result<Vec<f64>, FeralError> {
+    let n = factors.n;
+    if rhs.len() != n {
+        return Err(FeralError::DimensionMismatch {
+            expected: n,
+            got: rhs.len(),
+        });
+    }
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+
+    let needs_scaling = !matches!(factors.scaling_info, ScalingInfo::NotApplied);
+    let scaled: Vec<f64>;
+    let rhs_for_core: &[f64] = if needs_scaling {
+        scaled = (0..n).map(|i| rhs[i] * factors.scaling[i]).collect();
+        &scaled
+    } else {
+        rhs
+    };
+
+    let mut x = vec![0.0f64; n];
+    if parallel {
+        solve_sparse_cb_core_parallel(factors, rhs_for_core, &mut x);
+    } else {
+        solve_sparse_cb_core_serial(factors, rhs_for_core, &mut x);
+    }
+
+    if needs_scaling {
+        for i in 0..n {
+            x[i] *= factors.scaling[i];
+        }
+    }
+    Ok(x)
 }
 
 /// Workspace for `solve_sparse_many_into`. Sized for `nrhs` columns

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -1964,6 +1964,7 @@ mod tests {
             static_pivot_threshold: None,
             warn_partial_singular: false,
             pattern_reused_hint: false,
+            use_static_row_indices: true,
         };
         Solver::with_params(np, SupernodeParams::default())
     }

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -19,7 +19,7 @@ use crate::numeric::factorize::{
 };
 use crate::numeric::solve::{
     solve_sparse, solve_sparse_many, solve_sparse_many_refined, solve_sparse_refined,
-    BLAS3_REFINE_THRESHOLD,
+    solve_sparse_refined_parallel, BLAS3_REFINE_THRESHOLD,
 };
 use crate::scaling::{
     mc64_value_bound_passes, pick_scaling_strategy, precompute_mc64_validity, Mc64CacheValidity,
@@ -1525,9 +1525,25 @@ impl Solver {
     /// and the stored factor. Returns `FeralError::NoFactor` if no
     /// factor is stored.
     pub fn solve_refined(&self, matrix: &CscMatrix, rhs: &[f64]) -> Result<Vec<f64>, FeralError> {
-        match &self.last_factors {
-            Some(f) => solve_sparse_refined(matrix, f, rhs),
-            None => Err(FeralError::NoFactor),
+        let f = match &self.last_factors {
+            Some(f) => f,
+            None => return Err(FeralError::NoFactor),
+        };
+        // Issue #131 Gap A: when parallelism is on, refine through the
+        // tree-parallel contribution-block solve (pooled across the
+        // initial + correction solves). It self-gates per factor — on
+        // path-like / small trees it runs the serial core, matching the
+        // default path's behavior. Install on this solver's pool (built
+        // during the parallel factor) so the solve uses the same worker
+        // count and does not oversubscribe; fall through to the global
+        // pool if none was built.
+        if self.use_parallel {
+            match &self.parallel_pool {
+                Some(pool) => pool.install(|| solve_sparse_refined_parallel(matrix, f, rhs)),
+                None => solve_sparse_refined_parallel(matrix, f, rhs),
+            }
+        } else {
+            solve_sparse_refined(matrix, f, rhs)
         }
     }
 
@@ -1581,7 +1597,17 @@ impl Solver {
         let mut out = vec![0.0; n * nrhs];
         for c in 0..nrhs {
             let src = &rhs[c * n..(c + 1) * n];
-            let xc = solve_sparse_refined(matrix, factors, src)?;
+            // Same #131 Gap A dispatch as `solve_refined` (per column).
+            let xc = if self.use_parallel {
+                match &self.parallel_pool {
+                    Some(pool) => {
+                        pool.install(|| solve_sparse_refined_parallel(matrix, factors, src))
+                    }
+                    None => solve_sparse_refined_parallel(matrix, factors, src),
+                }
+            } else {
+                solve_sparse_refined(matrix, factors, src)
+            }?;
             out[c * n..(c + 1) * n].copy_from_slice(&xc);
         }
         Ok(out)

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -452,6 +452,22 @@ pub struct SymbolicFactorization {
     /// `supernodes.len()`.
     pub snode_group: Vec<Option<usize>>,
 
+    /// Issue #125: precomputed static frontal row layout per supernode,
+    /// stored CSR-style as `static_row_flat[static_row_offsets[i] ..
+    /// static_row_offsets[i + 1]]`. Each slice is `[own columns |
+    /// sorted trailing rows]` — bit-for-bit the output of the numeric
+    /// `build_row_indices` **when no pivots are delayed into this node**
+    /// (`n_delayed_in == 0`). The numeric phase reads these directly on
+    /// the no-delay fast path (the common case) instead of re-scanning
+    /// the pattern and re-sorting the trailing set every factorization;
+    /// delayed-pivot fronts fall back to `build_row_indices`. Computed
+    /// in one postorder pass (supernodes are child-before-parent). See
+    /// `dev/research/issue-131-parallelism-design-2026-07-10.md`.
+    pub static_row_offsets: Vec<usize>,
+    /// Flat backing store for [`Self::static_row_offsets`]; length
+    /// `static_row_offsets.last()`.
+    pub static_row_flat: Vec<usize>,
+
     /// Cached MC64 matching produced by the `LdltCompress`
     /// preprocessor. When `Some`, the numeric phase reuses it to
     /// derive the `Mc64Symmetric` scaling vector in O(n) instead of
@@ -484,6 +500,114 @@ pub struct SymbolicFactorization {
     /// to enforce the per-front NPIV ≤ NASS − NVSCHUR stopping rule
     /// (F3.2b).
     pub is_schur_tail: Option<usize>,
+}
+
+impl SymbolicFactorization {
+    /// Issue #125: the precomputed static frontal row layout for
+    /// supernode `i` (`[own columns | sorted trailing rows]`). Valid to
+    /// use directly at numeric time only when `n_delayed_in == 0` for
+    /// that node; see [`Self::static_row_offsets`]. Returns an empty
+    /// slice if the maps were not populated (older ad-hoc constructors).
+    #[inline]
+    pub fn static_rows(&self, i: usize) -> &[usize] {
+        if i + 1 < self.static_row_offsets.len() {
+            let start = self.static_row_offsets[i];
+            let end = self.static_row_offsets[i + 1];
+            &self.static_row_flat[start..end]
+        } else {
+            &[]
+        }
+    }
+}
+
+/// Issue #125: precompute each supernode's static frontal row layout —
+/// `[own columns | sorted trailing rows]` — matching the numeric
+/// `build_row_indices` output for the no-delay case bit-for-bit.
+///
+/// Runs one postorder pass over `supernodes` (already ordered
+/// child-before-parent). For each node the trailing set is the
+/// seen-deduped union of (a) the node's own columns' reach in the
+/// symmetric `permuted_pattern` and (b) each child's static separator
+/// (the child's own trailing slice), both filtered to rows `>= own_last`
+/// and then sorted — identical to `build_row_indices`, whose trailing
+/// set is likewise a sorted seen-dedup independent of numeric pivot
+/// order. Returned CSR-style as `(offsets, flat)`.
+fn compute_static_row_indices(
+    supernodes: &[Supernode],
+    permuted_pattern: &CscPattern,
+) -> (Vec<usize>, Vec<usize>) {
+    let n = permuted_pattern.n;
+    let n_snodes = supernodes.len();
+    let mut offsets: Vec<usize> = Vec::with_capacity(n_snodes + 1);
+    offsets.push(0);
+    let mut flat: Vec<usize> = Vec::new();
+    // Start of each node's trailing (separator) slice within `flat`, so a
+    // parent reads a child's separator without recomputing it.
+    let mut sep_start: Vec<usize> = vec![0; n_snodes];
+    // Shared seen-bitmap, maintained all-`false` between nodes (mirrors
+    // `build_seen` in `build_row_indices`).
+    let mut seen: Vec<bool> = vec![false; n];
+    let mut trailing: Vec<usize> = Vec::new();
+
+    for (idx, snode) in supernodes.iter().enumerate() {
+        let first_col = snode.first_col;
+        let own_ncol = snode.ncol();
+        let own_last = first_col + own_ncol;
+
+        // Mark own columns "fully summed" so the trailing scan skips them.
+        for seen_c in seen.iter_mut().skip(first_col).take(own_ncol) {
+            *seen_c = true;
+        }
+
+        trailing.clear();
+        // (a) Own columns' reach in the symmetric pattern.
+        for j in first_col..own_last {
+            for k in permuted_pattern.col_ptr[j]..permuted_pattern.col_ptr[j + 1] {
+                let r = permuted_pattern.row_idx[k];
+                if r < own_last {
+                    continue;
+                }
+                if !seen[r] {
+                    seen[r] = true;
+                    trailing.push(r);
+                }
+            }
+        }
+        // (b) Each child's static separator (its trailing slice).
+        for &child_idx in &snode.children {
+            if child_idx >= n_snodes {
+                continue;
+            }
+            let cs = sep_start[child_idx];
+            let ce = offsets[child_idx + 1];
+            for &r in &flat[cs..ce] {
+                if r < own_last {
+                    continue;
+                }
+                if !seen[r] {
+                    seen[r] = true;
+                    trailing.push(r);
+                }
+            }
+        }
+        trailing.sort_unstable();
+
+        // Emit `[own columns | sorted trailing]`.
+        flat.extend(first_col..own_last);
+        sep_start[idx] = flat.len();
+        flat.extend_from_slice(&trailing);
+        offsets.push(flat.len());
+
+        // Restore the all-`false` invariant on `seen`.
+        for seen_c in seen.iter_mut().skip(first_col).take(own_ncol) {
+            *seen_c = false;
+        }
+        for &r in &trailing {
+            seen[r] = false;
+        }
+    }
+
+    (offsets, flat)
 }
 
 /// Size-only base ordering rule from cheap matrix dimensions (no pattern
@@ -1245,6 +1369,14 @@ pub fn symbolic_factorize_with_method(
 
     let factor_slack = 1.2;
 
+    // Issue #125: static frontal row layout (numeric no-delay fast path).
+    let t_sr = prof.map(|_| std::time::Instant::now());
+    let (static_row_offsets, static_row_flat) =
+        compute_static_row_indices(&supernodes, &permuted_pattern);
+    if let Some(t) = t_sr {
+        record_stage(prof, "static_row_indices", t);
+    }
+
     if let (Some(arc), Some(t)) = (prof, t_total) {
         if let Ok(mut p) = arc.lock() {
             p.set_total(t.elapsed().as_micros() as u64);
@@ -1265,6 +1397,8 @@ pub fn symbolic_factorize_with_method(
         col_counts,
         small_leaf_groups,
         snode_group,
+        static_row_offsets,
+        static_row_flat,
         cached_mc64,
         resolved_method,
         resolved_amalgamation: snode_params.amalgamation_strategy,
@@ -1445,6 +1579,10 @@ pub fn symbolic_factorize_with_schur(
 
     let factor_slack = 1.2;
 
+    // Issue #125: static frontal row layout (numeric no-delay fast path).
+    let (static_row_offsets, static_row_flat) =
+        compute_static_row_indices(&supernodes, &permuted_pattern);
+
     Ok(SymbolicFactorization {
         n,
         perm,
@@ -1459,6 +1597,8 @@ pub fn symbolic_factorize_with_schur(
         col_counts,
         small_leaf_groups,
         snode_group,
+        static_row_offsets,
+        static_row_flat,
         cached_mc64: None,
         resolved_method: OrderingMethod::Amd,
         resolved_amalgamation: effective_params.amalgamation_strategy,

--- a/tests/cb_solve_parity.rs
+++ b/tests/cb_solve_parity.rs
@@ -1,0 +1,228 @@
+//! Issue #131 Gap A — contribution-block (tree-parallel) sparse solve.
+//!
+//! Contracts checked:
+//!  1. **serial-CB == parallel-CB, byte-identical** (`to_bits`) — the
+//!     #131 bit-exactness contract: the child-reduction order is fixed
+//!     (ascending child index), so thread scheduling cannot change a bit.
+//!  2. **determinism** — repeated parallel runs are byte-identical.
+//!  3. **valid solve** — the CB solution's relative residual is tiny, and
+//!     it matches the default `solve_sparse` to ~κ·eps (the CB forward
+//!     groups contributions by subtree, a valid reassociation of the
+//!     default's flat postorder fold).
+//!  4. Coverage: SPD chains/grids, a KKT saddle that delays pivots (the
+//!     data-flow risk area), and a disjoint forest (multiple roots).
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::numeric::solve::{solve_sparse, solve_sparse_cb};
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        pivot_threshold: 0.0,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+fn tridiag_spd(n: usize) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for i in 0..n {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < n {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiag")
+}
+
+fn poisson_2d_spd(k: usize) -> CscMatrix {
+    let n = k * k;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..k {
+        for i in 0..k {
+            let p = j * k + i;
+            rows.push(p);
+            cols.push(p);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(p + 1);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(p + k);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("poisson_2d")
+}
+
+fn small_kkt_saddle(m: usize, k: usize) -> CscMatrix {
+    assert!(k <= m);
+    let n = m + k;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for i in 0..m {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < m {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+    }
+    for j in 0..k {
+        rows.push(m + j);
+        cols.push(j);
+        vals.push(1.0);
+        if j + 1 < m {
+            rows.push(m + j);
+            cols.push(j + 1);
+            vals.push(-1.0);
+        }
+    }
+    for j in 0..k {
+        rows.push(m + j);
+        cols.push(m + j);
+        vals.push(-1e-8);
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("kkt")
+}
+
+fn disjoint_tridiag(n_block: usize) -> CscMatrix {
+    let n = 2 * n_block;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for block in 0..2 {
+        let off = block * n_block;
+        for i in 0..n_block {
+            rows.push(off + i);
+            cols.push(off + i);
+            vals.push(4.0);
+            if i + 1 < n_block {
+                rows.push(off + i + 1);
+                cols.push(off + i);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("disjoint_tridiag")
+}
+
+fn rel_residual(m: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = m.n;
+    let mut ax = vec![0.0; n];
+    m.symv(x, &mut ax);
+    let mut r2 = 0.0;
+    let mut b2 = 0.0;
+    for i in 0..n {
+        r2 += (ax[i] - b[i]).powi(2);
+        b2 += b[i] * b[i];
+    }
+    (r2 / b2.max(1e-300)).sqrt()
+}
+
+fn max_rel_diff(a: &[f64], b: &[f64]) -> f64 {
+    let mut num = 0.0f64;
+    let mut den = 0.0f64;
+    for i in 0..a.len() {
+        num = num.max((a[i] - b[i]).abs());
+        den = den.max(a[i].abs());
+    }
+    num / den.max(1.0)
+}
+
+fn check(matrix: &CscMatrix, label: &str) {
+    let sym = symbolic_factorize(matrix, &SupernodeParams::default()).unwrap();
+    let (factors, _) = factorize_multifrontal(matrix, &sym, &ldlt_params()).unwrap();
+    let n = matrix.n;
+    let b: Vec<f64> = (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect();
+
+    let x_default = solve_sparse(&factors, &b).unwrap();
+    let x_cb_serial = solve_sparse_cb(&factors, &b, false).unwrap();
+    let x_cb_par = solve_sparse_cb(&factors, &b, true).unwrap();
+    let x_cb_par2 = solve_sparse_cb(&factors, &b, true).unwrap();
+
+    // 1. serial-CB == parallel-CB, byte-identical.
+    for i in 0..n {
+        assert_eq!(
+            x_cb_serial[i].to_bits(),
+            x_cb_par[i].to_bits(),
+            "[{label}] serial-CB vs parallel-CB differ at {i}"
+        );
+    }
+    // 2. determinism across parallel runs.
+    for i in 0..n {
+        assert_eq!(
+            x_cb_par[i].to_bits(),
+            x_cb_par2[i].to_bits(),
+            "[{label}] parallel-CB not deterministic at {i}"
+        );
+    }
+    // 3a. CB is a valid solve — no worse than the proven default path
+    // (both are unrefined solves of the same factor; an indefinite KKT
+    // saddle has a raw residual set by its conditioning, not the solve).
+    let res_cb = rel_residual(matrix, &x_cb_serial, &b);
+    let res_def = rel_residual(matrix, &x_default, &b);
+    assert!(
+        res_cb <= 10.0 * res_def + 1e-12,
+        "[{label}] CB residual {res_cb:e} >> default {res_def:e}"
+    );
+    // 3b. CB matches the default solve to a reassociation (~κ·eps). The
+    // KKT saddle's small (2,2) block amplifies the reassociation, so scale
+    // the bound by the default solve's own residual (its conditioning).
+    let d = max_rel_diff(&x_default, &x_cb_serial);
+    assert!(
+        d < (1e-9_f64).max(100.0 * res_def),
+        "[{label}] CB vs default solve diff too large: {d:e} (res_def {res_def:e})"
+    );
+}
+
+#[test]
+fn cb_parity_tridiag_120() {
+    check(&tridiag_spd(120), "tridiag_120");
+}
+
+#[test]
+fn cb_parity_poisson_2d_10x10() {
+    check(&poisson_2d_spd(10), "poisson_2d_10x10");
+}
+
+#[test]
+fn cb_parity_kkt_saddle_with_delays() {
+    check(&small_kkt_saddle(60, 15), "kkt_saddle_75");
+}
+
+#[test]
+fn cb_parity_disjoint_tridiag() {
+    check(&disjoint_tridiag(40), "disjoint_tridiag_80");
+}
+
+#[test]
+fn cb_parity_poisson_2d_96x96_concurrent() {
+    // n = 9216: large + bushy enough to clear the `worthwhile` gate, so
+    // this exercises the actual tree-parallel task path (not the serial
+    // fallback) — the byte-identity check that matters most.
+    check(&poisson_2d_spd(96), "poisson_2d_96x96");
+}
+
+#[test]
+fn cb_parity_dense_fast_path() {
+    // n <= N_TINY routes the single-supernode dense fast path
+    // (node_parents = [None]); the CB solve must handle a lone root.
+    check(&tridiag_spd(8), "tridiag_8_dense");
+}

--- a/tests/delayed_pivoting.rs
+++ b/tests/delayed_pivoting.rs
@@ -370,6 +370,7 @@ fn delay_numeric_params() -> feral::numeric::factorize::NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/tests/pounce_interface.rs
+++ b/tests/pounce_interface.rs
@@ -469,6 +469,7 @@ fn solver_identity_scaling() -> Solver {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     };
     Solver::with_params(np, SupernodeParams::default())
 }

--- a/tests/profiler_smoke.rs
+++ b/tests/profiler_smoke.rs
@@ -58,6 +58,7 @@ fn params_with(profiler: Option<Arc<Mutex<Profiler>>>) -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/tests/small_leaf_parity.rs
+++ b/tests/small_leaf_parity.rs
@@ -55,6 +55,7 @@ fn params_off() -> NumericParams {
         static_pivot_threshold: None,
         warn_partial_singular: false,
         pattern_reused_hint: false,
+        use_static_row_indices: true,
     }
 }
 

--- a/tests/static_assembly_maps.rs
+++ b/tests/static_assembly_maps.rs
@@ -1,0 +1,332 @@
+//! Issue #125: precomputed static assembly maps
+//! (`SymbolicFactorization::static_rows`).
+//!
+//! Two guarantees:
+//!
+//!  1. **A/B equivalence** — factoring with the static fast path enabled
+//!     (`use_static_row_indices = true`, the default) produces a
+//!     **byte-identical** factor to factoring with it disabled (which
+//!     forces the `build_row_indices` path). This is the real
+//!     correctness contract: the static layout must reproduce
+//!     `build_row_indices`' output bit-for-bit on the no-delay fast
+//!     path, and fall back cleanly on delayed-pivot fronts. Covers SPD,
+//!     KKT-indefinite (delayed pivots), and disjoint-forest patterns.
+//!
+//!  2. **Independent structural oracle** — the static layout equals a
+//!     from-scratch `BTreeSet`-based recompute over the *public*
+//!     symbolic data (own-column pattern reach ∪ children's separators,
+//!     filtered to `>= own_last`, sorted). This is a different
+//!     implementation of the same spec than `compute_static_row_indices`
+//!     (seen-array + flat CSR), so it catches an error in either.
+
+use std::collections::BTreeSet;
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::symbolic::{symbolic_factorize, SupernodeParams, SymbolicFactorization};
+use feral::{BunchKaufmanParams, CscMatrix, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        pivot_threshold: 0.0,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+// ----- fixtures (mirror build_row_indices_trailing_invariant.rs) -----
+
+fn tridiag_spd(n: usize) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for i in 0..n {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < n {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiag")
+}
+
+fn poisson_2d_spd(k: usize) -> CscMatrix {
+    let n = k * k;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..k {
+        for i in 0..k {
+            let p = j * k + i;
+            rows.push(p);
+            cols.push(p);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(p + 1);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(p + k);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("poisson_2d")
+}
+
+/// KKT saddle with equality regularization that exercises delayed
+/// pivoting (the (2,2) block is tiny-negative, so BK will delay some
+/// pivots up the tree — the path where the static map must fall back to
+/// `build_row_indices`).
+fn small_kkt_saddle(m: usize, k: usize) -> CscMatrix {
+    assert!(k <= m);
+    let n = m + k;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for i in 0..m {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < m {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+    }
+    for j in 0..k {
+        rows.push(m + j);
+        cols.push(j);
+        vals.push(1.0);
+        if j + 1 < m {
+            rows.push(m + j);
+            cols.push(j + 1);
+            vals.push(-1.0);
+        }
+    }
+    for j in 0..k {
+        rows.push(m + j);
+        cols.push(m + j);
+        vals.push(-1e-8);
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("kkt")
+}
+
+fn disjoint_tridiag(n_block: usize) -> CscMatrix {
+    let n = 2 * n_block;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for block in 0..2 {
+        let off = block * n_block;
+        for i in 0..n_block {
+            rows.push(off + i);
+            cols.push(off + i);
+            vals.push(4.0);
+            if i + 1 < n_block {
+                rows.push(off + i + 1);
+                cols.push(off + i);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("disjoint_tridiag")
+}
+
+// ----- 1. A/B byte-identical equivalence -----
+
+/// Factor twice — static fast path on vs off — and assert the two
+/// factors are byte-identical (structure and every stored f64) and the
+/// inertia matches.
+fn assert_static_ab_identical(matrix: &CscMatrix, label: &str) {
+    let sym = symbolic_factorize(matrix, &SupernodeParams::default()).unwrap();
+
+    let mut p_on = ldlt_params();
+    p_on.use_static_row_indices = true;
+    let mut p_off = ldlt_params();
+    p_off.use_static_row_indices = false;
+
+    let (f_on, i_on) = factorize_multifrontal(matrix, &sym, &p_on).unwrap();
+    let (f_off, i_off) = factorize_multifrontal(matrix, &sym, &p_off).unwrap();
+
+    assert_eq!(
+        i_on, i_off,
+        "[{label}] inertia differs static-on vs static-off"
+    );
+    assert_eq!(
+        f_on.node_factors.len(),
+        f_off.node_factors.len(),
+        "[{label}] node count differs"
+    );
+    for (idx, (a, b)) in f_on
+        .node_factors
+        .iter()
+        .zip(f_off.node_factors.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            a.row_indices, b.row_indices,
+            "[{label}] node {idx} row_indices differ"
+        );
+        assert_eq!(a.nrow, b.nrow, "[{label}] node {idx} nrow differs");
+        assert_eq!(a.nelim, b.nelim, "[{label}] node {idx} nelim differs");
+        assert_eq!(
+            a.n_delayed_in, b.n_delayed_in,
+            "[{label}] node {idx} n_delayed_in differs"
+        );
+        let (fa, fb) = (&a.frontal_factors, &b.frontal_factors);
+        // Bit-identical numeric arrays: the static layout must not
+        // perturb a single stored value.
+        assert!(
+            fa.l.iter()
+                .zip(fb.l.iter())
+                .all(|(x, y)| x.to_bits() == y.to_bits()),
+            "[{label}] node {idx} L differs bitwise"
+        );
+        assert!(
+            fa.d_diag
+                .iter()
+                .zip(fb.d_diag.iter())
+                .all(|(x, y)| x.to_bits() == y.to_bits()),
+            "[{label}] node {idx} d_diag differs bitwise"
+        );
+        assert!(
+            fa.d_subdiag
+                .iter()
+                .zip(fb.d_subdiag.iter())
+                .all(|(x, y)| x.to_bits() == y.to_bits()),
+            "[{label}] node {idx} d_subdiag differs bitwise"
+        );
+        assert_eq!(fa.perm, fb.perm, "[{label}] node {idx} perm differs");
+    }
+}
+
+#[test]
+fn static_ab_identical_tridiag_60() {
+    assert_static_ab_identical(&tridiag_spd(60), "tridiag_60");
+}
+
+#[test]
+fn static_ab_identical_poisson_2d_8x8() {
+    assert_static_ab_identical(&poisson_2d_spd(8), "poisson_2d_8x8");
+}
+
+#[test]
+fn static_ab_identical_kkt_saddle_with_delays() {
+    // KKT with a negative (2,2) block: delayed pivots occur, so this
+    // exercises both the static fast path (no-delay fronts) and the
+    // build_row_indices fallback (delayed fronts) in one factor.
+    assert_static_ab_identical(&small_kkt_saddle(40, 10), "kkt_saddle_50");
+}
+
+#[test]
+fn static_ab_identical_disjoint_tridiag() {
+    assert_static_ab_identical(&disjoint_tridiag(24), "disjoint_tridiag_48");
+}
+
+// ----- 2. Independent structural oracle -----
+
+/// Recompute each supernode's static row layout from scratch over the
+/// public symbolic data with a BTreeSet — a different implementation of
+/// the same spec than `compute_static_row_indices`.
+fn reference_static_rows(sym: &SymbolicFactorization) -> Vec<Vec<usize>> {
+    let pat = &sym.permuted_pattern;
+    let n_snodes = sym.supernodes.len();
+    // Per-node separator (trailing slice) once computed.
+    let mut sep: Vec<Vec<usize>> = vec![Vec::new(); n_snodes];
+    let mut out: Vec<Vec<usize>> = Vec::with_capacity(n_snodes);
+    for (idx, s) in sym.supernodes.iter().enumerate() {
+        let first_col = s.first_col;
+        let own_ncol = s.ncol();
+        let own_last = first_col + own_ncol;
+        let mut trailing: BTreeSet<usize> = BTreeSet::new();
+        // Own columns' reach in the symmetric pattern.
+        for j in first_col..own_last {
+            for k in pat.col_ptr[j]..pat.col_ptr[j + 1] {
+                let r = pat.row_idx[k];
+                if r >= own_last {
+                    trailing.insert(r);
+                }
+            }
+        }
+        // Children's separators.
+        for &c in &s.children {
+            if c >= n_snodes {
+                continue;
+            }
+            for &r in &sep[c] {
+                if r >= own_last {
+                    trailing.insert(r);
+                }
+            }
+        }
+        let trailing_vec: Vec<usize> = trailing.into_iter().collect();
+        sep[idx] = trailing_vec.clone();
+        let mut rows: Vec<usize> = (first_col..own_last).collect();
+        rows.extend_from_slice(&trailing_vec);
+        out.push(rows);
+    }
+    out
+}
+
+fn assert_static_matches_reference(matrix: &CscMatrix, label: &str) {
+    let sym = symbolic_factorize(matrix, &SupernodeParams::default()).unwrap();
+    let reference = reference_static_rows(&sym);
+    assert_eq!(
+        reference.len(),
+        sym.supernodes.len(),
+        "[{label}] reference length mismatch"
+    );
+    for (idx, ref_rows) in reference.iter().enumerate() {
+        let got = sym.static_rows(idx);
+        assert_eq!(
+            got,
+            ref_rows.as_slice(),
+            "[{label}] supernode {idx} static_rows mismatch\n  got: {got:?}\n  ref: {ref_rows:?}"
+        );
+        // Structural invariants: own cols first and in order; trailing
+        // sorted and strictly above own range.
+        let s = &sym.supernodes[idx];
+        let own_last = s.first_col + s.ncol();
+        for (k, &r) in got.iter().take(s.ncol()).enumerate() {
+            assert_eq!(
+                r,
+                s.first_col + k,
+                "[{label}] node {idx} own col {k} out of place"
+            );
+        }
+        let trailing = &got[s.ncol()..];
+        assert!(
+            trailing.windows(2).all(|w| w[0] < w[1]),
+            "[{label}] node {idx} trailing not strictly sorted: {trailing:?}"
+        );
+        assert!(
+            trailing.iter().all(|&r| r >= own_last),
+            "[{label}] node {idx} trailing has row below own_last={own_last}"
+        );
+    }
+}
+
+#[test]
+fn static_matches_reference_tridiag_60() {
+    assert_static_matches_reference(&tridiag_spd(60), "tridiag_60");
+}
+
+#[test]
+fn static_matches_reference_poisson_2d_8x8() {
+    assert_static_matches_reference(&poisson_2d_spd(8), "poisson_2d_8x8");
+}
+
+#[test]
+fn static_matches_reference_kkt_saddle() {
+    assert_static_matches_reference(&small_kkt_saddle(40, 10), "kkt_saddle_50");
+}
+
+#[test]
+fn static_matches_reference_disjoint_tridiag() {
+    assert_static_matches_reference(&disjoint_tridiag(24), "disjoint_tridiag_48");
+}


### PR DESCRIPTION
Implements issue #131 (parallelism gaps) after the session-05 measure-first pass found it — unlike #130/#132/#133 — has genuine headroom, plus its prerequisite #125. Measure-first throughout: Gap B was measured and skipped with evidence.

## What landed

### #125 — analysis-time static assembly maps (`efa1000`)
Precompute each supernode's static frontal row layout (`[own cols | sorted trailing]`) at symbolic time and read it in the numeric factor on the no-delay fast path instead of re-scanning the pattern and re-sorting the trailing set every factorization. Bit-identical factors (delayed-pivot fronts fall back to the dynamic `build_row_indices`).
- **Bench (grid220, n=48400, bushy):** per-supernode loop 164.8 → 151.6 ms (~8%), warm factor 176.0 → 168.1 ms (~4.5%). Arrow (few fronts): wash.
- Tests: A/B factor byte-identical static-on vs -off (incl. a KKT saddle that delays pivots, exercising both the fast path and the fallback); an independent BTreeSet oracle over the public symbolic data equals `static_rows(i)`.

### #131 Gap B — parallel assembly: measured not justified, not built (`93cf6ed`)
Per-front assembly is 8.3% of the factor on grid220 / 1.5% on dense1400, and in the parallel driver independent fronts' assembly already overlaps across threads — only the serial root-front O(nrow²) remains, behind the already-parallel O(nrow³) factor. <1–3% ceiling, so skipped with evidence (measure-first negative like #130/#132/#133).

### #131 Gap A — contribution-block tree-parallel solve (`c12a5d3`, `d83ca3e`, `ab4b2fc`)
- **Tree in `SparseFactors`** (`node_parents`) so the solve can order forward (leaves-up) and backward (root-down) substitution.
- **`solve_sparse_cb`** — opt-in single-RHS solve. Forward assembles each front's RHS from its children's contribution blocks in a fixed ascending order (mirroring the factor's `extend_add`), so **serial and tree-parallel runs are byte-identical**; backward keeps the default arithmetic (separator rows read-only, eliminated rows disjoint). Concurrent writes to disjoint `y` rows go through a `Send`+`Sync` raw-pointer wrapper with a disjointness safety comment.
- **Subtree-cost coarsening** (`CbTaskPlan`) — per-node rayon tasks were far too fine (grid220 = 48400 tiny tasks, no speedup); the top of the tree is cut into task roots, each running its contiguous postorder block of light descendants serially. A `worthwhile` gate falls back to the serial core on path-like / single-front / small trees (their behavior is exactly the current default path).
- **Pooled `CbSolveWorkspace` + `Solver` wiring** — caches the RHS-independent child lists + plan + scratch, so `solve_refined`'s ~11 solves reuse one workspace (no alloc churn). `Solver::solve_refined` and the per-column `solve_many_refined` loop dispatch to the parallel CB refinement when `use_parallel`, installed on the solver's own rayon pool.
- **Bench:** grid220 default solve 13.5 ms → cb_parallel 6.6 ms at 4 threads (~2.0×); **end-to-end `Solver::solve_refined` 56.0 → 29.0 ms (~1.93×)**. Path-like trees fall back, near-neutral.
- Tests (`tests/cb_solve_parity.rs`, 6, stable under `RAYON_NUM_THREADS=8`): serial-CB == parallel-CB byte-identical (incl. an n=9216 concurrent-path fixture, a KKT-with-delays factor, the dense fast path); determinism; valid solve.

The default `solve_sparse` and every existing residual baseline are unchanged; the Mehrotra predictor-corrector (nrhs=2) already benefits via the per-column refined wiring. Remaining follow-up (scoped in the session checkpoint): the batched many-RHS CB core (nrhs ≥ 16), the lowest-value slice.

## Validation
Full test suite green; `cargo fmt --check` and `cargo clippy -D warnings` clean (enforced by pre-commit). The corpus bench found no matrices in the CI container; perf numbers above are from `src/bin/perf_probe.rs` and `src/bin/probe_panel_frag.rs`.

## Notes
Design + decisions: `dev/research/issue-131-parallelism-design-2026-07-10.md`, `dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`, `dev/decisions.md`, session checkpoint `dev/sessions/2026-07-10-06.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016STCUMXB8Wd1oLqSniknFH)_