### PR TITLE
release: feral v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-11
+
 ### Performance — split the symbolic pipeline for the ordering races (issue #127)
 
 - **#127** `OrderingPreprocess::Auto` and `OrderingMethod::AutoRace` previously

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.13.0"
+version = "0.14.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release feral v0.14.0

Bumps all six version strings 0.13.0 → 0.14.0 (root `Cargo.toml`/`Cargo.lock`, `python/Cargo.toml`/`Cargo.lock`/`pyproject.toml`) and cuts the CHANGELOG `[Unreleased]` section to `[0.14.0] - 2026-07-11`.

### What's in 0.14.0

**Correctness fixes** — the headline reason to ship:
- #114–#119 — LU/LDLᵀ audit fixes (silent NaN commits, wrong inertia certification, `O(1/d)` solve errors, eta-based dense LU update, KR guards).
- #120–#123 — LDLᵀ correctness-edge fixes (cascade-break scaling, symbolic-cache collision, ordering bijectivity/NaN 2×2 guard, MAXFROMM parity).
- #112 — Forrest–Tomlin compensated bump sweep (fixes spurious `TinyPivot` refactors on nonsingular bases).

**Performance / features** (all bit-identical or opt-in, defaults unchanged):
- #131 Gap A — opt-in tree-parallel single-RHS sparse solve (`solve_sparse_cb`).
- #125 (partial) — analysis-time static assembly maps.
- #124/#126/#128 — warm-path prologue + solve speedups.
- #112 — opt-in Bartels–Golub pivot search for the sparse LU update.
- #127 — symbolic pipeline split so ordering-race losers skip the tail.

Minor bump: additive, backward-compatible; the only new public surfaces are opt-in with safe defaults.

### Verification

- Root and `python/` `Cargo.lock` both pass `cargo metadata --locked`; no stray `0.13.0` version references remain.
- CI on the most recent code commit (#144, `8a6992e`) was green — full suite, clippy `-D warnings`, fmt, and the full-corpus bench (**inertia 100%** on both paths, all partition gates PASS).

Merging this, then publishing the `v0.14.0` GitHub Release triggers `release.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
