### PR TITLE
perf(kernel): explicit SIMD packed trailing update + x86 pulp dispatch fix (session 2026-08-09-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Performance — x86 SIMD kernels actually reach AVX2 (session 2026-08-09)
+
+- The x86_64 branches of the pulp dispatch helpers now route through
+  `Simd::vectorize`, which supplies the `#[target_feature]` context the AVX
+  intrinsics need to inline. Previously every pulp kernel on x86 executed its
+  lane ops as outlined function calls (~10× kernel slowdown; invisible on
+  aarch64 where NEON is a baseline feature). Bit-identical results.
+- The packed BLAS-3 trailing update's register-tile walk is now an explicit
+  pulp SIMD kernel (`packed_schur_tiles_{nofma,fma}`), one dispatch per panel.
+  It previously relied on autovectorization that never fired on x86 (fully
+  scalar codegen). Dense-front factor (n=2955): 4.24 s → 1.52 s serial nofma,
+  0.57-0.61 s with intrafront parallelism + opt-in FMA (x86 4-core AVX2
+  container, 3-run). Byte-exact at every SIMD width; enforced by extended
+  parity tests plus new hardcoded golden bit-digests (`tests/golden_bits.rs`).
+- The opt-in FMA path is fast again on x86: the packed kernel's scalar
+  `f64::mul_add` lowered to a libm `fma()` call at baseline codegen (~3×
+  slower than nofma since 0.13.x); pulp's `mul_add_f64s` restores real
+  `vfmadd` through runtime dispatch, making FMA the fastest x86 config.
+- Degenerate panels (fewer than 1024 multiply-subtracts) stay on the inline
+  scalar tile walk — the dispatch boundary costs more than the work there.
+  New env overrides: `FERAL_PACKED_SIMD=0` (restore the scalar tile walk)
+  and `FERAL_PACKED_SIMD_MIN_WORK=<n>` (retune the gate per arch).
+- The packed update's pack buffers are pooled in `FactorScratch` on the
+  serial path (issue #128 rest): warm factor −12% on a chain-structured KKT
+  proxy, −2..6% across the small parity fixtures.
+
+Note: aarch64 (M-series) performance revalidation of the new explicit-SIMD
+packed path is pending; correctness there is guarded by the golden digests,
+and `FERAL_PACKED_SIMD=0` restores the previous behavior if needed.
+
 ## [0.14.0] - 2026-07-11
 
 ### Performance — split the symbolic pipeline for the ordering races (issue #127)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,9 @@ name = "bench_dense_front"
 name = "bench_schur_micro"
 
 [[example]]
+name = "bench_packed_tiny"
+
+[[example]]
 name = "bench_qap15"
 
 [[example]]

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,122 +1,116 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-07-11T16:23:37Z
+Generated: 2026-08-09T01:16:25Z
 
 ## Latest Session
-File: dev/sessions/2026-07-11-01.md
+File: dev/sessions/2026-07-11-02.md
 ```
-# Session 2026-07-11-01
+# Session 2026-07-11-02
 
 ## Goal
 
-Review all open branches for up-to-dateness (user request). Two follow-on
-tasks emerged: (1) merge dev/ records stranded on closed-issue branches and
-delete the branches; (2) diagnose and fix a locally-failing test surfaced by
-the first task, and close the fixture-gating blind spot that hid it from CI.
+Continuation of 2026-07-11-01. Review the open issues for release-worthiness,
+do the pre-release housekeeping, implement the one issue worth doing first
+(#127), then cut and publish release 0.14.0.
 
 ## Benchmark comparison to previous session
 
-**No regression.** This session changed **no solver code** — only a test
-assertion, CI config, `.gitignore`, committed fixtures, and docs — so the
-bench reflects main's unchanged code (`dfae3c5` → `7c56427`). Inertia gate
-holds at **100.0%** on both paths. The last full-corpus run was 2026-05-21-04
-(the intervening container sessions had no corpus); vs that baseline the
-corpus grew by 1–2 matrices, inertia stayed 100%, residual-pass stayed 99.8%
-on both paths. Any May→July residual drift spans dozens of intervening solver
-PRs and is not attributable to this session.
+**No regression.** The only code change this session (#127) is a bit-identical
+refactor; the release commit changes no code. Full-corpus bench after #127 is
+identical to the 2026-07-11-01 baseline on both inertia (100%) and residual
+counts — see Benchmark Results.
 
 ## Accomplished
 
-- **Branch review + cleanup (PR #140, `805b85d`).** Verified branch-by-branch
-  that all *code* on every open branch had already landed on main (issue-112
-  tip byte-identical; #107 via PR #108; #99 packed-kernel via PR #103; four
-  branches 0 ahead). Three branches held dev/ records existing nowhere else;
-  merged them (issue-110's 545-line research note + 3 diagnostics study bins;
-  issue-102's stall-verify note + a journal entry; issue-99's container
-  checkpoint/journal renumbered `2026-07-01-03`→`-07` to avoid colliding with
-  main's different session -03). CI green, bins compile against main. Deleted
-  all nine stale branches; fast-forwarded local main `9596472`→`dfae3c5`.
+- **Issue triage → recommendation.** Reviewed all five open issues (#125,
+  #127, #128, #131, #134). Conclusion: all are deferred perf/robustness work,
+  none a correctness blocker; the strongest release argument is the ten
+  already-merged-but-unreleased correctness fixes (#114–#123). Recommended
+  releasing now and doing #127 first (highest value / lowest risk for the IPM
+  host workload). User agreed.
 
-- **Bisected the issue-65 test regression.** `cargo test` failed locally on
-  `issue65_mc64_fallback::explicit_infnorm_is_respected_no_fallback`
-  (expected `(789,670,116)`, got `(789,785,1)`) while CI was green on the
-  same SHA. Cause: the fixtures are gitignored + non-regenerable on CI, so
-  the guard SKIP-passed everywhere but this Mac. Bisect (fixtures unchanged
-  since Jun 3): `9596472` ok → `660224d`/#113 ok → **`8a980e4`/#135 FAILED**.
-  #135's rook fixes (#116 solve skips only exactly-zeroed pivots; #117 blocked
-  panel defers rook-eligible 1×1s to scalar) legitimately rescued 115 of 116
-  formerly force-zeroed pivots — moving the InfNorm signature *closer* to the
-  oracle `(789,786,0)`. An improvement that invalidated a pinned constant, not
-  a correctness bug.
+- **Housekeeping (PR #143, merged).** The Unreleased CHANGELOG credited #125
+  and #128 as done though only a slice of each had landed. Marked both as
+  partial and posted landed-vs-remaining status comments (with commit refs) on
+  issues #125 and #128; verified both new public surfaces (`solve_sparse_cb`,
+  `LuParams::update_pivot_search` + its Python keyword) are documented.
 
-- **Fixed it + closed the blind spot (PR #141, `7c56427`).**
-  - Test now asserts the contract (`mc64_scaling_fallback_count()==0`,
-    `inertia.zero>0`, components sum to n=1575) instead of a pivot-policy
-    signature that has now drifted once. Human-approved.
-  - Committed the two generated fixtures (~280 KB) via `.gitignore` negation
-    (`tests/data/large/*` + `!sawpath`/`!twirism1`); large fetchable
+- **Issue #127 (PR #144, merged; issue closed).** Split
+  `symbolic_factorize_with_method` into a cheap *prefix* (ordering → column
+  counts → `factor_nnz`) and a *finish* (supernodes, small-leaf, peak-contrib,
+  static rows, struct assembly). Both race dispatchers (preprocess-`Auto`,
+  `AutoRace`) now race prefixes and finish only the winner — previously each
+  candidate ran the full pipeline (up to ~8× symbolic when both races nest).
+  Chose prefix/finish over "estimate then recompute winner" (the latter would
+  double the LdltCompress MC64 matching when compression wins). Winner
+  selection bit-identical; produced `SymbolicFactorization` unchanged;
+  Schur-tail variant untouched; profiler "one run" behaviour preserved. New
+  self-consistency parity tests (`tests/issue127_pipeline_split.rs`) + a
+  thread-local `#[cfg(test)]` FINISH_RUNS counter proving losers never reach
+  the tail. Research/plan: `dev/research/issue-127-symbolic-pipeline-split.md`,
+  `dev/plans/issue-127-pipeline-split.md`.
+
+- **Release 0.14.0 (PR #145, merged; published).** Bumped all six version
+  strings 0.13.0 → 0.14.0 (root + python `Cargo.toml`/`Cargo.lock`,
+  `pyproject.toml`), cut the CHANGELOG `[0.14.0] - 2026-07-11` section, tagged
+  the `v0.14.0` GitHub Release. Both publish workflows succeeded:
+  `release.yml` → crates.io (cargo publish in dependency order),
 ```
 
 ## Git Status
 ```
+6589570 docs: session checkpoint 2026-07-11-02 (issue triage, #127, release 0.14.0) (#146)
 c05eb77 release: feral v0.14.0 (#145)
 8a6992e perf(symbolic): split pipeline so ordering-race losers skip the tail (#127) (#144)
 683933a docs(changelog): mark #125 and #128 as partial in Unreleased (#143)
 a0bf2db docs: session checkpoint 2026-07-11-01 (branch cleanup + issue-65 fix) (#142)
-7c56427 test(issue65): semantic assertion + commit fixtures, surface CI skips (#141)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 409 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.57s
+test result: ok. 407 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.93s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-11-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-11-02.md)
 
 
-cargo run --bin bench --release  (full local corpus, aarch64 M-series)
+cargo run --bin bench --release  (full local corpus, aarch64 M-series; after #127)
 
 --- Dense solver validation ---
-  Inertia match:  154429/154482 (100.0%)   [53 consensus-excluded]
-  Residual pass:  154149/154482 (99.8%)
-  Worst residual: 2.46e-1 (POLAK6_0021)     # known residual-hard case
+  Inertia match:  154429/154482 (100.0%)
+  Residual pass:  154149/154482 (99.8%)   worst 2.46e-1 (POLAK6_0021)
 
 --- Sparse solver validation ---
   Inertia match vs MUMPS: 154531/154590 (100.0%)
-  Residual pass:          154258/154590 (99.8%)
-  Worst residual:         2.94e-4 (ERRINBAR_0824)
+  Residual pass:          154258/154590 (99.8%)   worst 2.94e-4 (ERRINBAR_0824)
 
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-  small-frontal (<200)  count 147982  p90 1.72  <= 2.0  PASS
-  medium       (<500)   count 152145  p90 2.13  <= 3.0  PASS
+--- exit partitions ---
+  Dense  small-frontal p90 1.67 (<=2.0) PASS ; medium p90 2.08 (<=3.0) PASS
+  Sparse small-frontal p90 1.56 (<=2.0) PASS ; medium p90 1.57 (<=3.0) PASS
 
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-  small-frontal (<200)  count 153455  p90 1.61  <= 2.0  PASS
-  medium       (<500)   count 153560  p90 1.61  <= 3.0  PASS
-
-Worst factor-ratio vs MUMPS (dense): KIRBY2_0007 9.13×, HAHN1_0078 8.58×,
-CRESC132_0000 7.30× (n=5314) — the persistent small-n dense-front tail.
+Inertia AND residual counts are identical to the pre-#127 baseline
+(2026-07-11-01), confirming winner selection is unchanged (same factors).
 
 ```
 
@@ -240,8 +234,8 @@ tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -254,14 +248,6 @@ tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/growth_flag.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -273,13 +259,21 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
-tests/lu_dense_update_bg.rs
 tests/lu_dense.rs
+tests/lu_dense_update_bg.rs
 tests/lu_ft_widebump.rs
 tests/lu_scaling.rs
 tests/lu_sparse.rs
@@ -298,8 +292,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T01:16:25Z
+Generated: 2026-08-09T02:38:45Z
 
 ## Latest Session
-File: dev/sessions/2026-07-11-02.md
+File: dev/sessions/2026-08-09-01.md
 ```
-# Session 2026-07-11-02
+# Session 2026-08-09-01
 
 ## Goal
 
-Continuation of 2026-07-11-01. Review the open issues for release-worthiness,
-do the pre-release housekeeping, implement the one issue worth doing first
-(#127), then cut and publish release 0.14.0.
+Evidence-based kernel performance pass (user request: vectorization/SIMD
+opportunities, pure Rust, every change (1) correct, (2) faster,
+(3) bit-identical across platforms). Staged plan: measure-first, then
+packed-kernel SIMD, pack-buffer pooling, small-front eager-path SIMD.
 
-## Benchmark comparison to previous session
-
-**No regression.** The only code change this session (#127) is a bit-identical
-refactor; the release commit changes no code. Full-corpus bench after #127 is
-identical to the 2026-07-11-01 baseline on both inertia (100%) and residual
-counts — see Benchmark Results.
+Environment caveat: x86_64 4-core AVX2+AVX512 container; the 154k-matrix
+corpus is NOT present, so evidence comes from parity suites +
+bench_schur_micro / bench_dense_front / perf_probe on tests/data
+fixtures + a new hicks-like chain fixture. **All perf numbers below are
+x86; aarch64 M-series revalidation is pending (see follow-ups).**
 
 ## Accomplished
 
-- **Issue triage → recommendation.** Reviewed all five open issues (#125,
-  #127, #128, #131, #134). Conclusion: all are deferred perf/robustness work,
-  none a correctness blocker; the strongest release argument is the ten
-  already-merged-but-unreleased correctness fixes (#114–#123). Recommended
-  releasing now and doing #127 first (highest value / lowest risk for the IPM
-  host workload). User agreed.
+1. **x86 pulp dispatch fix (f0be9fa)** — `dispatch_nofma`/`dispatch_fma`
+   called `k.with_simd(v3)` instead of `pulp::Simd::vectorize(v3, k)`,
+   so every pulp kernel on x86 ran its AVX intrinsics as outlined
+   function calls since Phase 2.4.2 (invisible on aarch64 where NEON is
+   baseline). Strided kernel: 0.45 → 4.69-7.00 GFLOP/s (~10×).
+   Bit-identical by construction; all suites + golden digests unchanged.
 
-- **Housekeeping (PR #143, merged).** The Unreleased CHANGELOG credited #125
-  and #128 as done though only a slice of each had landed. Marked both as
-  partial and posted landed-vs-remaining status comments (with commit refs) on
-  issues #125 and #128; verified both new public surfaces (`solve_sparse_cb`,
-  `LuParams::update_pivot_search` + its Python keyword) are documented.
+2. **Explicit pulp SIMD packed trailing update (41c35b5)** — the
+   default BLAS-3 tile walk had compiled fully scalar on x86 (objdump:
+   ymm=0, packed SSE=0). Moved into
+   `schur_kernel::packed_schur_tiles_{nofma,fma}`, one dispatch per
+   panel; scalar walk kept as `FERAL_PACKED_SIMD=0` fallback. Also
+   repairs the opt-in FMA path (scalar `f64::mul_add` → libm call, was
+   a 3× x86 slowdown since 2026-07-01). New `tests/golden_bits.rs`
+   hardcoded digests = cross-arch tripwire.
 
-- **Issue #127 (PR #144, merged; issue closed).** Split
-  `symbolic_factorize_with_method` into a cheap *prefix* (ordering → column
-  counts → `factor_nnz`) and a *finish* (supernodes, small-leaf, peak-contrib,
-  static rows, struct assembly). Both race dispatchers (preprocess-`Auto`,
-  `AutoRace`) now race prefixes and finish only the winner — previously each
-  candidate ran the full pipeline (up to ~8× symbolic when both races nest).
-  Chose prefix/finish over "estimate then recompute winner" (the latter would
-  double the LdltCompress MC64 matching when compression wins). Winner
-  selection bit-identical; produced `SymbolicFactorization` unchanged;
-  Schur-tail variant untouched; profiler "one run" behaviour preserved. New
-  self-consistency parity tests (`tests/issue127_pipeline_split.rs`) + a
-  thread-local `#[cfg(test)]` FINISH_RUNS counter proving losers never reach
-  the tail. Research/plan: `dev/research/issue-127-symbolic-pipeline-split.md`,
-  `dev/plans/issue-127-pipeline-split.md`.
+3. **Work gate for degenerate panels (8358d1b)** — panels below 1024
+   multiply-subtracts stay on the inline scalar walk
+   (`FERAL_PACKED_SIMD_MIN_WORK` override): the ~100-200 ns dispatch
+   boundary can't be amortized there (`examples/bench_packed_tiny`),
+   and un-gated SIMD showed a warm-median artifact on HAHN1/AVION2
+   that in-kernel timing proved was not in-kernel cost (journal 04:10).
 
-- **Release 0.14.0 (PR #145, merged; published).** Bumped all six version
-  strings 0.13.0 → 0.14.0 (root + python `Cargo.toml`/`Cargo.lock`,
-  `pyproject.toml`), cut the CHANGELOG `[0.14.0] - 2026-07-11` section, tagged
-  the `v0.14.0` GitHub Release. Both publish workflows succeeded:
-  `release.yml` → crates.io (cargo publish in dependency order),
+4. **Pack-buffer pooling, issue #128 rest (484bda7)** — `PackPool` on
+   `FactorScratch`, serial path only; dirty-pool byte-parity sweep in
+   the unit test.
+
+5. **Eager-path SIMD tried and rejected (f509a18)** — full
+   implementation measured FLAT everywhere (eager n=512: 11.21 vs
+   11.23 ms) because the plain eager loops already autovectorize;
+   reverted same session per the pre-registered criterion, keeping the
+   byte-identical de-duplication of `do_1x1_pivot`'s twin loops.
+   Recorded in tried-and-rejected.
 ```
 
 ## Git Status
 ```
-6589570 docs: session checkpoint 2026-07-11-02 (issue triage, #127, release 0.14.0) (#146)
-c05eb77 release: feral v0.14.0 (#145)
-8a6992e perf(symbolic): split pipeline so ordering-race losers skip the tail (#127) (#144)
-683933a docs(changelog): mark #125 and #128 as partial in Unreleased (#143)
-a0bf2db docs: session checkpoint 2026-07-11-01 (branch cleanup + issue-65 fix) (#142)
+f509a18 refactor(kernel): dedup do_1x1_pivot update loops; record eager-SIMD rejection
+484bda7 perf(kernel): pool packed-update A/B pack buffers in FactorScratch
+8358d1b perf(kernel): work-gate the packed SIMD tile kernel; add tiny-call probe
+41c35b5 perf(kernel): explicit pulp SIMD tile kernel for the packed trailing update
+f0be9fa perf(kernel): route x86 pulp dispatch through Simd::vectorize
 ```
 
 ## Test Status
@@ -86,87 +86,97 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 407 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.93s
+test result: ok. 407 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.95s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-07-11-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-01.md)
 
 
-cargo run --bin bench --release  (full local corpus, aarch64 M-series; after #127)
+`cargo run --bin bench --release` (corpus absent — synthetic + 2
+regression fixtures only): 8 synthetic matrices benchmarked; KKT
+fixtures 1/1 dense inertia+residual pass (worst 1.14e-15), sparse 2/2
+vs MUMPS (worst 1.26e-16). Phase 2.8.1 partitions N/A (no oracle
+timings in container).
 
---- Dense solver validation ---
-  Inertia match:  154429/154482 (100.0%)
-  Residual pass:  154149/154482 (99.8%)   worst 2.46e-1 (POLAK6_0021)
+Kernel/fixture evidence (3-run medians, sequential, this container):
 
---- Sparse solver validation ---
-  Inertia match vs MUMPS: 154531/154590 (100.0%)
-  Residual pass:          154258/154590 (99.8%)   worst 2.94e-4 (ERRINBAR_0824)
+| measure | session start | session end |
+|---|---:|---:|
+| bench_dense_front 2955 nofma serial | 4236 ms (2.0 GF/s) | 1517-1556 ms (5.6 GF/s) |
+| bench_dense_front 2955 nofma intrafront | 1798 ms (4.8 GF/s) | 637-679 ms (12.7-13.5 GF/s) |
+| bench_dense_front 2955 fma intrafront | 4214 ms | 572-609 ms (14-15 GF/s) |
+| bench_dense_front 512 nofma serial | 39.4 ms | 10.0-10.9 ms |
+| strided micro 2048²·64 | 0.45 GF/s | 4.69 GF/s |
+| twirism1 warm factor | 4176-4217 µs | 2066-2195 µs |
+| hydcar20 | 295-300 µs | 206-218 µs |
+| sawpath | 826-830 µs | 671-745 µs |
+| vesuvio | 2108-2284 µs | 1857-2071 µs |
+| chain1200 (new fixture) | 985 µs (post-Stage-1) | 847-961 µs |
+| hahn1 | 839-842 µs | 739-762 µs |
+| avion2 | 39 µs | 34-35 µs |
 
---- exit partitions ---
-  Dense  small-frontal p90 1.67 (<=2.0) PASS ; medium p90 2.08 (<=3.0) PASS
-  Sparse small-frontal p90 1.56 (<=2.0) PASS ; medium p90 1.57 (<=3.0) PASS
-
-Inertia AND residual counts are identical to the pre-#127 baseline
-(2026-07-11-01), confirming winner selection is unchanged (same factors).
+No fixture worse than session start. All byte-exactness gates green
+throughout (407 lib tests, 83 test binaries, golden digests stable
+across default / FERAL_PACKED_SIMD=0 / FERAL_PACKED_SCHUR=0).
 
 ```
 
 ## Recent Decisions
-left on the critical path is the root/near-root fronts' O(nrow²), behind the
-root's O(nrow³) dense factor that intra-front parallelism (Lever 1.1) already
-targets — so column-partitioned parallel assembly would chase <1–3% of the
-factor. #125 already captured the tractable, bit-exact assembly win
-(`build_row_indices`). Not built. Evidence:
-`dev/research/issue-131-gapb-assembly-measure-2026-07-10.md`.
+nofma-serial 4236 → 1517-1556 ms (2.7-2.8×, 2.0 → 5.6 GF/s);
+nofma-intrafront 1798 → 637-679 ms (12.7-13.5 GF/s); fma-intrafront
+4214 → 572-609 ms (14-15 GF/s, fastest config); n=512 3.9×. Warm
+fixtures: twirism1 −46%, hydcar20 −26%, sawpath −18%. Small fixtures
+restored to baseline-or-better by the work gate.
 
-## 2026-07-11 — issue-65 guard: semantic assertion + committed fixtures (fixture-gating blind spot)
+**aarch64 status.** NOT yet measured on M-series (this container is
+x86). The structural bit-identity argument plus golden digests
+guarantee correctness there; performance must be re-validated —
+`FERAL_PACKED_SIMD=0` is the one-env-var mitigation if the NEON
+codegen regresses vs the old autovectorized walk.
 
-Two decisions from the post-#135 breakage of
-`tests/issue65_mc64_fallback.rs::explicit_infnorm_is_respected_no_fallback`:
+## 2026-08-09 — Pack-buffer pooling on the serial packed path (issue #128 rest)
 
-1. **The explicit-InfNorm test asserts the contract, not a pinned inertia.**
-   The pinned `(789,670,116)` was InfNorm's misfactoring signature under the
-   pre-#135 pivot policy; #135's rook fixes (#116/#117) legitimately changed
-   it to `(789,785,1)` (closer to the oracle `(789,786,0)`). The signature is
-   a pivot-policy artifact and will drift again; the invariant the test
-   guards is "explicit strategy respected": `mc64_scaling_fallback_count()
-   == 0`, `inertia.zero > 0` (zeros kept, not rescued), components sum to n.
-   Human-approved (session 2026-07-11).
+**Decision.** `FactorScratch` carries a `PackPool {apack, bpack0,
+bpack1}`; the serial packed dispatch path reuses it (mem::take'd
+around the scratch borrows), the intra-front rayon path keeps
+per-range fresh allocations (a shared pool cannot cross the parallel
+split; multi-slot pooling is on the tried-and-rejected list).
+`bpack0`/`bpack1` re-zero on reuse via `clear()+resize` (their zeros
+are load-bearing for out-of-range column lanes); `apack` skips the
+re-zero only when its length matches (every slot including padding is
+overwritten). Parity test carries a deliberately dirty pool across all
+shapes.
 
-2. **The two issue-65 fixtures are committed, not gitignored.** They are
-   small (~280 KB total) *generated* matrices that CI can never fetch or
-   regenerate (`regen_issue65_kkts.sh` needs pounce + a local .nl set), so
-   the SKIP-when-absent design made the guard local-only: PR #135 shipped
-   "full suite green" from a fixture-less container while breaking it.
-   `.gitignore` now uses `tests/data/large/*` with explicit negations;
-   large fetchable SuiteSparse matrices stay ignored. CI additionally
-   surfaces every remaining "SKIP:" line in the job summary
-   (`.github/workflows/ci.yml`) so skipped guards are visible, not silent.
+**Evidence (3-run warm medians).** chain1200 (hicks-like
+block-tridiagonal synthetic, added after the pounce#552 chain-KKT
+report) 985 → 847-961 µs (−12%); AVION2 −6%; twirism1 −6%; HYDCAR20
+−4%; VESUVIO −4%; HAHN1 −2%. Byte-exact (dirty-pool parity sweep +
+golden digests unchanged).
 
 ## Recent Tried-and-Rejected
-sweep replays across four hand constructions (journal 2026-07-10-01,
-research note §UPDATE).
+plain `for i in j..n { a[j*n+i] -= a[k*n+i]*alpha }` loops are
+textbook-autovectorizable, and the eager path's remaining time is
+pivot search + memory traffic, not multiply-subtract throughput.
+Explicit lanes duplicated what LLVM already did. This matches the
+2026-05-16 finding (pulp == scalar == manual unroll at lengths 3..128)
+at the whole-front scale.
 
-Also rejected en route: classic **Kahan** compensation for the sweep
-accumulator (its `y = v − c` pre-subtraction re-absorbs the compensation
-into the next 2²⁰-scale addend — computed `0.0` again; verified
-numerically); the **Neumaier** two-sum variant works and shipped. And three
-regression-matrix constructions whose base or replacement was numerically
-singular for every path (±1 cascade to 2³⁴: `σ_min(B') = 1.5e-16`; diag-4
-cascade: rescue-true `4.5e-13 <` ztol; spike-poison m=6: fresh LU burns the
-4e6 spike entry and deflates its tail pivot to 0) — any single-shot
-absorption reproducer necessarily has `σ_min(B') ⪅ δ·∏retained`, so the
-"fresh factor succeeds" oracle is unsatisfiable without a multi-update
-imbalance history.
+**What was kept.** The de-duplication refactor (shared scalar
+`rank1_scale_update_argmax`, byte-identical, golden digests unchanged)
+stays; the pulp kernel, its gate/env var, the dedicated parity test,
+and the A/B example were removed.
 
-**Shipped instead.** Always-on Neumaier-compensated scatter (recovers the
-true pivot bit-for-bit on the regression basis) + `update_pivot_search` as an
-always-on opt-in trajectory variant (bounded multipliers across chains),
-default false. See `dev/research/issue-112-bg-update.md` §UPDATE and
-`dev/decisions.md` 2026-07-10.
+**Lesson.** The small-front/MA57 gap is NOT lane width in the eager
+update. Remaining suspects, in evidence order: per-front fixed
+overhead (assembly/scatter/build-row, 8.8-14.8% on the small
+fixtures), pivot-search scans, `scalar_pivot_step` in blocked fronts,
+and the delayed-pivot cascade (per-factor-cost-cluster mechanism A).
+Any retry of eager-path SIMD must first show a front-level profile
+where the update loops are >30% of eager time AND not already
+vectorized in the disassembly.
 
 ## Source Files
 ```
@@ -247,6 +257,7 @@ tests/factor_workspace_parity.rs
 tests/factors_ld_export.rs
 tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
+tests/golden_bits.rs
 tests/growth_flag.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6022,3 +6022,86 @@ Two decisions from the post-#135 breakage of
    large fetchable SuiteSparse matrices stay ignored. CI additionally
    surfaces every remaining "SKIP:" line in the job summary
    (`.github/workflows/ci.yml`) so skipped guards are visible, not silent.
+
+## 2026-08-09 — x86 pulp dispatch must go through Simd::vectorize (kernel-wide fix)
+
+**Decision.** The x86_64 branches of `dispatch_nofma`/`dispatch_fma`
+(src/dense/schur_kernel.rs) call `pulp::Simd::vectorize(v3, k)` instead
+of `k.with_simd(v3)`. Only `vectorize` wraps the kernel body in V3's
+`#[target_feature(enable = "avx,avx2,fma,…")]` shim; the direct call ran
+every kernel in a baseline-feature codegen context where each AVX
+intrinsic wrapper stayed an outlined function call (objdump: standalone
+`_mm256_mul_pd` symbols called per lane op). The bug was invisible on
+the aarch64 M-series dev machines — NEON is a baseline feature, so
+`with_simd(NEON)` inlines regardless — and has throttled every pulp
+kernel on x86 since Phase 2.4.2. The aarch64 branch is unchanged.
+
+**Evidence.** bench_schur_micro strided kernel on the x86_64 AVX2
+container: 0.45-0.46 → 4.69-7.00 GFLOP/s (~10×). Bit-identical by
+construction (same per-lane instructions; only the inlining context
+changes): golden digests, parity suites, 407 lib tests all unchanged.
+
+**Constraint for future kernels.** Any new pulp entry point on x86 must
+dispatch via `Simd::vectorize` (or `Arch::dispatch`); verify with
+objdump that no `core_arch` thunks appear as call targets.
+
+## 2026-08-09 — Packed trailing update: explicit pulp SIMD tiles + work gate
+
+**Decision.** The packed BLAS-3 trailing update's register-tile walk
+moved from autovectorized-in-theory scalar Rust (factor.rs) into
+`schur_kernel::packed_schur_tiles_{nofma,fma}` — explicit pulp lanes
+over the MR axis, one dispatch per panel, `PACKED_MR=8`/`PACKED_NR=4`
+shared consts. Two escape hatches ship: `FERAL_PACKED_SIMD=0` restores
+the scalar tile walk (kept in-tree as the reference), and panels with
+`n_elim·rowspan·ncol < 1024` (`FERAL_PACKED_SIMD_MIN_WORK` override)
+stay on the scalar walk — the ~100-200 ns dispatch boundary
+(examples/bench_packed_tiny) cannot be amortized by degenerate panels
+(HAHN1's are nrow=10/ncol=1), and un-gated SIMD showed a warm-median
+artifact on such fixtures that the in-kernel timer proved was NOT
+in-kernel cost (journal 2026-08-09 04:10).
+
+**Why.** objdump proved the old tile walk compiled fully scalar on x86
+(ymm=0, packed SSE=0, 187 mulsd/subsd — ~6 GFLOP/s scalar-ILP peak).
+The same move repairs the opt-in FMA path, whose scalar `f64::mul_add`
+lowered to a libm `fma()` call at baseline codegen (~3× slower than
+nofma since packed became default 2026-07-01).
+
+**Bit-exactness.** Per-element chain unchanged (seed-from-C,
+ascending-q fold, mul→sub / fused-2×2 nofma shapes; chained mul_add
+fma shapes); PACKED_MR=8 divides every pulp lane width (scalar, NEON
+f64x2, AVX2 f64x4, AVX-512 f64x8) so no tail exists. Enforced by the
+extended `packed_matches_scalar_reference_bit_for_bit` (SIMD × scalar
+× pool sweep) and the new `tests/golden_bits.rs` hardcoded digests
+(cross-arch tripwire for the next M-series run).
+
+**Evidence (x86_64 AVX2 container, 3-run).** bench_dense_front 2955
+nofma-serial 4236 → 1517-1556 ms (2.7-2.8×, 2.0 → 5.6 GF/s);
+nofma-intrafront 1798 → 637-679 ms (12.7-13.5 GF/s); fma-intrafront
+4214 → 572-609 ms (14-15 GF/s, fastest config); n=512 3.9×. Warm
+fixtures: twirism1 −46%, hydcar20 −26%, sawpath −18%. Small fixtures
+restored to baseline-or-better by the work gate.
+
+**aarch64 status.** NOT yet measured on M-series (this container is
+x86). The structural bit-identity argument plus golden digests
+guarantee correctness there; performance must be re-validated —
+`FERAL_PACKED_SIMD=0` is the one-env-var mitigation if the NEON
+codegen regresses vs the old autovectorized walk.
+
+## 2026-08-09 — Pack-buffer pooling on the serial packed path (issue #128 rest)
+
+**Decision.** `FactorScratch` carries a `PackPool {apack, bpack0,
+bpack1}`; the serial packed dispatch path reuses it (mem::take'd
+around the scratch borrows), the intra-front rayon path keeps
+per-range fresh allocations (a shared pool cannot cross the parallel
+split; multi-slot pooling is on the tried-and-rejected list).
+`bpack0`/`bpack1` re-zero on reuse via `clear()+resize` (their zeros
+are load-bearing for out-of-range column lanes); `apack` skips the
+re-zero only when its length matches (every slot including padding is
+overwritten). Parity test carries a deliberately dirty pool across all
+shapes.
+
+**Evidence (3-run warm medians).** chain1200 (hicks-like
+block-tridiagonal synthetic, added after the pounce#552 chain-KKT
+report) 985 → 847-961 µs (−12%); AVION2 −6%; twirism1 −6%; HYDCAR20
+−4%; VESUVIO −4%; HAHN1 −2%. Byte-exact (dirty-pool parity sweep +
+golden digests unchanged).

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -131,3 +131,15 @@ jkitchin/pounce#552 (feral 3.5-4.8x vs MA27 on chain KKTs).
 (-12%), AVION2 36 -> 34 (-6%), twirism1 ~2270 -> 2066-2136 (-6%),
 HYDCAR20 ~220 -> 207-218 (-4%), VESUVIO ~1950 -> 1857-1931 (-4%),
 HAHN1 ~760 -> 739-746 (-2%). Acceptance (>=2% geomean small set) MET.
+
+* 06:20 :stage3:eager:simd:rejected:
+Stage 3 (eager rank-1 SIMD) implemented, measured FLAT, reverted same
+session per the pre-registered reject criterion. Fixture medians
+unchanged within noise; decisive A/B through the eager driver at
+n=512: 11.21 (simd) vs 11.23 ms (scalar) - the plain eager loops
+already autovectorize and the path is pivot-search/bandwidth-bound.
+Kept the byte-identical de-duplication of do_1x1_pivot's two fused
+loops (shared rank1_scale_update_argmax); removed the kernel, gate,
+env var, parity test, and A/B example. Full entry in
+tried-and-rejected.md. Small-front gap suspects now ranked: per-front
+overhead, pivot scans, scalar_pivot_step, delayed-pivot cascade.

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -79,3 +79,36 @@ on M-series; NEON baseline makes with_simd(NEON) harmless) - flagged
 for M-series re-eval anyway. Bits identical by construction (same lane
 ops, only codegen context changes): golden_bits digests unchanged,
 blocked_ldlt + lib suites green. Re-measuring.
+
+* 04:10 :stage1:gate:anomaly:measurement:
+Post-Stage-1 fixture sweep showed hahn1/avion2 warm medians +15% with
+the SIMD tile kernel while minima stayed equal. Root-caused as far as
+this container allows: (1) all packed calls on those fixtures are
+degenerate (hahn1: nrow=10 ncol=1 n_elim=7, ~1 call/iter, 112-206
+ns/call vs 10 ns inline scalar - examples/bench_packed_tiny); (2) a
+temporary cumulative timer INSIDE the packed impl measured only ~92 us
+total difference across 1000 iterations, i.e. ~0.1% of the ~120
+us/iter median shift - the changed code does not contain the cost; (3)
+hypotheses tested and refuted: AVX frequency-license transitions (tiny
+ymm burst + scalar busywork combo shows NO inflation), missing
+vzeroupper (present at all imp exits), env-var read cost (set-vs-unset
+equal). The inflation is a warm-loop interaction artifact of this
+container correlated with executing the outlined kernel call; no perf
+counters available here to chase further.
+Resolution independent of mechanism: work gate. Tiny panels gain
+nothing from the SIMD call, so route n_elim*rowspan*ncol <
+PACKED_SIMD_MIN_WORK=1024 to the inline scalar walk
+(FERAL_PACKED_SIMD_MIN_WORK overrides for M-series retune). Gate is
+bit-neutral (both sides byte-exact, all parity+golden tests green).
+After gate: hahn1 754-770 us (scalar-tiles level), avion2 36 us
+(better than session baseline 39), dense_front 2955 nofma-serial
+1556 ms (win intact, 2.7x vs baseline 4236). Stage 1 ACCEPTED.
+
+* 04:15 :pounce:context:small-front:
+User pointed to jkitchin/pounce#552: pounce-vs-Ipopt benchmark report.
+Relevant: FERAL factorization 3.5-4.8x slower than MA27/MA57 on
+long-horizon CHAIN-structured KKTs ("very long chain of tiny blocks",
+hicks N=1200: 0.307 s vs MA27 0.092 s), localized by them to the
+numeric kernel, not ordering/heuristics. Corroborates the Stage 3
+target (small-front eager path) and argues for adding a
+block-tridiagonal chain fixture to the probe set.

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -1,0 +1,19 @@
+#+TITLE: Session 2026-08-09-01 — kernel SIMD/vectorization perf pass
+#+DATE: 2026-08-09
+
+* 01:17 :orient:perf:kernel:
+Session goal: evidence-based kernel performance work per the staged plan
+(measure-first). Targets identified from dev/ history + code inspection:
+(1) packed trailing-update kernel (factor.rs apply_schur_panel_range_packed)
+relies on LLVM autovectorization only — on x86 that means SSE2 baseline
+codegen since no target-cpu and no pulp in that function; decisions.md
+2026-07-01 lists explicit-SIMD/pooling/tile-retune/cache-blocking as untuned
+headroom. (2) small-front eager scalar path (do_1x1_pivot) — ~87% of
+DENSEFACTOR_NS on the many-small-front corpus per
+dev/research/panel-fragmentation-2026-07-10.md, matching the feral/MA57
+small-bucket loss (4.23x geomean, external_benchmarks/comparison/REPORT.md).
+Environment: x86_64 container, 4 cores, AVX2+AVX512+FMA, corpus NOT present
+— evidence via parity suites + bench_schur_micro + bench_dense_front +
+perf_probe on tests/data fixtures. Hard rule for all stages: default path
+stays byte-exact vs scalar nofma reference (mul-then-sub, never mul_add);
+FMA remains opt-in.

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -17,3 +17,39 @@ Environment: x86_64 container, 4 cores, AVX2+AVX512+FMA, corpus NOT present
 perf_probe on tests/data fixtures. Hard rule for all stages: default path
 stays byte-exact vs scalar nofma reference (mul-then-sub, never mul_add);
 FMA remains opt-in.
+
+* 01:35 :stage0:objdump:packed-kernel:premise:
+Premise check on the packed trailing-update kernel
+(apply_schur_panel_range_packed, inlined into apply_schur_panel_range at
+0x315b0 in bench_dense_front): objdump over the region shows ymm=0,
+mulpd/subpd/addpd=0, mulsd/subsd=187. LLVM did NOT autovectorize the MR
+axis at all on x86 — the production default trailing update is pure
+scalar f64 code. The pulp strided kernels DO reach AVX2 (110
+vmulpd/vsubpd in the binary via V3 dispatch). Conclusion: Stage 1
+(explicit pulp in the packed kernel) is a scalar->4-wide-AVX2 upgrade on
+x86, bigger headroom than the planned SSE2->AVX2 2x estimate.
+
+* 01:45 :stage0:bench:micro:baseline:
+bench_schur_micro 3-run baselines (all byte-exact checks pass):
+  2048x2048 ke=64: strided 0.45-0.46 GF/s; packed 6.04-6.18 GF/s (13.3-13.8x)
+  512x512  ke=64: strided 0.46;            packed 6.33-6.35 (13.7x)
+  96x96    ke=32: strided 0.47;            packed 6.03 (12.8x)
+Variance across runs <3%. 6 GFLOP/s = roughly scalar mul+sub ILP peak at
+2.8 GHz, consistent with scalar codegen; AVX2 lanes leave ~3-4x on the
+kernel.
+
+* 01:55 :stage0:bench:dense-front:baseline:fma-regression:
+bench_dense_front 3-run baselines (production path, rayon=4):
+  n=2955: nofma-serial 4236/4303/4244 ms (2.0 GF/s);
+          nofma-intrafront 1798-1801 ms (4.78 GF/s, 2.35x);
+          fma-serial 12825-12949 ms (0.66 GF/s) <- 3x SLOWER than nofma;
+          fma-intrafront 4214-4314 ms.
+  n=512:  nofma 39-40 ms; fma 71-72 ms (1.8x slower). Intrafront inert
+          (below gate).
+FINDING: the opt-in FMA path regressed badly on x86 when the packed
+kernel became default (2026-07-01): the packed FMA variant uses scalar
+f64::mul_add (factor.rs:3767,:3789), which at baseline codegen (no fma
+target feature) lowers to a libm fma() call per element. The 2026-07-01
+x86 numbers showing fma 1.66x faster were measured on the pre-packed
+pulp strided path (real vfmadd via V3). Default nofma path unaffected.
+Stage 1 fixes this as a side effect (pulp mul_add_f64s -> vfmadd via V3).

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -112,3 +112,22 @@ hicks N=1200: 0.307 s vs MA27 0.092 s), localized by them to the
 numeric kernel, not ordering/heuristics. Corroborates the Stage 3
 target (small-front eager path) and argues for adding a
 block-tridiagonal chain fixture to the probe set.
+
+* 05:10 :stage2:pooling:issue-128:chain:
+Stage 2 (pack-buffer pooling, issue #128 rest) implemented: PackPool
+{apack,bpack0,bpack1} on FactorScratch, mem::take'd around the borrow
+of subdiag/d_panel, threaded through
+apply_blocked_schur->..->apply_schur_panel_range_packed_impl on the
+serial path only (rayon ranges keep fresh vecs). apack skips re-zero
+when length matches (fully overwritten incl. padding); bpack0/1
+re-zero via clear+resize because their zeros are load-bearing for
+out-of-range column lanes. Parity test extended with a dirty pool
+carried across all shapes (use_pool sweep) - byte-exact, 83/83 suites
+green.
+Also added a hicks-like block-tridiagonal chain fixture (scratch
+chain1200_kkt.mtx, n=1200 6x6 blocks) after user pointer to
+jkitchin/pounce#552 (feral 3.5-4.8x vs MA27 on chain KKTs).
+3-run medians vs post-gate Stage-1: chain1200 985 -> 867/847/961
+(-12%), AVION2 36 -> 34 (-6%), twirism1 ~2270 -> 2066-2136 (-6%),
+HYDCAR20 ~220 -> 207-218 (-4%), VESUVIO ~1950 -> 1857-1931 (-4%),
+HAHN1 ~760 -> 739-746 (-2%). Acceptance (>=2% geomean small set) MET.

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -53,3 +53,29 @@ target feature) lowers to a libm fma() call per element. The 2026-07-01
 x86 numbers showing fma 1.66x faster were measured on the pre-packed
 pulp strided path (real vfmadd via V3). Default nofma path unaffected.
 Stage 1 fixes this as a side effect (pulp mul_add_f64s -> vfmadd via V3).
+
+* 02:40 :stage1:pulp:dispatch-bug:regression:fix:
+First Stage-1 attempt (packed tile walk moved into schur_kernel.rs
+behind dispatch_nofma/dispatch_fma) was a 5x REGRESSION on x86:
+bench_dense_front 2955 nofma-serial 21126/21272/21203 ms vs 4236 ms
+baseline; FERAL_PACKED_SIMD=0 (scalar tiles) ran 3176 ms. Parity and
+golden-bits tests all PASSED throughout - correct but slow.
+Root cause found in pulp source: dispatch helpers call
+`k.with_simd(v3)` directly on the V3 token. pulp's intended entry is
+`Simd::vectorize(v3, k)`, whose V3 impl routes through a
+#[target_feature(enable="avx,avx2,fma,...")] shim so the AVX intrinsic
+wrappers inline. Called outside that context, every mul_f64s/sub_f64s
+stays an outlined core_arch function call (objdump: standalone
+`_mm256_mul_pd` symbols at 0x3c190). aarch64 never saw this because
+NEON is a baseline feature there - intrinsics inline regardless; the
+dispatch helpers were written and only ever profiled on M-series.
+This bug has been throttling EVERY pulp kernel on x86 (strided panel
+kernels, axpy/axpy2) since Phase 2.4.2 - the 0.45 GF/s strided
+baseline measured this session includes call-per-lane-op overhead, not
+just cache striding.
+Fix: x86_64 branch of dispatch_nofma/dispatch_fma now calls
+pulp::Simd::vectorize(v3, k). aarch64 branch left as-is (measured-good
+on M-series; NEON baseline makes with_simd(NEON) harmless) - flagged
+for M-series re-eval anyway. Bits identical by construction (same lane
+ops, only codegen context changes): golden_bits digests unchanged,
+blocked_ldlt + lib suites green. Re-measuring.

--- a/dev/journal/2026-08-09-01.org
+++ b/dev/journal/2026-08-09-01.org
@@ -143,3 +143,12 @@ loops (shared rank1_scale_update_argmax); removed the kernel, gate,
 env var, parity test, and A/B example. Full entry in
 tried-and-rejected.md. Small-front gap suspects now ranked: per-front
 overhead, pivot scans, scalar_pivot_step, delayed-pivot cascade.
+
+* 07:00 :session-end:checkpoint:
+Session-end protocol: bench run (corpus absent - synthetic + regression
+fixtures, all inertia/residual pass, worst residuals 1.14e-15 dense /
+1.26e-16 sparse), decisions.md x3, tried-and-rejected x1, CHANGELOG
+Unreleased entry, checkpoint dev/sessions/2026-08-09-01.md with the
+aarch64 revalidation list. Stages 4-6 (tile retune, L2 blocking,
+block32 quad) deferred with rationale - need M-series data and fresh
+profiles before more kernel surgery.

--- a/dev/research/kernel-simd-x86-baseline-2026-08-09.md
+++ b/dev/research/kernel-simd-x86-baseline-2026-08-09.md
@@ -1,0 +1,46 @@
+# Kernel SIMD x86 baseline — Stage 0 measurements (2026-08-09)
+
+Session: 2026-08-09-01. Container: x86_64, 4 cores, Intel Xeon @ 2.80GHz,
+AVX2 + AVX-512 + FMA. Corpus not present; evidence from parity fixtures +
+isolated harnesses. Build: `cargo build --release --all-targets`, default
+profile (`opt-level=3`, no target-cpu, `debug=true` = debuginfo only).
+
+## Motivation (from dev/ history)
+
+- `apply_schur_panel_range_packed` (src/dense/factor.rs:3621-3821) is the
+  default dense trailing-update since issue #99. decisions.md 2026-07-01
+  lists its untuned headroom: explicit-SIMD, pack-buffer pooling, tile
+  retune, cache blocking.
+- The feral/MA57 small bucket (n=102-888) is the one clear loss: 4.23x
+  geomean (external_benchmarks/comparison/REPORT.md). The small-front
+  scalar path is ~87% of DENSEFACTOR_NS on the many-small-front corpus
+  (dev/research/panel-fragmentation-2026-07-10.md).
+
+## Finding 1 — the packed kernel compiles to SCALAR code on x86 (premise check)
+
+Method: `objdump -d target/release/examples/bench_dense_front` over the
+`apply_schur_panel_range` region (packed kernel is inlined into it,
+0x315b0..0x356e0).
+
+| metric | count |
+|---|---:|
+| `ymm` references (AVX) | **0** |
+| packed SSE2 arithmetic (`mulpd`/`subpd`/`addpd`) | **0** |
+| scalar `mulsd`/`subsd` | 187 |
+| `xmm` references (scalar use only) | 1122 |
+
+LLVM did not autovectorize the MR-axis inner loop at all — not even to
+2-wide SSE2. Meanwhile the pulp strided kernels DO get AVX2 via runtime
+dispatch (110 `vmulpd`/`vsubpd` in the binary, in `core_arch::x86::avx`
+thunks reached from `pulp::x86::V3` dispatch).
+
+Implication: on x86 the production default trailing update runs scalar
+f64 arithmetic. Stage 1 (move the tile loop into `schur_kernel.rs` under
+pulp dispatch) upgrades it to 4-wide AVX2 — a larger headroom than the
+planned "SSE2→AVX2 ≈ 2x" estimate. On aarch64 (the project's usual bench
+host) NEON is baseline so LLVM may already vectorize there; the aarch64
+story must be re-measured on M-series (see cross-platform protocol).
+
+## Baseline numbers
+
+(to be filled below as Stage 0 proceeds)

--- a/dev/research/kernel-simd-x86-baseline-2026-08-09.md
+++ b/dev/research/kernel-simd-x86-baseline-2026-08-09.md
@@ -41,6 +41,82 @@ planned "SSE2→AVX2 ≈ 2x" estimate. On aarch64 (the project's usual bench
 host) NEON is baseline so LLVM may already vectorize there; the aarch64
 story must be re-measured on M-series (see cross-platform protocol).
 
-## Baseline numbers
+## Baseline numbers (3-run, this container)
 
-(to be filled below as Stage 0 proceeds)
+Test suite: `cargo test --release` all green (407 lib + integration suites).
+
+### bench_schur_micro (isolated kernel; byte-exact check passes on all runs)
+
+| shape | strided GF/s | packed GF/s | speedup |
+|---|---:|---:|---:|
+| 2048x2048 ke=64 | 0.45-0.46 | 6.04-6.18 | 13.3-13.8x |
+| 512x512 ke=64 | 0.46 | 6.33-6.35 | 13.7x |
+| 96x96 ke=32 | 0.47 | 6.03 | 12.8x |
+
+Run-to-run variance <3%. 6 GFLOP/s ~= scalar mul+sub ILP peak at 2.8 GHz —
+consistent with Finding 1 (scalar codegen). AVX2 leaves ~3-4x on the kernel.
+
+### bench_dense_front (production blocked path, rayon=4)
+
+| config | n=2955 (3 runs, ms) | GF/s | n=512 (ms) |
+|---|---|---:|---|
+| nofma serial | 4236 / 4303 / 4244 | 2.0 | 38.8-39.9 |
+| nofma intrafront | 1798-1801 | 4.78 | ~39.5 (gate off) |
+| fma serial | 12825-12949 | 0.66 | 71.2-71.9 |
+| fma intrafront | 4214-4314 | 2.0 | ~71.5 |
+
+**Finding 2 — opt-in FMA is a ~3x SLOWDOWN on x86 since the packed kernel
+became default (2026-07-01).** The packed FMA variant uses scalar
+`f64::mul_add` (factor.rs:3767/:3789); at baseline codegen (no `fma`
+target feature) that lowers to a libm `fma()` call per element. The
+2026-07-01 x86 measurement showing fma-serial 1.66x faster than nofma was
+taken on the pre-packed pulp strided path (real `vfmadd` via V3 dispatch).
+The default nofma path is unaffected. Stage 1 repairs this as a side
+effect: pulp `mul_add_f64s` reaches real FMA through V3 runtime dispatch.
+
+### perf_probe warm-factor medians (sequential driver, 3 runs)
+
+| fixture | n | iters | median_us (r1/r2/r3) |
+|---|---:|---:|---|
+| AVION2_0251 | 64 | 300 | 39 / 39 / 39 |
+| SWOPF_0000 | 175 | 300 | 180 / 177 / 176 |
+| CERI651A_0000 | 190 | 300 | 251 / 239 / 246 |
+| HYDCAR20_0000 | 198 | 300 | 295 / 300 / 299 |
+| ACOPP30_0000 | 209 | 300 | 223 / 222 / 223 |
+| HAHN1_0004 | 715 | 150 | 842 / 840 / 839 |
+| CRESC100_0000 | 806 | 150 | 652 / 726 / (noisy) |
+| VESUVIO_0021 | 3083 | 30 | 2108 / 2284 / — |
+| twirism1_kkt | 745 | 150 | 4217 / 4176 / — |
+| sawpath_kkt | 1575 | 100 | 830 / 826 / — |
+
+All inertia_stable=true. cresc100/vesuvio show ~5-8% run noise; per the
+2026-04-14 methodology rule, claims below 5% on those need extra runs.
+
+### probe_panel_frag attribution (gates Stage 3)
+
+| matrix | n | frag% | scal% | schur% | panelf% |
+|---|---:|---:|---:|---:|---:|
+| AVION2_0251 | 64 | 75.0 | 14.8 | 20.2 | 8.5 |
+| SWOPF_0000 | 175 | 85.7 | 37.1 | 30.6 | 15.4 |
+| CERI651A_0000 | 190 | 100.0 | 28.1 | 3.2 | 3.3 |
+| HYDCAR20_0000 | 198 | 95.5 | 45.6 | 29.3 | 15.1 |
+| ACOPP30_0000 | 209 | 70.6 | 25.4 | 25.1 | 20.1 |
+| HAHN1_0004 | 715 | 100.0 | 30.0 | 1.1 | 0.5 |
+| CRESC100_0000 | 806 | 66.7 | 15.6 | 3.1 | 2.0 |
+| twirism1_kkt | 745 | 92.0 | 44.4 | 26.9 | 10.2 |
+| sawpath_kkt | 1575 | 99.5 | 89.8 | 8.2 | 1.1 |
+
+Aggregate: panels full=19 partial=331 (frag 94.6%); pivots inline=648
+scalar=592 (47.7% scalar); schur=13.6% panel-factor=4.3% of aggregate
+dense-front time. Confirms the panel-fragmentation-2026-07-10 corpus
+steer: on small/KKT fronts the scalar pivot path, not the Schur update,
+is the dominant kernel bucket → Stage 3 (eager-path SIMD) is justified;
+Stage 1 primarily helps medium/large fronts (vesuvio, dense roots).
+
+## Stage ordering confirmed by Stage 0
+
+1. Stage 1 explicit pulp SIMD in packed kernel — scalar→AVX2, also
+   repairs the x86 opt-in-FMA regression (Finding 2).
+2. Stage 2 pack-buffer pooling (small/medium fronts, alloc traffic).
+3. Stage 3 eager-path SIMD (scal% dominates small fixtures).
+4. Stages 4-6 conditional on post-Stage-1 profiles.

--- a/dev/research/small-front-eager-simd-2026-08-09.md
+++ b/dev/research/small-front-eager-simd-2026-08-09.md
@@ -1,0 +1,97 @@
+# Small-front eager path: fused rank-1 update + argmax kernel (Stage 3)
+
+Session 2026-08-09-01. Prereq reading: `kernel-simd-x86-baseline-2026-08-09.md`
+(Stage 0 attribution + the Stage-1 dispatch-overhead lesson),
+`panel-fragmentation-2026-07-10.md` (corpus steer to the small-front path).
+
+## Why
+
+- The feral/MA57 comparison loses exactly one bucket: small (n=102-888),
+  4.23x geomean (`external_benchmarks/comparison/REPORT.md`). The
+  pounce#552 report shows the same signature end-to-end: 3.5-4.8x vs
+  MA27/MA57 on chain-structured KKTs ("very long chain of tiny blocks"),
+  localized by the pounce authors to the numeric kernel.
+- Stage-0 attribution on the small parity fixtures: the scalar pivot
+  path (`scal%`) is the dominant dense-front bucket (sawpath 89.8%,
+  hydcar20 45.6%, twirism1 44.4%); the Schur trailing update is 13.6%
+  aggregate. The blocked-path stages (1-2) cannot reach this time.
+- The eager path's hot loop is `do_1x1_pivot` (factor.rs): a fused
+  scale + rank-1 trailing update + argmax-of-next-column, pure scalar,
+  duplicated in the static-floor branch. `do_2x2_pivot` is the rank-2
+  analog (dominant on cascade KKTs per the 2026-05-13 pinene profile;
+  out of scope for the first cut, extend if 1x1 wins).
+
+## Design
+
+One new kernel in `schur_kernel.rs` (pulp boundary policy):
+
+    rank1_trailing_argmax_nofma(colk, tail, n, k, d) -> (f64, usize)
+
+- `colk` = rows `k+1..n` of the (already 1/d-scaled) pivot column
+  (read-only borrow from the `split_at_mut((k+1)*n)` head).
+- `tail` = columns `k+1..n` of the front, col-major stride `n`.
+- Column `j = k+1+c` update is an aligned axpy: `dst = tail[c*n+j..c*n+n]`,
+  `src = colk[c..]`, `alpha_c = colk[c]*d`, per element `dst -= src*alpha`
+  (`mul -> sub`, the exact nofma reference shape).
+- **One pulp dispatch per pivot step** — the column loop lives inside
+  the `with_simd` body. This is the load-bearing design constraint from
+  Stage 1: the dispatch boundary costs ~100-200 ns
+  (`examples/bench_packed_tiny`), so per-column dispatch on short
+  columns would lose. (This is also why the existing per-column
+  axpy kernels were never wired into `do_1x1_pivot`: the 2026-05-16
+  journal measured pulp == scalar at lengths 3..128 — call overhead
+  cancels lane gains. Interior column loop amortizes it.)
+- Column `k+1` (c = 0): diagonal handled separately (matches scalar),
+  off-diagonal rows tracked for argmax.
+
+## Argmax bit-semantics (no FP rounding involved)
+
+Scalar reference: ascending `i`, `val > best` strictly ⇒ result =
+(max |v|, smallest index attaining it); NaN never replaces; all-zero /
+empty column returns `(0.0, k+2)`.
+
+SIMD: per-lane running (max, earliest-index) via `greater_than` +
+`select`; horizontal reduce merges lane candidates with
+`val > best || (val == best && idx < best_idx)`; scalar remainder
+elements (indices above every vector element) merge with plain strict
+`>`. This reproduces "smallest index among attaining positions"
+exactly. Property test pins ties, ±0.0, denormals, NaN against the
+scalar loop.
+
+## Bit-exactness of the update
+
+Identical per-element chain (`round(dst - round(src*alpha))`) at every
+lane width; columns are independent; `colk` is read-only during the
+update. Same argument as Stage 1, enforced by: a bit-for-bit unit test
+of the refactored `do_1x1_pivot` against the preserved scalar shape,
+`tests/blocked_ldlt.rs` (blocked-vs-eager byte identity), the parity
+fixture suite, and the golden digests (which cover the eager path via
+`factor_frontal_blocked`'s scalar-tail? — no: golden fixtures route
+through the blocked panel path; ADD an eager-path golden case).
+
+## Gate
+
+`m = n-k-1`; SIMD when `m*(m+1)/2 >= 1024` mul-subs (m >= ~45),
+mirroring the Stage-1 packed work gate; below, the existing scalar
+loops run (bit-neutral gate — both sides byte-exact). Env override
+`FERAL_RANK1_SIMD_MIN_WORK` for M-series retune.
+
+## Acceptance / rejection
+
+Accept: >=3% geomean on the small fixture set (3-run medians), no
+fixture >2% worse. Reject and record in tried-and-rejected: if the
+small fixtures' pivot columns are mostly below the gate (chain blocks
+are 6-32 wide) and nothing moves.
+
+## Measured result — REJECTED (reverted same session)
+
+Implemented exactly as designed (one dispatch per pivot step, work gate
+1024, scalar argmax re-scan; byte-exact, all 83 suites + golden digests
+green). Performance was flat everywhere; the kernel and gate were
+reverted, keeping only the de-duplication of the two scalar copies.
+Full numbers and the failure analysis: dev/tried-and-rejected.md
+2026-08-09 entry. Key datum: direct eager-driver A/B at n=512 measured
+11.21 (SIMD) vs 11.23 ms (scalar) — the plain eager loops already
+autovectorize, and the eager path is pivot-search/bandwidth-bound.
+The small-front/MA57 gap must be attacked elsewhere (per-front
+overhead, pivot scans, scalar_pivot_step, delayed-pivot cascade).

--- a/dev/sessions/2026-08-09-01.md
+++ b/dev/sessions/2026-08-09-01.md
@@ -1,0 +1,121 @@
+# Session 2026-08-09-01
+
+## Goal
+
+Evidence-based kernel performance pass (user request: vectorization/SIMD
+opportunities, pure Rust, every change (1) correct, (2) faster,
+(3) bit-identical across platforms). Staged plan: measure-first, then
+packed-kernel SIMD, pack-buffer pooling, small-front eager-path SIMD.
+
+Environment caveat: x86_64 4-core AVX2+AVX512 container; the 154k-matrix
+corpus is NOT present, so evidence comes from parity suites +
+bench_schur_micro / bench_dense_front / perf_probe on tests/data
+fixtures + a new hicks-like chain fixture. **All perf numbers below are
+x86; aarch64 M-series revalidation is pending (see follow-ups).**
+
+## Accomplished
+
+1. **x86 pulp dispatch fix (f0be9fa)** — `dispatch_nofma`/`dispatch_fma`
+   called `k.with_simd(v3)` instead of `pulp::Simd::vectorize(v3, k)`,
+   so every pulp kernel on x86 ran its AVX intrinsics as outlined
+   function calls since Phase 2.4.2 (invisible on aarch64 where NEON is
+   baseline). Strided kernel: 0.45 → 4.69-7.00 GFLOP/s (~10×).
+   Bit-identical by construction; all suites + golden digests unchanged.
+
+2. **Explicit pulp SIMD packed trailing update (41c35b5)** — the
+   default BLAS-3 tile walk had compiled fully scalar on x86 (objdump:
+   ymm=0, packed SSE=0). Moved into
+   `schur_kernel::packed_schur_tiles_{nofma,fma}`, one dispatch per
+   panel; scalar walk kept as `FERAL_PACKED_SIMD=0` fallback. Also
+   repairs the opt-in FMA path (scalar `f64::mul_add` → libm call, was
+   a 3× x86 slowdown since 2026-07-01). New `tests/golden_bits.rs`
+   hardcoded digests = cross-arch tripwire.
+
+3. **Work gate for degenerate panels (8358d1b)** — panels below 1024
+   multiply-subtracts stay on the inline scalar walk
+   (`FERAL_PACKED_SIMD_MIN_WORK` override): the ~100-200 ns dispatch
+   boundary can't be amortized there (`examples/bench_packed_tiny`),
+   and un-gated SIMD showed a warm-median artifact on HAHN1/AVION2
+   that in-kernel timing proved was not in-kernel cost (journal 04:10).
+
+4. **Pack-buffer pooling, issue #128 rest (484bda7)** — `PackPool` on
+   `FactorScratch`, serial path only; dirty-pool byte-parity sweep in
+   the unit test.
+
+5. **Eager-path SIMD tried and rejected (f509a18)** — full
+   implementation measured FLAT everywhere (eager n=512: 11.21 vs
+   11.23 ms) because the plain eager loops already autovectorize;
+   reverted same session per the pre-registered criterion, keeping the
+   byte-identical de-duplication of `do_1x1_pivot`'s twin loops.
+   Recorded in tried-and-rejected.
+
+6. Research notes: `kernel-simd-x86-baseline-2026-08-09.md` (Stage 0
+   baselines + findings), `small-front-eager-simd-2026-08-09.md`
+   (design + rejection). Three decisions.md entries. Chain fixture
+   generator (hicks-like, after user pointer to jkitchin/pounce#552).
+
+## Benchmark Results
+
+`cargo run --bin bench --release` (corpus absent — synthetic + 2
+regression fixtures only): 8 synthetic matrices benchmarked; KKT
+fixtures 1/1 dense inertia+residual pass (worst 1.14e-15), sparse 2/2
+vs MUMPS (worst 1.26e-16). Phase 2.8.1 partitions N/A (no oracle
+timings in container).
+
+Kernel/fixture evidence (3-run medians, sequential, this container):
+
+| measure | session start | session end |
+|---|---:|---:|
+| bench_dense_front 2955 nofma serial | 4236 ms (2.0 GF/s) | 1517-1556 ms (5.6 GF/s) |
+| bench_dense_front 2955 nofma intrafront | 1798 ms (4.8 GF/s) | 637-679 ms (12.7-13.5 GF/s) |
+| bench_dense_front 2955 fma intrafront | 4214 ms | 572-609 ms (14-15 GF/s) |
+| bench_dense_front 512 nofma serial | 39.4 ms | 10.0-10.9 ms |
+| strided micro 2048²·64 | 0.45 GF/s | 4.69 GF/s |
+| twirism1 warm factor | 4176-4217 µs | 2066-2195 µs |
+| hydcar20 | 295-300 µs | 206-218 µs |
+| sawpath | 826-830 µs | 671-745 µs |
+| vesuvio | 2108-2284 µs | 1857-2071 µs |
+| chain1200 (new fixture) | 985 µs (post-Stage-1) | 847-961 µs |
+| hahn1 | 839-842 µs | 739-762 µs |
+| avion2 | 39 µs | 34-35 µs |
+
+No fixture worse than session start. All byte-exactness gates green
+throughout (407 lib tests, 83 test binaries, golden digests stable
+across default / FERAL_PACKED_SIMD=0 / FERAL_PACKED_SCHUR=0).
+
+## Decisions Made
+
+Three entries appended to dev/decisions.md (2026-08-09): the
+vectorize dispatch rule for x86 pulp entry points, the packed SIMD
+tile kernel + work gate + escape hatches, and serial-path pack-buffer
+pooling.
+
+## Abandoned Approaches
+
+One entry appended to dev/tried-and-rejected.md (2026-08-09): explicit
+SIMD for the eager rank-1 pivot update — flat at every size; eager
+loops already autovectorize; path is pivot-search/bandwidth-bound.
+
+## Next Session Should
+
+1. **aarch64 M-series revalidation (REQUIRED before corpus claims):**
+   run `cargo test --release` (golden_bits digests are the cross-arch
+   tripwire), `bench_dense_front 2955/512`, `bench_schur_micro`, the
+   perf_probe fixture set, and the full corpus bench. If NEON packed
+   SIMD regresses vs the old autovectorized walk, `FERAL_PACKED_SIMD=0`
+   is the one-env-var mitigation; retune `FERAL_PACKED_SIMD_MIN_WORK`
+   there.
+2. Re-run the Mittelmann/MA57 sweep — the packed-kernel x86 wins should
+   move the marine/pinene/robot cluster; the chain-KKT (pounce#552)
+   gap needs the small-front *overhead* work, not lane width (see
+   rejection entry): per-front fixed overhead, pivot scans,
+   scalar_pivot_step, delayed-pivot cascade are the ranked suspects.
+3. Conditional stages not attempted this session, in plan order:
+   MR/NR tile retune ({8,16}×{4,8} sweep, needs per-arch consts),
+   row-panel L2 blocking of the packed kernel (only if a fresh profile
+   shows large-front bandwidth-bound), block32 rank-2 quad kernel
+   (block_ldlt32.rs:240-246 deferral; needs the fused axpy2 rounding
+   shape).
+4. Consider promoting the chain1200 generator
+   (scratch-only this session) into tests/data or a checked-in
+   generator script — it is the pounce#552 workload proxy.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -4972,3 +4972,49 @@ true pivot bit-for-bit on the regression basis) + `update_pivot_search` as an
 always-on opt-in trajectory variant (bounded multipliers across chains),
 default false. See `dev/research/issue-112-bg-update.md` §UPDATE and
 `dev/decisions.md` 2026-07-10.
+
+## 2026-08-09 — Stage 3: explicit pulp SIMD for the eager rank-1 pivot update (reverted)
+
+**What was tried.** `do_1x1_pivot`'s fused scale + rank-1 trailing
+update + argmax (the small-front eager path's hot loop, duplicated in
+the static-floor branch) was refactored into a shared helper and given
+an explicit-SIMD route: one `schur_kernel::rank1_trailing_nofma` pulp
+dispatch per pivot step covering all trailing columns (per-element
+`mul → sub`, byte-exact — proven by an eager-path A/B parity test and
+the full 83-suite run incl. golden digests), with a work gate at
+1024 multiply-subtracts and a scalar argmax re-scan of column k+1.
+Motivation: the feral/MA57 small-bucket loss (4.23x geomean),
+panel-frag attribution (scal% up to 89.8% on sawpath), and the
+pounce#552 chain-KKT report.
+
+**Symptoms / numbers.** Perf was FLAT everywhere:
+- Warm fixture medians (3-run, sequential, x86_64 AVX2 container)
+  unchanged vs Stage-2 within noise: AVION2 34→34, SWOPF 152→153,
+  HYDCAR20 ~210→206-213, HAHN1 ~742→754-762, CRESC100 ~606→589-621,
+  chain1200 ~867→863-878, twirism1 ~2100→2138-2195, sawpath ~698→671-726.
+- Direct eager-driver A/B (gate default vs forced-off) on square
+  fronts where the gate demonstrably fires: n=512 11.21 vs 11.23 ms,
+  n=200 0.88 vs 0.89 ms, n=96 0.11 vs 0.11 ms. Zero effect at any size.
+
+**Why it failed.** Unlike the packed tile walk (whose guarded loop
+structure defeated autovectorization — Stage 1), the eager path's
+plain `for i in j..n { a[j*n+i] -= a[k*n+i]*alpha }` loops are
+textbook-autovectorizable, and the eager path's remaining time is
+pivot search + memory traffic, not multiply-subtract throughput.
+Explicit lanes duplicated what LLVM already did. This matches the
+2026-05-16 finding (pulp == scalar == manual unroll at lengths 3..128)
+at the whole-front scale.
+
+**What was kept.** The de-duplication refactor (shared scalar
+`rank1_scale_update_argmax`, byte-identical, golden digests unchanged)
+stays; the pulp kernel, its gate/env var, the dedicated parity test,
+and the A/B example were removed.
+
+**Lesson.** The small-front/MA57 gap is NOT lane width in the eager
+update. Remaining suspects, in evidence order: per-front fixed
+overhead (assembly/scatter/build-row, 8.8-14.8% on the small
+fixtures), pivot-search scans, `scalar_pivot_step` in blocked fronts,
+and the delayed-pivot cascade (per-factor-cost-cluster mechanism A).
+Any retry of eager-path SIMD must first show a front-level profile
+where the update loops are >30% of eager time AND not already
+vectorized in the disassembly.

--- a/examples/bench_packed_tiny.rs
+++ b/examples/bench_packed_tiny.rs
@@ -1,0 +1,160 @@
+//! Diagnostic micro-bench for tiny packed-tile calls (session
+//! 2026-08-09): times `schur_kernel::packed_schur_tiles_nofma` on the
+//! degenerate shape observed on HAHN1 (nrow=10, col_start=9, ncol=1,
+//! n_elim=7 — one active element) against a plain scalar walk, to
+//! isolate per-call overhead of the pulp dispatch boundary.
+//!
+//! Usage: cargo run --release --example bench_packed_tiny [-- REPS]
+
+use feral::dense::schur_kernel::{packed_schur_tiles_nofma, PACKED_MR, PACKED_NR};
+use std::time::Instant;
+
+fn main() {
+    let reps: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+
+    let nrow = 10usize;
+    let col_start = 9usize;
+    let ncol = 1usize;
+    let n_elim = 7usize;
+    let rowspan = nrow - col_start;
+    let npanels_i = rowspan.div_ceil(PACKED_MR);
+    let npanels_j = ncol.div_ceil(PACKED_NR);
+
+    let apack: Vec<f64> = (0..npanels_i * n_elim * PACKED_MR)
+        .map(|i| (i as f64).sin())
+        .collect();
+    let bpack0: Vec<f64> = (0..npanels_j * n_elim * PACKED_NR)
+        .map(|i| (i as f64).cos())
+        .collect();
+    let bpack1: Vec<f64> = Vec::new();
+    let d_panel: Vec<f64> = (0..n_elim).map(|i| 1.0 + i as f64).collect();
+    let subdiag_k = vec![0.0f64; n_elim];
+    let mut block = vec![1.0f64; ncol * nrow];
+
+    let t = Instant::now();
+    for _ in 0..reps {
+        packed_schur_tiles_nofma(
+            &mut block, &apack, &bpack0, &bpack1, &d_panel, &subdiag_k, nrow, col_start,
+        );
+        std::hint::black_box(&mut block);
+    }
+    let simd_ns = t.elapsed().as_nanos() as f64 / reps as f64;
+
+    // Scalar walk of the same tile (reference semantics).
+    let mut block2 = vec![1.0f64; ncol * nrow];
+    let col_end = col_start + ncol;
+    let t = Instant::now();
+    for _ in 0..reps {
+        for pj in 0..npanels_j {
+            let j0 = col_start + pj * PACKED_NR;
+            let bbase = pj * (n_elim * PACKED_NR);
+            for pi in 0..npanels_i {
+                let i0 = col_start + pi * PACKED_MR;
+                if i0 + PACKED_MR <= j0 {
+                    continue;
+                }
+                let abase = pi * (n_elim * PACKED_MR);
+                let mut acc = [[0.0f64; PACKED_MR]; PACKED_NR];
+                for (jr, accj) in acc.iter_mut().enumerate() {
+                    let j = j0 + jr;
+                    if j >= col_end {
+                        continue;
+                    }
+                    let colblk = (j - col_start) * nrow;
+                    for (ir, a) in accj.iter_mut().enumerate() {
+                        let i = i0 + ir;
+                        if i < nrow && i >= j {
+                            *a = block2[colblk + i];
+                        }
+                    }
+                }
+                let mut q = 0usize;
+                while q < n_elim {
+                    if d_panel[q] != 0.0 {
+                        let a0 = &apack[abase + q * PACKED_MR..][..PACKED_MR];
+                        let b0 = &bpack0[bbase + q * PACKED_NR..][..PACKED_NR];
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let bj = b0[jr];
+                            for (ir, acci) in accj.iter_mut().enumerate() {
+                                *acci -= bj * a0[ir];
+                            }
+                        }
+                    }
+                    q += 1;
+                }
+                for (jr, accj) in acc.iter().enumerate() {
+                    let j = j0 + jr;
+                    if j >= col_end {
+                        continue;
+                    }
+                    let colblk = (j - col_start) * nrow;
+                    for (ir, a) in accj.iter().enumerate() {
+                        let i = i0 + ir;
+                        if i < nrow && i >= j {
+                            block2[colblk + i] = *a;
+                        }
+                    }
+                }
+            }
+        }
+        std::hint::black_box(&mut block2);
+    }
+    let scalar_ns = t.elapsed().as_nanos() as f64 / reps as f64;
+
+    assert_eq!(
+        block[9].to_bits(),
+        block2[9].to_bits(),
+        "paths diverged (byte check)"
+    );
+    println!("tiny shape (nrow=10 ncol=1 ke=7): simd {simd_ns:.1} ns/call, scalar {scalar_ns:.1} ns/call");
+
+    // Frequency-license experiment (env FERAL_TINY_LICENSE=1): interleave
+    // ONE tiny 256-bit kernel call with ~700 µs of scalar busywork per
+    // "iteration", mimicking the HAHN1 warm-factor profile, and compare
+    // the busywork's own wall time against a pure-scalar control. If the
+    // isolated ymm burst taxes the whole iteration (license transition +
+    // downclock window), the combo runs measurably slower than control.
+    if std::env::var("FERAL_TINY_LICENSE").is_ok() {
+        let iters = 500usize;
+        let busy = |x0: f64| {
+            // ~700 µs of scalar dependent work (not vectorizable).
+            let mut x = x0;
+            for i in 0..400_000u64 {
+                x = (x * 1.000000001 + (i & 7) as f64).sqrt();
+            }
+            x
+        };
+        // Control: busywork only.
+        let mut acc = 0.0f64;
+        let mut ctrl = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            let t = Instant::now();
+            acc += busy(acc.fract() + 1.0);
+            ctrl.push(t.elapsed().as_micros() as u64);
+        }
+        // Combo: one tiny simd call, then the same busywork.
+        let mut combo = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            let t = Instant::now();
+            packed_schur_tiles_nofma(
+                &mut block, &apack, &bpack0, &bpack1, &d_panel, &subdiag_k, nrow, col_start,
+            );
+            std::hint::black_box(&mut block);
+            acc += busy(acc.fract() + 1.0);
+            combo.push(t.elapsed().as_micros() as u64);
+        }
+        std::hint::black_box(acc);
+        let stats = |mut v: Vec<u64>| {
+            v.sort_unstable();
+            let n = v.len() - 1;
+            (v[0], v[n / 2], v[n * 9 / 10])
+        };
+        let (c0, c50, c90) = stats(ctrl);
+        let (s0, s50, s90) = stats(combo);
+        println!("license probe: control busywork  p0={c0} p50={c50} p90={c90} us");
+        println!("license probe: simd+busywork     p0={s0} p50={s50} p90={s90} us");
+    }
+}

--- a/src/bin/perf_probe.rs
+++ b/src/bin/perf_probe.rs
@@ -82,6 +82,26 @@ fn main() {
     let symbolic_reran = solver.symbolic_call_count() != calls_before;
     let inertia_stable = solver.inertia().cloned() == baseline_inertia;
 
+    // Optional full distribution dump (session 2026-08-09): median-vs-min
+    // gaps on warm loops turned out to hide bimodal iteration mixtures;
+    // the histogram disambiguates steady-state cost from periodic events.
+    if std::env::var("FERAL_PROBE_DUMP_WALLS").is_ok() {
+        let mut sorted = walls.clone();
+        sorted.sort_unstable();
+        let pct = |p: usize| sorted[(sorted.len() - 1) * p / 100];
+        eprintln!(
+            "walls_us p0={} p10={} p25={} p50={} p75={} p90={} p99={} p100={}",
+            pct(0),
+            pct(10),
+            pct(25),
+            pct(50),
+            pct(75),
+            pct(90),
+            pct(99),
+            pct(100)
+        );
+    }
+
     println!(
         "matrix={} n={} nnz={} driver={} iters={} min_us={} median_us={} \
          symbolic_reran={} inertia_stable={} inertia={}",

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -5168,6 +5168,60 @@ fn swap_rows_cols(a: &mut [f64], n: usize, p: usize, q: usize, perm: &mut [usize
 /// MUMPS dfac_front_aux.F:1494-1495 and SSIDS options%u semantics:
 /// the pivot must dominate its column by at least 1/u, otherwise the
 /// rank-1 update would amplify rounding by ~1/|d| per position.
+/// Scale column `k` by `1/d`, apply the rank-1 trailing update to
+/// columns `k+1..n`, and return the fused `(gamma0, argmax-row)` of the
+/// updated column `k+1` — the shared tail of both `do_1x1_pivot`
+/// branches (main and static-floor, previously duplicated).
+///
+/// Deliberately scalar: an explicit pulp SIMD route (one dispatch per
+/// pivot step, byte-exact) was built and measured flat at every size —
+/// eager n=512: 11.21 vs 11.23 ms; n=200/96 identical; all warm fixture
+/// medians unchanged — because these plain loops already autovectorize
+/// and the eager path is pivot-search/bandwidth-bound. Reverted; see
+/// dev/tried-and-rejected.md 2026-08-09 and
+/// dev/research/small-front-eager-simd-2026-08-09.md before retrying.
+fn rank1_scale_update_argmax(a: &mut [f64], n: usize, k: usize, d: f64) -> (f64, usize) {
+    let d_inv = 1.0 / d;
+    for i in (k + 1)..n {
+        a[k * n + i] *= d_inv;
+    }
+
+    let mut next_gamma0 = 0.0;
+    let mut next_r = k + 2;
+
+    // Fused rank-1 update + argmax of column k+1.
+    // Column k+1 is only updated in the j=k+1 iteration, so it is
+    // handled separately to track the argmax during the same memory
+    // pass.
+    if k + 1 < n {
+        let j = k + 1;
+        let l_jk = a[k * n + j];
+        let l_jk_d = l_jk * d;
+        // Update diagonal
+        a[j * n + j] -= a[k * n + j] * l_jk_d;
+        // Update off-diagonal and track argmax
+        for i in (j + 1)..n {
+            a[j * n + i] -= a[k * n + i] * l_jk_d;
+            let val = a[j * n + i].abs();
+            if val > next_gamma0 {
+                next_gamma0 = val;
+                next_r = i;
+            }
+        }
+    }
+
+    // Remaining columns: plain update (no argmax tracking)
+    for j in (k + 2)..n {
+        let l_jk = a[k * n + j];
+        let l_jk_d = l_jk * d;
+        for i in j..n {
+            a[j * n + i] -= a[k * n + i] * l_jk_d;
+        }
+    }
+
+    (next_gamma0, next_r)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn do_1x1_pivot(
     a: &mut [f64],
@@ -5202,34 +5256,7 @@ fn do_1x1_pivot(
         } else {
             *neg += 1;
         }
-        let d_inv = 1.0 / d;
-        for i in (k + 1)..n {
-            a[k * n + i] *= d_inv;
-        }
-        let mut next_gamma0 = 0.0;
-        let mut next_r = k + 2;
-        if k + 1 < n {
-            let j = k + 1;
-            let l_jk = a[k * n + j];
-            let l_jk_d = l_jk * d;
-            a[j * n + j] -= a[k * n + j] * l_jk_d;
-            for i in (j + 1)..n {
-                a[j * n + i] -= a[k * n + i] * l_jk_d;
-                let val = a[j * n + i].abs();
-                if val > next_gamma0 {
-                    next_gamma0 = val;
-                    next_r = i;
-                }
-            }
-        }
-        for j in (k + 2)..n {
-            let l_jk = a[k * n + j];
-            let l_jk_d = l_jk * d;
-            for i in j..n {
-                a[j * n + i] -= a[k * n + i] * l_jk_d;
-            }
-        }
-        return Ok((next_gamma0, next_r));
+        return Ok(rank1_scale_update_argmax(a, n, k, d));
     }
 
     let threshold = (params.pivot_threshold * col_max).max(params.null_pivot_tol);
@@ -5328,46 +5355,7 @@ fn do_1x1_pivot(
         }
     }
 
-    let d_inv = 1.0 / d;
-
-    // Compute L column entries: L[i,k] = A[i,k] / d
-    for i in (k + 1)..n {
-        a[k * n + i] *= d_inv;
-    }
-
-    let mut next_gamma0 = 0.0;
-    let mut next_r = k + 2;
-
-    // Fused rank-1 update + argmax of next column (k+1).
-    // Column k+1 is only updated in the j=k+1 iteration, so we handle it
-    // separately to track the argmax during the same memory pass.
-    if k + 1 < n {
-        let j = k + 1;
-        let l_jk = a[k * n + j];
-        let l_jk_d = l_jk * d;
-        // Update diagonal
-        a[j * n + j] -= a[k * n + j] * l_jk_d;
-        // Update off-diagonal and track argmax
-        for i in (j + 1)..n {
-            a[j * n + i] -= a[k * n + i] * l_jk_d;
-            let val = a[j * n + i].abs();
-            if val > next_gamma0 {
-                next_gamma0 = val;
-                next_r = i;
-            }
-        }
-    }
-
-    // Remaining columns: plain update (no argmax tracking)
-    for j in (k + 2)..n {
-        let l_jk = a[k * n + j];
-        let l_jk_d = l_jk * d;
-        for i in j..n {
-            a[j * n + i] -= a[k * n + i] * l_jk_d;
-        }
-    }
-
-    Ok((next_gamma0, next_r))
+    Ok(rank1_scale_update_argmax(a, n, k, d))
 }
 
 /// Perform a 2×2 pivot at positions {k, k+1}.

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -3769,7 +3769,23 @@ fn apply_schur_panel_range_packed_impl(
     // `schur_kernel::packed_schur_tiles_nofma` for the bit-exactness
     // contract), scalar reference tile loop below via
     // `FERAL_PACKED_SIMD=0`. Byte-exact either way.
-    if use_simd {
+    //
+    // Work gate: a panel's tile walk touches `rowspan × ncol` dst
+    // elements over `n_elim` pivots. Below ~1k multiply-subtracts the
+    // dispatch boundary (outlined `#[target_feature]` call, ~100-200 ns)
+    // costs more than the inline scalar walk (~10 ns on a degenerate
+    // HAHN1-shaped panel, `examples/bench_packed_tiny`), so tiny panels
+    // stay on the scalar walk. The gate is bit-neutral — both sides are
+    // byte-exact — and `FERAL_PACKED_SIMD_MIN_WORK` overrides the
+    // threshold for per-arch retuning (aarch64 M-series re-measure
+    // pending).
+    const PACKED_SIMD_MIN_WORK: usize = 1024;
+    let simd_work = n_elim.saturating_mul(nrow - col_start).saturating_mul(ncol);
+    let min_work = std::env::var("FERAL_PACKED_SIMD_MIN_WORK")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(PACKED_SIMD_MIN_WORK);
+    if use_simd && simd_work >= min_work {
         if fma {
             schur_kernel::packed_schur_tiles_fma(
                 block,

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -3591,6 +3591,20 @@ fn packed_schur_enabled() -> bool {
     )
 }
 
+/// Whether the packed trailing update runs the explicit-SIMD pulp tile
+/// kernel (`schur_kernel::packed_schur_tiles_*`) or the scalar reference
+/// tile loop. Default `true`; `FERAL_PACKED_SIMD=0|off|false|no`
+/// restores the scalar loop for A/B benchmarking or as a safety
+/// override (e.g. while re-validating a new arch). Byte-exact either
+/// way — same per-element fold, lane width free.
+#[inline]
+fn packed_simd_enabled() -> bool {
+    !matches!(
+        std::env::var("FERAL_PACKED_SIMD").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("no")
+    )
+}
+
 /// Packed, register-tiled equivalent of [`apply_schur_panel_range`]
 /// (issue #99, BLAS-3 — Phase B-2). Computes the same lower-triangular
 /// rank-`n_elim` trailing update for `i >= j`, packing the panel into
@@ -3629,14 +3643,47 @@ fn apply_schur_panel_range_packed(
     subdiag: &[f64],
     fma: bool,
 ) {
+    apply_schur_panel_range_packed_impl(
+        head,
+        block,
+        col_start,
+        nrow,
+        k,
+        n_elim,
+        d_panel,
+        subdiag,
+        fma,
+        packed_simd_enabled(),
+    );
+}
+
+/// Implementation of the packed trailing update with an explicit
+/// `use_simd` switch so the parity test can pin the pulp tile kernel and
+/// the scalar reference tile loop against each other without touching
+/// process-global env state.
+#[allow(clippy::too_many_arguments)]
+fn apply_schur_panel_range_packed_impl(
+    head: &[f64],
+    block: &mut [f64],
+    col_start: usize,
+    nrow: usize,
+    k: usize,
+    n_elim: usize,
+    d_panel: &[f64],
+    subdiag: &[f64],
+    fma: bool,
+    use_simd: bool,
+) {
     let ncol = block.len() / nrow;
     if ncol == 0 || n_elim == 0 {
         return;
     }
     // Register-tile dimensions. MR rows × NR cols per tile; the MR (row)
-    // axis is the contiguous SIMD axis the compiler autovectorizes.
-    const MR: usize = 8;
-    const NR: usize = 4;
+    // axis is the contiguous SIMD axis (explicit pulp lanes on the
+    // default path, autovectorization on the scalar reference loop).
+    // Shared with `schur_kernel::packed_schur_tiles_*`.
+    const MR: usize = schur_kernel::PACKED_MR;
+    const NR: usize = schur_kernel::PACKED_NR;
 
     // A 2×2 pivot pair starts at `q` when `subdiag[k+q] != 0` and `q+1`
     // is still in-panel. Same predicate as the strided fallback; the
@@ -3717,7 +3764,37 @@ fn apply_schur_panel_range_packed(
         }
     }
 
-    // Tiled update over the lower triangle (i >= j).
+    // Tiled update over the lower triangle (i >= j): explicit-SIMD pulp
+    // tile kernel by default (one dispatch per panel; see
+    // `schur_kernel::packed_schur_tiles_nofma` for the bit-exactness
+    // contract), scalar reference tile loop below via
+    // `FERAL_PACKED_SIMD=0`. Byte-exact either way.
+    if use_simd {
+        if fma {
+            schur_kernel::packed_schur_tiles_fma(
+                block,
+                &apack,
+                &bpack0,
+                &bpack1,
+                &d_panel[..n_elim],
+                &subdiag[k..],
+                nrow,
+                col_start,
+            );
+        } else {
+            schur_kernel::packed_schur_tiles_nofma(
+                block,
+                &apack,
+                &bpack0,
+                &bpack1,
+                &d_panel[..n_elim],
+                &subdiag[k..],
+                nrow,
+                col_start,
+            );
+        }
+        return;
+    }
     for pj in 0..npanels_j {
         let j0 = col_start + pj * NR;
         let bbase = pj * (n_elim * NR);
@@ -6327,26 +6404,33 @@ mod packed_schur_tests {
                 scalar_ref(
                     &head, &mut b_ref, col_start, nrow, k, n_elim, &d_panel, &subdiag, fma,
                 );
-                let mut b_packed = block0.clone();
-                apply_schur_panel_range_packed(
-                    &head,
-                    &mut b_packed,
-                    col_start,
-                    nrow,
-                    k,
-                    n_elim,
-                    &d_panel,
-                    &subdiag,
-                    fma,
-                );
-                for lc in 0..ncol {
-                    let j = col_start + lc;
-                    for i in j..nrow {
-                        assert_eq!(
-                            b_packed[lc * nrow + i].to_bits(),
-                            b_ref[lc * nrow + i].to_bits(),
-                            "packed != scalar (fma={fma}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
-                        );
+                // Both the explicit-SIMD pulp tile kernel (use_simd =
+                // true, the default) and the scalar reference tile loop
+                // (the `FERAL_PACKED_SIMD=0` fallback) must match the
+                // scalar per-column reference bit-for-bit.
+                for use_simd in [true, false] {
+                    let mut b_packed = block0.clone();
+                    apply_schur_panel_range_packed_impl(
+                        &head,
+                        &mut b_packed,
+                        col_start,
+                        nrow,
+                        k,
+                        n_elim,
+                        &d_panel,
+                        &subdiag,
+                        fma,
+                        use_simd,
+                    );
+                    for lc in 0..ncol {
+                        let j = col_start + lc;
+                        for i in j..nrow {
+                            assert_eq!(
+                                b_packed[lc * nrow + i].to_bits(),
+                                b_ref[lc * nrow + i].to_bits(),
+                                "packed != scalar (fma={fma}, simd={use_simd}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
+                            );
+                        }
                     }
                 }
             }

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -310,6 +310,22 @@ pub struct FactorScratch {
     /// `Vec<Vec<f64>>` pool was tried and regressed bench p90 by ~0.2
     /// (small) / ~0.3 (medium) — see issue #13 Phase C investigation.
     pub contrib_pool: Option<Vec<f64>>,
+    /// Pooled pack buffers for the packed trailing update (issue #128
+    /// rest, session 2026-08-09). Reused across panels/fronts on the
+    /// serial dispatch path only — the intra-front rayon path keeps
+    /// per-range fresh allocations (a shared pool cannot cross the
+    /// parallel split). Byte-exact: reuse re-zeroes via
+    /// `clear()`+`resize(len, 0.0)`, so kernel inputs are identical to
+    /// fresh allocations.
+    pub pack_pool: PackPool,
+}
+
+/// Reusable buffers for the packed trailing update's A/B micro-panels.
+#[derive(Default, Debug, Clone)]
+pub struct PackPool {
+    apack: Vec<f64>,
+    bpack0: Vec<f64>,
+    bpack1: Vec<f64>,
 }
 
 impl FactorScratch {
@@ -2173,6 +2189,11 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
     scratch.subdiag.resize(nrow, 0.0);
     scratch.d_panel.clear();
     scratch.d_panel.resize(bs, 0.0);
+    // Take the pack pool out of the scratch so it can be threaded down
+    // into the trailing update while `subdiag`/`d_panel` hold their own
+    // borrows of `scratch`. Restored at the end of the function; early
+    // error returns merely drop the pool (next call re-allocates once).
+    let mut pack_pool = std::mem::take(&mut scratch.pack_pool);
     let subdiag: &mut [f64] = scratch.subdiag.as_mut_slice();
     let d_panel: &mut [f64] = scratch.d_panel.as_mut_slice();
     let mut pos = 0usize;
@@ -2296,6 +2317,7 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
             &*subdiag,
             params.fma,
             params.intrafront_parallel,
+            Some(&mut pack_pool),
         );
         phase_timing::stop(&phase_timing::SCHUR_NS, _pt);
         k += n_elim;
@@ -2432,6 +2454,9 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
     }
 
     flag_growth_for_refinement(&l, &mut needs_refinement);
+
+    // Return the pack pool to the scratch for the next front.
+    scratch.pack_pool = pack_pool;
 
     Ok(FrontalFactors {
         nrow,
@@ -3185,6 +3210,7 @@ fn apply_blocked_schur(
     subdiag: &[f64],
     fma: bool,
     intrafront_parallel: bool,
+    pool: Option<&mut PackPool>,
 ) {
     if n_elim == 0 || j_start >= nrow {
         return;
@@ -3210,6 +3236,7 @@ fn apply_blocked_schur(
             subdiag,
             fma,
             intrafront_parallel,
+            pool,
         );
         return;
     }
@@ -3238,6 +3265,7 @@ fn apply_blocked_schur(
             subdiag,
             fma,
             intrafront_parallel,
+            pool,
         );
         return;
     }
@@ -3330,6 +3358,7 @@ fn apply_blocked_schur_panel(
     subdiag: &[f64],
     fma: bool,
     intrafront_parallel: bool,
+    pool: Option<&mut PackPool>,
 ) {
     // Stack-friendly upper bound on n_elim. Sized at 128 to cover
     // the default `params.block_size = 64` and the larger panels
@@ -3375,12 +3404,17 @@ fn apply_blocked_schur_panel(
             .enumerate()
             .for_each(|(ci, block)| {
                 let col_start = j_start + ci * chunk_cols;
+                // Per-range fresh pack buffers: a shared pool cannot
+                // cross the parallel split (and multi-slot pooling is
+                // on the tried-and-rejected list).
                 apply_schur_panel_range(
-                    head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+                    head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma, None,
                 );
             });
     } else {
-        apply_schur_panel_range(head, tail, j_start, nrow, k, n_elim, d_panel, subdiag, fma);
+        apply_schur_panel_range(
+            head, tail, j_start, nrow, k, n_elim, d_panel, subdiag, fma, pool,
+        );
     }
 }
 
@@ -3416,6 +3450,7 @@ fn apply_schur_panel_range(
     d_panel: &[f64],
     subdiag: &[f64],
     fma: bool,
+    pool: Option<&mut PackPool>,
 ) {
     const MAX_N_ELIM: usize = 128;
     assert!(
@@ -3437,7 +3472,7 @@ fn apply_schur_panel_range(
     // A/B benchmarking and as a safety override.
     if packed_schur_enabled() {
         apply_schur_panel_range_packed(
-            head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma,
+            head, block, col_start, nrow, k, n_elim, d_panel, subdiag, fma, pool,
         );
         return;
     }
@@ -3642,6 +3677,7 @@ fn apply_schur_panel_range_packed(
     d_panel: &[f64],
     subdiag: &[f64],
     fma: bool,
+    pool: Option<&mut PackPool>,
 ) {
     apply_schur_panel_range_packed_impl(
         head,
@@ -3654,6 +3690,7 @@ fn apply_schur_panel_range_packed(
         subdiag,
         fma,
         packed_simd_enabled(),
+        pool,
     );
 }
 
@@ -3673,11 +3710,21 @@ fn apply_schur_panel_range_packed_impl(
     subdiag: &[f64],
     fma: bool,
     use_simd: bool,
+    pool: Option<&mut PackPool>,
 ) {
     let ncol = block.len() / nrow;
     if ncol == 0 || n_elim == 0 {
         return;
     }
+    // Pooled or fresh pack buffers (issue #128 rest). Pooled reuse
+    // re-zeroes via `clear()` + `resize(len, 0.0)`, making the buffer
+    // contents identical to a fresh `vec![0.0; len]` — the packing
+    // loops below then see indistinguishable inputs, so pooling is
+    // byte-exact by construction. (`bpack0`'s zeros ARE load-bearing:
+    // out-of-range column lanes are only ever zero-filled, never
+    // written.)
+    let mut local = PackPool::default();
+    let pool = pool.unwrap_or(&mut local);
     // Register-tile dimensions. MR rows × NR cols per tile; the MR (row)
     // axis is the contiguous SIMD axis (explicit pulp lanes on the
     // default path, autovectorization on the scalar reference loop).
@@ -3700,8 +3747,15 @@ fn apply_schur_panel_range_packed_impl(
     let npanels_j = ncol.div_ceil(NR);
 
     // Pack A (source rows): `apack[pi][q][ir] = L[row0+pi*MR+ir, k+q]`,
-    // `L[x, k+q] = head[(k+q)*nrow + x]`.
-    let mut apack = vec![0.0f64; npanels_i * n_elim * MR];
+    // `L[x, k+q] = head[(k+q)*nrow + x]`. Every slot (including the
+    // past-`nrow` padding) is overwritten below, so pooled reuse skips
+    // the re-zero when the length already matches.
+    let alen = npanels_i * n_elim * MR;
+    let apack = &mut pool.apack;
+    if apack.len() != alen {
+        apack.clear();
+        apack.resize(alen, 0.0);
+    }
     for pi in 0..npanels_i {
         let i0 = row0 + pi * MR;
         for q in 0..n_elim {
@@ -3727,12 +3781,18 @@ fn apply_schur_panel_range_packed_impl(
     // has no 2×2 pivot start (the `is_2x2_start`-gated indexing is then never
     // reached), full-sized otherwise.
     let has_2x2 = (0..n_elim).any(is_2x2_start);
-    let mut bpack0 = vec![0.0f64; npanels_j * n_elim * NR];
-    let mut bpack1 = if has_2x2 {
-        vec![0.0f64; npanels_j * n_elim * NR]
-    } else {
-        Vec::new()
-    };
+    let blen = npanels_j * n_elim * NR;
+    // `bpack0`/`bpack1` zeros are load-bearing (out-of-range column
+    // lanes stay zero), so pooled reuse must re-zero: `clear()` +
+    // `resize(blen, 0.0)` memsets while preserving capacity.
+    let bpack0 = &mut pool.bpack0;
+    bpack0.clear();
+    bpack0.resize(blen, 0.0);
+    let bpack1 = &mut pool.bpack1;
+    bpack1.clear();
+    if has_2x2 {
+        bpack1.resize(blen, 0.0);
+    }
     for pj in 0..npanels_j {
         let j0 = col_start + pj * NR;
         for q in 0..n_elim {
@@ -3764,6 +3824,11 @@ fn apply_schur_panel_range_packed_impl(
         }
     }
 
+    // Packing complete — read-only from here.
+    let apack: &[f64] = apack;
+    let bpack0: &[f64] = bpack0;
+    let bpack1: &[f64] = bpack1;
+
     // Tiled update over the lower triangle (i >= j): explicit-SIMD pulp
     // tile kernel by default (one dispatch per panel; see
     // `schur_kernel::packed_schur_tiles_nofma` for the bit-exactness
@@ -3789,9 +3854,9 @@ fn apply_schur_panel_range_packed_impl(
         if fma {
             schur_kernel::packed_schur_tiles_fma(
                 block,
-                &apack,
-                &bpack0,
-                &bpack1,
+                apack,
+                bpack0,
+                bpack1,
                 &d_panel[..n_elim],
                 &subdiag[k..],
                 nrow,
@@ -3800,9 +3865,9 @@ fn apply_schur_panel_range_packed_impl(
         } else {
             schur_kernel::packed_schur_tiles_nofma(
                 block,
-                &apack,
-                &bpack0,
-                &bpack1,
+                apack,
+                bpack0,
+                bpack1,
                 &d_panel[..n_elim],
                 &subdiag[k..],
                 nrow,
@@ -6381,6 +6446,10 @@ mod packed_schur_tests {
                 .wrapping_add(1442695040888963407);
             ((s >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
         };
+        // Pool carried dirty across every case/shape below, so pooled
+        // reuse exercises stale lengths and stale contents — the
+        // re-zero path must make it byte-identical to fresh buffers.
+        let mut pool = PackPool::default();
         // (nrow, k, n_elim, col_start, subdiag-pattern). Patterns:
         //   "1x1"  — all 1×1
         //   "2x2"  — 2×2 pairs at q = 2 and q = 5 (where they fit)
@@ -6425,27 +6494,30 @@ mod packed_schur_tests {
                 // (the `FERAL_PACKED_SIMD=0` fallback) must match the
                 // scalar per-column reference bit-for-bit.
                 for use_simd in [true, false] {
-                    let mut b_packed = block0.clone();
-                    apply_schur_panel_range_packed_impl(
-                        &head,
-                        &mut b_packed,
-                        col_start,
-                        nrow,
-                        k,
-                        n_elim,
-                        &d_panel,
-                        &subdiag,
-                        fma,
-                        use_simd,
-                    );
-                    for lc in 0..ncol {
-                        let j = col_start + lc;
-                        for i in j..nrow {
-                            assert_eq!(
-                                b_packed[lc * nrow + i].to_bits(),
-                                b_ref[lc * nrow + i].to_bits(),
-                                "packed != scalar (fma={fma}, simd={use_simd}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
-                            );
+                    for use_pool in [false, true] {
+                        let mut b_packed = block0.clone();
+                        apply_schur_panel_range_packed_impl(
+                            &head,
+                            &mut b_packed,
+                            col_start,
+                            nrow,
+                            k,
+                            n_elim,
+                            &d_panel,
+                            &subdiag,
+                            fma,
+                            use_simd,
+                            if use_pool { Some(&mut pool) } else { None },
+                        );
+                        for lc in 0..ncol {
+                            let j = col_start + lc;
+                            for i in j..nrow {
+                                assert_eq!(
+                                    b_packed[lc * nrow + i].to_bits(),
+                                    b_ref[lc * nrow + i].to_bits(),
+                                    "packed != scalar (fma={fma}, simd={use_simd}, pool={use_pool}, pat={pat}) at (i={i},j={j}) nrow={nrow} n_elim={n_elim}"
+                                );
+                            }
                         }
                     }
                 }

--- a/src/dense/schur_kernel.rs
+++ b/src/dense/schur_kernel.rs
@@ -2383,6 +2383,328 @@ pub fn schur_panel_minus_fma_strided_quad(
     });
 }
 
+// ---------------------------------------------------------------------
+// Packed BLAS-3 tile kernels (issue #99 follow-up, session 2026-08-09).
+//
+// `dense::factor::apply_schur_panel_range_packed` packs the eliminated
+// panel into `q`-contiguous MR×NR micro-panels and runs a register-tiled
+// accumulation walk. That walk previously lived in `factor.rs` as plain
+// scalar Rust relying on autovectorization — which, measured on x86
+// (objdump, dev/research/kernel-simd-x86-baseline-2026-08-09.md), never
+// happened: the inner loop compiled to scalar `mulsd`/`subsd` and ran at
+// ~6 GFLOP/s (scalar ILP peak) while pulp's strided kernels reach AVX2
+// through runtime dispatch. These kernels move the tile walk behind the
+// same `dispatch_nofma`/`dispatch_fma` helpers, one dispatch per panel.
+//
+// Bit-exactness contract (default nofma path): each C element (i, j) is
+// seeded from the trailing block and then folded over the pivot stream
+// in ascending `q` with per-step rounding
+//   1×1:  acc = round(acc − round(b·a))            (mul → sub)
+//   2×2:  acc = round(acc − round(round(d0·a0) + round(d1·a1)))
+// — exactly the scalar reference in `factor.rs` and the strided
+// `axpy_minus_unroll4_nofma` / `axpy2_minus_unroll4_nofma` shapes. SIMD
+// lanes run that identical per-element sequence on independent elements
+// (IEEE per-lane mul/add/sub ≡ scalar), so the result is bit-identical
+// to the scalar walk at every lane width (scalar, NEON f64x2, AVX2
+// f64x4, AVX-512 f64x8). The FMA variants chain `mul_add` per element
+// exactly like the scalar `f64::mul_add` opt-in path (both are
+// single-rounding fused ops). Gated by
+// `packed_matches_scalar_reference_bit_for_bit` and the byte-exact
+// factor-parity suite.
+
+/// Register-tile row count for the packed trailing update. The MR (row)
+/// axis is the contiguous SIMD axis. Shared with the packing code in
+/// `dense::factor`.
+pub const PACKED_MR: usize = 8;
+/// Register-tile column count for the packed trailing update.
+pub const PACKED_NR: usize = 4;
+
+struct PackedTiles<'a, const FMA: bool> {
+    block: &'a mut [f64],
+    apack: &'a [f64],
+    bpack0: &'a [f64],
+    bpack1: &'a [f64],
+    d_panel: &'a [f64],
+    subdiag_k: &'a [f64],
+    nrow: usize,
+    col_start: usize,
+}
+
+impl<const FMA: bool> pulp::WithSimd for PackedTiles<'_, FMA> {
+    type Output = ();
+
+    #[inline(always)]
+    fn with_simd<S: pulp::Simd>(self, simd: S) {
+        let Self {
+            block,
+            apack,
+            bpack0,
+            bpack1,
+            d_panel,
+            subdiag_k,
+            nrow,
+            col_start,
+        } = self;
+        let n_elim = d_panel.len();
+        let ncol = block.len() / nrow;
+        let row0 = col_start;
+        let rowspan = nrow - row0;
+        let col_end = col_start + ncol;
+        let npanels_i = rowspan.div_ceil(PACKED_MR);
+        let npanels_j = ncol.div_ceil(PACKED_NR);
+        // Same 2×2-start predicate as the packing code and the strided
+        // fallback: the second element of a pair is never re-entered.
+        let is_2x2_start = |q: usize| q + 1 < n_elim && subdiag_k[q] != 0.0;
+
+        for pj in 0..npanels_j {
+            let j0 = col_start + pj * PACKED_NR;
+            let bbase = pj * (n_elim * PACKED_NR);
+            for pi in 0..npanels_i {
+                let i0 = row0 + pi * PACKED_MR;
+                // Tiles entirely in the strict upper triangle have no
+                // element with i >= j.
+                if i0 + PACKED_MR <= j0 {
+                    continue;
+                }
+                let abase = pi * (n_elim * PACKED_MR);
+
+                // Seed the C tile (lower-triangle, in-range elements
+                // only; out-of-range/upper lanes stay 0 and are never
+                // stored). Scalar guarded copy, identical to the
+                // reference walk in `factor.rs`.
+                let mut acc = [[0.0f64; PACKED_MR]; PACKED_NR];
+                for (jr, accj) in acc.iter_mut().enumerate() {
+                    let j = j0 + jr;
+                    if j >= col_end {
+                        continue;
+                    }
+                    let colblk = (j - col_start) * nrow;
+                    for (ir, a) in accj.iter_mut().enumerate() {
+                        let i = i0 + ir;
+                        if i < nrow && i >= j {
+                            *a = block[colblk + i];
+                        }
+                    }
+                }
+
+                // Pivot-stream walk in ascending `q`; lane-parallel over
+                // the MR axis. PACKED_MR = 8 is a multiple of every lane
+                // width pulp instantiates (1/2/4/8), so `as_simd_f64s`
+                // never produces a tail here.
+                let mut q = 0usize;
+                while q < n_elim {
+                    if is_2x2_start(q) {
+                        let (a0v, _) =
+                            S::as_simd_f64s(&apack[abase + q * PACKED_MR..][..PACKED_MR]);
+                        let (a1v, _) =
+                            S::as_simd_f64s(&apack[abase + (q + 1) * PACKED_MR..][..PACKED_MR]);
+                        let b0 = &bpack0[bbase + q * PACKED_NR..][..PACKED_NR];
+                        let b1 = &bpack1[bbase + q * PACKED_NR..][..PACKED_NR];
+                        for (jr, accj) in acc.iter_mut().enumerate() {
+                            let (accv, _) = S::as_mut_simd_f64s(&mut accj[..]);
+                            if FMA {
+                                // Two chained FMAs, matching the scalar
+                                // opt-in path (`f64::mul_add`).
+                                let n0 = simd.splat_f64s(-b0[jr]);
+                                let n1 = simd.splat_f64s(-b1[jr]);
+                                for (accl, (av0, av1)) in
+                                    accv.iter_mut().zip(a0v.iter().zip(a1v.iter()))
+                                {
+                                    *accl = simd.mul_add_f64s(
+                                        n1,
+                                        *av1,
+                                        simd.mul_add_f64s(n0, *av0, *accl),
+                                    );
+                                }
+                            } else {
+                                // t = round(round(d0·a0) + round(d1·a1));
+                                // acc = round(acc − t) — the axpy2 nofma
+                                // shape.
+                                let d0 = simd.splat_f64s(b0[jr]);
+                                let d1 = simd.splat_f64s(b1[jr]);
+                                for (accl, (av0, av1)) in
+                                    accv.iter_mut().zip(a0v.iter().zip(a1v.iter()))
+                                {
+                                    let t = simd
+                                        .add_f64s(simd.mul_f64s(d0, *av0), simd.mul_f64s(d1, *av1));
+                                    *accl = simd.sub_f64s(*accl, t);
+                                }
+                            }
+                        }
+                        q += 2;
+                    } else {
+                        // 1×1; skip a zero pivot exactly as the
+                        // reference does.
+                        if d_panel[q] != 0.0 {
+                            let (a0v, _) =
+                                S::as_simd_f64s(&apack[abase + q * PACKED_MR..][..PACKED_MR]);
+                            let b0 = &bpack0[bbase + q * PACKED_NR..][..PACKED_NR];
+                            for (jr, accj) in acc.iter_mut().enumerate() {
+                                let (accv, _) = S::as_mut_simd_f64s(&mut accj[..]);
+                                if FMA {
+                                    let nb = simd.splat_f64s(-b0[jr]);
+                                    for (accl, av) in accv.iter_mut().zip(a0v.iter()) {
+                                        *accl = simd.mul_add_f64s(nb, *av, *accl);
+                                    }
+                                } else {
+                                    let bv = simd.splat_f64s(b0[jr]);
+                                    for (accl, av) in accv.iter_mut().zip(a0v.iter()) {
+                                        *accl = simd.sub_f64s(*accl, simd.mul_f64s(bv, *av));
+                                    }
+                                }
+                            }
+                        }
+                        q += 1;
+                    }
+                }
+
+                // Store back the lower-triangle, in-range elements.
+                for (jr, accj) in acc.iter().enumerate() {
+                    let j = j0 + jr;
+                    if j >= col_end {
+                        continue;
+                    }
+                    let colblk = (j - col_start) * nrow;
+                    for (ir, a) in accj.iter().enumerate() {
+                        let i = i0 + ir;
+                        if i < nrow && i >= j {
+                            block[colblk + i] = *a;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Validate the shared geometry/lengths of a packed tile call, then
+/// return `(ncol, npanels_i, npanels_j)`. Panics (like the other kernel
+/// entry asserts in this file) on malformed inputs so the SIMD body can
+/// index without per-access surprises.
+#[allow(clippy::too_many_arguments)]
+fn packed_tiles_checked_geom(
+    block_len: usize,
+    apack_len: usize,
+    bpack0_len: usize,
+    bpack1_len: usize,
+    d_panel_len: usize,
+    subdiag_k_len: usize,
+    nrow: usize,
+    col_start: usize,
+) -> (usize, usize, usize) {
+    assert!(nrow > 0, "packed_schur_tiles: nrow must be positive");
+    assert_eq!(
+        block_len % nrow,
+        0,
+        "packed_schur_tiles: block length must be a multiple of nrow"
+    );
+    let ncol = block_len / nrow;
+    assert!(
+        col_start + ncol <= nrow,
+        "packed_schur_tiles: columns exceed nrow"
+    );
+    let npanels_i = (nrow - col_start).div_ceil(PACKED_MR);
+    let npanels_j = ncol.div_ceil(PACKED_NR);
+    assert_eq!(
+        apack_len,
+        npanels_i * d_panel_len * PACKED_MR,
+        "packed_schur_tiles: apack length mismatch"
+    );
+    assert_eq!(
+        bpack0_len,
+        npanels_j * d_panel_len * PACKED_NR,
+        "packed_schur_tiles: bpack0 length mismatch"
+    );
+    assert!(
+        bpack1_len == 0 || bpack1_len == bpack0_len,
+        "packed_schur_tiles: bpack1 must be empty or match bpack0"
+    );
+    assert!(
+        subdiag_k_len >= d_panel_len,
+        "packed_schur_tiles: subdiag_k shorter than d_panel"
+    );
+    (ncol, npanels_i, npanels_j)
+}
+
+/// Packed register-tiled trailing update, **nofma** (default) rounding
+/// contract: per element `mul → sub` (1×1) / add-then-sub (2×2), two
+/// roundings per multiply-accumulate — bit-identical to the scalar
+/// reference walk at every lane width. `d_panel.len()` is `n_elim`;
+/// `subdiag_k` is the `subdiag` slice rebased at the panel (`[k..]`).
+/// `bpack1` may be empty when the panel has no 2×2 start (issue #128A).
+#[allow(clippy::too_many_arguments)]
+pub fn packed_schur_tiles_nofma(
+    block: &mut [f64],
+    apack: &[f64],
+    bpack0: &[f64],
+    bpack1: &[f64],
+    d_panel: &[f64],
+    subdiag_k: &[f64],
+    nrow: usize,
+    col_start: usize,
+) {
+    packed_tiles_checked_geom(
+        block.len(),
+        apack.len(),
+        bpack0.len(),
+        bpack1.len(),
+        d_panel.len(),
+        subdiag_k.len(),
+        nrow,
+        col_start,
+    );
+    dispatch_nofma(PackedTiles::<false> {
+        block,
+        apack,
+        bpack0,
+        bpack1,
+        d_panel,
+        subdiag_k,
+        nrow,
+        col_start,
+    });
+}
+
+/// Packed register-tiled trailing update, **FMA** (opt-in) rounding
+/// contract: one/two chained fused multiply-adds per element, matching
+/// the scalar `f64::mul_add` opt-in path bit-for-bit (both are
+/// single-rounding fused ops). Dispatching through pulp also restores
+/// real `vfmadd` codegen on x86, where the scalar `f64::mul_add` fallback
+/// lowers to a libm call at baseline codegen (measured ~3× slower than
+/// nofma; dev/research/kernel-simd-x86-baseline-2026-08-09.md Finding 2).
+#[allow(clippy::too_many_arguments)]
+pub fn packed_schur_tiles_fma(
+    block: &mut [f64],
+    apack: &[f64],
+    bpack0: &[f64],
+    bpack1: &[f64],
+    d_panel: &[f64],
+    subdiag_k: &[f64],
+    nrow: usize,
+    col_start: usize,
+) {
+    packed_tiles_checked_geom(
+        block.len(),
+        apack.len(),
+        bpack0.len(),
+        bpack1.len(),
+        d_panel.len(),
+        subdiag_k.len(),
+        nrow,
+        col_start,
+    );
+    dispatch_fma(PackedTiles::<true> {
+        block,
+        apack,
+        bpack0,
+        bpack1,
+        d_panel,
+        subdiag_k,
+        nrow,
+        col_start,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/dense/schur_kernel.rs
+++ b/src/dense/schur_kernel.rs
@@ -337,8 +337,17 @@ fn dispatch_fma<K: pulp::WithSimd>(k: K) -> K::Output {
     }
     #[cfg(target_arch = "x86_64")]
     {
+        // `Simd::vectorize`, NOT `k.with_simd(v3)`: vectorize wraps the
+        // body in V3's `#[target_feature(enable = "avx,avx2,fma,…")]`
+        // shim so the AVX intrinsics inline. Calling `with_simd`
+        // directly runs the body in a baseline-feature context where
+        // every lane op stays an outlined `core_arch` function call —
+        // measured ~7× slower on the packed tile kernel
+        // (dev/research/kernel-simd-x86-baseline-2026-08-09.md,
+        // Finding 3). Same instructions per lane either way, so results
+        // are bit-identical; only the codegen context changes.
         match pulp::x86::V3::try_new() {
-            Some(v3) => k.with_simd(v3),
+            Some(v3) => pulp::Simd::vectorize(v3, k),
             None => pulp::Arch::new().dispatch(k),
         }
     }
@@ -550,8 +559,13 @@ fn dispatch_nofma<K: pulp::WithSimd>(k: K) -> K::Output {
     }
     #[cfg(target_arch = "x86_64")]
     {
+        // `Simd::vectorize`, NOT `k.with_simd(v3)` — see the twin
+        // comment in `dispatch_fma`: vectorize supplies the
+        // `#[target_feature]` context that lets the AVX intrinsics
+        // inline; direct `with_simd` leaves them as outlined calls
+        // (~7× slower, bit-identical results).
         match pulp::x86::V3::try_new() {
-            Some(v3) => k.with_simd(v3),
+            Some(v3) => pulp::Simd::vectorize(v3, k),
             None => pulp::Arch::new().dispatch(k),
         }
     }

--- a/tests/golden_bits.rs
+++ b/tests/golden_bits.rs
@@ -1,0 +1,166 @@
+//! Golden bit-pattern test for the dense blocked LDLᵀ (session
+//! 2026-08-09, Stage 1 of the kernel-SIMD pass).
+//!
+//! The byte-exactness contract for the default (nofma) kernels is
+//! *cross-platform*: the per-element fold is `mul → sub` (two roundings)
+//! at every lane width, so scalar, NEON f64x2, AVX2 f64x4, and AVX-512
+//! f64x8 all produce identical bits. The in-repo parity suites pin the
+//! kernels against each other *on the machine running the tests*; this
+//! test pins them against **hardcoded** u64 digests, so a divergence
+//! between architectures fails loudly the first time the suite runs on
+//! the other machine (e.g. the aarch64 M-series corpus host).
+//!
+//! The FMA (opt-in) path is also covered: `f64::mul_add`, libm `fma`,
+//! x86 `vfmadd`, and NEON `vfmaq_f64` are all exactly-rounded fused
+//! multiply-adds, so its digests are cross-platform too — just different
+//! from the nofma digests (one rounding vs two).
+//!
+//! If a digest here ever changes, that is a change to factorization
+//! results, not a refactor — treat it as a correctness event.
+
+use feral::dense::factor::factor_frontal_blocked;
+use feral::{BunchKaufmanParams, SymmetricMatrix};
+
+/// SplitMix64, the same generator the dense-front benches use.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+    }
+}
+
+/// Indefinite front with a sign-alternating dominant diagonal (mostly
+/// 1×1 pivots) — the `bench_dense_front` fixture shape.
+fn build_indefinite_front(n: usize, seed: u64) -> SymmetricMatrix {
+    let mut rng = Rng(seed);
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            data[j * n + i] = if i == j {
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                sign * (n as f64) + rng.next_f64()
+            } else {
+                0.30 * rng.next_f64()
+            };
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+/// A front with a *weak* diagonal so Bunch-Kaufman takes 2×2 pivots and
+/// the mixed 1×1/2×2 packed streams are exercised.
+fn build_2x2_heavy_front(n: usize, seed: u64) -> SymmetricMatrix {
+    let mut rng = Rng(seed);
+    let mut data = vec![0.0f64; n * n];
+    for j in 0..n {
+        for i in j..n {
+            data[j * n + i] = if i == j {
+                0.01 * rng.next_f64()
+            } else {
+                rng.next_f64()
+            };
+        }
+    }
+    SymmetricMatrix { n, data }
+}
+
+/// FNV-1a over the bit patterns of a f64 slice.
+fn digest(vals: &[f64]) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325u64;
+    for v in vals {
+        for b in v.to_bits().to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01B3);
+        }
+    }
+    h
+}
+
+fn factor_digest(matrix: &SymmetricMatrix, fma: bool) -> (u64, u64, u64, (usize, usize, usize)) {
+    let params = BunchKaufmanParams {
+        fma,
+        ..BunchKaufmanParams::default()
+    };
+    let ff = factor_frontal_blocked(matrix, matrix.n, false, &params).expect("factor failed");
+    let inertia = (ff.inertia.positive, ff.inertia.negative, ff.inertia.zero);
+    (
+        digest(&ff.l),
+        digest(&ff.d_diag),
+        digest(&ff.d_subdiag),
+        inertia,
+    )
+}
+
+#[test]
+fn golden_bits_nofma_indefinite_256() {
+    let m = build_indefinite_front(256, 0x1234_5678_9ABC_DEF0);
+    let (l, d, sd, inertia) = factor_digest(&m, false);
+    assert_eq!(inertia, (128, 128, 0), "inertia drifted");
+    assert_eq!(
+        (l, d, sd),
+        (
+            GOLDEN_NOFMA_IND[0],
+            GOLDEN_NOFMA_IND[1],
+            GOLDEN_NOFMA_IND[2]
+        ),
+        "nofma indefinite-256 factor bits drifted from the golden digests"
+    );
+}
+
+#[test]
+fn golden_bits_nofma_2x2_heavy_96() {
+    let m = build_2x2_heavy_front(96, 0x5EED_CAFE_F00D_D00D);
+    let (l, d, sd, _inertia) = factor_digest(&m, false);
+    assert_eq!(
+        (l, d, sd),
+        (
+            GOLDEN_NOFMA_2X2[0],
+            GOLDEN_NOFMA_2X2[1],
+            GOLDEN_NOFMA_2X2[2]
+        ),
+        "nofma 2x2-heavy-96 factor bits drifted from the golden digests"
+    );
+}
+
+#[test]
+fn golden_bits_fma_indefinite_256() {
+    let m = build_indefinite_front(256, 0x1234_5678_9ABC_DEF0);
+    let (l, d, sd, inertia) = factor_digest(&m, true);
+    assert_eq!(inertia, (128, 128, 0), "inertia drifted (fma)");
+    assert_eq!(
+        (l, d, sd),
+        (GOLDEN_FMA_IND[0], GOLDEN_FMA_IND[1], GOLDEN_FMA_IND[2]),
+        "fma indefinite-256 factor bits drifted from the golden digests"
+    );
+}
+
+// Golden digests, recorded on x86_64 (AVX2 via pulp V3 dispatch) at
+// session 2026-08-09-01. The nofma digests must reproduce on every
+// platform; the fma digests must reproduce on every platform whose
+// fused multiply-add is exactly rounded (all supported ones).
+// Cross-checked identical on this host across all three kernel paths:
+// default (pulp SIMD), FERAL_PACKED_SIMD=0 (scalar tile loop), and
+// FERAL_PACKED_SCHUR=0 (strided per-column kernels).
+const GOLDEN_NOFMA_IND: [u64; 3] = [0x7073f0edec336dbe, 0x2f1419d50d39b641, 0x28c31cf8df2ec325];
+const GOLDEN_NOFMA_2X2: [u64; 3] = [0x3701e106f647e9f1, 0xb36ca5290912f46b, 0x2f16488fbf9b6fd7];
+const GOLDEN_FMA_IND: [u64; 3] = [0x8ac5b55facb8b9dd, 0x2f1419d50d39b641, 0x28c31cf8df2ec325];
+
+/// Prints the digests so they can be hardcoded above. Run with
+/// `cargo test --release --test golden_bits -- --ignored --nocapture`.
+#[test]
+#[ignore]
+fn record_golden() {
+    let m = build_indefinite_front(256, 0x1234_5678_9ABC_DEF0);
+    let (l, d, sd, i) = factor_digest(&m, false);
+    println!("GOLDEN_NOFMA_IND: [{l:#018x}, {d:#018x}, {sd:#018x}]  inertia={i:?}");
+    let m2 = build_2x2_heavy_front(96, 0x5EED_CAFE_F00D_D00D);
+    let (l, d, sd, i) = factor_digest(&m2, false);
+    println!("GOLDEN_NOFMA_2X2: [{l:#018x}, {d:#018x}, {sd:#018x}]  inertia={i:?}");
+    let (l, d, sd, i) = factor_digest(&m, true);
+    println!("GOLDEN_FMA_IND:   [{l:#018x}, {d:#018x}, {sd:#018x}]  inertia={i:?}");
+}


### PR DESCRIPTION
## Summary

Evidence-based kernel performance pass. Three default-path changes landed, all **byte-exact** (bit-identical factors, enforced by extended parity tests plus new hardcoded golden digests), one experiment honestly rejected and recorded. All performance numbers are from an x86_64 4-core AVX2 container; **aarch64 M-series revalidation is the first follow-up** (see checkpoint).

### 1. x86 pulp dispatch fix (`f0be9fa`)

`dispatch_nofma`/`dispatch_fma` called `k.with_simd(v3)` instead of `pulp::Simd::vectorize(v3, k)`. Without vectorize's `#[target_feature]` wrapper, every AVX intrinsic in every pulp kernel compiled as an **outlined function call** on x86 (objdump: standalone `_mm256_mul_pd` symbols called per lane op) — since Phase 2.4.2, invisible on aarch64 where NEON is baseline. Strided kernel: 0.45 → 4.7–7.0 GFLOP/s (~10×). Bit-identical by construction.

### 2. Explicit pulp SIMD packed trailing update + work gate (`41c35b5`, `8358d1b`)

The default BLAS-3 tile walk (issue #99) relied on autovectorization that never fired on x86 — fully scalar codegen (zero `ymm`, zero packed SSE, ~6 GFLOP/s scalar-ILP peak). The tile walk now lives in `schur_kernel::packed_schur_tiles_{nofma,fma}`, one dispatch per panel, same per-element rounding shapes:

| n=2955 front | before | after |
|---|---:|---:|
| nofma serial | 4236 ms (2.0 GF/s) | 1517–1556 ms (5.6 GF/s) |
| nofma intrafront | 1798 ms | 637–679 ms (12.7–13.5 GF/s) |
| fma intrafront | 4214 ms | 572–609 ms (14–15 GF/s) |

Warm end-to-end fixtures: twirism1 −46%, hydcar20 −26%, sawpath −18%. Also repairs the opt-in FMA path, which had silently become a ~3× x86 slowdown since packed became default (scalar `f64::mul_add` → libm `fma()` call at baseline codegen).

Degenerate panels (< 1024 multiply-subtracts) stay on the retained inline scalar walk — the ~100–200 ns dispatch boundary can't be amortized there. Escape hatches: `FERAL_PACKED_SIMD=0` (scalar tile walk), `FERAL_PACKED_SIMD_MIN_WORK=<n>` (gate retune).

### 3. Pack-buffer pooling (`484bda7`, issue #128 rest)

`PackPool {apack, bpack0, bpack1}` on `FactorScratch`, serial path only (rayon ranges keep fresh allocations). `bpack0/1` re-zero on reuse (their zeros are load-bearing); the parity test carries a deliberately dirty pool across all shapes. Warm factor −12% on a hicks-like chain-KKT proxy (motivated by pounce#552), −2…−6% across the small parity fixtures.

### 4. Rejected: eager-path rank-1 SIMD (`f509a18`)

Fully implemented, measured **flat at every size** (eager n=512: 11.21 vs 11.23 ms — the plain eager loops already autovectorize; the path is pivot-search/memory-bound), reverted per the pre-registered criterion. The byte-identical de-duplication of `do_1x1_pivot`'s twin loops is kept. Full entry in `dev/tried-and-rejected.md`; the chain-KKT/MA57 small-front gap is per-front overhead, not lane width.

## Correctness evidence

- Per-element fold order unchanged everywhere (nofma `mul→sub`, fused 2×2, chained `mul_add` for opt-in FMA); SIMD lanes are independent elements, so results are bit-identical at every lane width (scalar / NEON f64x2 / AVX2 f64x4 / AVX-512 f64x8).
- `packed_matches_scalar_reference_bit_for_bit` extended to sweep SIMD × scalar-fallback × dirty-pool against the scalar reference for fma × nofma.
- New `tests/golden_bits.rs`: hardcoded u64 digests of L/D — cross-checked identical across all three kernel paths on this host; fails loudly on any cross-arch divergence at the next M-series run.
- Full suite green throughout (407 lib tests, 83 test binaries); session bench inertia/residual checks all pass.

## Follow-ups (in `dev/sessions/2026-08-09-01.md`)

1. **aarch64 M-series revalidation** before any corpus-level claim (`FERAL_PACKED_SIMD=0` is the one-env-var rollback if NEON codegen regresses).
2. Re-run the Mittelmann/MA57 sweep; attack the chain-KKT gap via per-front overhead / pivot scans / `scalar_pivot_step` / delayed-pivot cascade.
3. Deferred conditional stages: MR/NR tile retune, packed-kernel L2 blocking, block32 rank-2 quad kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F87aJtwLT34CTG8KLj5fqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01F87aJtwLT34CTG8KLj5fqm)_