### PR TITLE
docs: merge stranded dev/ records from closed-issue branches

### DIFF
--- a/crates/feral-diagnostics/src/bin/study_latched_race.rs
+++ b/crates/feral-diagnostics/src/bin/study_latched_race.rs
@@ -1,0 +1,388 @@
+//! Issue #110 end-to-end prototype: the **latched actual-time ordering race**.
+//!
+//! §5.7 (`study_ordering_timemem`) showed no cheap symbolic proxy reaches the
+//! time-oracle, so the deterministic way to capture the §5.6 factor-time headroom is
+//! to *measure* candidate orderings on a real factor and reuse the fastest. This
+//! binary prototypes that end-to-end on real IPM iterate sequences and asks: does
+//! racing candidate orderings on the FIRST iterate, latching the fastest, and reusing
+//! it for the rest of the sequence beat `Auto` / `AutoRace` — *including* the race
+//! overhead?
+//!
+//! It drives the public `Solver` API only (no core-solver change): a latched race is
+//! just "factor iterate 0 with each candidate ordering, keep the Solver whose factor
+//! was fastest, and continue factoring the sequence with it." Ordering choice is
+//! inertia-neutral, so this carries no correctness risk.
+//!
+//! Real IPM sequences change sparsity pattern at the first iterate or two (the active
+//! set settling), then hold a stable pattern; only the pattern-*reused* iterates are the
+//! long-run steady state, so all steady-state metrics are geomeans over reused iterates.
+//!
+//! For each family under the corpus root (default `data/matrices/kkt-mittelmann`)
+//! with ≥ `MIN_ITERS` iterates and a first-iterate factor above `FLOOR_US` (small
+//! matrices don't matter — §5.6), it runs the full grid (each of 5 explicit orderings
+//! × each iterate, capped at `MAX_ITERS`) plus `Auto` and `AutoRace`, then reports:
+//!   * winner ordering (argmin factor time on the first iterate — what a "race the first
+//!     factor, latch it" strategy picks);
+//!   * steady-state per-iterate cost of the latched winner vs `Auto` / `AutoRace`;
+//!   * representativeness: how often the first-iterate winner equals the
+//!     steady-state-optimal ordering (does racing the transient first factor pick right?);
+//!   * race-overhead amortization: the break-even iterate count where the k−1 extra
+//!     first-factors pay back at the per-iterate steady-state saving vs `Auto`.
+//!
+//! Usage:
+//!   cargo run --release --bin study_latched_race
+//!   cargo run --release --bin study_latched_race -- data/matrices/kkt-mittelmann --max-iters 12
+
+use feral::symbolic::OrderingMethod;
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const FLOOR_US: u128 = 200;
+const MIN_ITERS: usize = 3;
+
+const CANDIDATES: &[(&str, OrderingMethod)] = &[
+    ("amd", OrderingMethod::Amd),
+    ("amf", OrderingMethod::Amf),
+    ("metis", OrderingMethod::MetisND),
+    ("scotch", OrderingMethod::ScotchND),
+    ("kahip", OrderingMethod::KahipND),
+];
+
+/// Per-iterate measurement: wall-clock (us) and whether this factor reused the cached
+/// symbolic (pattern unchanged from the previous iterate). IPM sequences typically see
+/// a pattern change at the first iterate or two (active set settling), then a stable
+/// pattern — only the reused iterates are the true steady state.
+struct IterMeas {
+    us: u128,
+    reused: bool,
+}
+
+/// Factor every matrix in `seq` with one fixed `method` on a single reusing `Solver`.
+/// The first iterate's factor includes the one-off symbolic build; later iterates
+/// reuse the cached symbolic when the pattern is unchanged (numeric only) and rebuild
+/// it when the pattern shifts. Single-pass timing — a real sequence is factored once.
+/// `None` if any factor fails.
+fn factor_sequence(seq: &[CscMatrix], method: OrderingMethod) -> Option<Vec<IterMeas>> {
+    let mut solver = Solver::new().with_ordering(method);
+    let mut out = Vec::with_capacity(seq.len());
+    for m in seq {
+        let t = Instant::now();
+        if !matches!(solver.factor(m, None), FactorStatus::Success) {
+            return None;
+        }
+        let us = t.elapsed().as_micros();
+        let reused = solver
+            .last_factor_stats()
+            .map(|s| s.pattern_reused)
+            .unwrap_or(false);
+        out.push(IterMeas { us, reused });
+    }
+    Some(out)
+}
+
+fn collect_families(root: &Path) -> Vec<(String, Vec<PathBuf>)> {
+    let mut out = Vec::new();
+    let Ok(rd) = std::fs::read_dir(root) else {
+        eprintln!("error: cannot read {}", root.display());
+        return out;
+    };
+    let mut subs: Vec<PathBuf> = rd
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    subs.sort();
+    for sub in subs {
+        let Ok(inner) = std::fs::read_dir(&sub) else {
+            continue;
+        };
+        let mut mtxs: Vec<PathBuf> = inner
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("mtx"))
+            .collect();
+        mtxs.sort();
+        let name = sub
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        if mtxs.len() >= MIN_ITERS {
+            out.push((name, mtxs));
+        }
+    }
+    out
+}
+
+fn geomean(v: &[f64]) -> f64 {
+    if v.is_empty() {
+        return f64::NAN;
+    }
+    (v.iter().map(|x| x.ln()).sum::<f64>() / v.len() as f64).exp()
+}
+
+/// Geomean of the `us` field over iterates that reused the cached symbolic — the true
+/// steady-state per-iterate cost of a long run. Falls back to all iterates if none
+/// reused (e.g. every iterate changed the pattern).
+fn steady_state(meas: &[IterMeas]) -> f64 {
+    let reused: Vec<f64> = meas
+        .iter()
+        .filter(|m| m.reused)
+        .map(|m| m.us as f64)
+        .collect();
+    if reused.is_empty() {
+        geomean(&meas.iter().map(|m| m.us as f64).collect::<Vec<_>>())
+    } else {
+        geomean(&reused)
+    }
+}
+
+struct FamilyResult {
+    family: String,
+    n: usize,
+    iters: usize,
+    n_reused: usize,
+    winner: String,
+    // iterate-0 race winner == the steady-state-optimal ordering?
+    winner_is_ss_optimal: bool,
+    // Steady-state per-iterate cost (geomean over reused iterates).
+    ss_latched: f64,
+    ss_auto: f64,
+    ss_autorace: f64,
+    // Race overhead expressed as iterations-to-amortize vs the Auto baseline.
+    breakeven_iters_vs_auto: Option<f64>,
+}
+
+fn main() {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut max_iters = 12usize;
+    let mut positional = Vec::new();
+    let mut it = raw.into_iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--max-iters" => {
+                if let Some(v) = it.next().and_then(|s| s.parse().ok()) {
+                    max_iters = v;
+                }
+            }
+            _ => positional.push(a),
+        }
+    }
+    let root = PathBuf::from(
+        positional
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "data/matrices/kkt-mittelmann".to_string()),
+    );
+
+    eprintln!("scanning {} ...", root.display());
+    let fams = collect_families(&root);
+    eprintln!("{} families with >= {} iterates", fams.len(), MIN_ITERS);
+
+    let mut results: Vec<FamilyResult> = Vec::new();
+    let mut skipped = 0usize;
+
+    for (fi, (family, paths)) in fams.iter().enumerate() {
+        eprintln!(
+            "  [{}/{}] {} ({} iterates)",
+            fi,
+            fams.len(),
+            family,
+            paths.len()
+        );
+        // Load the (capped) iterate sequence.
+        let take = paths.len().min(max_iters);
+        let mut seq: Vec<CscMatrix> = Vec::with_capacity(take);
+        for p in paths.iter().take(take) {
+            match read_mtx(p).and_then(|m| m.to_csc()) {
+                Ok(c) if c.n > 0 => seq.push(c),
+                _ => {}
+            }
+        }
+        if seq.len() < MIN_ITERS {
+            skipped += 1;
+            continue;
+        }
+        let n = seq[0].n;
+
+        // Full grid: each candidate ordering over the whole sequence.
+        let mut grid: Vec<Vec<IterMeas>> = Vec::new();
+        let mut failed = false;
+        for (_, method) in CANDIDATES.iter() {
+            match factor_sequence(&seq, method.clone()) {
+                Some(times) => grid.push(times),
+                None => {
+                    failed = true;
+                    break;
+                }
+            }
+        }
+        if failed || grid.len() != CANDIDATES.len() {
+            skipped += 1;
+            continue;
+        }
+        // Size gate: skip if the first iterate factors too fast to matter.
+        let iter0_min: u128 = grid.iter().map(|t| t[0].us).min().unwrap_or(0);
+        if iter0_min < FLOOR_US {
+            skipped += 1;
+            continue;
+        }
+
+        let (Some(auto), Some(autorace)) = (
+            factor_sequence(&seq, OrderingMethod::Auto),
+            factor_sequence(&seq, OrderingMethod::AutoRace),
+        ) else {
+            skipped += 1;
+            continue;
+        };
+
+        let ni = seq.len();
+        let n_reused = grid[0].iter().filter(|m| m.reused).count();
+        // The latched race picks the ordering fastest on iterate 0 (the first factor).
+        let winner_ci = (0..CANDIDATES.len())
+            .min_by(|&a, &b| grid[a][0].us.cmp(&grid[b][0].us))
+            .unwrap();
+        // The steady-state-optimal ordering (best geomean over reused iterates) — the
+        // ideal latch. Representativeness = does racing on iterate 0 find it?
+        let ss_opt_ci = (0..CANDIDATES.len())
+            .min_by(|&a, &b| {
+                steady_state(&grid[a])
+                    .partial_cmp(&steady_state(&grid[b]))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .unwrap();
+
+        // Steady-state per-iterate cost (geomean over reused iterates). After the
+        // latch, every steady iterate uses the winner ordering, so ss_latched is the
+        // winner candidate's steady state.
+        let ss_latched = steady_state(&grid[winner_ci]);
+        let ss_auto = steady_state(&auto);
+        let ss_autorace = steady_state(&autorace);
+
+        // Race overhead as iterations-to-amortize vs Auto: the k−1 extra first-factors
+        // (race_cost minus the one first-factor Auto also pays), divided by the
+        // steady-state per-iterate saving of the latched winner over Auto.
+        let race_cost: u128 = grid.iter().map(|t| t[0].us).sum();
+        let extra_overhead = race_cost.saturating_sub(auto[0].us) as f64;
+        let per_iter_saving = ss_auto - ss_latched;
+        let breakeven_iters_vs_auto = if per_iter_saving > 0.0 {
+            Some(extra_overhead / per_iter_saving)
+        } else {
+            None // latched not faster than Auto at steady state → never amortizes
+        };
+
+        results.push(FamilyResult {
+            family: family.clone(),
+            n,
+            iters: ni,
+            n_reused,
+            winner: CANDIDATES[winner_ci].0.to_string(),
+            winner_is_ss_optimal: winner_ci == ss_opt_ci,
+            ss_latched,
+            ss_auto,
+            ss_autorace,
+            breakeven_iters_vs_auto,
+        });
+    }
+
+    // --- report ---
+    println!();
+    println!(
+        "=== issue #110 latched actual-time race prototype ({} families, {} skipped) ===",
+        results.len(),
+        skipped
+    );
+    println!(
+        "root: {}   (iterates capped at {}; steady state = geomean over pattern-reused iterates)",
+        root.display(),
+        max_iters
+    );
+    println!();
+    println!(
+        "{:<16}{:>8}{:>4}{:>5}  {:>7}  {:>20}  {:>12}",
+        "family", "n", "N", "reus", "winner", "steady/iter vs", "breakeven"
+    );
+    println!(
+        "{:<16}{:>8}{:>4}{:>5}  {:>7}  {:>20}  {:>12}",
+        "", "", "", "", "(ssopt?)", "auto     race", "iters(vAuto)"
+    );
+    println!("{}", "-".repeat(80));
+    for r in &results {
+        let vs_auto = r.ss_latched / r.ss_auto.max(1.0);
+        let vs_race = r.ss_latched / r.ss_autorace.max(1.0);
+        println!(
+            "{:<16}{:>8}{:>4}{:>5}  {:>3}{:<4}  {:>8.2} {:>8.2}  {:>12}",
+            r.family,
+            r.n,
+            r.iters,
+            r.n_reused,
+            r.winner,
+            if r.winner_is_ss_optimal {
+                " ✓"
+            } else {
+                " ✗"
+            },
+            vs_auto,
+            vs_race,
+            r.breakeven_iters_vs_auto
+                .map(|b| format!("{b:.0}"))
+                .unwrap_or_else(|| "never".to_string()),
+        );
+    }
+
+    // --- aggregate ---
+    let n = results.len().max(1);
+    let vs_auto: Vec<f64> = results
+        .iter()
+        .map(|r| r.ss_latched / r.ss_auto.max(1.0))
+        .collect();
+    let vs_race: Vec<f64> = results
+        .iter()
+        .map(|r| r.ss_latched / r.ss_autorace.max(1.0))
+        .collect();
+    let repr = results.iter().filter(|r| r.winner_is_ss_optimal).count();
+    let mut breakevens: Vec<f64> = results
+        .iter()
+        .filter_map(|r| r.breakeven_iters_vs_auto)
+        .collect();
+    breakevens.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median_be = if breakevens.is_empty() {
+        f64::NAN
+    } else {
+        breakevens[breakevens.len() / 2]
+    };
+    let never = results
+        .iter()
+        .filter(|r| r.breakeven_iters_vs_auto.is_none())
+        .count();
+
+    println!();
+    println!("STEADY STATE (per-iterate, pattern-reused iterates — the long-run asymptote):");
+    println!(
+        "  latched winner vs Auto:     geomean {:.3}  ({:.1}% faster)",
+        geomean(&vs_auto),
+        100.0 * (1.0 - geomean(&vs_auto))
+    );
+    println!(
+        "  latched winner vs AutoRace: geomean {:.3}  ({:.1}% faster)",
+        geomean(&vs_race),
+        100.0 * (1.0 - geomean(&vs_race))
+    );
+    println!();
+    println!("REPRESENTATIVENESS: iterate-0 race winner == steady-state-optimal ordering");
+    println!(
+        "  {}/{} ({:.0}%) — how often racing on the first factor picks the right latch.",
+        repr,
+        n,
+        100.0 * repr as f64 / n as f64
+    );
+    println!();
+    println!("RACE OVERHEAD amortization vs Auto (the good baseline):");
+    println!("  break-even iterate count (k−1 extra first-factors / per-iterate saving):");
+    println!(
+        "    median {:.0} iterations   |   {} of {} families never amortize (latched not faster)",
+        median_be, never, n
+    );
+    println!("  => latched race pays off once the pattern is reused past ~the break-even count.");
+}

--- a/crates/feral-diagnostics/src/bin/study_ordering_gap.rs
+++ b/crates/feral-diagnostics/src/bin/study_ordering_gap.rs
@@ -1,0 +1,372 @@
+//! Issue #110 measurement study: does the cheap `Auto` ordering heuristic
+//! (`choose_adaptive`) leave material fill on the table vs the measure-then-choose
+//! `AutoRace`, and how expensive is `AutoRace` by comparison?
+//!
+//! This is the gating measurement for the issue #110 research note
+//! (`dev/research/issue-110-learned-tuner.md`): a learned ordering surrogate only
+//! earns its keep if the deterministic cheap pick is materially worse than the
+//! race optimum on a real corpus. If the gap is small, the hand-written heuristic
+//! already captures the value and a model is not worth the maintenance surface.
+//!
+//! For each family in a corpus root (default `data/matrices/kkt`), one
+//! representative matrix (the first `.mtx`; ordering fill depends only on the
+//! sparsity pattern, which is shared across a family's IPM-iteration dumps) is
+//! factored symbolically under seven ordering choices:
+//!   AMD, AMF, MetisND, ScotchND, KahipND, Auto (cheap heuristic), AutoRace.
+//! All use `SupernodeParams::default()` (so preprocess = Auto for every one —
+//! apples to apples, the only variable is the ordering method).
+//!
+//! Reported per matrix (CSV to `--csv <path>`, default none) and aggregated to
+//! stdout:
+//! * `oracle_best`  = min fill over the 5 explicit methods (incl. AMF).
+//! * `ratio_auto`   = fill_auto / oracle_best (>= 1; cheap pick's loss).
+//! * `ratio_race`   = fill_autorace / oracle_best (race's loss; AutoRace does not
+//!   race AMF, so this can exceed 1).
+//! * `auto_vs_race` = fill_auto / fill_autorace (cheap pick vs the race).
+//! * time_auto vs time_autorace (the cost the race pays for its pick).
+//!
+//! Usage:
+//!   cargo run --release --bin study_ordering_gap
+//!   cargo run --release --bin study_ordering_gap -- data/matrices/kkt --csv /tmp/gap.csv
+//!   cargo run --release --bin study_ordering_gap -- <root> --limit 200
+
+use feral::read_mtx;
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+struct Rec {
+    family: String,
+    n: usize,
+    nnz: usize,
+    fill_amd: u64,
+    fill_amf: u64,
+    fill_metis: u64,
+    fill_scotch: u64,
+    fill_kahip: u64,
+    fill_auto: u64,
+    fill_autorace: u64,
+    t_auto_us: u128,
+    t_autorace_us: u128,
+}
+
+fn measure(
+    matrix: &feral::sparse::csc::CscMatrix,
+    params: &SupernodeParams,
+    method: OrderingMethod,
+) -> Option<(u64, u128)> {
+    let t = Instant::now();
+    let sym = symbolic_factorize_with_method(matrix, params, method).ok()?;
+    let us = t.elapsed().as_micros();
+    Some((sym.factor_nnz_estimate as u64, us))
+}
+
+/// One representative matrix per family subdirectory of `root`.
+fn collect_representatives(root: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let rd = match std::fs::read_dir(root) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: cannot read {}: {}", root.display(), e);
+            return out;
+        }
+    };
+    let mut subs: Vec<PathBuf> = rd
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    subs.sort();
+    for sub in subs {
+        let inner = match std::fs::read_dir(&sub) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let mut mtxs: Vec<PathBuf> = inner
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("mtx"))
+            .collect();
+        mtxs.sort();
+        if let Some(first) = mtxs.into_iter().next() {
+            out.push(first);
+        }
+    }
+    out
+}
+
+fn geomean(vals: &[f64]) -> f64 {
+    if vals.is_empty() {
+        return f64::NAN;
+    }
+    let n = vals.len() as f64;
+    (vals.iter().map(|v| v.ln()).sum::<f64>() / n).exp()
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[idx]
+}
+
+fn main() {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut csv_path: Option<PathBuf> = None;
+    let mut limit: Option<usize> = None;
+    let mut positional: Vec<String> = Vec::new();
+    let mut it = raw.into_iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--csv" => csv_path = it.next().map(PathBuf::from),
+            "--limit" => limit = it.next().and_then(|s| s.parse().ok()),
+            _ => positional.push(arg),
+        }
+    }
+    let root = PathBuf::from(
+        positional
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "data/matrices/kkt".to_string()),
+    );
+
+    eprintln!("scanning {} for family representatives ...", root.display());
+    let mut files = collect_representatives(&root);
+    if let Some(l) = limit {
+        files.truncate(l);
+    }
+    if files.is_empty() {
+        eprintln!("no family representatives found under {}", root.display());
+        std::process::exit(1);
+    }
+    eprintln!("{} family representatives", files.len());
+
+    let params = SupernodeParams::default();
+    let mut recs: Vec<Rec> = Vec::new();
+    let mut skipped = 0usize;
+
+    for (idx, path) in files.iter().enumerate() {
+        let family = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        if idx % 50 == 0 {
+            eprintln!("  [{}/{}] {}", idx, files.len(), family);
+        }
+        let mtx = match read_mtx(path) {
+            Ok(m) => m,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        let csc = match mtx.to_csc() {
+            Ok(c) => c,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        if csc.n == 0 {
+            skipped += 1;
+            continue;
+        }
+        let n = csc.n;
+        let nnz = csc.row_idx.len();
+
+        let (
+            Some((fill_amd, _)),
+            Some((fill_amf, _)),
+            Some((fill_metis, _)),
+            Some((fill_scotch, _)),
+            Some((fill_kahip, _)),
+            Some((fill_auto, t_auto_us)),
+            Some((fill_autorace, t_autorace_us)),
+        ) = (
+            measure(&csc, &params, OrderingMethod::Amd),
+            measure(&csc, &params, OrderingMethod::Amf),
+            measure(&csc, &params, OrderingMethod::MetisND),
+            measure(&csc, &params, OrderingMethod::ScotchND),
+            measure(&csc, &params, OrderingMethod::KahipND),
+            measure(&csc, &params, OrderingMethod::Auto),
+            measure(&csc, &params, OrderingMethod::AutoRace),
+        )
+        else {
+            skipped += 1;
+            continue;
+        };
+
+        recs.push(Rec {
+            family,
+            n,
+            nnz,
+            fill_amd,
+            fill_amf,
+            fill_metis,
+            fill_scotch,
+            fill_kahip,
+            fill_auto,
+            fill_autorace,
+            t_auto_us,
+            t_autorace_us,
+        });
+    }
+
+    if let Some(p) = &csv_path {
+        match std::fs::File::create(p) {
+            Ok(mut f) => {
+                let _ = writeln!(
+                    f,
+                    "family,n,nnz,fill_amd,fill_amf,fill_metis,fill_scotch,fill_kahip,fill_auto,fill_autorace,oracle_best,ratio_auto,ratio_race,auto_vs_race,t_auto_us,t_autorace_us"
+                );
+                for r in &recs {
+                    let oracle = r
+                        .fill_amd
+                        .min(r.fill_amf)
+                        .min(r.fill_metis)
+                        .min(r.fill_scotch)
+                        .min(r.fill_kahip)
+                        .max(1);
+                    let ratio_auto = r.fill_auto as f64 / oracle as f64;
+                    let ratio_race = r.fill_autorace as f64 / oracle as f64;
+                    let auto_vs_race = r.fill_auto as f64 / r.fill_autorace.max(1) as f64;
+                    let _ = writeln!(
+                        f,
+                        "{},{},{},{},{},{},{},{},{},{},{},{:.4},{:.4},{:.4},{},{}",
+                        r.family,
+                        r.n,
+                        r.nnz,
+                        r.fill_amd,
+                        r.fill_amf,
+                        r.fill_metis,
+                        r.fill_scotch,
+                        r.fill_kahip,
+                        r.fill_auto,
+                        r.fill_autorace,
+                        oracle,
+                        ratio_auto,
+                        ratio_race,
+                        auto_vs_race,
+                        r.t_auto_us,
+                        r.t_autorace_us,
+                    );
+                }
+                eprintln!("wrote per-matrix CSV to {}", p.display());
+            }
+            Err(e) => eprintln!("could not write CSV {}: {}", p.display(), e),
+        }
+    }
+
+    // --- aggregate ---
+    let mut ratio_auto: Vec<f64> = Vec::new();
+    let mut ratio_race: Vec<f64> = Vec::new();
+    let mut auto_vs_race: Vec<f64> = Vec::new();
+    let (mut auto_optimal, mut auto_ties_race, mut auto_beats_race, mut race_beats_auto) =
+        (0usize, 0usize, 0usize, 0usize);
+    let (mut loss_gt_2, mut loss_gt_10, mut loss_gt_50) = (0usize, 0usize, 0usize);
+    let (mut t_auto_total, mut t_race_total) = (0u128, 0u128);
+
+    for r in &recs {
+        let oracle = r
+            .fill_amd
+            .min(r.fill_amf)
+            .min(r.fill_metis)
+            .min(r.fill_scotch)
+            .min(r.fill_kahip)
+            .max(1);
+        let ra = r.fill_auto as f64 / oracle as f64;
+        let rr = r.fill_autorace as f64 / oracle as f64;
+        let avr = r.fill_auto as f64 / r.fill_autorace.max(1) as f64;
+        ratio_auto.push(ra);
+        ratio_race.push(rr);
+        auto_vs_race.push(avr);
+        if r.fill_auto <= oracle {
+            auto_optimal += 1;
+        }
+        if r.fill_auto == r.fill_autorace {
+            auto_ties_race += 1;
+        } else if r.fill_auto < r.fill_autorace {
+            auto_beats_race += 1;
+        } else {
+            race_beats_auto += 1;
+        }
+        if ra > 1.02 {
+            loss_gt_2 += 1;
+        }
+        if ra > 1.10 {
+            loss_gt_10 += 1;
+        }
+        if ra > 1.50 {
+            loss_gt_50 += 1;
+        }
+        t_auto_total += r.t_auto_us;
+        t_race_total += r.t_autorace_us;
+    }
+
+    let mut sa = ratio_auto.clone();
+    sa.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut sr = ratio_race.clone();
+    sr.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let m = recs.len().max(1);
+    println!();
+    println!(
+        "=== issue #110 ordering-selection gap study ({} matrices, {} skipped) ===",
+        recs.len(),
+        skipped
+    );
+    println!("root: {}", root.display());
+    println!();
+    println!("fill of cheap `Auto` vs the 5-method oracle (min incl. AMF):");
+    println!(
+        "  Auto == oracle optimum : {}/{}  ({:.1}%)",
+        auto_optimal,
+        recs.len(),
+        100.0 * auto_optimal as f64 / m as f64
+    );
+    println!("  ratio_auto = fill_auto / oracle_best   (1.000 = optimal):");
+    println!(
+        "    geomean {:.4}   p50 {:.4}   p90 {:.4}   p99 {:.4}   max {:.4}",
+        geomean(&ratio_auto),
+        percentile(&sa, 0.50),
+        percentile(&sa, 0.90),
+        percentile(&sa, 0.99),
+        percentile(&sa, 1.0),
+    );
+    println!(
+        "  matrices where Auto loses >2% / >10% / >50% fill: {} / {} / {}",
+        loss_gt_2, loss_gt_10, loss_gt_50
+    );
+    println!();
+    println!("fill of `AutoRace` vs the 5-method oracle (AutoRace does not race AMF):");
+    println!(
+        "  ratio_race geomean {:.4}   p50 {:.4}   p90 {:.4}   p99 {:.4}   max {:.4}",
+        geomean(&ratio_race),
+        percentile(&sr, 0.50),
+        percentile(&sr, 0.90),
+        percentile(&sr, 0.99),
+        percentile(&sr, 1.0),
+    );
+    println!();
+    println!("cheap `Auto` vs `AutoRace` head to head:");
+    println!(
+        "  Auto ties race: {}   Auto beats race: {}   race beats Auto: {}",
+        auto_ties_race, auto_beats_race, race_beats_auto
+    );
+    println!(
+        "  auto_vs_race = fill_auto / fill_autorace geomean {:.4}",
+        geomean(&auto_vs_race)
+    );
+    println!();
+    println!("symbolic time (the cost AutoRace pays for its pick):");
+    println!(
+        "  total t_auto = {} us   total t_autorace = {} us   race/auto = {:.2}x",
+        t_auto_total,
+        t_race_total,
+        t_race_total as f64 / (t_auto_total.max(1)) as f64
+    );
+}

--- a/crates/feral-diagnostics/src/bin/study_ordering_timemem.rs
+++ b/crates/feral-diagnostics/src/bin/study_ordering_timemem.rs
@@ -1,0 +1,498 @@
+//! Issue #110 follow-up study: the TIME/MEMORY-objective version of
+//! `study_ordering_gap`. The fill study (`study_ordering_gap`) showed feral's
+//! deterministic ordering selection is near-optimal *by fill* — but fill is a proxy
+//! that provably diverges from factor wall-clock and peak memory (see the #110 note
+//! §5.5.1 and nql180). This binary measures the real objectives directly, so we can
+//! quantify the *potential* of a time/memory-aware tuner.
+//!
+//! For each family representative under `data/matrices/kkt`, for each of the 5
+//! explicit orderings (AMD, AMF, MetisND, ScotchND, KahipND) plus `Auto` and
+//! `AutoRace`, it measures:
+//!   * numeric factor wall-clock (min over reps; symbolic is reused across reps, so
+//!     this is the IPM-relevant per-iteration numeric cost, not the one-off analysis).
+//!   * peak memory model = 16 * nnz_l (stored factor) + peak_contrib_bytes
+//!     (transient multifrontal contribution-block stack) — feral's own accounting.
+//!   * fill (factor_nnz_estimate), for cross-check against the fill study.
+//!
+//! The headline questions:
+//!   1. How often does the FILL-optimal ordering (what `AutoRace` picks) differ from
+//!      the TIME-optimal / MEMORY-optimal ordering? (the fill-lies rate)
+//!   2. If you always pick fill-optimal, how much time / memory do you leave on the
+//!      table vs a perfect per-matrix oracle? (the ceiling for a time/mem tuner)
+//!   3. How much would a perfect time-oracle beat feral's actual `Auto` today?
+//!
+//! Timing on tiny matrices is dominated by overhead and irrelevant (nobody tunes a
+//! 5 us solve), so the regret distributions are reported both over all matrices and
+//! over the "meaningful" subset (min factor time >= TIME_FLOOR_US).
+//!
+//! Usage:
+//!   cargo run --release --bin study_ordering_timemem -- data/matrices/kkt --csv /tmp/tm.csv
+//!   cargo run --release --bin study_ordering_timemem -- <root> --limit 200
+
+use feral::symbolic::{OrderingMethod, SupernodeParams};
+use feral::{read_mtx, CscMatrix, Solver};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Factor-time floor (us) below which a matrix is too small for its timing to be
+/// meaningful; excluded from the regret distributions (but kept in the CSV).
+const TIME_FLOOR_US: u128 = 50;
+
+/// Orderings measured, in a fixed order. Indices used throughout.
+const METHODS: &[(&str, OrderingMethod)] = &[
+    ("amd", OrderingMethod::Amd),
+    ("amf", OrderingMethod::Amf),
+    ("metis", OrderingMethod::MetisND),
+    ("scotch", OrderingMethod::ScotchND),
+    ("kahip", OrderingMethod::KahipND),
+    ("auto", OrderingMethod::Auto),
+    ("autorace", OrderingMethod::AutoRace),
+];
+
+#[derive(Clone)]
+struct Meas {
+    fill: u64,
+    /// Dense-multifrontal work proxy: Σ over supernodes of `ncol · nrow²`. The
+    /// standard "flops" estimate — a candidate cheap *time* proxy to race on instead
+    /// of fill (issue-73 flagged it unreliable on nql180; this study measures how it
+    /// does across the corpus).
+    flop_proxy: u128,
+    /// Largest frontal dimension (max `nrow`) — another cheap time/parallelism proxy.
+    max_front: u64,
+    nnz_l: u64,
+    peak_bytes: u64,
+    time_us: u128,
+}
+
+struct Rec {
+    family: String,
+    n: usize,
+    nnz: usize,
+    /// One `Meas` per entry in `METHODS` (None if that ordering failed).
+    per_method: Vec<Option<Meas>>,
+}
+
+/// Factor `matrix` with a fixed `method`, reusing the cached symbolic across reps.
+/// Returns (fill, nnz_l, peak_bytes, min factor time). `None` if the factor fails.
+fn measure(matrix: &CscMatrix, method: OrderingMethod) -> Option<Meas> {
+    let mut solver = Solver::new().with_ordering(method);
+    // Warm-up factor: builds the symbolic analysis (which we do NOT time) plus the
+    // first numeric factor. Its wall-clock also sets the rep budget below.
+    let warm_t = Instant::now();
+    if !matches!(solver.factor(matrix, None), feral::FactorStatus::Success) {
+        return None;
+    }
+    let warm_dt = warm_t.elapsed();
+    let stats = solver.last_factor_stats()?;
+    let sym = solver.symbolic()?;
+    let peak_bytes = 16u64.saturating_mul(stats.nnz_l as u64) + sym.peak_contrib_bytes as u64;
+    let fill = sym.factor_nnz_estimate as u64;
+    // Cheap symbolic time proxies (no numeric work): dense-front work Σ ncol·nrow²
+    // and the largest front dimension.
+    let mut flop_proxy: u128 = 0;
+    let mut max_front: u64 = 0;
+    for sn in &sym.supernodes {
+        let ncol = sn.ncol as u128;
+        let nrow = sn.nrow as u128;
+        flop_proxy += ncol * nrow * nrow;
+        max_front = max_front.max(sn.nrow as u64);
+    }
+
+    // Timed reps: each factor() reuses the cached symbolic (same pattern) and redoes
+    // the numeric factorization — the IPM per-iteration cost. Take the min over reps
+    // (least OS noise), adaptively repeating until a time budget or rep cap. The
+    // minimum rep count is warmup-time-aware so multi-second factors (n~10^5) don't
+    // force dozens of seconds of work: fast factors get more reps (noise), slow ones
+    // get few (already stable, expensive). Note: `warm_dt` includes the one-off
+    // symbolic build, so it is an upper bound on the numeric cost and never enters
+    // `best`.
+    let min_reps = if warm_dt > Duration::from_millis(200) {
+        2
+    } else if warm_dt > Duration::from_millis(20) {
+        3
+    } else {
+        5
+    };
+    let mut best = Duration::from_secs(3600);
+    let budget = Duration::from_millis(40);
+    let started = Instant::now();
+    let mut reps = 0u32;
+    while reps < 200 && (reps < min_reps || started.elapsed() < budget) {
+        let t = Instant::now();
+        let ok = matches!(solver.factor(matrix, None), feral::FactorStatus::Success);
+        let dt = t.elapsed();
+        if !ok {
+            return None;
+        }
+        if dt < best {
+            best = dt;
+        }
+        reps += 1;
+    }
+    Some(Meas {
+        fill,
+        flop_proxy,
+        max_front,
+        nnz_l: stats.nnz_l as u64,
+        peak_bytes,
+        time_us: best.as_micros(),
+    })
+}
+
+fn collect_representatives(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(rd) = std::fs::read_dir(root) else {
+        eprintln!("error: cannot read {}", root.display());
+        return out;
+    };
+    let entries: Vec<PathBuf> = rd.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+    // Flat layout: `.mtx` files directly under `root` (e.g. tests/data/large). Use
+    // each file as its own "family" so the study works on ad-hoc large-matrix dirs.
+    let mut flat: Vec<PathBuf> = entries
+        .iter()
+        .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("mtx"))
+        .cloned()
+        .collect();
+    if !flat.is_empty() {
+        flat.sort();
+        return flat;
+    }
+    // Per-family layout: one representative (first `.mtx`) per subdirectory.
+    let mut subs: Vec<PathBuf> = entries.into_iter().filter(|p| p.is_dir()).collect();
+    subs.sort();
+    for sub in subs {
+        let Ok(inner) = std::fs::read_dir(&sub) else {
+            continue;
+        };
+        let mut mtxs: Vec<PathBuf> = inner
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("mtx"))
+            .collect();
+        mtxs.sort();
+        if let Some(first) = mtxs.into_iter().next() {
+            out.push(first);
+        }
+    }
+    out
+}
+
+fn geomean(vals: &[f64]) -> f64 {
+    if vals.is_empty() {
+        return f64::NAN;
+    }
+    (vals.iter().map(|v| v.ln()).sum::<f64>() / vals.len() as f64).exp()
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    sorted[((sorted.len() as f64 - 1.0) * p).round() as usize]
+}
+
+/// Index of the min-`key` method among the first 5 (explicit) methods; `None` if all
+/// failed. Ties break to the earliest (AMD < AMF < Metis < Scotch < KaHIP).
+fn argmin_explicit(rec: &Rec, key: impl Fn(&Meas) -> u128) -> Option<usize> {
+    (0..5)
+        .filter_map(|i| rec.per_method[i].as_ref().map(|m| (i, key(m))))
+        .min_by(|a, b| a.1.cmp(&b.1))
+        .map(|(i, _)| i)
+}
+
+fn main() {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut csv_path: Option<PathBuf> = None;
+    let mut limit: Option<usize> = None;
+    let mut positional = Vec::new();
+    let mut it = raw.into_iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--csv" => csv_path = it.next().map(PathBuf::from),
+            "--limit" => limit = it.next().and_then(|s| s.parse().ok()),
+            _ => positional.push(a),
+        }
+    }
+    let root = PathBuf::from(
+        positional
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "data/matrices/kkt".to_string()),
+    );
+
+    eprintln!("scanning {} ...", root.display());
+    let mut files = collect_representatives(&root);
+    if let Some(l) = limit {
+        files.truncate(l);
+    }
+    if files.is_empty() {
+        eprintln!("no family representatives found");
+        std::process::exit(1);
+    }
+    eprintln!("{} family representatives", files.len());
+
+    let _ = SupernodeParams::default(); // (defaults used inside Solver::new)
+    let mut recs: Vec<Rec> = Vec::new();
+    let mut skipped = 0usize;
+
+    for (idx, path) in files.iter().enumerate() {
+        // Flat layout (file sits directly in `root`): label by file stem.
+        // Family layout (file in a subdir): label by the subdir name.
+        let flat = path.parent() == Some(root.as_path());
+        let family = if flat {
+            path.file_stem().and_then(|s| s.to_str())
+        } else {
+            path.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|s| s.to_str())
+        }
+        .unwrap_or("?")
+        .to_string();
+        if idx % 25 == 0 {
+            eprintln!("  [{}/{}] {}", idx, files.len(), family);
+        }
+        let Ok(mtx) = read_mtx(path) else {
+            skipped += 1;
+            continue;
+        };
+        let Ok(csc) = mtx.to_csc() else {
+            skipped += 1;
+            continue;
+        };
+        if csc.n == 0 {
+            skipped += 1;
+            continue;
+        }
+        let per_method: Vec<Option<Meas>> = METHODS
+            .iter()
+            .map(|(_, m)| measure(&csc, m.clone()))
+            .collect();
+        // Need the 5 explicit methods to all succeed for a clean oracle comparison.
+        if per_method[..5].iter().any(|m| m.is_none()) {
+            skipped += 1;
+            continue;
+        }
+        recs.push(Rec {
+            family,
+            n: csc.n,
+            nnz: csc.row_idx.len(),
+            per_method,
+        });
+    }
+
+    // --- CSV ---
+    if let Some(p) = &csv_path {
+        if let Ok(mut f) = std::fs::File::create(p) {
+            let mut hdr = String::from("family,n,nnz");
+            for (name, _) in METHODS {
+                hdr.push_str(&format!(",{name}_fill,{name}_nnzl,{name}_peakb,{name}_us"));
+            }
+            let _ = writeln!(f, "{hdr}");
+            for r in &recs {
+                let mut line = format!("{},{},{}", r.family, r.n, r.nnz);
+                for m in &r.per_method {
+                    match m {
+                        Some(m) => line.push_str(&format!(
+                            ",{},{},{},{}",
+                            m.fill, m.nnz_l, m.peak_bytes, m.time_us
+                        )),
+                        None => line.push_str(",,,,"),
+                    }
+                }
+                let _ = writeln!(f, "{line}");
+            }
+            eprintln!("wrote per-matrix CSV to {}", p.display());
+        }
+    }
+
+    // --- aggregate ---
+    // For each matrix: the fill-optimal, time-optimal, memory-optimal explicit
+    // ordering. Then the regret of the fill-optimal pick on time and memory.
+    let mut time_regret_all: Vec<f64> = Vec::new();
+    let mut time_regret_big: Vec<f64> = Vec::new();
+    let mut mem_regret_all: Vec<f64> = Vec::new();
+    let (mut fill_eq_time, mut fill_eq_time_big, mut big_n) = (0usize, 0usize, 0usize);
+    let mut fill_eq_mem = 0usize;
+    // Totals for the "oracle vs Auto today" comparison (meaningful subset only).
+    let (mut tot_auto_us, mut tot_autorace_us, mut tot_timeoracle_us) = (0u128, 0u128, 0u128);
+    // Deterministic proxy-race prototype: totals + per-matrix time-regret of picking
+    // the ordering that minimizes each cheap symbolic proxy (vs the time-oracle).
+    // A proxy that lands near the oracle means a deterministic race on it (no ML)
+    // captures the §5.6 headroom.
+    let (mut tot_fill_us, mut tot_flop_us, mut tot_maxfront_us) = (0u128, 0u128, 0u128);
+    let mut flop_regret: Vec<f64> = Vec::new();
+    let mut maxfront_regret: Vec<f64> = Vec::new();
+
+    for r in &recs {
+        let fill_best = argmin_explicit(r, |m| m.fill as u128).unwrap();
+        let time_best = argmin_explicit(r, |m| m.time_us).unwrap();
+        let mem_best = argmin_explicit(r, |m| m.peak_bytes as u128).unwrap();
+        let flop_best = argmin_explicit(r, |m| m.flop_proxy).unwrap();
+        let maxfront_best = argmin_explicit(r, |m| m.max_front as u128).unwrap();
+
+        let t_fillpick = r.per_method[fill_best].as_ref().unwrap().time_us.max(1);
+        let t_timebest = r.per_method[time_best].as_ref().unwrap().time_us.max(1);
+        let mem_fillpick = r.per_method[fill_best].as_ref().unwrap().peak_bytes.max(1);
+        let mem_membest = r.per_method[mem_best].as_ref().unwrap().peak_bytes.max(1);
+
+        let treg = t_fillpick as f64 / t_timebest as f64;
+        let mreg = mem_fillpick as f64 / mem_membest as f64;
+        time_regret_all.push(treg);
+        mem_regret_all.push(mreg);
+        if fill_best == time_best {
+            fill_eq_time += 1;
+        }
+        if fill_best == mem_best {
+            fill_eq_mem += 1;
+        }
+
+        // Meaningful subset: the time-best ordering is above the noise floor.
+        if t_timebest >= TIME_FLOOR_US {
+            big_n += 1;
+            time_regret_big.push(treg);
+            if fill_best == time_best {
+                fill_eq_time_big += 1;
+            }
+            // Oracle vs Auto today (only where timing is meaningful).
+            tot_timeoracle_us += t_timebest;
+            if let Some(a) = &r.per_method[5] {
+                tot_auto_us += a.time_us.max(1);
+            }
+            if let Some(ar) = &r.per_method[6] {
+                tot_autorace_us += ar.time_us.max(1);
+            }
+            // Deterministic proxy-race prototype: the factor time you'd get by racing
+            // on each cheap proxy and picking its argmin ordering.
+            let t_flop = r.per_method[flop_best].as_ref().unwrap().time_us.max(1);
+            let t_maxfront = r.per_method[maxfront_best].as_ref().unwrap().time_us.max(1);
+            tot_fill_us += t_fillpick;
+            tot_flop_us += t_flop;
+            tot_maxfront_us += t_maxfront;
+            flop_regret.push(t_flop as f64 / t_timebest as f64);
+            maxfront_regret.push(t_maxfront as f64 / t_timebest as f64);
+        }
+    }
+
+    let sort = |mut v: Vec<f64>| {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        v
+    };
+    let tra = sort(time_regret_all.clone());
+    let trb = sort(time_regret_big.clone());
+    let mra = sort(mem_regret_all.clone());
+    let m = recs.len().max(1);
+
+    println!();
+    println!(
+        "=== issue #110 TIME/MEMORY ordering study ({} matrices, {} skipped) ===",
+        recs.len(),
+        skipped
+    );
+    println!("root: {}", root.display());
+    println!(
+        "timing: min-of-reps numeric factor, symbolic reused; meaningful subset = \
+         time-best >= {} us ({} of {} matrices)",
+        TIME_FLOOR_US, big_n, m
+    );
+    println!();
+    println!("does the FILL-optimal ordering match the TIME-optimal ordering?");
+    println!(
+        "  all: {}/{} ({:.1}%) agree   |   meaningful subset: {}/{} ({:.1}%) agree",
+        fill_eq_time,
+        m,
+        100.0 * fill_eq_time as f64 / m as f64,
+        fill_eq_time_big,
+        big_n.max(1),
+        100.0 * fill_eq_time_big as f64 / big_n.max(1) as f64,
+    );
+    println!("  => the fill-lies rate (fill-best != time-best) is the complement.");
+    println!();
+    println!("TIME regret of always picking the fill-optimal ordering (t_fill / t_time_best):");
+    println!(
+        "  all matrices     : geomean {:.3}  p50 {:.3}  p90 {:.3}  p99 {:.3}  max {:.3}",
+        geomean(&time_regret_all),
+        percentile(&tra, 0.50),
+        percentile(&tra, 0.90),
+        percentile(&tra, 0.99),
+        percentile(&tra, 1.0),
+    );
+    println!(
+        "  meaningful subset: geomean {:.3}  p50 {:.3}  p90 {:.3}  p99 {:.3}  max {:.3}",
+        geomean(&time_regret_big),
+        percentile(&trb, 0.50),
+        percentile(&trb, 0.90),
+        percentile(&trb, 0.99),
+        percentile(&trb, 1.0),
+    );
+    println!("  (1.00 = fill pick is also time-optimal; >1 = time left on the table)");
+    println!();
+    println!("does the FILL-optimal ordering match the MEMORY-optimal ordering?");
+    println!(
+        "  all: {}/{} ({:.1}%) agree",
+        fill_eq_mem,
+        m,
+        100.0 * fill_eq_mem as f64 / m as f64
+    );
+    println!(
+        "  MEMORY regret (peak_fill / peak_mem_best): geomean {:.3}  p90 {:.3}  p99 {:.3}  max {:.3}",
+        geomean(&mem_regret_all),
+        percentile(&mra, 0.90),
+        percentile(&mra, 0.99),
+        percentile(&mra, 1.0),
+    );
+    println!();
+    println!("upper bound on a TIME-oracle tuner vs feral today (meaningful subset totals):");
+    println!(
+        "  total factor us: Auto = {}   AutoRace = {}   time-oracle = {}",
+        tot_auto_us, tot_autorace_us, tot_timeoracle_us
+    );
+    println!(
+        "  a perfect per-matrix time-oracle would cut total factor time to {:.1}% of Auto \
+         ({:.2}x speedup) and {:.1}% of AutoRace",
+        100.0 * tot_timeoracle_us as f64 / tot_auto_us.max(1) as f64,
+        tot_auto_us as f64 / tot_timeoracle_us.max(1) as f64,
+        100.0 * tot_timeoracle_us as f64 / tot_autorace_us.max(1) as f64,
+    );
+
+    // --- deterministic proxy-race prototype ---
+    // How close does a *cheap symbolic proxy* race (no numeric factoring, no ML) get
+    // to the time-oracle? `fill` is what AutoRace uses today; `flop`=Σncol·nrow² and
+    // `max_front` are the candidate time-aware proxies. A proxy whose total ≈ oracle
+    // and whose regret ≈ 1.0 means "just race on this proxy" closes the §5.6 gap with
+    // no model; a stubborn residual over the best proxy is the actual learned-model case.
+    let frs = sort(flop_regret.clone());
+    let mfs = sort(maxfront_regret.clone());
+    println!();
+    println!(
+        "deterministic proxy-race prototype (meaningful subset; pick argmin(proxy) per matrix):"
+    );
+    println!(
+        "  total factor us:  fill-race = {}   flop-race = {}   maxfront-race = {}   oracle = {}",
+        tot_fill_us, tot_flop_us, tot_maxfront_us, tot_timeoracle_us
+    );
+    println!(
+        "  vs oracle:        fill-race {:.3}x   flop-race {:.3}x   maxfront-race {:.3}x   (1.00 = matches oracle)",
+        tot_fill_us as f64 / tot_timeoracle_us.max(1) as f64,
+        tot_flop_us as f64 / tot_timeoracle_us.max(1) as f64,
+        tot_maxfront_us as f64 / tot_timeoracle_us.max(1) as f64,
+    );
+    println!(
+        "  per-matrix time-regret vs oracle:  fill-race geo {:.3} p90 {:.3} max {:.3}",
+        geomean(&time_regret_big),
+        percentile(&trb, 0.90),
+        percentile(&trb, 1.0),
+    );
+    println!(
+        "                                     flop-race geo {:.3} p90 {:.3} max {:.3}",
+        geomean(&flop_regret),
+        percentile(&frs, 0.90),
+        percentile(&frs, 1.0),
+    );
+    println!(
+        "                                 maxfront-race geo {:.3} p90 {:.3} max {:.3}",
+        geomean(&maxfront_regret),
+        percentile(&mfs, 0.90),
+        percentile(&mfs, 1.0),
+    );
+}

--- a/dev/journal/2026-07-01-07.org
+++ b/dev/journal/2026-07-01-07.org
@@ -1,4 +1,7 @@
-* 2026-07-01-04 :issue99:dense-front:fma:performance:
+# Provenance: recorded as 2026-07-01-03 on branch claude/issue-99-b9zphx;
+# renumbered to -07 on merge to main to pair with dev/sessions/2026-07-01-07.md
+# (main's session -03 is a different session). Entries unchanged.
+* 2026-07-01-03 :issue99:dense-front:fma:performance:
 
 * 09:00 :orientation:blocker:
 Task: "loop over all levers until faer-level performance" on issue #99
@@ -161,41 +164,3 @@ at SAME inertia -> confirmed a matrix-specific BK pivoting interaction of
 fma rounding on the degenerate +-n-diagonal synthetic (both paths packed),
 not a kernel effect. Not a regression (fma was ~15s here at session start).
 Reinforces FMA opt-in.
-
-* 13:20 :issue-102:verify:ordering:parallel-dense-front:
-Verified issue #102 (PR #92 regresses cont5_2_4_l / dirichlet120 to a
-0%-CPU dense-front stall) at the code level — the matrices, the
-.sample.txt profiles, POUNCE/ripopt are all absent from this container,
-and the symptom is macOS-specific (__psynch_mutexwait) on 14 cores vs
-this 4-core Linux box, so no end-to-end repro is possible here.
-
-Key finding: PR #92 (d4502f1) changes TWO things, not one. Besides the
-OrderingPreprocess::Auto fill-verified race in src/symbolic/mod.rs, it
-also halves INTRAFRONT_MIN_AREA in src/dense/factor.rs:
-  git show d4502f1~1:src/dense/factor.rs -> `256 * 256` (65536)
-  main                                   -> `256 * 128` (32768)
-This lowers the trailing-update area floor above which a front's Schur
-update is dispatched to the nested rayon `par_chunks_mut` path
-(apply_blocked_schur_panel, factor.rs:3339) — the exact path the issue's
-profile shows stalled. The issue's bisection ("only the ordering change
-matters, #93/#94/#95 are getters") is under-specified: #92 bundles an
-ordering change AND a parallel-scheduling change, and both co-vary
-between v0.11.3 (healthy, floor 65536) and main (stalled, floor 32768).
-
-Argument that scheduling, not ordering, is the culprit: a bigger/denser
-front from a worse ordering would be slow at HIGH CPU; 0% CPU with
-workers in __psynch_mutexwait + main on LockLatch::wait_and_reset is a
-synchronization stall, and the only sync-path thing #92 changed is
-INTRAFRONT_MIN_AREA. Confirmed feral's own parallel path holds no
-explicit mutex (lock-free split_at_mut + par_chunks_mut, no alloc); the
-mutex samples are rayon injector/allocator under nested contention
-(tree-parallel scope.spawn of factor_one_supernode with inner
-par_chunks_mut nested inside).
-
-Clean isolating experiment for the reporter (byte-exact env knob,
-factor.rs:704): `FERAL_INTRAFRONT_MIN_AREA=65536 pounce cont5_2_4_l.nl`
-on main. Solves -> Lever B scheduling is the cause, not ordering.
-Still stalls -> ordering implicated, build the None-vs-LdltCompress
-front-dim harness (feral already loads symmetric mtx via read_mtx).
-
-Wrote dev/research/issue-102-pr92-dense-front-stall-verify.md.

--- a/dev/journal/2026-07-02-02.org
+++ b/dev/journal/2026-07-02-02.org
@@ -1,0 +1,203 @@
+* 14:30 :release:
+Published v0.13.0 (issue #107 OrderingMethod::External). Bumped six version
+strings via scripts/release-checklist.sh bump 0.13.0, cut CHANGELOG
+[0.13.0] - 2026-07-02, re-executed five notebooks against the 0.13.0 wheel
+(0 errors, version output 0.12.0 -> 0.13.0). PR #109 merged, tag v0.13.0
+pushed, GitHub release published. release.yml + python-wheels.yml both
+success; crates.io feral = 0.13.0, PyPI feral-solver = 0.13.0 confirmed live.
+Closed issue #107 manually (PR #108 lacked a Closes keyword so it never
+auto-closed).
+
+* 15:10 :issue-110:investigation:tuner:
+Investigated issue #110 (learned auto-tuner for factorization). Branch
+investigate/issue-110-learned-tuner.
+
+Findings (two parallel agents + own repo scan):
+- rslab's tuner is a learned SURROGATE COST-MODEL + explicit knob-grid search,
+  NOT an end-to-end policy net. Two MLPs (one per path), LDLT is 37->64->32->2
+  ReLU predicting [log factor_ms, log peak_mb]. Pure-Rust hand-rolled inference
+  (Vec<Vec<f64>> matmul), serde_json + include_str!. Offline Python training,
+  weights ship embedded + runtime-swappable tuner_profile.json. Three
+  deterministic backstops: a-priori memory gate from EXACT symbolic fill (not
+  the MLP), OOD -> exact-fill ordering race, deviation hysteresis (MIN_GAIN 8%).
+- feral already has the deterministic-heuristic ancestor of this: choose_adaptive,
+  pick_scaling_strategy, pick_ordering_preprocess (verify-by-fill), AutoRace, and
+  runtime feedback loops (pivot-growth escalation #102, quality escalation). The
+  cheap feature vector (n, nnz, avg_deg, diag ratio, max_col_nnz, arrow signature)
+  + SymbolicFactorization (front shapes, factor_nnz_estimate, peak_contrib_bytes,
+  etree) covers ~all of rslab's 37 inputs. bench_orderings/bench_solver_corpus +
+  the 153k KKT corpus mean label generation is a sweep extension, not new infra.
+- Constraint mismatch: feral has NO memory-mode knob (rslab's has one), and the
+  public Solver is LDLT-only (no auto LDLT-vs-LU dispatch), so a first model is
+  single-path LDLT.
+- GOVERNING constraint: exact inertia. Scoped the knobs into inertia-neutral
+  (ordering, preprocess, amalgamation, kernel gates -- but even FMA/reduction
+  order can flip a borderline BK classification per tried-and-rejected, so gate
+  must be validated) vs inertia-sensitive (scaling, pivot-u -- keep under existing
+  deterministic escalation, ML must not own them).
+
+Conclusion: feasible and well-matched, but honest first increment is narrow.
+Recommended measurement-first: quantify how often choose_adaptive's cheap
+ordering pick differs from the AutoRace optimum and by how much, BEFORE committing
+to a model + trainer + weight-artifact maintenance surface. Lowest-risk slice is a
+learned surrogate for AutoRace ordering selection (strictly inertia-neutral,
+trivially backstopped by falling back to AutoRace on OOD). Wrote
+dev/research/issue-110-learned-tuner.md. No code change proposed.
+
+* 16:05 :issue-110:measurement:ordering:
+Ran the gating measurement (issue #110). Built
+crates/feral-diagnostics/src/bin/study_ordering_gap.rs: per family representative
+under data/matrices/kkt, measured factor_nnz_estimate under
+AMD/AMF/MetisND/ScotchND/KahipND/Auto/AutoRace (default preprocess, ordering the
+only variable). 568 families measured (705 dirs; 135 keep .mtx in nested subdirs
+the collector skips -- layout artifact, not bias).
+
+Results:
+- Auto == 5-method oracle on 489/568 = 86.1%. ratio_auto geomean 1.012, p90 1.014,
+  p99 1.287, max 1.608. Losses >2%/>10%/>50%: 56/22/4 families.
+- AutoRace == oracle on 546/568 = 96.1%. ratio_race geomean 1.0015, max 1.115.
+- AutoRace symbolic time 8.95x Auto (292ms vs 33ms total).
+
+Two decisive findings:
+1. Every one of the 22 families where Auto loses >10% has ratio_race=1.0000 --
+   AutoRace already hits the oracle on the ENTIRE meaningful tail. So a learned
+   model is not needed for reachable quality; it could only recover AutoRace's 9x
+   symbolic cost, which is amortized to ~0 across IPM pattern reuse (up to 3000
+   factors per symbolic). Weak motivation.
+2. AutoRace misses the oracle on exactly 22/568 (3.9%) -- the same families where
+   Auto beats the race -- because choose_adaptive knows AMF but the AutoRace set
+   {AMD,MetisND,ScotchND,KahipND} does NOT race AMF. {AutoRace + AMF} == oracle by
+   construction. So adding AMF to the race set makes the deterministic race
+   oracle-optimal on 100% of families -- one-line, no ML.
+
+Conclusion: recommend AGAINST a learned ordering tuner. The deterministic
+Auto+AutoRace pair already spans the quality/cost frontier; the one real gap
+(AMF missing from race) is ML-free. Updated dev/research/issue-110-learned-tuner.md
+(sections 5.5, 6, 7). Follow-up candidate: add Amf to AutoRace's race set.
+
+* 16:45 :issue-110:caveat:fill-vs-time:
+Recorded a correctness caveat on the #110 fill study (issue comment + note
+sections 5.5.1, 7, status header). The study optimizes FILL, a proxy that
+provably diverges from factor wall-clock / peak memory. feral's own nql180
+(src/symbolic/mod.rs:311, issue-73 note): MetisND has smaller fill (nnz_L 0.98x)
+AND smaller flop_proxy (0.86x) yet AMF is 2.05x faster on real factor+solve
+(1.90s vs 3.95s) -- "fill is NOT a reliable speed predictor". So "86% fill-optimal"
+does not imply time-optimal; the fill study is structurally blind to the
+nql180-type regime where a time/memory objective (hence a learned surrogate) could
+beat fill-based selection. Real design axis = HOW the time signal is injected:
+online per-matrix surrogate (rslab) vs offline-measured deterministic regime
+branches (feral). Correct gating experiment: predict factor wall-clock + peak
+memory from cheap features across a wider-than-KKT distribution. Next: gather that
+time/memory data.
+
+* 17:40 :issue-110:measurement:time-memory:
+Gathered the TIME/MEMORY data the #110 fill study called for. Built
+crates/feral-diagnostics/src/bin/study_ordering_timemem.rs: per ordering, measure
+numeric factor wall-clock (min-of-reps, symbolic reused = IPM per-iteration cost)
+and peak-memory model (16*nnz_l + peak_contrib_bytes). Three corpora, meaningful
+subset = time-best >= 50us.
+
+Results (fill-best=time-best agree | time-regret geo/max | mem-regret geo/max |
+oracle vs Auto | vs AutoRace):
+- KKT reps (33):   24% | 1.02/1.13 | 1.01/2.12 | 1.02x | 1.02x
+- large (10):      30% | 1.16/1.60 | 1.01/1.07 | 1.52x | 1.06x
+- mittelmann (41): 22% | 1.14/3.61 | 1.13/3.90 | 1.43x | 1.12x
+
+Key findings:
+- Fill is a bad speed predictor at scale: min-fill pick leaves ~14-16% factor time
+  on large/thin-large, up to 3.6x on svanberg n=100k (min-fill AMD 3.61x slower than
+  SCOTCH). Small KKT reps hid this (~2%) -- too small for front-shape/BLAS-3 effects.
+- The objective COMPOUNDS: numeric factor time is paid every IPM iteration (up to
+  3000), so a 10-15% better ordering saves 10-15% each time -- does NOT amortize away
+  (unlike selection cost). This reverses part of the earlier amortization argument.
+- Neither Auto nor AutoRace dominates: mittelmann head-to-head Auto 18 / AutoRace 22
+  / tie 1. AutoRace avoids ND-blowup disasters (qap15 9x, c-big metis 5x); Auto's
+  thin-large->AMF reroute helps elsewhere. Both jointly miss svanberg (min-fill=AMD,
+  both pick the 3.6x-slow one) -- only a time-aware selector escapes.
+- Memory a separate/larger opportunity on thin-large: min-fill uses up to 3.9x peak
+  mem of mem-best (dtoc2 n=104k AMF vs AMD), geo +13%. Fill & AutoRace ignore memory.
+- Time-oracle beats default Auto 1.43-1.52x, beats AutoRace 6-12%, on large matrices.
+
+Conclusion revised: not "don't build it." Fill selection is solved; time/memory
+selection has real non-amortizable headroom, concentrated on large matrices and
+MOSTLY reachable deterministically. Recommended next: a deterministic time/memory-
+AWARE race (select on measured/predicted factor time+peak mem, not fill) -- measure
+how close it gets to the oracle before reaching for a learned model. Updated note
+sections 5.6, 7, status.
+
+* 18:20 :issue-110:prototype:time-race:
+Prototyped the deterministic time-aware race (extended study_ordering_timemem with
+flop_proxy=Σncol·nrow² and max_front per ordering; race each cheap proxy, measure
+time-regret vs the oracle). DECISIVE NEGATIVE RESULT.
+
+Mittelmann (41 meaningful), per-matrix time-regret vs oracle (geo):
+- fill-race     1.134  (total 1.13x oracle)
+- flop-race     1.198  (total 1.26x oracle)
+- maxfront-race 1.208  (total 1.28x oracle)
+
+No cheap symbolic proxy reaches the time-oracle, and FILL is the BEST of the three --
+flop_proxy and max_front are WORSE time predictors than fill. Confirms issue-73's
+nql180 observation at corpus scale: symbolic structure -> numeric factor time is not
+captured by any single cheap scalar. (Large set totals c-big-dominated/noisy but same
+ranking: flop never beats fill.) Corollary: adding AMF to the race to minimize FILL
+(#111) is fill-optimal but slightly time-NEGATIVE on a few large matrices (c-big: AMF
+fill-min yet 1.6x slower than KaHIP) -- #111 stands as a fill/oracle fix, not a time win.
+
+Implication: cheap deterministic time-race is off the table. Two viable ways to capture
+the §5.6 headroom:
+1. ACTUAL-time race latched per pattern -- factor k candidates once, keep fastest,
+   latch (reuse feral's ordering_escalated latch). Reaches oracle by construction; cost
+   k-1 extra factors ONCE per pattern, amortized to ~0 over up-to-3000 IPM reuse iters.
+   No ML. RECOMMENDED.
+2. Learned multi-feature model -- only cheap way to beat single proxies; justified over
+   option 1 only when actual-time race is unaffordable (one-shot/non-reuse solves, NOT
+   feral's IPM core).
+Sharpens #110 to a crisp decision. Updated note §5.6/§5.7/§7/status. Posted time/memory
+data + prototype to issue #110.
+
+* 19:30 :issue-110:prototype:latched-race:
+Built the latched actual-time race end-to-end (study_latched_race.rs; drives public
+Solver API, no core change). Race candidate orderings on the first factor of a
+family's real IPM iterate sequence, latch the fastest, measure steady-state per
+iterate over PATTERN-REUSED iterates only (IPM changes pattern at iterate 0->1 as the
+active set settles -- nql180 nnz 874500->939300 -- then stable).
+
+Corrected results (29 mittelmann families, max-iters 10):
+- Steady-state: latched winner 9.3% faster/iter than Auto (geomean); up to 40% on
+  some (henon 0.59, optmass 0.72, cont5_2_2 0.61) but SLOWER on others (dtoc1nd 1.20,
+  lane_emden 1.27) where the pick was wrong. High variance.
+- vs AutoRace: 0.7% (essentially tied). AutoRace reuses its raced pick on the stable
+  tail. (An earlier draft saw AutoRace ~79% slower -- ARTIFACT of averaging in the one
+  iterate where the pattern changes and AutoRace re-runs its whole symbolic race.
+  Corrected by measuring steady state over reused iterates only.)
+- Representativeness only 38%: racing on the TRANSIENT first iterate picks the
+  steady-state-optimal ordering just 38% of the time (iterate 0 pattern != stable
+  pattern). A per-PATTERN latch would race on the stable pattern's first occurrence.
+- Break-even median 206 iterations; 11/29 never amortize. The 5-factor race overhead
+  needs ~200 same-pattern reuses to pay back at 9%/iter; typical IPM is 20-50. So the
+  "amortizes to ~0" claim in §5.7 was wrong for real single-solve sequences.
+
+Verdict: the actual-time race is NOT the free win §5.7 implied. Prize ~9% over the
+already-good Auto, only on large problems, amortizes over hundreds of same-pattern
+reuses, ties AutoRace on the stable tail. Reversal: since race OVERHEAD is the killer,
+a learned predictor (zero inference cost, picks on the stable pattern) is the MORE
+viable capture vehicle than a race -- opposite of §5.7. But ~9% on a subset is a modest
+prize; recommend NOT building a time-aware selector without a specific high-repeat
+large-matrix workload. One clear action stays: the ML-free fill fix (#111). Updated
+note §5.8/§7/status.
+
+* 20:10 :issue-111:review:reversal:
+Reviewed issue #111 (add AMF to AutoRace race set) against the #110 time/memory
+evidence that post-dates its filing. REVERSED it. AutoRace SELECTS BY FILL; adding
+AMF (low-fill-but-sometimes-slow) can only lower chosen fill but can RAISE chosen
+time. Measured across 51 large/thin-large matrices: adding AMF regresses AutoRace
+factor time on 8 (c-big 1.60x, dtoc2 1.43x, dirichlet120 1.12x, ex1/ex4/ex42_160
+1.11x, bcsstk38 1.09x, cont5_1_l 1.02x), improves 6 (r05 0.75x, rocket 0.78x, dtoc1nd
+0.80x, bratu3d 0.86x), 37 unchanged. c-big verified: AMF fill 78.3M < KaHIP 91.9M so
+race switches to AMF, but AMF time 20.9M vs KaHIP 13.1M = 1.60x slower. The worst
+regressions are the largest matrices (where AutoRace matters); #111's fill wins
+(VESUVIOU n=3083, GAUSS2 758, HAHN1 715) are small matrices where fill barely affects
+time. So #111 trades fill where irrelevant for time-regression where critical.
+Recommend CLOSING #111 -- the limitation is the fill SELECTION CRITERION, not the
+candidate set, and time-aware selection isn't worth building (§5.8). Updated note §5.7
+corollary + §7 (withdrew #111 from recommendations) + status. Posted review to #111.

--- a/dev/research/issue-102-pr92-dense-front-stall-verify.md
+++ b/dev/research/issue-102-pr92-dense-front-stall-verify.md
@@ -1,0 +1,120 @@
+# issue #102 — verifying the PR #92 cont5_2_4_l / dirichlet120 stall — 2026-07-01
+
+Verification pass on the issue-#102 claim: PR #92 (`d4502f1`) regresses
+`cont5_2_4_l` and `dirichlet120` (POUNCE mittelmann) from converged to a 300 s
+timeout spent at **~0 % CPU** inside `factor_frontal_blocked_in_place_with_scratch`.
+The issue attributes the regression to #92's **ordering** change (the
+`OrderingPreprocess::Auto` fill-verified race) by elimination — the other three
+post-0.11.3 commits only add diagnostic getters.
+
+## What can and cannot be reproduced in this container
+
+- **The matrices are not here.** No POUNCE, no `../ripopt`, no `benchmarks/mittelmann/nl/`,
+  no dumped KKTs. `cont5_2_4_l` (n=90 600) and `dirichlet120` (n=53 881) cannot be
+  factored here without the dumps.
+- **The `.sample.txt` profiles the issue cites are not on this branch** either
+  (`dev/research/issue-91-cont5_2_4_l-*.sample.txt` do not exist in the repo).
+- **Wrong platform / core count.** The stall symptom is a macOS `__psynch_mutexwait`
+  on a 14-core M4 Pro. This container is 4-core Linux; `__psynch_mutexwait` is a
+  macOS pthread primitive and the parallel contention profile is core-count
+  sensitive. A 0 %-CPU parallel stall is not expected to reproduce identically here.
+
+So this is a **code-level verification** of the causal claim, not an end-to-end
+repro. The end-to-end repro must run on the reporter's machine with the dumps.
+
+## Finding: #92 changed TWO things, not one — and the issue omits the second
+
+`git show --stat d4502f1` — PR #92 touches `src/dense/factor.rs` as well as
+`src/symbolic/mod.rs`. The `factor.rs` change is **Lever B**:
+
+```
+-pub const INTRAFRONT_MIN_AREA: usize = 256 * 256;   // 65536  (v0.11.3 / pre-#92)
++pub const INTRAFRONT_MIN_AREA: usize = 256 * 128;   // 32768  (#92 / main)
+```
+
+`INTRAFRONT_MIN_AREA` is the trailing-update area `(nrow−j_start)·n_elim` below
+which a dense front's Schur update **stays serial**; at or above it the update is
+dispatched to the intra-front parallel `par_chunks_mut` path
+(`apply_blocked_schur_panel`, `src/dense/factor.rs:3339`). #92 **halved** the
+floor, so every front with trailing area in `[32768, 65536)` that v0.11.3
+factored serially now goes onto the parallel path — the exact path the issue's
+profile shows stalling.
+
+The issue's bisection ("only #92's ordering change is the cause") is therefore
+**under-specified**: it correctly rules out #93/#94/#95, but #92 itself bundles
+an ordering change *and* a parallel-scheduling change. Both co-vary between
+v0.11.3 (healthy) and `main` (stalled):
+
+| | v0.11.3 (252 % CPU, 8.1 s) | `main` (0 % CPU, timeout) |
+|---|---|---|
+| `OrderingPreprocess::Auto` | trusts `pick_ordering_preprocess` (LdltCompress when predicate fires) | fill-verified race (may fall back to None) |
+| `INTRAFRONT_MIN_AREA` | 65536 | **32768** |
+
+## Why the 0 %-CPU symptom points at scheduling, not front size
+
+If #92's *ordering* alone selected a larger/denser front, the factorization would
+be **slower at high CPU** (more serial arithmetic, or a well-parallelized bigger
+front) — not **0 % CPU**. A 0 %-CPU stall with workers parked in
+`__psynch_mutexwait` and the main thread on `LockLatch::wait_and_reset` is a
+**synchronization pathology**, and the only thing #92 changed on the
+synchronization path is `INTRAFRONT_MIN_AREA`.
+
+Mechanism (verified in code):
+
+- Tree-level parallelism dispatches supernodes via `rayon::scope` + `scope.spawn`
+  (`src/numeric/factorize.rs:2092`, `2171`). `factor_one_supernode` runs on a
+  rayon worker.
+- Inside it, `factor_frontal_blocked_in_place_with_scratch` → `apply_blocked_schur_panel`
+  calls `par_chunks_mut` (`factor.rs:3349`) — **nested** rayon parallelism.
+- Lowering the floor turns medium fronts that were serial leaves into nested
+  parallel sections. On a saturated pool the outer spawns occupy workers while
+  each inner `par_chunks_mut` needs help that cannot arrive; the main thread
+  (calling from outside the pool via `in_worker_cold`) parks on the completion
+  latch. The macOS `__psynch_mutexwait` samples are rayon's injector/job-queue
+  lock (or the allocator) under this nested-contention shape — feral's own
+  parallel path holds **no explicit mutex** (`apply_blocked_schur_panel` is a
+  lock-free `split_at_mut` + `par_chunks_mut`, no allocation).
+
+This is consistent with `dev/research/issue-91-parallel-dense-front-2026-06-30.md`:
+the intra-front path already had a ~40 % serial floor and "scales only ~2×." A
+front shape that pushes fork-join overhead past the work it parallelizes can tip
+"~2×" into "net-negative / stall," and the lower floor admits exactly such fronts.
+
+## The one-line experiment that isolates the two hypotheses
+
+`INTRAFRONT_MIN_AREA` has a **byte-exact env override** (`factor.rs:704`):
+
+```
+FERAL_INTRAFRONT_MIN_AREA=65536   # restore the v0.11.3 floor, ordering untouched
+```
+
+On the reporter's M4 with the dumps, re-run `main`:
+
+1. `FERAL_INTRAFRONT_MIN_AREA=65536 pounce cont5_2_4_l.nl` — if it **solves**, the
+   regression is Lever B (scheduling), *not* the ordering, and the issue's
+   diagnosis needs correcting.
+2. If it still stalls, the ordering change is implicated and the next step is the
+   ordering-comparison harness (factor the dumped KKT under None vs LdltCompress,
+   compare front dims + intrafront dispatch counts).
+
+This override is pure scheduling (per-column reduction is thread-independent), so
+(1) changes nothing numerically — a clean bisection of the two bundled changes.
+
+## Suggested feral-level reproducer (needs the dumps)
+
+feral already loads symmetric MatrixMarket KKTs (`src/io/mtx.rs::read_mtx`). A
+turnkey harness would take a dumped `cont5_2_4_l.mtx` and factor it four ways —
+{None, LdltCompress} × {INTRAFRONT 32768, 65536} — reporting per-front
+`(nrow, n_elim, area, serial|parallel)` and wall time, plus the resolved ordering.
+That directly answers "which of the two #92 changes stalls, and on which front."
+Not built here (no dump to validate against); flagged as the concrete next step.
+
+## Status
+
+- Verified (code): #92 bundles an ordering change **and** an `INTRAFRONT_MIN_AREA`
+  halving; the issue's causal claim considers only the former.
+- Verified (mechanism): the 0 %-CPU symptom is a synchronization stall on the
+  nested-parallel dense-front path, which is what the halved floor feeds.
+- Not verified (no matrices / wrong platform): the end-to-end stall itself, and
+  which of the two changes actually trips it. Isolable on the reporter's machine
+  with `FERAL_INTRAFRONT_MIN_AREA=65536`.

--- a/dev/research/issue-110-learned-tuner.md
+++ b/dev/research/issue-110-learned-tuner.md
@@ -1,0 +1,545 @@
+# Research Note: Learned auto-tuner / classifier for factorization (issue #110)
+
+**Status:** Investigation complete — fill (§5.5), time/memory (§5.6), cheap-proxy race
+(§5.7), and an end-to-end latched actual-time race prototype (§5.8). Findings: fill
+selection is already solved; the time/memory objective has real headroom on large
+matrices (§5.6) but no cheap proxy captures it (§5.7); the actual-time race captures only
+~9 % over the already-good `Auto`, amortizes over a median ~206 same-pattern reuses (far
+more than typical IPM), mis-picks on the transient first iterate, and ties `AutoRace` on
+the stable tail (§5.8). **Net: the ordering-selection prize is real but marginal; do not
+build a time-aware selector (race or model) without a specific high-repeat, large-matrix
+workload.** (The AMF-in-AutoRace follow-up #111 was *withdrawn on review* — §5.7
+corollary: it optimizes fill but regresses time on the largest matrices.) Deliverables: this note +
+`study_ordering_gap` (fill) + `study_ordering_timemem` (time/memory + proxy race) +
+`study_latched_race` (end-to-end latched race) binaries.
+**Date:** 2026-07-02
+**Related spec sections:** 5.1 (feature lifecycle); symbolic + numeric pipelines
+**Key references:** issue #110; rslab (github.com/milanofthe/rslab) `src/auto_tune.rs`,
+`src/tuning.rs`, `src/auto_tune_model_{ldlt,lu}.json`, `xtask/src/main.rs`,
+`benches/train_tuner.py`; feral's own `Auto` dispatchers (`choose_adaptive`,
+`pick_scaling_strategy`, `pick_ordering_preprocess`) and `AutoRace`.
+
+## 1. What the issue proposes
+
+Port rslab's "learned auto-tuner" idea to feral: a small ML model that, from a
+matrix's cheap structural features, selects the solver configuration (ordering,
+amalgamation, kernel gates, scaling, pivot threshold, memory mode) — guarded by a
+deterministic memory backstop so it never uses more memory than the default, with
+an out-of-distribution fallback to a deterministic exact-fill ordering race.
+Trained on a complete-distribution corpus (curl-curl Maxwell, Stokes/KKT
+saddle-point, convection-diffusion swept over grid-Péclet).
+
+## 2. How rslab actually does it (verified against the repo)
+
+rslab's tuner is **not** an end-to-end policy net that emits a config. It is a
+**learned surrogate cost-model + explicit knob-grid search + deterministic
+backstops**:
+
+- **Model:** two small MLPs, one per factorization path (LDLᵀ and unsymmetric
+  LU). The LDLᵀ net is a 3-layer FC `37 → 64 → 32 → 2`, ReLU hidden, linear out.
+  It maps `(structural features ⊕ log-transformed knobs) → [log factor_ms,
+  log peak_mb]` — a cost predictor, not a classifier.
+- **Selection:** the tuner scores a candidate grid of configs through the net and
+  picks the one minimizing `w·log(time) + (1−w)·log(mem)`, `w=0.7`. The knobs it
+  varies are fed *into* the net as inputs, so the same net scores every candidate.
+- **Inference is pure Rust, hand-rolled** — `struct Layer { w: Vec<Vec<f64>>, b:
+  Vec<f64> }`, plain matmul+bias+ReLU. No candle/burn/tract/ONNX. Weights embedded
+  at compile time via `include_str!` + `serde_json::from_str` (~2.5k f64s).
+- **Three deterministic backstops (the important part):**
+  1. *A-priori memory gate* — reject any candidate whose memory exceeds default by
+     more than ~2% (`MEM_TOL_LN = 0.0198`); the real gate is computed from **exact
+     symbolic fill + flops + a realistic memory floor**, not the MLP prediction, so
+     "never more memory than default" holds *by construction* before any numeric work.
+  2. *OOD fallback* — when `factor_flops > flops_ood_cap` the net is refused and the
+     tuner returns `default().with_ordering(AutoRace)`, a deterministic exact-fill
+     ordering race.
+  3. *Deviation hysteresis* — must beat default by ≥8% (`MIN_GAIN`) to deviate,
+     ≥20% to flip factorization method, calibrated to the machine's timing-noise floor.
+- **Training is offline in Python.** `cargo xtask tune` runs sweep → `python
+  benches/train_tuner.py` → hardware-calibrate → assemble → **held-out validate
+  with a ship-gate that refuses to ship a model that regresses the default**.
+  Weights ship as embedded JSON + a runtime-swappable `tuner_profile.json`.
+
+The pattern to copy is the *discipline*: the ML only ever chooses among configs
+that a deterministic layer has already proven are no worse than the default on the
+guaranteed axis (memory), and it never extrapolates out of distribution.
+
+## 3. feral's current state — the tuner would replace/augment this
+
+### 3a. Configuration surface (knobs a tuner could set)
+The public `Solver` is **symmetric LDLᵀ multifrontal only**; the unsymmetric LU
+code (`src/lu/`) is a *separate* simplex-basis API with no auto LDLᵀ-vs-LU
+dispatch. So a first tuner tunes the LDLᵀ `Solver`. Knobs (all in
+`src/numeric/solver.rs` builders over `NumericParams` / `SupernodeParams` /
+`BunchKaufmanParams`):
+
+- **Ordering method** — `OrderingMethod` {Amd, Amf, MetisND, ScotchND, KahipND,
+  Auto, AutoRace, External}. Default `Auto`.
+- **Ordering preprocess** — `OrderingPreprocess` {None, LdltCompress, Auto=default}.
+- **Ordering-escalation-growth** — `Option<f64>`, default `Some(1e24)`.
+- **Scaling** — `ScalingStrategy` {InfNorm, Mc64Symmetric, Identity, External,
+  Auto=default}.
+- **Amalgamation** — `nemin` (default **16**), `AmalgamationStrategy`
+  {Adjacency, Renumber, Auto=default}, small-leaf grouping.
+- **Pivot threshold `u`** (LDLᵀ) — `bk.pivot_threshold`, effective default `1e-8`.
+- **Kernel gates** — global FMA (`with_fma`), per-front FMA row gate
+  (`with_fma_large_fronts`), BLAS-3 (internal, front-size gated),
+  intra-front parallelism (internal, area-gated), block size 64, global
+  parallel toggle + flop gate.
+- **Stability** — delayed pivots, cascade-break (+ auto-arm), static-pivot
+  threshold, SQD mode, MC64 cache.
+- **Memory mode — DOES NOT EXIST.** No `MemoryMode`/`with_memory` knob; memory is
+  managed structurally (contrib-block pooling). rslab's memory *knob* has no feral
+  analogue, though its memory *backstop* (bound peak from symbolic fill) maps
+  directly onto feral's `SymbolicFactorization.peak_contrib_bytes`.
+
+### 3b. Current automatic selection (already sophisticated, hand-written)
+- Ordering: `choose_adaptive` (cheap n/avg-deg/arrow-signature rules) or `AutoRace`
+  (runs full symbolic on 4 orderings, keeps min `factor_nnz_estimate`).
+- Preprocess: `pick_ordering_preprocess` + **verify-by-fill** (run both ways, keep
+  `LdltCompress` only within 2× fill of `None` — issue #91).
+- Runtime feedback: escalate to `LdltCompress` on pivot growth `>1e24` (#102);
+  quality escalation bumps scaling then pivot-`u` on instability (Ipopt-style).
+- Scaling: `pick_scaling_strategy` (arrow-head + slack-mass → Mc64 else InfNorm),
+  sticky per pattern, with MC64 fallback policy.
+- Amalgamation: `pick_amalgamation_strategy` (etree path-vs-bushy).
+
+**These hand-written cheap-feature dispatchers are exactly rslab's target — feral
+has independently built the deterministic-heuristic version of the same idea.** The
+learned tuner is a natural evolution, not a greenfield capability.
+
+### 3c. Features already computed (ready-made classifier inputs)
+Cheap O(nnz) pattern scans the heuristics already do: `n`, `nnz`, `avg_deg`,
+`diag_only/n`, `max_col_nnz`, low-degree-column fraction, arrow/bordered signature.
+Rich symbolic outputs on `SymbolicFactorization`: per-front `ncol`/`nrow` shape
+distribution, `factor_nnz_estimate`, `peak_contrib_bytes`, `etree`, `col_counts`.
+Numeric diagnostics: pivot growth, inertia, `ScalingInfo`, `Mc64MatchStats`. This
+covers ~all of rslab's 37-input feature vector except a couple of derived
+tree-width / arithmetic-intensity terms that are trivial to add.
+
+### 3d. Training infrastructure that already exists
+`crates/feral-diagnostics/src/bin/bench_orderings.rs` already sweeps 4 orderings
+per matrix recording fill+time; `bench_solver_corpus.rs` walks a corpus by family;
+`bench_one_matrix.rs` emits a per-matrix sidecar (n, nnz, inertia, analyse/factor/
+solve µs, rel_res, status) — a ready template for a training-label record. feral
+has a 153k-matrix KKT corpus plus the MUMPS/SSIDS oracles under
+`external_benchmarks/`. Label generation (best config per matrix) is a sweep
+extension, not new infrastructure.
+
+## 4. Feasibility under feral's hard constraints
+
+- **Zero non-Rust deps / pure Rust / stable toolchain** — ✅ trivially met.
+  rslab's own inference is a hand-rolled MLP + `serde_json` + `include_str!`; feral
+  already depends on `serde`. No BLAS/ML crate needed. Offline training in Python
+  is out-of-tree (a dev tool, like the existing `scripts/*.py`), weights ship as an
+  embedded JSON artifact.
+- **Correctness before performance / exact inertia** — ⚠️ **the governing
+  constraint, and where feral differs from rslab.** feral's headline guarantee is
+  *exact certified inertia*. A tuner must be scoped so it can only ever change
+  *performance*, never *which inertia is reported*:
+  - **Inertia-neutral knobs** (safe for ML to pick freely): ordering method,
+    ordering preprocess, amalgamation (`nemin`/strategy), all kernel gates
+    (FMA/BLAS-3/parallelism/block size), parallel toggle, MC64 cache. These change
+    fill/FLOPs/scheduling but not the eliminated pivot sequence's signs. *Caveat:
+    FMA and reduction order can flip a borderline pivot's Bunch-Kaufman
+    classification at the rounding boundary (see `tried-and-rejected.md` FMA
+    inertia-flip entries) — so even "neutral" kernel gates must be validated
+    against the inertia gate, not assumed free.*
+  - **Inertia-sensitive knobs** (ML must NOT own these, or must be backstopped by
+    the existing deterministic escalation): scaling strategy and pivot threshold
+    `u` change which pivots are accepted and can flip inertia on near-singular /
+    borderline KKTs — precisely the matrices #102/#63 already handle with
+    deterministic feedback loops. The safe design keeps scaling/`u` under the
+    existing deterministic escalation and lets ML tune only the performance axis.
+  - **Backstop analogue:** rslab's "never worse than default on memory" becomes
+    feral's "never wrong on inertia and never worse than default on the corpus
+    inertia gate." The `AutoRace` OOD fallback already exists deterministically.
+- **Clean-room / no architectural dependency on references** — ✅ the idea is
+  reimplemented from the design, not rslab's code (MIT, but we build our own).
+
+## 5. Assessment & recommended scope
+
+**Verdict: feasible and well-matched to feral, but the honest first increment is
+narrow and measurement-driven, not a full multi-knob tuner.**
+
+feral already *has* the deterministic version of this system (§3b) and it is
+well-tuned. The learned tuner earns its keep only where the hand-written
+dispatchers demonstrably leave performance on the table. The two places most
+likely to pay off, in priority order:
+
+1. **Ordering selection as a learned surrogate for `AutoRace`.** `AutoRace` runs
+   full symbolic 4× to pick the min-fill ordering — accurate but expensive. A tiny
+   surrogate that predicts `factor_nnz_estimate` (or factor µs) per ordering from
+   cheap features, picking the argmin *without* running the race, is:
+   (a) strictly inertia-neutral (ordering never changes inertia, modulo the FMA
+   caveat which ordering doesn't touch), (b) backstopped trivially (fall back to
+   `AutoRace` when features are OOD or predictions are close), (c) directly
+   measurable against `AutoRace`/`Auto` on the existing corpus, and (d) reuses
+   `bench_orderings` for labels. This is the lowest-risk, highest-clarity slice.
+
+2. **Amalgamation `nemin` / kernel-gate tuning** — also inertia-neutral, but the
+   payoff is smaller and the BLAS-3/FMA gates are already shape-dispatched.
+
+Explicitly **out of scope for a first cut:** letting ML own scaling or pivot-`u`
+(inertia-sensitive; keep deterministic), and any unsymmetric-LU model (separate
+API, no auto-dispatch to hang it on yet).
+
+**Recommended next step (if we proceed):** a focused *measurement study first* —
+extend `bench_orderings` to dump per-matrix (features, per-ordering fill+time) over
+the corpus, and quantify how often `choose_adaptive`'s cheap pick differs from the
+`AutoRace` optimum and by how much. If the gap is small, the deterministic
+heuristics already capture most of the value and a learned model is not worth the
+maintenance surface. If the gap is material, we have both the motivation and the
+labeled corpus in hand, and Phase 2 is the pure-Rust surrogate + ship-gate
+(rslab's "never regress the default" discipline, adapted to the inertia gate).
+
+## 5.5. Measurement results (the gating study — ran 2026-07-02)
+
+Built `crates/feral-diagnostics/src/bin/study_ordering_gap.rs`: for one
+representative matrix per family under `data/matrices/kkt` (fill depends only on
+the pattern, shared across a family's IPM dumps), measure `factor_nnz_estimate`
+under AMD / AMF / MetisND / ScotchND / KahipND / `Auto` / `AutoRace`, all with the
+default preprocess (apples-to-apples; ordering is the only variable). **568 family
+representatives** measured (of 705 family dirs; 135 store their `.mtx` in nested
+subdirs the collector doesn't descend into — a coverage gap, not a bias, since it's
+purely a directory-layout artifact). `oracle_best` = min fill over the 5 explicit
+methods.
+
+Headline numbers:
+
+| metric | value |
+|---|---|
+| `Auto` == oracle optimum | **489/568 = 86.1 %** |
+| `ratio_auto` = fill_auto / oracle_best | geomean **1.012**, p50 1.000, p90 **1.014**, p99 1.287, max **1.608** |
+| families where `Auto` loses >2 % / >10 % / >50 % fill | 56 / 22 / 4 |
+| `AutoRace` == oracle optimum | **546/568 = 96.1 %** |
+| `ratio_race` = fill_autorace / oracle_best | geomean 1.0015, p90 1.000, max 1.115 |
+| `AutoRace` symbolic time vs `Auto` | **8.95× slower** (292 ms vs 33 ms total) |
+
+Two findings that change the recommendation:
+
+1. **The entire meaningful fill tail is already recovered deterministically by
+   `AutoRace`.** For *every one* of the 22 families where `Auto` loses >10 % fill,
+   `ratio_race = 1.0000` — `AutoRace` hits the oracle. So a learned model is **not
+   needed for reachable quality**: the deterministic system already reaches the
+   optimum on the tail. The only thing ML could add is reaching that quality at
+   `Auto`'s cost instead of `AutoRace`'s ~9× symbolic cost — and symbolic is done
+   *once per pattern* and amortized across up to 3000 numeric factors in the IPM
+   reuse workload, so that 9× is near-zero in the setting that dominates feral's
+   corpus. The cost argument for ML is therefore weak.
+
+2. **The one real deterministic gap is ML-free to close.** `AutoRace` misses the
+   oracle on exactly 22/568 (3.9 %) families — and those are exactly the 22 where
+   `Auto` *beats* the race, because `choose_adaptive` knows AMF and the `AutoRace`
+   set {AMD, MetisND, ScotchND, KahipND} does **not** race AMF. `{AutoRace ∪ AMF}`
+   equals the 5-method oracle by construction, so **adding AMF to the `AutoRace`
+   race set makes the deterministic race oracle-optimal on 100 % of these families**
+   — a trivial, deterministic, inertia-neutral change that dominates what a learned
+   ordering surrogate could achieve on quality. (Tail families losing the most:
+   VESUVIOU/VESUVIA n=3083 at 1.61×/1.59×, GAUSS2 n=758 at 1.58×, HAHN1 n=715 at
+   1.56× — all fully recovered by AMD/ND methods the race already runs; the
+   remaining Auto-only wins are AMF picks.)
+
+### 5.5.1. Caveat — this study optimizes *fill*, which under-tests the real question
+
+The study scores orderings by **fill** (`factor_nnz_estimate`), but fill is only a
+*proxy* for what actually matters — factor wall-clock and peak memory. So the
+"recommend against a learned ordering tuner" conclusion holds **narrowly**: for
+ordering selection *scored by fill on KKT matrices*, not for the time/memory
+objective a learned tuner is actually built around. `86 % fill-optimal` says nothing
+about *time*-optimality.
+
+Fill is blind to: dense-front work (∝ Σ `ncol·nrow²`, not linear in fill); achieved
+BLAS-3 GFLOP/s (fat fronts run near peak, tiny fronts scalar — *more* fill in fat
+fronts can be *faster*); parallel critical-path / etree balance; and peak transient
+memory (`peak_contrib_bytes` can exceed `nnz(L)`). feral has a **documented
+counterexample**: nql180 (`src/symbolic/mod.rs:311`,
+`dev/research/issue-73-n100k-thin-regime.md`) has smaller fill *and* smaller
+flop-proxy under MetisND (`nnz_L` 0.98×, flop 0.86×) yet AMF is **2.05× faster** on
+real factor+solve (1.90 s vs 3.95 s) — "fill … is NOT a reliable speed predictor."
+
+So a fill-optimal ordering can be materially time-suboptimal, and the nql180-type
+divergence is precisely the regime where a **time** objective (and hence a learned
+surrogate) could beat fill-based selection — a regime this fill study is structurally
+incapable of seeing.
+
+Why this does not automatically revive #110: feral already injects the time signal,
+just not with an online model — it runs offline wall-time A/Bs per structural regime
+and bakes the result into deterministic reroutes (thin-large / would-be-MetisND →
+AMF, unconditionally, knowingly "wrongly demoting nql180" because AMF wins the whole
+population). The real design axis is therefore not *fill vs time* but *how the time
+signal gets in*: an online per-matrix surrogate (rslab) vs offline-measured discrete
+structural branches (feral). feral's discrete branches win when the fill↔time
+divergence clusters into a few nameable regimes; they lose to a learned time-surrogate
+only when the divergence is high-dimensional and matrix-specific, with no clean branch
+to capture it. **The correct gating experiment (superseding this fill study): predict
+factor wall-clock and peak memory from cheap features across a distribution wider than
+KKT, and measure how much a continuous model beats feral's discrete regime-branches on
+the residual nql180-like cases.**
+
+## 5.6. The time/memory data (ran 2026-07-02 — the experiment §5.5.1 called for)
+
+Built `crates/feral-diagnostics/src/bin/study_ordering_timemem.rs`: for each of the
+5 explicit orderings plus `Auto`/`AutoRace`, measure **numeric factor wall-clock**
+(min-of-reps, symbolic reused — the IPM per-iteration cost) and a **peak-memory
+model** (`16·nnz_l` stored factor + `peak_contrib_bytes` transient stack). Ran three
+corpora: the 568 small KKT family reps, the 10 large matrices in `tests/data/large`
+(n up to 345 k), and the 41/48 `kkt-mittelmann` thin-large families (n up to 260 k —
+the nql180 / dtoc2 / pinene regime). Restricted to matrices whose fastest ordering
+takes ≥ 50 µs (below that, timing is pure overhead).
+
+| corpus (meaningful subset) | N | fill-best = time-best | time-regret of fill-pick (geo / max) | mem-regret (geo / max) | time-oracle vs `Auto` | vs `AutoRace` |
+|---|---|---|---|---|---|---|
+| KKT reps | 33 | 24 % | 1.02 / 1.13 | 1.01 / 2.12 | 1.02× | 1.02× |
+| large (`tests/data/large`) | 10 | 30 % | **1.16 / 1.60** | 1.01 / 1.07 | **1.52×** | 1.06× |
+| mittelmann (thin-large) | 41 | 22 % | **1.14 / 3.61** | **1.13 / 3.90** | **1.43×** | **1.12×** |
+
+What the fill study missed, now visible:
+
+1. **Fill is a bad speed predictor on big matrices, confirmed at scale.** Picking the
+   min-fill ordering leaves ~14–16 % factor time on the table (geomean) on
+   large/thin-large, up to **3.6×** on a single matrix (svanberg n=100 k: min-fill AMD
+   is 3.61× slower than SCOTCH). The tiny KKT reps hid this (~2 %) purely because they
+   are too small for the front-shape / BLAS-3 effects to matter.
+2. **The objective compounds — this reverses the amortization argument.** Selection
+   cost (AutoRace's 9× symbolic) amortizes away over IPM reuse, yes — but the thing
+   being optimized here, *numeric factor time*, is paid on **every** one of the up-to-
+   3000 iterations. A 10–15 % better ordering choice saves 10–15 % on every factor.
+   So picking the ordering once (even expensively) to get a faster numeric factor
+   thousands of times is exactly the trade feral's architecture rewards.
+3. **Neither deterministic path dominates.** On mittelmann, `Auto` is faster on 18
+   families, `AutoRace` on 22 (1 tie) — they win in different regimes (AutoRace's
+   fill-race avoids the ND-blowup disasters like qap15's 9× and c-big's 5×; `Auto`'s
+   thin-large→AMF reroute helps where the fill-min is slow). A perfect per-matrix
+   **time-oracle beats the default `Auto` by 1.43–1.52×** and still beats the better
+   `AutoRace` by **6–12 %** on large matrices. And both deterministic paths *jointly*
+   miss cases: svanberg is min-fill for AMD, so `Auto` and `AutoRace` both pick the
+   3.6×-slow ordering — only a time-aware selector escapes it.
+4. **Memory is a separate, larger opportunity on thin-large.** Min-fill orderings use
+   up to **3.9×** the peak memory of the memory-optimal ordering (dtoc2 n=104 k: AMF
+   min-fill vs AMD), geomean +13 %. Fill and `AutoRace` optimize neither time nor
+   memory directly, so a memory-constrained caller on this regime is badly served today.
+
+**Interpretation.** There *is* real, non-amortizable headroom — ~1.4–1.5× total factor
+time over the default `Auto`, ~10 % over `AutoRace`, plus up-to-3.9× peak-memory swings
+— but it is (a) concentrated on large / thin-large matrices (negligible on small KKT),
+and (b) *mostly* reachable deterministically. The natural next move is a
+**time/memory-aware race** — race the candidates and select on numeric factor time /
+peak memory instead of on fill. Whether that race can use a *cheap* proxy (no numeric
+factoring) is the pivotal question, tested in §5.7.
+
+## 5.7. Prototype — can a *cheap* deterministic time-race close the gap? (No.)
+
+`study_ordering_timemem` also records two cheap symbolic *time* proxies per ordering
+(no numeric work): `flop_proxy = Σ ncol·nrow²` (dense-front work) and `max_front`
+(largest frontal dimension). If racing on one of these picked orderings near the
+time-oracle, a deterministic proxy-race would capture the §5.6 headroom with no model
+and no numeric factoring. It does not. On the mittelmann thin-large corpus (41
+meaningful matrices), racing each proxy and picking its argmin ordering, per-matrix
+time-regret vs the oracle:
+
+| proxy raced on | total vs oracle | per-matrix regret (geo / p90 / max) |
+|---|---|---|
+| **fill** (what `AutoRace` uses) | **1.13×** | **1.134** / 1.33 / 3.60 |
+| `flop_proxy` (Σ ncol·nrow²) | 1.26× | 1.198 / 1.90 / 3.60 |
+| `max_front` | 1.28× | 1.208 / 1.94 / 3.60 |
+
+**No cheap symbolic proxy reaches the oracle, and `fill` is the *best* of the three** —
+`flop_proxy` and `max_front` are *worse* time predictors than fill. This is issue-73's
+nql180 observation confirmed at corpus scale: the mapping from symbolic structure to
+numeric factor time is not captured by any single cheap scalar. (On the large set the
+totals are c-big-dominated and within timing noise, but the same ranking holds: flop
+never beats fill.) **Corollary that reverses #111 (reviewed 2026-07-02):** because
+`fill` disagrees with *time* and AMF is a low-fill-but-sometimes-slow ordering, adding
+AMF to the fill-selecting `AutoRace` set is *not* the clean win #111 claimed. Measured
+across 51 large/thin-large matrices, adding AMF changes `AutoRace`'s pick to a **slower**
+ordering on **8** of them (c-big 1.60×, dtoc2 1.43×, dirichlet120 1.12×,
+ex1/ex4/ex42_160 1.11×, bcsstk38 1.09×, cont5_1_l 1.02×) versus **6** where it helps
+(r05 0.75×, rocket 0.78×, dtoc1nd 0.80×, bratu3d 0.86×); 37 unchanged. The two worst
+regressions are the largest, most expensive matrices — exactly where `AutoRace` is used
+— while #111's fill "wins" (VESUVIOU n=3083, GAUSS2 n=758, HAHN1 n=715) are all small
+matrices where fill barely affects time. So #111 trades fill on matrices where it is
+irrelevant for a time-regression risk where it is critical. It optimizes fill (the wrong
+metric) and can regress time (the right one); recommend closing it rather than merging.
+A fill-selecting race cannot be "fixed" by adding candidates — the selection criterion,
+not the candidate set, is the limitation, and §5.8 already showed time-aware selection
+isn't worth building.
+
+**So a cheap deterministic time-race is off the table.** That leaves exactly two ways
+to capture the §5.6 time headroom:
+
+1. **Actual-time race, latched per pattern.** Factor the k candidate orderings once
+   each, measure real factor time (and peak memory), keep the winner, and latch it for
+   the pattern — feral already has per-pattern latch machinery (the `ordering_escalated`
+   path). This reaches the oracle *by construction*. Its cost is k−1 extra numeric
+   factors paid **once per pattern**, then amortized over the up-to-3000 IPM reuse
+   iterations — i.e. ~0 in feral's dominant workload. Deterministic, correctness-
+   preserving, no ML. **This is the recommended way to capture the headroom.**
+2. **A learned multi-feature model** (rslab-style). The *only* way to beat the cheap
+   single proxies without paying for actual factoring — a model over many features
+   (front-shape distribution, tree width, arithmetic intensity, …) rather than one
+   scalar. This is where #110's learned tuner would genuinely earn its keep, but it is
+   justified over option 1 **only when the actual-time race is unaffordable** — i.e.
+   one-shot / non-reuse solves, which is *not* feral's dominant IPM workload.
+
+The §5.7 result therefore *appeared* to sharpen #110 to a crisp decision — an
+actual-time race latched per pattern. But building that race end-to-end (§5.8) walked
+the "amortizes to free" claim back substantially.
+
+## 5.8. End-to-end prototype of the latched actual-time race (ran 2026-07-02)
+
+Built `crates/feral-diagnostics/src/bin/study_latched_race.rs` — the actual-time race,
+driving the public `Solver` API only (no core change; ordering choice is inertia-neutral
+so there's no correctness exposure). For each mittelmann family's real IPM iterate
+sequence it factors the full grid (5 orderings × iterates), plus `Auto` and `AutoRace`,
+picks the ordering fastest on the first factor, "latches" it, and compares steady-state
+per-iterate cost. Crucially it measures the steady state over **pattern-reused iterates
+only** — real IPM sequences change pattern at the first iterate or two (the active set
+settling: e.g. nql180 nnz 874 500 → 939 300 at iterate 1, then stable), and only the
+reused tail is the long-run cost.
+
+Results (29 families, iterates capped at 10):
+
+- **Steady-state headroom is real but modest: the latched winner is 9.3 % faster per
+  iterate than `Auto`** (geomean), up to ~40 % on specific large families (henon120
+  0.59×, optmass 0.72×, cont5_2_2_l 0.61×) — but *slower* than `Auto` on several
+  (dtoc1nd 1.20×, lane_emden120 1.27×) where the pick was wrong. High variance.
+- **Versus `AutoRace` it is ~0 % (0.7 %).** On the pattern-stable tail `AutoRace` reuses
+  its raced choice correctly, so it already matches the latched winner. (An earlier draft
+  of this study saw `AutoRace` as ~79 % slower; that was an artifact of averaging in the
+  one iterate where the pattern changes and `AutoRace` re-runs its whole symbolic race.
+  Corrected: `AutoRace` is *not* pathological under stable reuse.)
+- **Two obstacles kill the naive "race iterate 0, latch" plan:**
+  1. **Representativeness is only 38 %.** Racing on the *transient* first iterate picks
+     the steady-state-optimal ordering just 38 % of the time, because iterate 0's pattern
+     differs from the stable pattern. (Fixable in principle: a per-*pattern* latch would
+     race on the first occurrence of the *stable* pattern, not the transient one — but
+     the prototype exposes that "race on the first factor you see" is wrong.)
+  2. **Overhead needs ~200 iterations to amortize.** The k−1 extra first-factors cost a
+     **median 206 stable iterations** to pay back at the 9 % per-iterate saving, and
+     **11/29 families never amortize** (the latch wasn't faster than `Auto`). Typical IPM
+     runs 20–50 iterations — well short. The "amortizes to ~0" claim in §5.7 assumed
+     up-to-3000 reuses of one pattern; real single-solve sequences are far shorter, so the
+     5-factor race overhead usually does *not* pay off.
+
+**What this changes.** The actual-time race is not the free win §5.7 implied. Its
+steady-state prize over the already-good `Auto` is ~9 % (concentrated on large problems),
+its overhead amortizes only across hundreds of same-pattern factors (not typical IPM),
+and it matches — not beats — `AutoRace` on the stable tail. And note the reversal it
+implies: because the *race overhead* is the killer, a **learned predictor** (zero
+inference cost, picks on the stable pattern with no trial factors) is actually the *more*
+viable vehicle for capturing this specific ~9 % than the deterministic race is — the
+opposite of §5.7's lean. But ~9 % on a subset of large problems is a modest prize either
+way; `Auto` is already within it.
+
+**Honest bottom line across §5.5–5.8.** Fill selection is solved (§5.5). The time/memory
+objective has real headroom on large matrices (§5.6). No cheap proxy captures it (§5.7).
+The actual-time race captures ~9 % over `Auto` but only amortizes over hundreds of
+same-pattern reuses and mis-picks on the transient iterate (§5.8). Net: the ordering-
+selection prize for feral is real but small (~9 % on large problems) and awkward to
+capture; `Auto`/`AutoRace` are already close; neither a deterministic race nor a learned
+model is clearly worth its cost for feral's typical IPM iterate counts. Even the one
+follow-up this investigation spun off — #111, add AMF to `AutoRace` — was *withdrawn on
+review*: it optimizes fill but regresses factor time on the largest matrices (§5.7
+corollary), because the limitation is `AutoRace`'s fill *selection criterion*, not its
+candidate set. Net action items from #110: **none to the core solver.** A time-aware
+selector — race or model — is justified only by a specific high-repeat, large-matrix
+workload that does not currently exist in the corpus.
+
+## 6. Risks / open questions
+
+- **Does the deterministic `Auto` already leave enough on the table to justify a
+  model?** **Answered by §5.5: no, not for ordering.** `Auto` is oracle-optimal on
+  86 % of KKT families and within 1.4 % on 90 %; the entire >10 % tail is already
+  recovered by the deterministic `AutoRace`, and the one real deterministic gap
+  (AMF absent from the race set, 3.9 % of families) closes with a one-line change,
+  no ML. A learned ordering surrogate would only trade the race's amortized-away 9×
+  symbolic cost — a weak motivation. The other candidate knobs (amalgamation,
+  kernel gates) were not measured here and remain open, but ordering was the
+  strongest a-priori case and it did not survive measurement.
+- **Corpus completeness / distribution shift.** rslab needed 90 conv-diff problems
+  to lift held-out R² 0.75→0.98 on the LU path. feral's corpus is KKT-heavy; a
+  model must be validated as not regressing on non-KKT structure, and OOD fallback
+  must be the default posture, not the exception.
+- **Maintenance surface vs. a hard-real project.** An embedded weight artifact + an
+  offline trainer + a sweep harness is real ongoing surface. It must be gated on a
+  demonstrated, corpus-measured win, and shipped behind a deterministic fallback so
+  a stale/bad model can never break correctness or regress the default.
+- **Determinism.** Inference must be bit-reproducible (fixed weights, deterministic
+  matmul order) to keep feral's byte-exact posture; straightforward with f64 and a
+  fixed evaluation order.
+
+## 7. Conclusion
+
+The idea maps cleanly onto feral's architecture and constraints — pure-Rust
+inference is trivial, the feature vector and a labeled corpus already largely
+exist, and feral has independently built the deterministic-heuristic ancestor of
+rslab's tuner. feral's correctness-first / exact-inertia guarantee means any learned
+tuner may own only inertia-neutral performance knobs (ordering, amalgamation, kernel
+gates — the latter still validated against the inertia gate), while scaling and
+pivot-`u` stay under the existing deterministic escalation.
+
+**But the gating measurement (§5.5) says do not build a learned ordering tuner
+now — scored by fill.** On 568 KKT families the cheap `Auto` heuristic is
+fill-optimal 86 % of the time and within 1.4 % on 90 %; the entire >10 % fill tail is
+already recovered by the existing deterministic `AutoRace`; and the one genuine
+deterministic gap (`AutoRace` doesn't race AMF, 3.9 % of families) closes with a
+one-line change, not a model. A learned surrogate would only recover `AutoRace`'s
+~9× symbolic cost, which is amortized to near-zero across the IPM's pattern-reuse — a
+weak payoff for a weight-artifact + offline-trainer + sweep-harness maintenance
+surface.
+
+**Read that conclusion narrowly (see §5.5.1).** The study optimizes *fill*, a proxy
+that provably diverges from factor wall-clock and peak memory — feral's own nql180
+case has smaller fill under MetisND yet AMF is 2.05× faster. So "86 % fill-optimal"
+does not imply "time-optimal."
+
+**The time/memory measurement (§5.6) bears this out and materially changes the
+picture.** On large / thin-large matrices, picking the min-fill ordering leaves
+~14–16 % factor time on the table (geomean, up to 3.6× on one matrix) and up to 3.9×
+peak memory; a perfect per-matrix time-oracle beats the default `Auto` by 1.43–1.52×
+and the fill-racing `AutoRace` by 6–12 %; and — unlike selection cost — this
+numeric-factor-time gain is paid on every IPM iteration, so it does **not** amortize
+away. Neither deterministic path dominates (Auto and AutoRace split 18/22 on
+mittelmann; both miss svanberg). So there *is* real, non-amortizable headroom — just
+concentrated on large matrices and mostly reachable deterministically.
+
+The §5.7 prototype then answers the "how" cleanly: **no cheap symbolic proxy
+(fill/flop/max_front) reaches the time-oracle** (fill is the best of them, still ~13 %
+short; flop and max_front worse), so the deterministic capture is an **actual-time
+ordering race latched per pattern** — factor the candidates once, keep the fastest,
+reuse across the up-to-3000 IPM iterations, amortizing the selection cost to ~0. That
+reaches the oracle with no model. A learned tuner is the right tool only for callers
+who cannot amortize even one extra factor (one-shot / non-reuse solves) — a real but
+narrower audience than feral's IPM core.
+
+**Recommendations, in priority order:**
+1. ~~**Deterministic, ML-free, cheap (fill):** add `Amf` to the `AutoRace` race
+   set.~~ **Withdrawn (see §5.7 corollary, reviewed 2026-07-02).** Filed as #111 on the
+   fill evidence, but the time data reverses it: `AutoRace` selects by *fill*, and adding
+   the low-fill-but-slow AMF regresses factor *time* on 8/51 large matrices (c-big 1.60×,
+   dtoc2 1.43×) — the biggest problems where AutoRace matters — while its fill "wins" are
+   on small matrices where fill barely affects time. Recommend **closing #111**; the
+   limitation is the fill *selection criterion*, not the candidate set.
+2. **Time/memory ordering selection is real but marginal — do NOT build it speculatively.**
+   §5.6 found ~1.4–1.5×-over-`Auto` headroom, but §5.7 showed no cheap proxy captures it
+   and §5.8 showed the actual-time race captures only ~9 % over `Auto` at steady state,
+   amortizes only over a median ~206 same-pattern reuses (typical IPM is 20–50), mis-picks
+   on the transient first iterate (38 % representativeness), and merely ties `AutoRace` on
+   the stable tail. `Auto`/`AutoRace` are already within ~9 %. Pursue a time-aware selector
+   **only** if a concrete high-repeat, large-matrix workload demands it — and if so, note
+   §5.8's reversal: since the race *overhead* is the limiter, a **learned predictor** (zero
+   inference cost, picks on the stable pattern) is the more viable vehicle than a
+   deterministic race, not less.
+3. **If a learned model is pursued,** keep it to inertia-neutral knobs (ordering,
+   amalgamation, kernel gates — validated against the inertia gate); ship behind a
+   deterministic fallback + the inertia gate, rslab-style. But weigh it against a ~9 %
+   prize on a subset of large problems — likely below the maintenance bar unless the
+   workload is specifically ordering-sensitive and high-repeat.
+4. **Do not** put scaling or pivot-`u` under a model — inertia-sensitive, already
+   handled by deterministic escalation.
+
+The investigation deliverables are this note plus two reusable study binaries:
+`crates/feral-diagnostics/src/bin/study_ordering_gap.rs` (fill) and
+`study_ordering_timemem.rs` (numeric factor time + peak memory). No change to the
+core solver is proposed.

--- a/dev/sessions/2026-07-01-07.md
+++ b/dev/sessions/2026-07-01-07.md
@@ -1,0 +1,231 @@
+# Session 2026-07-01-07
+
+> Provenance: recorded as `2026-07-01-03` on branch `claude/issue-99-b9zphx`
+> (a parallel container session); renumbered to `-07` when merged to main,
+> which already had a different session `2026-07-01-03` (qap15 profiling /
+> PR #92 merge). Content below is unchanged. Companion journal:
+> `dev/journal/2026-07-01-07.org` (same renumbering).
+
+## Goal
+
+Issue #99: "loop over all levers until faer-level performance" on the dense-front
+factorization throughput gap (~3.5× to faer on the qap15 conic KKT, dominated by
+a 2955×2955 indefinite root).
+
+## Reality check (reported up-front, per protocol)
+
+The issue's premises are **not reproducible on this branch**, and I established
+this before writing code:
+
+- **PR #92 is open/unmerged.** It (issue #91) contains the `OrderingPreprocess::Auto`
+  fill-verification fix that made qap15 tractable *and* the qap15 fixture
+  generator + `bench_qap15` harness. This branch is cut from current `main` and
+  lacks all of it — `INTRAFRONT_MIN_AREA` is still `256*256`, not #92's `256*128`.
+- **The qap15 fixture, its generator, `examples/{profile,bench}_qap15.rs`, and the
+  two research notes the issue cites for "the full diagnosis" exist on no remote
+  branch** (unpushed/lost work). The end-to-end qap15 number that defines the
+  target cannot be reproduced here.
+- **This container has 4 cores; the issue's numbers are 10-core.** The
+  parallel-scaling levers (1 assembly, 2 schur scaling) cannot be validated
+  against the issue's targets here.
+- The issue itself states **no byte-exact lever closes 3.5×**; faer-class needs a
+  policy decision (default-on FMA / static-SQD) the owner deliberately deferred.
+
+I attempted to ask the owner the fixture-strategy and policy questions via
+`AskUserQuestion`; the harness failed to deliver it (permission-stream error).
+Told to continue, I proceeded autonomously with the **defensible subset**:
+additive, default-off, byte-exact-preserving, measurable-here work only — no
+unilateral default flips, no unvalidatable parallel retunes.
+
+## Accomplished
+
+**Issue #99 Lever 3 (per-core kernel throughput) — delivered as an opt-in knob.**
+
+- New `examples/bench_dense_front.rs`: self-contained synthetic indefinite front
+  (no external fixture), factored through the real `factor_frontal_blocked` path,
+  timing nofma/FMA × serial/intrafront with an inertia-equality gate. Fills the
+  measurement-harness hole the issue's (missing) `bench_qap15` left.
+- New `BunchKaufmanParams::fma_min_front_area: Option<usize>` (default `None`) +
+  `effective_front_fma(params, nrow, ncol)` helper. Gated at the single dense
+  front-factor entry `factor_frontal_blocked_in_place_with_scratch` by shadowing
+  `params` with an fma-flipped clone **only when the gate fires** (unarmed path
+  pays nothing). Both multifrontal drivers funnel through this entry, so one
+  insertion covers all.
+- New `Solver::with_fma_large_fronts(min_area)` — writes straight to
+  `numeric_params.bk` (no `NumericParams` field / funnel needed; low churn).
+- `None` default ⇒ strict no-op: the production cross-arch bit-exact contract is
+  untouched. Enabling changes bit patterns only on the gated large fronts.
+
+### Evidence
+
+- `bench_dense_front 2955 5` (4-core x86_64), best of 5:
+
+  | variant          | ms      | GFLOP/s | vs nofma-serial |
+  |------------------|--------:|--------:|----------------:|
+  | nofma serial     | 25586   | 0.34    | 1.00×           |
+  | nofma intrafront | 8632    | 1.00    | 2.96×           |
+  | fma serial       | 15423   | 0.56    | **1.66×**       |
+  | fma intrafront   | 5143    | 1.67    | **4.98×**       |
+
+  Inertia `(+1478, −1477, 0)` **identical across all four** — the throughput-lever
+  correctness gate holds. FMA and intrafront compose multiplicatively.
+- `tests/issue99_fma_front_gate.rs` (4 tests, all pass): gate ≥ threshold is
+  bit-identical to `fma=true`; below threshold bit-identical to nofma default;
+  inertia preserved; threshold is exactly `nrow*ncol` with `>=` semantics.
+- **Full suite: 734 passed, 0 failed.** `cargo fmt --check` + `cargo clippy
+  --all-targets -- -D warnings` clean. `bench --release`: no failures (default
+  path byte-for-byte unchanged).
+
+## Benchmark Results
+
+```
+cargo run --bin bench --release  →  Sparse failure analysis: no failures
+Dense ∩ Sparse failure overlap: 0 / 0 / 0
+(no oracle timings loaded in this environment; perf partitions N/A)
+Default path unchanged (gate defaults None) → residual gate identical to the
+2026-07-01-02 baseline (2/2, worst residual 1.26e-16).
+
+examples/bench_dense_front 2955 5 (the new issue-99 harness):
+  nofma serial     25586.15 ms  0.34 GFLOP/s  1.00×
+  nofma intrafront  8631.85 ms  1.00 GFLOP/s  2.96×
+  fma   serial     15422.96 ms  0.56 GFLOP/s  1.66×
+  fma   intrafront  5142.82 ms  1.67 GFLOP/s  4.98×
+  inertia (+1478,−1477,0) identical across all four variants ✓
+```
+
+## Decisions Made
+
+- Opt-in per-front FMA size gate on `BunchKaufmanParams`, default `None`, set via
+  `Solver::with_fma_large_fronts`. Full rationale in `dev/decisions.md`
+  (2026-07-01) and `dev/research/issue-99-dense-front-fma-gate.md`.
+
+## Abandoned Approaches
+
+- Mirroring the `fma` plumbing with a **separate `NumericParams::fma_min_front_area`
+  field + solver funnel** — broke dozens of fully-enumerated `NumericParams`
+  literals across tests/examples/diagnostics. Replaced with a `BunchKaufmanParams`-
+  only field written straight into `bk` by the builder (bk is nearly always
+  `..Default::default()`, so zero churn). Not a research dead-end — a plumbing
+  choice — so not logged in tried-and-rejected.
+
+## Next Session Should
+
+1. **Merge/rebase PR #92 first** (or regenerate the qap15 fixture) so issue #99
+   can be measured end-to-end. Everything below is blocked on a runnable target
+   and a representative core count.
+2. **Owner policy call** (the question the harness dropped): (a) flip
+   FMA-on-large to default via the new gate — measured 1.66× per-core, inertia
+   identical on the tested front — accepting cross-arch bit-pattern change on
+   large fronts; and/or (b) authorize Lever 4 (static-SQD perturbation + iterative
+   refinement). Byte-exact ceiling is ~1.8× (issue's own analysis); faer-class
+   needs one of these.
+3. **Lever 1** — recalibrate/adapt `INTRAFRONT_MIN_AREA` (front-shape aware) with
+   a no-regression sweep across the *actual* bench corpus.
+4. **Lever 2** — parallelize the multifrontal assembly (the serial ~10%).
+5. **The real ceiling: 2-D tiled BLAS-3 GEMM** (`dev/plans/dense-kernel-blas3.md`)
+   — the measured 1.67 GFLOP/s vs ~50–100 for a tuned core is the structural gap;
+   no single issue-#99 lever closes it.
+
+---
+
+## UPDATE 2 — PR #92 merged; byte-exact intra-front win found (maintainer: "break the rules")
+
+The maintainer asked to rebase PR #92 (qap15 ordering fix + harness) onto this
+branch and to break the bit-exactness/inertia rules to see what is possible.
+
+**Merged PR #92** (`refs/pull/92/head`; merge-base = current main, clean): the
+`OrderingPreprocess::Auto` fix, the qap15 gen/bench/profile harnesses, the
+dense-front research notes, and Lever B (`INTRAFRONT_MIN_AREA` 256² → 256×128).
+
+**The real qap15 fixture is unobtainable** (its generator needs POUNCE + highspy
++ qap15.mps). Wrote `dev/scripts/gen_synth_kkt.py` — an arrowhead stand-in (dense
+`K=2000` border = root front + `L=30000` degree-2 leaves = LdltCompress
+signature), 32000×32000, runnable end-to-end via `bench_qap15`.
+
+**Profiling found the real bottleneck (not what the issue assumed).** The dense
+border factors as **~117 tall-thin fronts of `2000 × 16`** (leaves break
+supernode amalgamation), carrying 99.9% of the schur loop. **Both** per-front
+gates key on *area* and miss this shape:
+- FMA gate `nrow*ncol` = 32000 < 65536 — never fired.
+- intra-front parallel gate `(nrow-j)*n_elim` = 31744 < 32768 — never fired, so
+  the dominant fronts ran **serially** even on the parallel driver.
+
+**Fixes + results (synthetic KKT, 32000², 4-core x86_64, `bench_qap15` steady):**
+
+| config | ms | vs orig | correctness |
+|---|---:|---:|---|
+| original default | 9247 | 1.00× | byte-exact |
+| **+ shape-aware intra-front (Lever 1)** | **3457** | **2.68×** | **byte-exact** |
+| **+ FMA (Lever 3, opt-in)** | **2347** | **3.94×** | opt-in (inertia identical) |
+
+- **Lever 1 (byte-exact):** `intrafront_tall_gate(cols≥512 && n_elim≥8)` OR-ed
+  with the area gate. Pure scheduling; `parallel_parity` (parallel==sequential
+  bit-for-bit) stays green. Confirmed first via `FERAL_INTRAFRONT_MIN_AREA=16384`
+  (9.25→4.35 s byte-exact).
+- **Lever 3:** `fma_min_front_area` → `fma_min_front_rows`, gate on `nrow≥t`
+  (fixes the same area blindness). `with_fma_large_fronts(256)` == global FMA
+  end-to-end.
+
+**The biggest lever was byte-exact**, not the rule-breaking FMA — the area metric
+was a latent scheduling bug hitting both gates. Full suite **735 passed / 0
+failed**; clippy clean; inertia `(+30000,−2000,0)` identical throughout.
+
+**Caveat / next:** the synthetic fixture is a stand-in. The tall-thin-front
+phenomenon and the `512/8` thresholds should be re-validated on the *real* qap15
+(needs POUNCE) at 10 cores before promoting to a hard default. The remaining gap
+to faer-class per-core GFLOP/s is still the 2-D tiled BLAS-3 GEMM
+(`dev/plans/dense-kernel-blas3.md`), which no gate closes.
+
+---
+
+## UPDATE 3 — packed BLAS-3 trailing update (maintainer: "take on the GEMM")
+
+Profiling showed the dense trailing update (~94% of a dense factor) ran at only
+~0.35 GFLOP/s — ~10× below scalar peak. `examples/bench_schur_micro` isolated the
+cause: the strided per-column kernels re-read the panel at column-stride `nrow`
+every `q`, scattering cache lines. A packed, register-tiled (MR=8×NR=4) kernel
+(`apply_schur_panel_range_packed`) with a contiguous `q`-loop is **22–26× faster
+in isolation and byte-exact**, giving:
+
+| case | strided | packed | speedup |
+|---|---:|---:|---:|
+| dense-1500 schur phase | 3165 ms | 309 ms | 10.2× |
+| dense-2955 nofma serial | 25586 ms | 3202 ms | 8.0× (0.34→2.69 GFLOP/s) |
+| synth qap15 stand-in end-to-end | 3379 ms | 2029 ms | 1.67× on top of intra-front |
+
+**Full byte-exact stack** (shape-aware intra-front + packed) on the synth qap15
+stand-in: **9247 → 2029 ms = 4.56×**, inertia `(+30000,−2000,0)` unchanged.
+Suite **736 passed / 0 failed** (all byte-exact parity gates green with packed
+default) + a dedicated packed-vs-scalar unit test; clippy clean.
+
+Reached only for all-1×1-pivot panels; 2×2 panels (strongly indefinite fronts,
+and the fma path) use the un-packed fallback → **Phase B-2** (pack the 2×2 path)
+is the clear next step. Gotcha logged: `cargo build --release` does not rebuild
+examples — the first "packed" measurements used stale example binaries.
+
+---
+
+## UPDATE 4 — Phase B-2: packed 2×2 pivot streams (byte-exact)
+
+Extended the packed trailing update to a **mixed 1×1/2×2/zero-d pivot stream**,
+so strongly-indefinite fronts (2×2-pivot panels) get the packed win too — not
+only definite/SQD/SPD fronts. Each element walks the stream: 1×1 → `mul→sub` /
+`mul_add`; 2×2 → the fused `dl0·L_q + dl1·L_{q+1}` add-then-sub (nofma) / two
+chained FMAs (fma). Byte-exact with `do_1x1_update`/`do_2x2_update` and the
+strided `axpy`/`axpy2` fallback. `subdiag` threaded through the panel dispatch;
+`apply_blocked_schur` now routes every panel through packed (strided fast-path +
+fallback stay under `FERAL_PACKED_SCHUR=0`).
+
+- **Correctness:** full suite **736 / 0**, incl. the indefinite/2×2 KKT parity
+  gates byte-exact with packed default; `packed_matches_scalar_reference_bit_for_bit`
+  now sweeps 1×1/2×2/zero-d in both fma modes.
+- **Perf:** indefinite 2955 front nofma serial **25586 → 2780 ms (9.2×**, 0.34 →
+  3.09 GFLOP/s).
+- **FMA note:** on the degenerate ±n-diagonal `bench_dense_front` synthetic, fma
+  is ~5× slower than nofma at equal inertia — a BK pivoting interaction (fma
+  rounding shifts 1×1-vs-2×2 choices), not a kernel effect; both use packed. Not
+  a regression. Reinforces keeping FMA opt-in.
+
+**Remaining follow-ups:** tune absolute packed throughput (8×4 tile, L2
+cache-blocking, explicit-SIMD packed kernel, FMA-in-packed) on target hardware;
+and re-validate the whole stack on the real qap15 KKT (needs POUNCE) at 10 cores.


### PR DESCRIPTION
## Summary

Branch-cleanup prerequisite: merges the `dev/` records (research notes, journal entries, a session checkpoint) and three diagnostic study binaries that existed **only** on three investigation branches. All three branches belong to closed issues, and all of their *code* work already landed on main via other PRs — these docs were the only unmerged content.

| Source branch | Issue(s) | What was stranded |
|---|---|---|
| `investigate/issue-110-learned-tuner` | #110, #111 (closed) | `dev/research/issue-110-learned-tuner.md` (545-line "recommend against a learned tuner" investigation), journal `2026-07-02-02.org`, 3 `feral-diagnostics` study binaries backing the note's measurements |
| `claude/issue-102-cj8lj5` | #102 (closed) | `dev/research/issue-102-pr92-dense-front-stall-verify.md`, a journal entry appended to `2026-07-01-04.org` (the INTRAFRONT_MIN_AREA co-variation finding) |
| `claude/issue-99-b9zphx` | #99 (closed via PR #103) | The branch's session checkpoint + journal, renumbered `2026-07-01-03` → `-07` with provenance notes (main already has a different session `-03`); content otherwise unchanged |

## Verification that nothing else is stranded

- `claude/issue-112-0885lr`: tip is byte-identical to main (landed via PRs #113, #135–#139)
- `claude/issues-review-79g033`: #107 External ordering + checkpoint landed via PR #108
- `claude/issue-99-b9zphx`: packed-kernel code landed via PR #103 (spot-checked branch-authored `factor.rs` lines all present on main)
- `claude/issue-63-diagnosis`, `issue-64-arrow-ordering`, `issue-87-fq0r4p`, `open-issue-review-UCoRw`: 0 commits ahead

## Testing

- `cargo build -p feral-diagnostics --bins` — the three study binaries compile against current main
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean
- `cargo test`: 18 suites pass; one **pre-existing** local failure, `issue65_mc64_fallback::explicit_infnorm_is_respected_no_fallback` (expects inertia `{789, 670, 116}`, gets `{789, 785, 1}`) — reproduces on **pristine main** (dfae3c5) on this macOS box while CI on the same SHA is green, so it is platform-specific and unrelated to this docs-only + diagnostics-bins change (which doesn't touch `feral` lib code)

After merge, all nine branches above get deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
