### PR TITLE
release: feral v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-09
+
 ### Fixed — the profiler no longer reports small fronts as costless (issue #148)
 
 - **Breaking (diagnostic API).** `SupernodeTiming` now records **nanoseconds**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/dev/journal/2026-08-09-03.org
+++ b/dev/journal/2026-08-09-03.org
@@ -199,3 +199,16 @@ Verified independently: single [Unreleased] heading, no stray 0.14.0
 refs beyond the six to bump, working tree clean and in sync with
 origin, 84 binaries / 800 passed / 0 failed / 21 ignored on the exact
 release tree.
+
+* 17:30 :release:0.15.0:
+PR #150 merged as fad5670 (squash). Cut the release commit: all six
+version strings 0.14.0 -> 0.15.0 (root Cargo.toml/lock,
+python/Cargo.toml/lock x2, python/pyproject.toml), CHANGELOG
+[Unreleased] -> [0.15.0] - 2026-08-09. Verified: grep for 0.14.0 comes
+back empty across all five files; `cargo metadata --locked` passes in
+BOTH the root and python/ workspaces (the python one is a separate
+workspace with its own lockfile - the thing that broke CI earlier
+today); 84 binaries / 800 passed / 0 failed on the release tree.
+NOT publishing the GitHub Release - release.yml fires on
+`release: published` and pushes to crates.io, which cannot be
+un-published. That is the maintainer's call.

--- a/dev/plans/release-0.15.0-checklist.md
+++ b/dev/plans/release-0.15.0-checklist.md
@@ -125,7 +125,6 @@ change `PAR_MIN_SEEDS` and record it in decisions.md.
       `release: published` (not on tag push), and it verifies the tag
       matches `Cargo.toml`. This is the irreversible step: crates.io
       versions can be yanked but never re-published.
-- [ ] Tag + publish (crates.io, PyPI wheels via the existing workflow)
 - [ ] Notify pounce (issue #148 / pounce#552) so the factorization
       comparison can be re-run against a released feral
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.14.0"
+version = "0.15.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts 0.15.0. Version bump + CHANGELOG only — no code changes.

## Contents

A performance release whose **defaults are bit-identical to 0.14.0**. Three strands, all measured on x86_64 *and* aarch64:

- **Dense SIMD kernels now actually vectorize** (#149). The x86 pulp dispatch helpers ran lane ops as outlined function calls (~10× kernel slowdown), and the packed BLAS-3 trailing update's tile walk compiled fully scalar. Dense front n=2955: 4.24 s → 1.52 s serial nofma on x86; on aarch64 fma-serial is **2.94×** vs 0.14.0 (11.3 → 34.1 GFLOP/s). Not an x86-only story — the NEON FMA path was previously buying nothing.
- **Parallel factorization no longer loses to serial** (#148, #150). One rayon task per *subtree* instead of one boxed task per supernode (~1.8M allocations per solve on chain-structured KKTs). Paired A/B on six real KKT matrices, 0.14.0 vs this: **wins all twelve arms**, clnlbeam parallel 2.29×, steering_12800 parallel 1.73×, with identical solve-vector hashes.
- **The profiler stopped reporting small fronts as costless.** Supernode timings used `as_micros()`, so every front under a microsecond recorded zero — 5651 of 11171 supernodes on one fixture. Now nanoseconds, with microsecond accessors kept and the Python API unchanged.

## Release-checklist verification

| item | status |
|---|---|
| All **six** version strings bumped | ✅ `Cargo.toml`, `Cargo.lock`, `python/Cargo.toml`, `python/Cargo.lock` (×2: `feral`, `feral-python`), `python/pyproject.toml` |
| No stray `0.14.0` references | ✅ grep empty across all five files |
| Both lockfiles resolve | ✅ `cargo metadata --locked` passes in the root **and** in `python/` (separate workspace) |
| Test suite | ✅ 84 binaries, 800 passed, 0 failed |
| CHANGELOG cut | ✅ `[Unreleased]` → `[0.15.0] - 2026-08-09` |

**aarch64 gates (verified at `6fd12d4`):** corpus of 156,929 matrices — dense and sparse inertia both **100.0%**, all four Phase 2.8.1 exit partitions PASS, worst residuals identical to the x86_64 baseline *to the digit* (2.46e-1 `POLAK6_0021`, 2.94e-4 `ERRINBAR_0824`), and `tests/golden_bits.rs` digests recorded on x86 reproduce unmodified on M-series.

## After merging

`release.yml` fires on **GitHub Release published** (not on tag push) and verifies the tag matches `Cargo.toml`. Publishing the release is the irreversible step — crates.io versions can be yanked but never re-published — so I've deliberately left it to you.

Once it's out, pounce can drop its `[patch.crates-io]` redirect and re-run the pounce#552 headline models against a pinned version, which is the measurement that's been missing since that issue was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F87aJtwLT34CTG8KLj5fqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01F87aJtwLT34CTG8KLj5fqm)_