### PR TITLE
perf(symbolic): split pipeline so ordering-race losers skip the tail (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — split the symbolic pipeline for the ordering races (issue #127)
+
+- **#127** `OrderingPreprocess::Auto` and `OrderingMethod::AutoRace` previously
+  ran the **full** symbolic pipeline for every candidate (up to 2× and 4×
+  respectively, and ~8× when both nest) even though the winner is chosen on
+  `factor_nnz_estimate` alone. The pipeline is now split into a *prefix*
+  (ordering → column counts → `factor_nnz`) and a *finish* (supernode
+  detection, small-leaf grouping, peak-memory accounting, static row indices);
+  the races compare prefixes and run the finish only for the winner, so the
+  losing candidates never pay the tail. Winner selection is bit-identical
+  (same `factor_nnz_estimate`, same tie-break), and the produced
+  `SymbolicFactorization` is unchanged — this is purely *when* the tail work
+  happens. Benefits the IPM-host workload, whose slack-heavy KKTs fire the
+  preprocess race on every cache-miss factorization.
+
 ### Added — tree-parallel sparse solve (issue #131 Gap A)
 
 - **`solve_sparse_cb(factors, rhs, parallel)`** — an opt-in contribution-block

--- a/dev/journal/2026-07-11-01.org
+++ b/dev/journal/2026-07-11-01.org
@@ -46,3 +46,44 @@ locally; CI will now exercise them on Linux/x86 for the first time —
 if the pinned (789,786,0)/(432,313,0) constants in the other two tests
 diverge there, that is new (wanted) platform information, not noise.
 Recorded in dev/decisions.md (2026-07-11 entry).
+
+* 12:30 :issue127:symbolic:refactor:performance:
+Implemented issue #127 — split symbolic_factorize_with_method into a
+cheap prefix (ordering -> col_counts -> factor_nnz) and a finish (tail:
+find_supernodes, small_leaf, peak_contrib, static rows, struct build).
+Both race dispatchers (preprocess-Auto: None vs LdltCompress;
+OrderingMethod::AutoRace: 4 ordering candidates) now race PREFIXES and
+run the finish only on the winner, so losers never pay the tail
+(previously up to ~8x symbolic when both races nest). Chose prefix/finish
+split over "estimate then recompute winner" because the latter would
+recompute the winner's ordering — doubling the LdltCompress MC64 matching
+(the dominant cost) when compression wins.
+
+Winner selection is bit-identical: same factor_nnz_estimate compare, same
+< / <= none_limit operators, same PREPROCESS_FILL_INFLATION_LIMIT. Verified
+by self-consistency tests (no golden constants): AutoRace result byte-matches
+the concrete resolved_method result and IS the argmin estimate;
+preprocess-Auto matches the concrete resolved_preprocess arm. Losers-skip-tail
+proven by a thread-local FINISH_RUNS cfg(test) counter (== 1 after both
+default-Auto and AutoRace factorizations) — thread-local not global atomic
+so parallel tests don't clobber it (symbolic runs single-threaded per call).
+
+Profiler "one run" behaviour preserved: raced arms/candidates use fresh
+profilers; the winner's prefix carries its profiler arc; finish appends the
+tail + set_total there; finish_and_copy copies to the shared profiler iff a
+different Arc (ptr_eq). tests/symbolic_profiler.rs green (5/5,
+accounted<=total, no warnings).
+
+Gates: cargo clippy --all-targets -D warnings clean; full suite green
+(82 test-result: ok, 0 failed); targeted issue127 (3) + finish_runs unit
+(2) + auto_strategy (7) + issue91_preprocess_misfire (1, qap15 fill guard)
++ symbolic_profiler (5) all pass. Bench numbers below.
+
+Bench (full corpus, bit-identical to the pre-#127 baseline — as designed):
+  Dense  inertia 154429/154482 (100.0%), residual 154149/154482 (99.8%),
+         worst 2.46e-1 POLAK6_0021.
+  Sparse inertia vs MUMPS 154531/154590 (100.0%), residual 154258/154590
+         (99.8%), worst 2.94e-4 ERRINBAR_0824.
+  Partition gates all PASS (dense p90 1.67/2.08; sparse 1.56/1.57).
+  Identical inertia AND residual counts confirm winner selection is
+  unchanged (same factors), the #127 correctness contract.

--- a/dev/plans/issue-127-pipeline-split.md
+++ b/dev/plans/issue-127-pipeline-split.md
@@ -1,0 +1,72 @@
+# Plan — issue #127 symbolic pipeline split
+
+Refactor `src/symbolic/mod.rs` only. No public API change.
+
+## Steps
+
+1. **`struct SymbolicPrefix`** (private): `n`, `perm`, `perm_inv`,
+   `permuted_pattern`, `etree`, `col_counts`, `factor_nnz`,
+   `factor_nnz_estimate`, `factor_slack`, `cached_mc64`, `resolved_method`,
+   `resolved_preprocess`, `effective_params: SupernodeParams`,
+   `t_total: Option<Instant>`.
+
+2. **`fn symbolic_prefix_concrete(matrix, snode_params, method) ->
+   Result<SymbolicPrefix>`** — move body `mod.rs:1068..=1335` here. Assumes
+   `method` is concrete (not AutoRace) and `preprocess` is concrete
+   (`Auto` resolved by the caller for the *fill race*; the internal
+   `resolved_preprocess` match at 1117 still handles `None`/`LdltCompress`/
+   `External`-forced-`None`). Returns the struct; runs no tail stage.
+   Captures `t_total` at entry.
+
+3. **`fn symbolic_finish(prefix: SymbolicPrefix) -> SymbolicFactorization`** —
+   move body `mod.rs:1337..=1407` here. Reads profiler from
+   `prefix.effective_params.symbolic_profiler`. `#[cfg(test)]` increment of a
+   `FINISH_RUNS` atomic at the top. `set_total` from `prefix.t_total`.
+
+4. **`fn symbolic_prefix_preprocess_auto(matrix, snode_params, method) ->
+   Result<SymbolicPrefix>`** — rewrite of today's
+   `symbolic_factorize_preprocess_auto` to return the winning **prefix**
+   instead of a finished factorization. Same predicate, same
+   `PREPROCESS_FILL_INFLATION_LIMIT` compare on `factor_nnz_estimate`, same
+   fresh-profiler-per-arm handling — but no `copy_profiler` here (deferred to
+   the finisher). Each arm calls `symbolic_prefix_concrete` with the arm's
+   `preprocess` forced.
+
+5. **`fn resolve_prefix(matrix, snode_params, method) ->
+   Result<SymbolicPrefix>`** — External validation (as at 1053-1056);
+   if `preprocess == Auto && !external` → `symbolic_prefix_preprocess_auto`,
+   else → `symbolic_prefix_concrete`.
+
+6. **`fn finish_and_copy(prefix, shared: Option<&Arc<Mutex<..>>>) ->
+   SymbolicFactorization`** — clone the prefix's profiler arc; `symbolic_finish`;
+   if `shared` is Some and not `Arc::ptr_eq` to the prefix's arc, copy the
+   prefix arc's snapshot into `shared`.
+
+7. **Rewrite `symbolic_factorize_with_method`**: keep the `AutoRace` guard
+   (→ `symbolic_factorize_race`); otherwise
+   `Ok(finish_and_copy(resolve_prefix(matrix, snode_params, method)?,
+   snode_params.symbolic_profiler.as_ref()))`.
+
+8. **Rewrite `symbolic_factorize_race`**: for each `RACE_CANDIDATES`,
+   fresh cand profiler, `resolve_prefix(matrix, &cand_params, cand)`; keep the
+   prefix with the smallest `factor_nnz_estimate` (same `<` as today);
+   `finish_and_copy(best_prefix, snode_params.symbolic_profiler.as_ref())`
+   once. Error only if every candidate failed.
+
+## Tests first (write before steps 2-8)
+
+- `tests/issue127_pipeline_split.rs`:
+  - `autorace_matches_winning_concrete_method` — over a few real/synth KKTs.
+  - `preprocess_auto_matches_winning_arm` — a None-wins and an
+    LdltCompress-wins matrix (reuse fixtures from `issue91_preprocess_misfire`
+    / `auto_strategy` if handy).
+- in-module `#[cfg(test)] mod tests` in `mod.rs`:
+  - `finish_runs_once_under_preprocess_auto`
+  - `finish_runs_once_under_autorace`
+  (reset `FINISH_RUNS`, factorize, assert `== 1`).
+
+## Bench
+
+`cargo run --bin bench --release` full corpus (inertia gate). Plus a
+symbolic-phase A/B on an Auto-firing KKT if a probe is cheap. Record in the
+checkpoint per protocol.

--- a/dev/research/issue-127-symbolic-pipeline-split.md
+++ b/dev/research/issue-127-symbolic-pipeline-split.md
@@ -1,0 +1,98 @@
+# Issue #127 — split the symbolic pipeline so race losers skip the tail
+
+## Problem
+
+`symbolic_factorize_with_method` (`src/symbolic/mod.rs`) is a monolithic
+pipeline. Two dispatchers race multiple candidates through the **whole**
+pipeline but decide on `factor_nnz_estimate` alone:
+
+- `symbolic_factorize_preprocess_auto` (preprocess `Auto`): races `None` vs
+  `LdltCompress`, ~2× symbolic on every cache-miss factorization whose
+  structural predicate fires (typical slack-heavy IPM KKTs).
+- `symbolic_factorize_race` (`OrderingMethod::AutoRace`): races 4 ordering
+  candidates → up to 4×. With preprocess `Auto` the two nest → up to ~8×.
+
+Everything after the decision value is wasted for the losers.
+
+## Split point
+
+The decision value is `factor_nnz = total_factor_nnz(&col_counts)` at
+`mod.rs:1335`, from which `factor_nnz_estimate = (factor_nnz * factor_slack)
+as usize` (slack = 1.2). The stages *before* it (ordering — including the
+LdltCompress MC64 matching, which is the dominant cost — permutes, etree,
+postorder, col_counts, and the Phase-2.12 Renumber rebuild which itself
+feeds col_counts) are all needed to compute the estimate. The stages
+*after* it are the wasted tail for losers:
+
+- `find_supernodes` + `assign_delayed_capacities`
+- `find_small_leaf_groups`
+- `compute_peak_contrib` (contrib_sizes)
+- `compute_static_row_indices` (#125)
+- struct assembly
+
+So: **prefix** = `mod.rs:1068..=1335` (through `factor_nnz`); **finish** =
+`mod.rs:1337..=1407` (tail + build `SymbolicFactorization`).
+
+## Why prefix/finish split, not "estimate then recompute winner"
+
+A cheaper-looking alternative — run an estimate-only prefix per candidate,
+then re-run the *full* `symbolic_factorize_with_method` on the winner —
+recomputes the winner's ordering. For the preprocess `Auto` case the
+LdltCompress arm's MC64 matching is the dominant cost and would run **twice**
+when LdltCompress wins, a regression on that path. The prefix/finish split
+keeps the winner's already-computed prefix and finishes it exactly once, so
+no ordering/MC64 work is ever repeated.
+
+## Invariants (must hold; how tested)
+
+1. **Bit-identical winner selection.** The estimate compared is
+   `factor_nnz_estimate` (the post-`* slack` `as usize` truncation), with the
+   exact same `<` / `<= none_limit` operators as today, so ties break
+   identically. Tested by *self-consistency*, no golden constants:
+   - `AutoRace` result byte-matches the result of directly requesting the
+     argmin concrete ordering method (`resolve` the winner, compare
+     `perm`, `perm_inv`, `supernodes`, `factor_nnz_estimate`,
+     `resolved_method`, `col_counts`).
+   - preprocess-`Auto` result byte-matches the winning concrete-preprocess
+     result on a None-wins matrix and an LdltCompress-wins matrix.
+2. **Losers skip the tail.** A `#[cfg(test)]` atomic counter incremented at
+   the top of `symbolic_finish`; an in-module unit test asserts it is `1`
+   after a default-params (`Auto` preprocess) `symbolic_factorize` and `1`
+   after an `AutoRace` — i.e. exactly one finish regardless of candidate
+   count.
+3. **Profiler still reflects exactly one run.** Preserved by keeping the
+   existing "fresh profiler per raced candidate/arm; the winner's tail is
+   recorded into that same fresh profiler; snapshot copied into the caller's
+   shared profiler once, at the end" discipline. `set_total` is called once,
+   in `symbolic_finish`, from a `t_total` captured at prefix start and
+   carried in the prefix — so `total_us` spans prefix+finish and
+   `accounted_us <= total_us` with no validation warnings. Guarded by the
+   existing `tests/symbolic_profiler.rs`.
+
+## Profiler bookkeeping (the fiddly part; diagnostics-only)
+
+`SymbolicPrefix` carries the effective `SupernodeParams` it ran under
+(hence the profiler arc used for its prefix stages) and `t_total`.
+`symbolic_finish` records the tail stages and `set_total` into
+*that same* profiler arc. The caller then copies the arc's snapshot into
+the shared profiler iff it is a different `Arc` (`Arc::ptr_eq`) — i.e. the
+concrete top-level path records straight into the shared profiler (no copy),
+while a raced arm/candidate records into its fresh profiler and is copied
+once at the end. This mirrors today's `copy_profiler` behaviour, just moved
+after the single finish.
+
+## Blast radius
+
+Only the standard `symbolic_factorize_with_method` path and its two race
+dispatchers. The Schur-tail variant (`symbolic_factorize_with_schur_tail`,
+a separate function that does not race) is untouched. No public signature
+changes; `SymbolicFactorization` is unchanged.
+
+## Validation plan
+
+- Full suite green, especially `tests/auto_strategy.rs`,
+  `tests/issue91_preprocess_misfire.rs`, `tests/symbolic_profiler.rs`,
+  the delayed-pivoting suites, plus the new parity + finish-count tests.
+- Bench before/after in the checkpoint: symbolic-phase wall on an
+  Auto-firing slack-heavy KKT should drop toward 1× + counts-only overhead
+  (the tail no longer runs per loser). Inertia gate must stay 100%.

--- a/src/symbolic/mod.rs
+++ b/src/symbolic/mod.rs
@@ -867,16 +867,21 @@ fn symbolic_factorize_race(
     matrix: &CscMatrix,
     snode_params: &SupernodeParams,
 ) -> Result<SymbolicFactorization, FeralError> {
-    let mut best: Option<SymbolicFactorization> = None;
+    // Issue #127: race only each candidate's *prefix* (through the
+    // `factor_nnz_estimate` the decision uses) and finish just the winner,
+    // so the losers never pay the tail (`find_supernodes`, small-leaf,
+    // peak-contrib, static rows). Selection is bit-identical to finishing
+    // every candidate: the same `factor_nnz_estimate` and the same `<`
+    // (first-wins on ties) as before.
+    let mut best: Option<SymbolicPrefix> = None;
     // S7: when a symbolic profiler is attached, give each candidate its
     // own fresh profiler instead of letting all RACE_CANDIDATES append
     // into the caller's shared one. Sharing accumulated one full stage
     // list per candidate (~4x) against a single candidate's `total_us`,
     // tripping the "stage sum exceeds total" warning and inflating every
-    // pct_of_total. We keep the winning candidate's profiler and copy it
-    // into the caller's shared profiler at the end, so the report
-    // reflects exactly one ordering run.
-    let mut best_prof: Option<SymbolicProfiler> = None;
+    // pct_of_total. The winner's profiler (with the tail appended by
+    // `finish_and_copy`) is copied into the caller's shared profiler, so
+    // the report reflects exactly one ordering run.
     let mut last_err: Option<FeralError> = None;
     for cand in RACE_CANDIDATES {
         let cand_prof = snode_params
@@ -884,21 +889,20 @@ fn symbolic_factorize_race(
             .as_ref()
             .map(|_| std::sync::Arc::new(std::sync::Mutex::new(SymbolicProfiler::new())));
         let cand_params = SupernodeParams {
-            symbolic_profiler: cand_prof.clone(),
+            symbolic_profiler: cand_prof,
             ..snode_params.clone()
         };
         // `cand: &OrderingMethod` — `OrderingMethod` is no longer `Copy`
         // (the `External` variant carries a `Vec`); clone the concrete
         // candidate (all `RACE_CANDIDATES` are payload-free unit variants).
-        match symbolic_factorize_with_method(matrix, &cand_params, cand.clone()) {
-            Ok(sym) => {
+        match resolve_prefix(matrix, &cand_params, cand.clone()) {
+            Ok(prefix) => {
                 let is_better = best
                     .as_ref()
-                    .map(|b| sym.factor_nnz_estimate < b.factor_nnz_estimate)
+                    .map(|b| prefix.factor_nnz_estimate < b.factor_nnz_estimate)
                     .unwrap_or(true);
                 if is_better {
-                    best = Some(sym);
-                    best_prof = cand_prof.and_then(|a| a.lock().ok().map(|g| g.clone()));
+                    best = Some(prefix);
                 }
             }
             Err(e) => {
@@ -906,18 +910,15 @@ fn symbolic_factorize_race(
             }
         }
     }
-    // Copy the winning candidate's stage timings into the caller's shared
-    // profiler so `report()` reflects one run, not all four concatenated.
-    if let (Some(shared), Some(winner)) = (snode_params.symbolic_profiler.as_ref(), best_prof) {
-        if let Ok(mut p) = shared.lock() {
-            *p = winner;
-        }
-    }
-    best.ok_or_else(|| {
+    let best = best.ok_or_else(|| {
         last_err.unwrap_or_else(|| {
             FeralError::InvalidInput("AutoRace: no candidates available".to_string())
         })
-    })
+    })?;
+    Ok(finish_and_copy(
+        best,
+        snode_params.symbolic_profiler.as_ref(),
+    ))
 }
 
 /// Resolve [`OrderingPreprocess::Auto`] by verifying fill rather than
@@ -940,52 +941,46 @@ fn symbolic_factorize_race(
 /// going to be applied anyway; its MC64 matching (the dominant cost)
 /// runs regardless.
 ///
-/// Profiler handling mirrors [`symbolic_factorize_race`]: each candidate
-/// gets a fresh profiler and the winner's is copied into the caller's
-/// shared one, so the report reflects exactly one run.
-fn symbolic_factorize_preprocess_auto(
+/// Profiler handling mirrors [`symbolic_factorize_race`]: each arm gets a
+/// fresh profiler carried in the returned prefix; [`finish_and_copy`] copies
+/// the winner's (with the tail appended) into the caller's shared profiler,
+/// so the report reflects exactly one run.
+///
+/// Issue #127: returns the winning *prefix* rather than a finished
+/// factorization, so the losing arm never pays the tail. Selection is
+/// bit-identical — same predicate, same `factor_nnz_estimate` comparison and
+/// `PREPROCESS_FILL_INFLATION_LIMIT` as before.
+fn symbolic_prefix_preprocess_auto(
     matrix: &CscMatrix,
     snode_params: &SupernodeParams,
     method: OrderingMethod,
-) -> Result<SymbolicFactorization, FeralError> {
+) -> Result<SymbolicPrefix, FeralError> {
     debug_assert_eq!(snode_params.preprocess, OrderingPreprocess::Auto);
 
-    // Run one concrete preprocessor with an isolated profiler. Returns
-    // `(symbolic, profiler-snapshot)` so the caller can keep the winner's.
-    let run = |pp: OrderingPreprocess| -> Result<(SymbolicFactorization, Option<SymbolicProfiler>), FeralError> {
+    // Run one concrete preprocessor's prefix with an isolated profiler
+    // (carried in the returned prefix's `effective_params`).
+    let run = |pp: OrderingPreprocess| -> Result<SymbolicPrefix, FeralError> {
         let cand_prof = snode_params
             .symbolic_profiler
             .as_ref()
             .map(|_| std::sync::Arc::new(std::sync::Mutex::new(SymbolicProfiler::new())));
         let cand_params = SupernodeParams {
             preprocess: pp,
-            symbolic_profiler: cand_prof.clone(),
+            symbolic_profiler: cand_prof,
             ..snode_params.clone()
         };
         // `method` is captured by this closure and used across up to two
         // runs (None vs LdltCompress); `OrderingMethod` is no longer `Copy`,
         // so clone. `External` never reaches here — it is guarded to
         // `OrderingPreprocess::None` before the preprocess-`Auto` race.
-        let sym = symbolic_factorize_with_method(matrix, &cand_params, method.clone())?;
-        let snap = cand_prof.and_then(|a| a.lock().ok().map(|g| g.clone()));
-        Ok((sym, snap))
-    };
-
-    let copy_profiler = |snap: Option<SymbolicProfiler>| {
-        if let (Some(shared), Some(winner)) = (snode_params.symbolic_profiler.as_ref(), snap) {
-            if let Ok(mut p) = shared.lock() {
-                *p = winner;
-            }
-        }
+        symbolic_prefix_concrete(matrix, &cand_params, method.clone())
     };
 
     // The predicate is the *only* thing that could recommend compression;
     // when it declines, `None` is the baseline and there is nothing to
     // verify against.
     if pick_ordering_preprocess(matrix) == OrderingPreprocess::None {
-        let (sym, snap) = run(OrderingPreprocess::None)?;
-        copy_profiler(snap);
-        return Ok(sym);
+        return run(OrderingPreprocess::None);
     }
 
     // Predicate recommends compression — honor it *unless* it inflates
@@ -1001,18 +996,12 @@ fn symbolic_factorize_preprocess_auto(
     // 6.3×. Validated by the full corpus suite (no inertia regression) plus
     // `tests/issue91_preprocess_misfire.rs`.
     let none = run(OrderingPreprocess::None)?;
-    let none_limit = (none.0.factor_nnz_estimate as f64) * PREPROCESS_FILL_INFLATION_LIMIT;
+    let none_limit = (none.factor_nnz_estimate as f64) * PREPROCESS_FILL_INFLATION_LIMIT;
     match run(OrderingPreprocess::LdltCompress) {
-        Ok((comp_sym, comp_snap)) if (comp_sym.factor_nnz_estimate as f64) <= none_limit => {
-            copy_profiler(comp_snap);
-            Ok(comp_sym)
-        }
+        Ok(comp) if (comp.factor_nnz_estimate as f64) <= none_limit => Ok(comp),
         // LdltCompress inflates fill past the catastrophe limit (or failed)
         // — use None.
-        _ => {
-            copy_profiler(none.1);
-            Ok(none.0)
-        }
+        _ => Ok(none),
     }
 }
 
@@ -1036,13 +1025,70 @@ pub fn symbolic_factorize_with_method(
     snode_params: &SupernodeParams,
     method: OrderingMethod,
 ) -> Result<SymbolicFactorization, FeralError> {
-    // AutoRace is resolved here by running each concrete candidate
-    // through this same function and picking the smallest
-    // `factor_nnz_estimate`. The recursive call passes a concrete
-    // `OrderingMethod`, so there is no infinite loop.
+    // AutoRace is resolved here by racing each concrete candidate's
+    // *prefix* (issue #127) and finishing only the winner. The recursive
+    // call passes a concrete `OrderingMethod`, so there is no infinite loop.
     if method == OrderingMethod::AutoRace {
         return symbolic_factorize_race(matrix, snode_params);
     }
+    // Issue #127: split the pipeline into a cheap "prefix" (ordering →
+    // column counts → `factor_nnz`) and the "finish" (supernodes, small-leaf,
+    // peak-contrib, static rows, struct assembly). The preprocess-`Auto` and
+    // `AutoRace` races decide on `factor_nnz_estimate` alone, so they race
+    // prefixes and finish only the winner — the losers never pay the tail.
+    let prefix = resolve_prefix(matrix, snode_params, method)?;
+    Ok(finish_and_copy(
+        prefix,
+        snode_params.symbolic_profiler.as_ref(),
+    ))
+}
+
+/// The intermediate produced by the symbolic pipeline *prefix* (issue
+/// #127): everything computed up to and including `factor_nnz`, i.e. all
+/// the state the `factor_nnz_estimate`-based races decide on, without any
+/// of the tail work ([`symbolic_finish`]). Carries the effective
+/// [`SupernodeParams`] it ran under (hence the profiler arc for its prefix
+/// stages) and `t_total`, so the finish records the tail into the same
+/// profiler and sets a total spanning prefix+finish.
+struct SymbolicPrefix {
+    n: usize,
+    perm: Vec<usize>,
+    perm_inv: Vec<usize>,
+    permuted_pattern: CscPattern,
+    etree: EliminationTree,
+    col_counts: Vec<usize>,
+    factor_nnz_estimate: usize,
+    factor_slack: f64,
+    cached_mc64: Option<crate::scaling::Mc64Cache>,
+    resolved_method: OrderingMethod,
+    resolved_preprocess: supernode::OrderingPreprocess,
+    /// The effective params (amalgamation `Auto` already resolved). Its
+    /// `symbolic_profiler` is the arc the prefix recorded stages into.
+    effective_params: SupernodeParams,
+    /// Wall-clock start captured at prefix entry (Some iff a profiler is
+    /// attached); [`symbolic_finish`] uses it for `set_total`.
+    t_total: Option<std::time::Instant>,
+}
+
+// Per-thread count of `symbolic_finish` calls — a `#[cfg(test)]` probe
+// proving the #127 property that race losers never reach the tail (exactly
+// one finish per top-level factorization regardless of candidate count).
+// Thread-local, not a global atomic: symbolic factorization runs
+// single-threaded per call, so a test resets and reads its own thread's
+// count without interference from other tests running concurrently.
+#[cfg(test)]
+thread_local! {
+    static FINISH_RUNS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Resolve external validation and the preprocess-`Auto` fill race into a
+/// [`SymbolicPrefix`] (no tail work). `method` must be concrete (the
+/// `AutoRace` sentinel is handled by [`symbolic_factorize_with_method`]).
+fn resolve_prefix(
+    matrix: &CscMatrix,
+    snode_params: &SupernodeParams,
+    method: OrderingMethod,
+) -> Result<SymbolicPrefix, FeralError> {
     // Issue #107: a caller-supplied external ordering. Validate the
     // permutation is a bijection of `0..n` up front (a wrong length /
     // out-of-range / duplicate is `InvalidInput`, never a panic). `External`
@@ -1063,8 +1109,21 @@ pub fn symbolic_factorize_with_method(
     // fill (issue #91: qap15 conic KKT, 7.16M → 45.4M, 0.77s → 15.4s).
     // Race None vs LdltCompress on symbolic fill and keep the smaller.
     if snode_params.preprocess == OrderingPreprocess::Auto && !is_external {
-        return symbolic_factorize_preprocess_auto(matrix, snode_params, method);
+        return symbolic_prefix_preprocess_auto(matrix, snode_params, method);
     }
+    symbolic_prefix_concrete(matrix, snode_params, method)
+}
+
+/// The concrete symbolic pipeline *prefix* (issue #127): runs ordering →
+/// column counts → `factor_nnz` and returns a [`SymbolicPrefix`], doing
+/// none of the tail work. `method` and `preprocess` are concrete here
+/// (`AutoRace` and preprocess-`Auto` are resolved by the callers above).
+fn symbolic_prefix_concrete(
+    matrix: &CscMatrix,
+    snode_params: &SupernodeParams,
+    method: OrderingMethod,
+) -> Result<SymbolicPrefix, FeralError> {
+    let is_external = matches!(method, OrderingMethod::External(_));
     let n = matrix.n;
 
     // Phase 2.13b per-stage profiler. Every timer is `Some` only when
@@ -1333,6 +1392,56 @@ pub fn symbolic_factorize_with_method(
         record_stage(prof, "renumber", t);
     }
     let factor_nnz = total_factor_nnz(&col_counts);
+    let factor_slack = 1.2;
+    let factor_nnz_estimate = (factor_nnz as f64 * factor_slack) as usize;
+
+    // `snode_params` here is `&effective_params` (amalgamation `Auto`
+    // resolved above). Move the owned `effective_params` into the prefix so
+    // the finish can consult its amalgamation strategy, small-leaf params,
+    // and profiler arc. This is the last use of the borrow.
+    Ok(SymbolicPrefix {
+        n,
+        perm,
+        perm_inv,
+        permuted_pattern,
+        etree,
+        col_counts,
+        factor_nnz_estimate,
+        factor_slack,
+        cached_mc64,
+        resolved_method,
+        resolved_preprocess,
+        effective_params,
+        t_total,
+    })
+}
+
+/// The symbolic pipeline *finish* (issue #127): the tail stages a race
+/// runs only for the winning [`SymbolicPrefix`] — supernode detection,
+/// small-leaf grouping, peak-memory accounting, static row indices (#125),
+/// and struct assembly. Records the tail stages into the prefix's profiler
+/// and sets the run total spanning prefix+finish.
+fn symbolic_finish(prefix: SymbolicPrefix) -> SymbolicFactorization {
+    #[cfg(test)]
+    FINISH_RUNS.with(|c| c.set(c.get() + 1));
+
+    let SymbolicPrefix {
+        n,
+        perm,
+        perm_inv,
+        permuted_pattern,
+        etree,
+        col_counts,
+        factor_nnz_estimate,
+        factor_slack,
+        cached_mc64,
+        resolved_method,
+        resolved_preprocess,
+        effective_params,
+        t_total,
+    } = prefix;
+    let snode_params = &effective_params;
+    let prof = snode_params.symbolic_profiler.as_ref();
 
     // Step 7: Supernode detection on the postordered etree
     let t_find = prof.map(|_| std::time::Instant::now());
@@ -1367,8 +1476,6 @@ pub fn symbolic_factorize_with_method(
         record_stage(prof, "peak_contrib", t);
     }
 
-    let factor_slack = 1.2;
-
     // Issue #125: static frontal row layout (numeric no-delay fast path).
     let t_sr = prof.map(|_| std::time::Instant::now());
     let (static_row_offsets, static_row_flat) =
@@ -1383,12 +1490,12 @@ pub fn symbolic_factorize_with_method(
         }
     }
 
-    Ok(SymbolicFactorization {
+    SymbolicFactorization {
         n,
         perm,
         perm_inv,
         supernodes,
-        factor_nnz_estimate: (factor_nnz as f64 * factor_slack) as usize,
+        factor_nnz_estimate,
         factor_slack,
         contrib_sizes,
         peak_contrib_bytes,
@@ -1404,7 +1511,29 @@ pub fn symbolic_factorize_with_method(
         resolved_amalgamation: snode_params.amalgamation_strategy,
         resolved_preprocess,
         is_schur_tail: None,
-    })
+    }
+}
+
+/// Finish the winning prefix and reconcile the profiler. When the prefix
+/// recorded into a *detached* profiler (a raced arm/candidate got its own
+/// fresh one so losers don't pollute the shared report), copy the winner's
+/// completed run into the caller's `shared` profiler; when the prefix
+/// already used the shared arc (the concrete top-level path), the arcs are
+/// identical and the copy is skipped.
+fn finish_and_copy(
+    prefix: SymbolicPrefix,
+    shared: Option<&std::sync::Arc<std::sync::Mutex<SymbolicProfiler>>>,
+) -> SymbolicFactorization {
+    let used = prefix.effective_params.symbolic_profiler.clone();
+    let sym = symbolic_finish(prefix);
+    if let (Some(shared), Some(used)) = (shared, used.as_ref()) {
+        if !std::sync::Arc::ptr_eq(shared, used) {
+            if let (Ok(u), Ok(mut s)) = (used.lock(), shared.lock()) {
+                *s = u.clone();
+            }
+        }
+    }
+    sym
 }
 
 /// Symbolic factorization with a user-supplied Schur tail (F3.2a).
@@ -1922,6 +2051,55 @@ fn compute_peak_contrib(supernodes: &[Supernode], contrib_sizes: &[usize]) -> us
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A small tridiagonal SPD matrix for the finish-count probes.
+    fn tridiag(n: usize) -> CscMatrix {
+        let mut rows = Vec::new();
+        let mut cols = Vec::new();
+        let mut vals = Vec::new();
+        for i in 0..n {
+            rows.push(i);
+            cols.push(i);
+            vals.push(4.0);
+            if i + 1 < n {
+                rows.push(i + 1);
+                cols.push(i);
+                vals.push(-1.0);
+            }
+        }
+        CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiag")
+    }
+
+    /// Issue #127: the preprocess-`Auto` race finishes exactly one prefix
+    /// (the winner), never the losing arm.
+    #[test]
+    fn finish_runs_once_under_preprocess_auto() {
+        let m = tridiag(40);
+        // Default params → `Auto` preprocess, `Auto` (non-race) method.
+        FINISH_RUNS.with(|c| c.set(0));
+        let _ = symbolic_factorize(&m, &SupernodeParams::default()).expect("factor");
+        assert_eq!(
+            FINISH_RUNS.with(|c| c.get()),
+            1,
+            "preprocess-Auto must finish exactly one prefix",
+        );
+    }
+
+    /// Issue #127: `AutoRace` finishes exactly one prefix regardless of the
+    /// candidate count (4 ordering candidates × up to 2 preprocess arms).
+    #[test]
+    fn finish_runs_once_under_autorace() {
+        let m = tridiag(40);
+        let params = SupernodeParams::default();
+        FINISH_RUNS.with(|c| c.set(0));
+        let _ = symbolic_factorize_with_method(&m, &params, OrderingMethod::AutoRace)
+            .expect("autorace");
+        assert_eq!(
+            FINISH_RUNS.with(|c| c.get()),
+            1,
+            "AutoRace must finish exactly one prefix (the winner)",
+        );
+    }
 
     #[test]
     fn test_symbolic_factorize_basic() {

--- a/tests/issue127_pipeline_split.rs
+++ b/tests/issue127_pipeline_split.rs
@@ -1,0 +1,178 @@
+//! Issue #127 regression: splitting the symbolic pipeline so race losers
+//! skip the tail stages must not change *which* candidate wins or the
+//! factorization produced from it.
+//!
+//! Strategy (no golden constants): the race dispatchers must be
+//! self-consistent — the `AutoRace` / preprocess-`Auto` result must be
+//! byte-identical to the result of directly requesting the concrete
+//! `resolved_method` / `resolved_preprocess` the race reports. That is
+//! exactly the property the prefix/finish split must preserve: the winner
+//! is finished from its own prefix, and no other candidate influences it.
+
+use feral::symbolic::{
+    symbolic_factorize, symbolic_factorize_with_method, OrderingMethod, OrderingPreprocess,
+    SupernodeParams,
+};
+use feral::CscMatrix;
+
+/// 2D 5-point grid Laplacian on a `k×k` grid (SPD, n = k²). Rich enough
+/// that the four ordering backends can reach different fills, and all of
+/// them succeed on it.
+fn grid_laplacian(k: usize) -> CscMatrix {
+    let n = k * k;
+    let idx = |r: usize, c: usize| r * k + c;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for r in 0..k {
+        for c in 0..k {
+            let i = idx(r, c);
+            let mut deg = 0.0f64;
+            for (dr, dc) in [(0isize, 1isize), (1, 0)] {
+                let (nr, nc) = (r as isize + dr, c as isize + dc);
+                if nr >= 0 && nr < k as isize && nc >= 0 && nc < k as isize {
+                    let j = idx(nr as usize, nc as usize);
+                    // off-diagonal -1, stored once in the lower triangle
+                    // (CscMatrix keeps only row >= col; the matrix is symmetric).
+                    rows.push(i.max(j));
+                    cols.push(i.min(j));
+                    vals.push(-1.0);
+                    deg += 1.0;
+                }
+            }
+            // diagonal: degree + 4 (strictly diagonally dominant → SPD)
+            rows.push(i);
+            cols.push(i);
+            vals.push(deg + 4.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("build grid laplacian")
+}
+
+/// Compare the fields that fully determine a symbolic factorization. `perm`
+/// equality alone forces the whole downstream (deterministic) result to
+/// match; the rest are cheap belt-and-suspenders checks.
+fn assert_same_symbolic(
+    a: &feral::symbolic::SymbolicFactorization,
+    b: &feral::symbolic::SymbolicFactorization,
+    ctx: &str,
+) {
+    assert_eq!(a.perm, b.perm, "{ctx}: perm differs");
+    assert_eq!(a.perm_inv, b.perm_inv, "{ctx}: perm_inv differs");
+    assert_eq!(
+        a.factor_nnz_estimate, b.factor_nnz_estimate,
+        "{ctx}: factor_nnz_estimate differs"
+    );
+    assert_eq!(
+        a.resolved_method, b.resolved_method,
+        "{ctx}: resolved_method differs"
+    );
+    assert_eq!(
+        a.resolved_preprocess, b.resolved_preprocess,
+        "{ctx}: resolved_preprocess differs"
+    );
+    assert_eq!(a.col_counts, b.col_counts, "{ctx}: col_counts differs");
+    assert_eq!(
+        a.supernodes.len(),
+        b.supernodes.len(),
+        "{ctx}: supernode count differs"
+    );
+    for (i, (sa, sb)) in a.supernodes.iter().zip(b.supernodes.iter()).enumerate() {
+        assert_eq!(sa.first_col, sb.first_col, "{ctx}: supernode {i} first_col");
+        assert_eq!(sa.ncol, sb.ncol, "{ctx}: supernode {i} ncol");
+        assert_eq!(sa.nrow, sb.nrow, "{ctx}: supernode {i} nrow");
+    }
+}
+
+/// The `AutoRace` winner must byte-match the concrete method it reports,
+/// and its estimate must be the minimum over all raced candidates.
+#[test]
+fn autorace_matches_winning_concrete_method() {
+    let candidates = [
+        OrderingMethod::Amd,
+        OrderingMethod::MetisND,
+        OrderingMethod::ScotchND,
+        OrderingMethod::KahipND,
+    ];
+    for &preprocess in &[OrderingPreprocess::None, OrderingPreprocess::Auto] {
+        for k in [6usize, 10, 15] {
+            let m = grid_laplacian(k);
+            let params = SupernodeParams {
+                preprocess,
+                ..SupernodeParams::default()
+            };
+
+            let race = symbolic_factorize_with_method(&m, &params, OrderingMethod::AutoRace)
+                .expect("autorace");
+
+            // The concrete result for the reported winning method must match.
+            let concrete =
+                symbolic_factorize_with_method(&m, &params, race.resolved_method.clone())
+                    .expect("concrete winner");
+            assert_same_symbolic(
+                &race,
+                &concrete,
+                &format!("autorace k={k} preprocess={preprocess:?}"),
+            );
+
+            // The winner's estimate must be the minimum across candidates.
+            let min_est = candidates
+                .iter()
+                .filter_map(|c| {
+                    symbolic_factorize_with_method(&m, &params, c.clone())
+                        .ok()
+                        .map(|s| s.factor_nnz_estimate)
+                })
+                .min()
+                .expect("at least one candidate");
+            assert_eq!(
+                race.factor_nnz_estimate, min_est,
+                "autorace k={k} preprocess={preprocess:?}: winner is not the argmin estimate",
+            );
+        }
+    }
+}
+
+/// The preprocess-`Auto` winner must byte-match the concrete
+/// preprocess it reports (proving the finish uses the winning arm's prefix).
+#[test]
+fn preprocess_auto_matches_resolved_arm() {
+    for k in [6usize, 10, 15, 20] {
+        let m = grid_laplacian(k);
+        let auto_params = SupernodeParams {
+            preprocess: OrderingPreprocess::Auto,
+            ..SupernodeParams::default()
+        };
+        // Fix the ordering method so only the preprocess race varies.
+        let auto = symbolic_factorize_with_method(&m, &auto_params, OrderingMethod::Amd)
+            .expect("auto preprocess");
+
+        let arm_params = SupernodeParams {
+            preprocess: auto.resolved_preprocess,
+            ..SupernodeParams::default()
+        };
+        let arm = symbolic_factorize_with_method(&m, &arm_params, OrderingMethod::Amd)
+            .expect("resolved arm");
+
+        assert_same_symbolic(&auto, &arm, &format!("preprocess-auto k={k}"));
+    }
+}
+
+/// `symbolic_factorize` (default params → `Auto` preprocess, `Auto` method)
+/// must equal the concrete resolution it reports for both dimensions.
+#[test]
+fn default_symbolic_matches_its_resolution() {
+    for k in [8usize, 12] {
+        let m = grid_laplacian(k);
+        let auto = symbolic_factorize(&m, &SupernodeParams::default()).expect("default auto");
+
+        let concrete_params = SupernodeParams {
+            preprocess: auto.resolved_preprocess,
+            ..SupernodeParams::default()
+        };
+        let concrete =
+            symbolic_factorize_with_method(&m, &concrete_params, auto.resolved_method.clone())
+                .expect("concrete resolution");
+        assert_same_symbolic(&auto, &concrete, &format!("default k={k}"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #127. `OrderingPreprocess::Auto` and `OrderingMethod::AutoRace` previously ran the **full** symbolic pipeline for every candidate (up to 2× and 4× respectively, ~8× when both nest) even though the winner is chosen on `factor_nnz_estimate` alone. The pipeline is now split into a **prefix** (ordering → column counts → `factor_nnz`) and a **finish** (supernode detection, small-leaf grouping, peak-memory accounting, static row indices, struct assembly); the races compare prefixes and run the finish only for the winner, so the losing candidates never pay the tail.

This benefits the IPM-host workload directly: slack-heavy KKTs fire the preprocess race on every cache-miss factorization.

## Correctness — bit-identical, by construction

- **Winner selection unchanged**: same `factor_nnz_estimate`, same `<` / `<= none_limit` operators, same `PREPROCESS_FILL_INFLATION_LIMIT`. The produced `SymbolicFactorization` is unchanged — this only moves *when* the tail runs.
- Chose the prefix/finish split over "estimate then recompute the winner" because recomputing the winner's ordering would double the LdltCompress MC64 matching (the dominant cost) when compression wins.
- The Schur-tail variant is untouched. No public API change.
- Profiler "reflects one run" behaviour preserved (fresh profiler per raced arm/candidate; the winner's tail is appended to its own profiler; copied to the shared profiler iff a different `Arc`).

## Tests

New `tests/issue127_pipeline_split.rs` (self-consistency, no golden constants):
- `autorace_matches_winning_concrete_method` — AutoRace byte-matches the concrete `resolved_method` result **and** is the argmin estimate.
- `preprocess_auto_matches_resolved_arm` / `default_symbolic_matches_its_resolution`.

In-module unit tests: `finish_runs_once_under_{preprocess_auto,autorace}` — a thread-local `#[cfg(test)]` counter proves losers never reach the tail (exactly one finish regardless of candidate count).

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; full suite green (82 test-result ok, 0 failed) including `symbolic_profiler` (5/5, `accounted <= total`, no warnings), `auto_strategy` (7), `issue91_preprocess_misfire` (qap15 fill-inflation guard).
- Bench full corpus **bit-identical** to baseline: inertia 100% on both paths, residual counts `154149/154482` (dense) and `154258/154590` (sparse) unchanged, worst residuals identical, partition gates all PASS.

Design notes: `dev/research/issue-127-symbolic-pipeline-split.md`, `dev/plans/issue-127-pipeline-split.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
