### PR TITLE
Amalgamation cost-model guard (opt-in) — and why neither amalgamation lever ships

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,9 @@ name = "bench_schur_micro"
 name = "bench_packed_tiny"
 
 [[example]]
+name = "probe_kr_warmstart"
+
+[[example]]
 name = "bench_qap15"
 
 [[example]]

--- a/crates/feral-diagnostics/src/bin/diag_dense_tail.rs
+++ b/crates/feral-diagnostics/src/bin/diag_dense_tail.rs
@@ -57,6 +57,7 @@ fn configs() -> Vec<ConfigSpec> {
             params: SupernodeParams {
                 nemin: 32,
                 preprocess: OrderingPreprocess::None,
+                merge_flop_budget: None,
                 small_leaf: Default::default(),
                 amalgamation_strategy: Default::default(),
                 symbolic_profiler: None,
@@ -67,6 +68,7 @@ fn configs() -> Vec<ConfigSpec> {
             params: SupernodeParams {
                 nemin: 5,
                 preprocess: OrderingPreprocess::None,
+                merge_flop_budget: None,
                 small_leaf: Default::default(),
                 amalgamation_strategy: Default::default(),
                 symbolic_profiler: None,
@@ -77,6 +79,7 @@ fn configs() -> Vec<ConfigSpec> {
             params: SupernodeParams {
                 nemin: 1,
                 preprocess: OrderingPreprocess::None,
+                merge_flop_budget: None,
                 small_leaf: Default::default(),
                 amalgamation_strategy: Default::default(),
                 symbolic_profiler: None,
@@ -87,6 +90,7 @@ fn configs() -> Vec<ConfigSpec> {
             params: SupernodeParams {
                 nemin: 32,
                 preprocess: OrderingPreprocess::LdltCompress,
+                merge_flop_budget: None,
                 small_leaf: Default::default(),
                 amalgamation_strategy: Default::default(),
                 symbolic_profiler: None,
@@ -97,6 +101,7 @@ fn configs() -> Vec<ConfigSpec> {
             params: SupernodeParams {
                 nemin: 5,
                 preprocess: OrderingPreprocess::LdltCompress,
+                merge_flop_budget: None,
                 small_leaf: Default::default(),
                 amalgamation_strategy: Default::default(),
                 symbolic_profiler: None,

--- a/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
+++ b/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
@@ -1,0 +1,338 @@
+//! Re-check of the `nemin` amalgamation lever **after** the 0.15.0
+//! SIMD kernel work.
+//!
+//! Why this exists when the sweep is already in
+//! `dev/tried-and-rejected.md` (2026-05-16, issue #10 lever 5): that
+//! rejection turned on one quantity — "chain-link merges blow trailing
+//! fill faster than the wider panel can amortize". The amortization
+//! rate is precisely what 0.15.0 changed. The trailing update went from
+//! an SSE2-baseline scalar tile walk to explicit AVX2/NEON (n=2955:
+//! 4.24 s -> 1.52 s on x86; 2.25-3.19x on NEON), so a wide front is now
+//! several times cheaper per flop while the fill penalty of a larger
+//! `nemin` is unchanged. If the break-even moved, it moved here.
+//!
+//! Methodology follows `dev/decisions.md` 2026-08-09: **paired
+//! alternating** A/B (all `nemin` values are timed once per pair, in
+//! order, so drift hits every arm equally), `min_us` per arm, and a
+//! sign test over the pairs. Do not compare medians collected at
+//! different times — this container has produced a 1.9x spread on
+//! identical code.
+//!
+//! `nemin` changes fill **and** numerics, so byte-parity does not
+//! apply. Inertia and the true relative residual are reported per arm
+//! as the local correctness signal; the shipping gate is a full corpus
+//! run, which this container does not have.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin diag_nemin_post_simd \
+//!       -- <matrix.mtx> [more.mtx ...]
+//!
+//! Env:
+//!   FERAL_NEMIN_LIST=1,4,8,16,32,64   arms to sweep (default this list)
+//!   FERAL_NEMIN_PAIRS=10              paired repetitions (default 10)
+//!   FERAL_MERGE_BUDGET_LIST=0,1e3,..  sweep `merge_flop_budget` instead
+//!                                     of `nemin`; arms are budgets and
+//!                                     `nemin` is held at its default.
+//!                                     The baseline arm is the shipped
+//!                                     `None` (printed as `off`).
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::symbolic::{symbolic_factorize, SupernodeParams, SymbolicFactorization};
+use feral::{read_mtx, CscMatrix, Solver};
+
+/// One configuration under test. The baseline arm is whichever one
+/// equals the shipped default; every ratio is taken against it.
+#[derive(Clone, Copy)]
+enum Arm {
+    /// Sweep `nemin` with the cost-model guard off (shipped rule).
+    Nemin(usize),
+    /// Sweep `merge_flop_budget` with `nemin` at its default.
+    Budget(Option<u128>),
+}
+
+impl Arm {
+    fn params(self) -> SupernodeParams {
+        match self {
+            Arm::Nemin(nemin) => SupernodeParams {
+                nemin,
+                ..SupernodeParams::default()
+            },
+            Arm::Budget(b) => SupernodeParams {
+                merge_flop_budget: b,
+                ..SupernodeParams::default()
+            },
+        }
+    }
+
+    fn is_baseline(self) -> bool {
+        let d = SupernodeParams::default();
+        match self {
+            Arm::Nemin(nemin) => nemin == d.nemin,
+            Arm::Budget(b) => b == d.merge_flop_budget,
+        }
+    }
+
+    fn label(self) -> String {
+        match self {
+            Arm::Nemin(nemin) => nemin.to_string(),
+            Arm::Budget(None) => "off".into(),
+            Arm::Budget(Some(b)) => b.to_string(),
+        }
+    }
+}
+
+struct Shape {
+    n_snodes: usize,
+    ncol_mean: f64,
+    ncol_p50: usize,
+    ncol_p90: usize,
+    ncol_max: usize,
+    /// Fraction of supernodes with <= 8 eliminated columns — the
+    /// quantity the PR #150 review cited for clnlbeam (90%).
+    frac_le8: f64,
+    nrow_mean: f64,
+}
+
+fn shape_of(sym: &SymbolicFactorization) -> Shape {
+    let mut ncols: Vec<usize> = sym.supernodes.iter().map(|s| s.ncol).collect();
+    let nrow_sum: usize = sym.supernodes.iter().map(|s| s.nrow).sum();
+    ncols.sort_unstable();
+    let n = ncols.len().max(1);
+    let pct = |p: f64| ncols[(((ncols.len().max(1) - 1) as f64) * p).round() as usize];
+    Shape {
+        n_snodes: ncols.len(),
+        ncol_mean: ncols.iter().sum::<usize>() as f64 / n as f64,
+        ncol_p50: pct(0.50),
+        ncol_p90: pct(0.90),
+        ncol_max: ncols.last().copied().unwrap_or(0),
+        frac_le8: ncols.iter().filter(|&&c| c <= 8).count() as f64 / n as f64,
+        nrow_mean: nrow_sum as f64 / n as f64,
+    }
+}
+
+/// True relative residual ||Ax-b||_inf / ||b||_inf of a single solve at
+/// this `nemin`, using the public `Solver` path (so scaling, refinement
+/// and the permute cache are exercised exactly as a caller would).
+fn residual_at(csc: &CscMatrix, arm: Arm) -> Option<(String, f64)> {
+    let mut solver = Solver::with_params(NumericParams::default(), arm.params());
+    let _ = solver.factor(csc, None);
+    let inertia = solver.inertia()?.to_string();
+    let b = vec![1.0f64; csc.n];
+    let x = solver.solve(&b).ok()?;
+    let mut num: f64 = 0.0;
+    let mut ax = vec![0.0f64; csc.n];
+    for j in 0..csc.n {
+        for k in csc.col_ptr[j]..csc.col_ptr[j + 1] {
+            let i = csc.row_idx[k];
+            let v = csc.values[k];
+            ax[i] += v * x[j];
+            if i != j {
+                ax[j] += v * x[i];
+            }
+        }
+    }
+    for i in 0..csc.n {
+        num = num.max((ax[i] - b[i]).abs());
+    }
+    Some((inertia, num))
+}
+
+fn geomean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return f64::NAN;
+    }
+    (xs.iter().map(|v| v.ln()).sum::<f64>() / xs.len() as f64).exp()
+}
+
+fn main() {
+    let paths: Vec<PathBuf> = std::env::args().skip(1).map(PathBuf::from).collect();
+    if paths.is_empty() {
+        eprintln!("usage: diag_nemin_post_simd <matrix.mtx> [more.mtx ...]");
+        std::process::exit(2);
+    }
+    // Budget mode takes precedence when both are set: the budget sweep
+    // is the newer lever and holding `nemin` fixed is what isolates it.
+    let arms: Vec<Arm> = match std::env::var("FERAL_MERGE_BUDGET_LIST") {
+        Ok(s) => {
+            let mut v: Vec<Arm> = vec![Arm::Budget(None)];
+            v.extend(
+                s.split(',')
+                    .filter_map(|t| t.trim().parse::<u128>().ok())
+                    .map(|b| Arm::Budget(Some(b))),
+            );
+            v
+        }
+        Err(_) => match std::env::var("FERAL_NEMIN_LIST") {
+            Ok(s) => s
+                .split(',')
+                .filter_map(|t| t.trim().parse().ok())
+                .map(Arm::Nemin)
+                .collect(),
+            Err(_) => [1, 4, 8, 16, 32, 64].into_iter().map(Arm::Nemin).collect(),
+        },
+    };
+    let pairs: usize = std::env::var("FERAL_NEMIN_PAIRS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+    let base_idx = arms.iter().position(|a| a.is_baseline());
+
+    println!(
+        "pairs={pairs} arms=[{}] base={}",
+        arms.iter()
+            .map(|a| a.label())
+            .collect::<Vec<_>>()
+            .join(", "),
+        base_idx
+            .map(|i| arms[i].label())
+            .unwrap_or_else(|| "NONE".into())
+    );
+    // Per-arm geomean accumulators across matrices.
+    let mut t_ratio: Vec<Vec<f64>> = vec![Vec::new(); arms.len()];
+    let mut nnz_ratio: Vec<Vec<f64>> = vec![Vec::new(); arms.len()];
+
+    for path in &paths {
+        let label = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let Ok(csc) = read_mtx(Path::new(path)).and_then(|m| m.to_csc()) else {
+            println!("\n=== {label}: LOAD FAILED ===");
+            continue;
+        };
+        println!("\n=== {label} n={} nnz={} ===", csc.n, csc.row_idx.len());
+
+        // Symbolic once per arm; only the numeric phase is timed, so the
+        // measurement isolates the lever from ordering/analysis noise.
+        let mut syms: Vec<Option<SymbolicFactorization>> = Vec::new();
+        for arm in &arms {
+            syms.push(symbolic_factorize(&csc, &arm.params()).ok());
+        }
+
+        let np = NumericParams::default();
+        // Warm every arm before timing so allocator and cache state are
+        // comparable across arms.
+        let mut nnz: Vec<Option<usize>> = Vec::new();
+        for s in &syms {
+            nnz.push(match s {
+                Some(sym) => factorize_multifrontal(&csc, sym, &np)
+                    .ok()
+                    .map(|(f, _)| f.factor_nnz()),
+                None => None,
+            });
+        }
+
+        // Paired alternating timing.
+        let mut times: Vec<Vec<u128>> = vec![Vec::new(); arms.len()];
+        for _ in 0..pairs {
+            for (ai, sym) in syms.iter().enumerate() {
+                let Some(sym) = sym else { continue };
+                let t = Instant::now();
+                let ok = factorize_multifrontal(&csc, sym, &np).is_ok();
+                let us = t.elapsed().as_micros();
+                if ok {
+                    times[ai].push(us);
+                }
+            }
+        }
+
+        println!(
+            "{:>6}  {:>7} {:>9} {:>6} {:>6} {:>7} {:>7} {:>9}  {:>11} {:>7}  {:>9} {:>6} {:>5}  {:>10} {:>12}",
+            "nemin",
+            "snodes",
+            "ncol_mean",
+            "p50",
+            "p90",
+            "max",
+            "%<=8",
+            "nrow_mean",
+            "factor_nnz",
+            "x_nnz",
+            "min_us",
+            "x_t",
+            "wins",
+            "inertia",
+            "resid_inf"
+        );
+        for (ai, &arm) in arms.iter().enumerate() {
+            let name = arm.label();
+            let Some(sym) = &syms[ai] else {
+                println!("{name:>6}  symbolic FAILED");
+                continue;
+            };
+            if times[ai].is_empty() {
+                println!("{name:>6}  factor FAILED");
+                continue;
+            }
+            let sh = shape_of(sym);
+            let mn = times[ai].iter().copied().min().unwrap_or(0);
+            // Sign test vs the baseline arm, pair by pair.
+            let (x_t, wins) = match base_idx {
+                Some(bi) if bi != ai && !times[bi].is_empty() => {
+                    let base_mn = times[bi].iter().copied().min().unwrap_or(1).max(1);
+                    let w = times[ai]
+                        .iter()
+                        .zip(times[bi].iter())
+                        .filter(|(a, b)| a < b)
+                        .count();
+                    (
+                        mn as f64 / base_mn as f64,
+                        format!("{w}/{}", times[ai].len()),
+                    )
+                }
+                _ => (1.0, "-".into()),
+            };
+            let x_nnz = match (nnz[ai], base_idx.and_then(|bi| nnz[bi])) {
+                (Some(a), Some(b)) if b > 0 => a as f64 / b as f64,
+                _ => f64::NAN,
+            };
+            let (inertia, resid) = residual_at(&csc, arm)
+                .map(|(i, r)| (i, format!("{r:.3e}")))
+                .unwrap_or_else(|| ("FAIL".into(), "-".into()));
+            println!(
+                "{:>6}  {:>7} {:>9.2} {:>6} {:>6} {:>7} {:>6.1}% {:>9.1}  {:>11} {:>7.3}  {:>9} {:>6.3} {:>5}  {:>10} {:>12}",
+                name,
+                sh.n_snodes,
+                sh.ncol_mean,
+                sh.ncol_p50,
+                sh.ncol_p90,
+                sh.ncol_max,
+                100.0 * sh.frac_le8,
+                sh.nrow_mean,
+                nnz[ai].map(|v| v.to_string()).unwrap_or_else(|| "-".into()),
+                x_nnz,
+                mn,
+                x_t,
+                wins,
+                inertia,
+                resid
+            );
+            if base_idx.is_some() {
+                t_ratio[ai].push(x_t);
+                if x_nnz.is_finite() {
+                    nnz_ratio[ai].push(x_nnz);
+                }
+            }
+        }
+    }
+
+    if paths.len() > 1 {
+        println!(
+            "\n=== geomean across {} matrices (vs base) ===",
+            paths.len()
+        );
+        println!("{:>6}  {:>10}  {:>10}", "arm", "x_time", "x_nnz");
+        for (ai, &arm) in arms.iter().enumerate() {
+            println!(
+                "{:>6}  {:>10.3}  {:>10.3}",
+                arm.label(),
+                geomean(&t_ratio[ai]),
+                geomean(&nnz_ratio[ai])
+            );
+        }
+    }
+}

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T03:25:16Z
+Generated: 2026-08-09T16:11:10Z
 
 ## Latest Session
-File: dev/sessions/2026-08-09-02.md
+File: dev/sessions/2026-08-09-03.md
 ```
-# Session 2026-08-09-02
+# Session 2026-08-09-03
 
 ## Goal
 
-Issue #148: the default parallel multifrontal driver is slower than
-serial on 3 of 4 POUNCE problems (~1.8M `scope.spawn` boxed-closure
-allocations per solve, glibc arena contention growing with thread
-count). Fix via the issue's suggested directions 1+2: work-based task
-coarsening and a serial fallback. Environment: x86_64 4-core container
-(issue reproduces at 2-4 threads); POUNCE `.nl` problems unavailable —
-synthetic proxies (chain / grid / banded-QP KKT) built and measured
-with interleaved old-vs-new binaries (git worktree at e8e1c5a).
+Post-0.15.0 optimization queue item 2: the `nemin` amalgamation sweep
+(`dev/plans/release-0.15.0-checklist.md` §4.2), motivated by the PR #150
+review — 90% of clnlbeam's supernodes are ≤8 columns and they are 35.9%
+of its factorization loop.
 
 ## Accomplished
 
-1. **Reproduction** (research note): chain12000 parallel never beats
-   serial; sparseqp proxy degrades monotonically with threads; grid250
-   is the one winner but pays +19% single-thread driver overhead.
-2. **TaskPlan coarsening (7814bfe)**: one spawn per subtree task —
-   boundaries at tree roots and at children of nodes with >= 2 sibling
-   subtrees each >= `FERAL_PAR_TASK_MIN_FLOPS` (default 1e6); lone big
-   children continue inline (chains collapse to one task; the naive
-   subtree>=cutoff rule produced 6319 tasks of 6564 supernodes on the
-   banded-QP proxy, the sibling rule 1). Owned nodes factored serially
-   in postorder inside their task; parent-task trampoline via
-   task-children pending counters; `seeds < 2` delegates to the
-   sequential driver (intrafront parallelism kept on).
-   `FERAL_DEBUG_TASK_PLAN=1` dumps plan shapes.
-3. **Byte-exactness**: scheduling-only; new `tests/task_plan_parity.rs`
-   pins fine (cutoff=1: 153 tasks/132 seeds), default, and fallback
-   configurations bit-identical to the sequential driver; 84/84 test
-   binaries green.
-4. **chainW anomaly investigated and documented**: the old per-node
-   driver oddly beat both sequential drivers ~20% on one wide-block
-   chain proxy; AtomicLockStats telemetry located the difference
-   *inside* `factor_one_supernode` (912 vs 1276 ms per 9 factors) —
-   not spawn/lock overhead, not intrafront, not tree parallelism.
-   Unexplainable further without perf/heaptrack (absent here);
-   accepted as a proxy quirk since the issue's real chains lose under
-   per-node spawning. Full analysis in the research note.
+**Both amalgamation levers measured and rejected. Nothing ships; the
+default path is bit-identical to 0.15.0.**
 
-## Benchmark Results
+Harness: `crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs` —
+paired alternating A/B per `decisions.md` 2026-08-09 (all arms timed once
+per pair, `min_us`, sign test), symbolic computed once per arm so only
+the numeric phase is timed, inertia + true ∞-norm residual reported per
+arm. 61 CUTEst KKT parity fixtures (n = 3 … 5314) + 4 structured KKTs
+(clnlbeam_like n=100000, grid250, sparseqp_kkt, chain12000_kkt).
+x86_64, 4 cores, AVX2. Criterion pre-registered before the first run.
 
-Session bench (corpus absent): synthetic set + regression fixtures all
-inertia/residual pass; oracle partitions N/A in container.
+### 1. The queue item's direction is dead, and re-confirmed
 
-Interleaved old-vs-new (warm medians, default parallel config):
+Geomean vs shipped `nemin=16`, time / factor_nnz:
 
-| proxy | old par@4 | new par@4 | old serial | new serial |
-|---|---:|---:|---:|---:|
+| arm | 1 | 4 | 8 | 32 | 64 |
+|---|---|---|---|---|---|
+| 61 parity | 1.21/0.67 | 1.02/0.83 | 0.986/0.89 | 1.02/1.19 | 1.15/1.65 |
+| 4 structured | 1.33/0.37 | 0.99/0.51 | 0.925/0.68 | 1.13/1.60 | 1.53/2.74 |
+
+Every arm above 16 loses on time and inflates fill on every class. This
+re-confirms the 2026-05-16 rejection (issue #10 lever 5) after the one
+development that could have overturned it — that rejection turned
+entirely on "the wider panel cannot amortize the fill", and the 0.15.0
+kernel rewrite is exactly what changed the amortization rate. It did not
+buy the fill back.
+
+### 2. `nemin=8` wins but fails its pre-registered criterion
+
+Better on both axes on structured KKTs (clnlbeam_like 0.925× time at
+0.579× fill; chain12000 0.815/0.640). But the criterion was ≥5% geomean
+with ≥8/10 sign test on ≥2 classes and no fixture regressing >2%: parity
+geomean is 1.4%, and CERI651A_0000 regresses 16% (178→207 µs, 2/15 wins
+— an effect, not noise), DEGENLPB_0046 12%, BQPGASIM_0012 10%.
+
+### 3. Cost-model merge guard: implemented, works, rejected on accuracy
+
+The size rule (`child_ncol < nemin && parent_ncol < nemin`) never asks
+what a merge costs. Front height is `col_counts[first_col].max(ncol)`,
 ```
 
 ## Git Status
 ```
-7814bfe perf(parallel): coarsen factor tasks to subtrees; serial fallback for chains (#148)
-80f849f research: issue #148 reproduction + task-coarsening design note
+f39a5db perf(symbolic): amalgamation cost-model guard (opt-in) + nemin re-sweep
+e2ba443 research: falsify the scaling warm-start hypothesis (post-0.15.0 item 1)
+808babb release: feral v0.15.0 (#151)
+fad5670 perf(parallel): task-per-subtree coarsening + profiler nanoseconds (#150)
 e8e1c5a perf(kernel): explicit SIMD packed trailing update + x86 pulp dispatch fix (#149)
-6589570 docs: session checkpoint 2026-07-11-02 (issue triage, #127, release 0.14.0) (#146)
-c05eb77 release: feral v0.14.0 (#145)
 ```
 
 ## Test Status
@@ -86,87 +86,88 @@ test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 407 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.99s
+test result: ok. 409 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.89s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-03.md)
 
 
-Session bench (corpus absent): synthetic set + regression fixtures all
-inertia/residual pass; oracle partitions N/A in container.
+The corpus bench (`cargo run --bin bench --release`) is not runnable
+here — `data/matrices` holds 2 files in this container, not the 154k
+corpus. The default path is unchanged and bit-identical, so the release
+gates are unaffected by this session. Local suite:
 
-Interleaved old-vs-new (warm medians, default parallel config):
+cargo test --release
+84/84 test binaries, 802 passed, 0 failed
+cargo fmt --check / cargo clippy -- -D warnings / clippy -p feral-diagnostics: pass
 
-| proxy | old par@4 | new par@4 | old serial | new serial |
-|---|---:|---:|---:|---:|
-| sparseqpL (issue signature) | 82.4-88.0 ms | 71.7-76.3 ms | 69.9-74.6 | 70.7-72.2 |
-| grid250 | 78.8-92.7 ms | 71.4-73.4 ms | 123.0-128.7 | 122.0-128.0 |
-| chainW | 186.7-216.6 ms | 221.1-223.9 ms | 228.1-229.5 | 214.9-215.7 |
-| chain12000 | 12.0-12.5 ms | 11.9-12.5 ms | 11.3-11.7 | 10.9-11.0 |
+Medium-front throughput probe for the next item (`bench_dense_front`,
+nofma serial, 30 reps, dense front of order n):
 
-Spawn reduction: grid250 11171 → 51 tasks; chains → 1 (sequential
-path). Small fixtures in the noise band (−6%..+4%). The chainW par@4
-old-vs-new gap is the documented anomaly above (old-par was beating
-serial there; new ≈ serial).
+n=32   0.77 GFLOP/s     n=192   3.13
+n=48   1.42             n=256   3.51
+n=64   1.85             n=512   4.40
+n=96   2.95             n=1024  5.05
+n=128  3.45
 
 ```
 
 ## Recent Decisions
-`FERAL_PAR_TASK_MIN_FLOPS` (default 1e6) estimated flops; a lone big
-child continues inline, so chain-shaped trees collapse to one task per
-root. One `scope.spawn` per task, owned nodes factored serially in
-postorder inside it, parent-task trampoline via task-children pending
-counters. Task graphs with < 2 seeds delegate to the sequential driver
-(with intrafront parallelism kept on).
+run medians. `min_us` per invocation is the preferred per-sample
+statistic (least interfered). Cross-time comparison of numbers taken in
+different sessions is not evidence at all.
 
-**Why.** Issue #148: one boxed spawn per supernode ⇒ ~1.8M allocations
-per POUNCE sparseqp solve, glibc arena contention growing with thread
-count, parallel slower than serial on 3 of 4 problems. Spawn counts:
-grid250 11171 → 51; chains → 1 (sequential path).
+**Why.** Measured on the issue-#148 chainW proxy (session 2026-08-09-03):
+three `FERAL_PAR_TASK_MIN_FLOPS` settings that produce *identical* task
+plans — same code path, byte-identical work — measured 139.6 / 259.1 /
+155.5 ms, a 1.9x spread. Eight invocations of one fixed config spanned
+min_us 124.7-163.2 ms (31%) and median_us 149.2-183.7 ms (23%). Two
+conclusions had already been drawn from inside that band and were both
+wrong: a claimed "chainW anomaly" (per-node spawning 20% faster than
+sequential) and a claimed 5-18% regression from PR #150. Paired
+re-measurement reversed both — 9/12 pairs favour the new code (median
+ratio 0.961) and 9/10 favour coarse over fine-grained tasks (median
+1.045, sign-test p~0.02).
 
-**Evidence.** Interleaved old-vs-new, x86_64 4-core: sparseqpL par@4
-82-88 → 71.7-76.3 ms (old lost 15-25% to serial; new ≈ serial);
-grid250 par@4 78.8-92.7 → 71.4-73.4 ms; small fixtures noise-band.
-Byte-exact (scheduling only): tests/task_plan_parity.rs pins
-fine/default/fallback plans against the sequential driver bit-for-bit;
-84/84 suites green.
+**Relationship to the existing rule.** The 2026-04-14 entry ("any
+bench-p90 delta smaller than ~5% must be confirmed with a 3-run
+median") is necessary but NOT sufficient: three consecutive medians can
+all land inside one drift excursion, which is exactly how both wrong
+conclusions above were reached. Paired A/B supersedes it for container
+measurement; the 3-run rule still applies to the corpus bench on a
+quiet machine.
 
-**Documented open question.** On one synthetic proxy (chainW, wide-
-block chain) the OLD per-node-spawn driver beat both sequential
-drivers by ~20% — telemetry places the difference inside
-factor_one_supernode (912 vs 1276 ms per 9 factors), an unexplained
-workspace/allocator interaction, not driver overhead. Accepted as a
-proxy quirk (the issue's real chains lose under per-node spawning);
-full analysis in dev/research/issue-148-parallel-task-granularity.md.
-
-**Deferred.** Issue #148 suggestion 3 (collect() temporaries):
-re-profile after this lands. #128 nrow-underestimate still skews flop
-estimates; harmless for this gate.
+**Consequence for prior sessions.** Numbers in
+dev/sessions/2026-08-09-01.md and -02.md were collected unpaired.
+Those with large effects (dense-front kernel 2.7-7x, grid250, sparseqpL
+- since re-confirmed paired at 10/10 and 9/10) stand; sub-10% fixture
+deltas in those checkpoints should be treated as unresolved rather than
+as measured wins until re-run paired.
 
 ## Recent Tried-and-Rejected
-plain `for i in j..n { a[j*n+i] -= a[k*n+i]*alpha }` loops are
-textbook-autovectorizable, and the eager path's remaining time is
-pivot search + memory traffic, not multiply-subtract throughput.
-Explicit lanes duplicated what LLVM already did. This matches the
-2026-05-16 finding (pulp == scalar == manual unroll at lengths 3..128)
-at the whole-front scale.
+`nemin=8`, MEYER3NE 83× at `nemin=4`), which is what makes it a property
+of the direction rather than of this rule.
 
-**What was kept.** The de-duplication refactor (shared scalar
-`rank1_scale_update_argmax`, byte-identical, golden digests unchanged)
-stays; the pulp kernel, its gate/env var, the dedicated parity test,
-and the A/B example were removed.
+**Why rejected.** "Correctness before performance, always" is a hard
+constraint. 2–7% of factor time and 11–45% of fill does not buy seven
+digits of residual. Neither my pre-registered criterion nor the queue
+item thought to check the axis that decided it — recorded here because
+the next person to have this idea will not think to check it either.
 
-**Lesson.** The small-front/MA57 gap is NOT lane width in the eager
-update. Remaining suspects, in evidence order: per-front fixed
-overhead (assembly/scatter/build-row, 8.8-14.8% on the small
-fixtures), pivot-search scans, `scalar_pivot_step` in blocked fronts,
-and the delayed-pivot cascade (per-factor-cost-cluster mechanism A).
-Any retry of eager-path SIMD must first show a front-level profile
-where the update loops are >30% of eager time AND not already
-vectorized in the disassembly.
+The knob stays in-tree defaulting to `None` (bit-identical default path)
+as the reproduction apparatus, with the accuracy result in its doc
+comment. Research note:
+`dev/research/amalgamation-cost-model-2026-08-09.md`.
+
+**Also redirects the target.** pounce#552's re-measurement against a
+released 0.15.0 (comment 5232409020) shows clnlbeam more than halved
+(8.05× → 3.54× vs MA57) and **no longer the worst case** — `dtoc1nd` is,
+at 3.77×, and it is a dense-front matrix (nnz/dim 23.0, fronts of 33–64
+columns). Amalgamation is a chain-KKT lever aimed at a problem that has
+largely receded.
 
 ## Source Files
 ```

--- a/dev/journal/2026-08-09-04.org
+++ b/dev/journal/2026-08-09-04.org
@@ -1,0 +1,39 @@
+#+TITLE: Session 2026-08-09-04 — scaling warm-start (post-0.15.0 item 1)
+#+DATE: 2026-08-09
+
+* 18:00 :orient:scaling:warm-start:
+Goal: the top post-release item. Reviewer's profile on six real KKT
+matrices (PR #150): the WARM prologue is 15-39% of factorization and
+Knight-Ruiz equilibration is 63-81% of that — re-derived from scratch on
+every call. On rocket_12800 scaling alone is 34% of the whole factor.
+Crucially they showed the prologue DOES warm for everything else
+(permute collapses 4443->539 us on clnlbeam, 25647->1584 on dtoc2 across
+calls 0->2) while scaling stays flat (3909 / 19850 us). Ceiling measured
+by POUNCE_FERAL_SCALING=none: clnlbeam 34.89->30.98 ms (-11%), dtoc2
+121.93->98.04 (-20%).
+CONSTRAINT: unlike everything in 0.15.0, this CHANGES NUMERICAL OUTPUT —
+different scaling => different pivots => different factors. Not
+byte-exact, so the golden_bits/parity apparatus does NOT gate it; the
+gate is a full corpus run (inertia 100% + Phase 2.8.1 partitions +
+residuals), which this container lacks. Plan accordingly: design +
+implement + local tests here, hand off corpus validation.
+
+* 18:45 :scaling:warm-start:falsified:convergence:
+Built examples/probe_kr_warmstart.rs to measure the headroom BEFORE
+implementing. Result: warm-start gives ZERO iteration reduction on 6/6
+fixtures (2->2 or 10->10). Diagnosis from the per-iteration trace:
+convergence is clean linear at ratio ~1/2 (Ruiz ∞-norm equilibration's
+known rate), and at the max_iter=10 cap max_dev is still ~1.4e-2 vs
+tol=1e-8 — ~30 iterations would be needed. The tolerance is unreachable
+by construction, so the loop ALWAYS runs 10 passes on the hard class and
+no starting point can reduce a fixed iteration count.
+4 of 6 fixtures hit the cap, contradicting the code comment ("a few
+pathological ones need all 10") — they are truncated, not converged.
+Consequence: the reviewer's item (3) as scoped does not exist as a free
+win. Cheapening scaling means fewer passes, which is a conditioning
+trade: cap 10 -> 5 takes max_dev 1.4e-2 -> 3.7e-1 (26x worse) for maybe
+5-15% of factor time. Recorded in tried-and-rejected + a research note
+with four ranked alternatives (do nothing / warm-start for QUALITY as a
+continued iteration across the IPM / faster-converging algorithm /
+lower cap). Not implementing any without a corpus gate — all of them
+change numerics, and golden_bits does NOT cover this.

--- a/dev/journal/2026-08-09-05.org
+++ b/dev/journal/2026-08-09-05.org
@@ -1,0 +1,99 @@
+* 19:20 :branch:housekeeping:
+Restarted claude/feral-kernel-perf-dx0fkq from origin/main after #151
+(v0.15.0) merged; cherry-picked edd3260 (scaling-warm-start research,
+docs only) onto it as e2ba443. First attempt with `git cherry-pick -q`
+appeared to no-op (log showed only 808babb/fad5670 and files absent);
+re-running without -q applied it cleanly. Lesson: verify cherry-picks
+by file existence, not by the command's apparent success.
+
+* 19:35 :nemin:amalgamation:prior-art:
+Post-release queue item 2 is the `nemin` amalgamation sweep, motivated
+by the PR #150 review (90% of clnlbeam's supernodes are <=8 columns;
+35.9% of its loop time). Before writing any code, searched
+tried-and-rejected per CLAUDE.md. This lever has been swept THREE times
+already, and the most recent one targeted clnlbeam by name:
+
+- 2026-04-19: nemin in {1,5,32} on AVION2/BATCH. nemin=32 optimal;
+  nemin=1 regressed 30-40%.
+- 2026-05-03 (Phase A, decisions.md): {8,16,32,64} x {AMD,METIS-ND} on
+  PoissonControl -> default lowered 32 -> 16. nemin=8 recovers memory
+  but the wall regresses.
+- 2026-05-03 (Phase B): {8,16,24,32,48} on MUONSINE/KIRBY2/ACOPR30/
+  SWOPF. Shape-dispatched nemin abandoned: path-like factor_nnz is
+  invariant in nemin and the wall signal was pure noise (nemin=48 was
+  8% faster in run 1, 29% slower in run 2).
+- 2026-05-16 (issue #10 lever 5): {16,32,64,128} on the 4-family
+  Mittelmann panel. clnlbeam geomean vs nemin=16: 1.032 / 1.356 /
+  1.989. ncol_mean doubles at 64 but factor_nnz inflates 1.23-1.33x.
+  nemin in {256,MAX} HUNG on clnlbeam_0000 (one near-dense front of
+  order > n/2). Issue #10 closed as "hardware floor".
+
+So the reviewer's item 2, in the obvious direction (raise nemin to fuse
+the <=8-column supernodes), is already falsified ON THE EXACT MATRIX
+FAMILY, by a paired sweep, with fill numbers attached.
+
+One thing has genuinely changed since 2026-05-16, and it is the thing
+the rejection turned on. The May conclusion was "the wider panel cannot
+amortize the extra fill". That amortization rate is exactly what the
+0.15.0 kernel work altered: on x86 the trailing update went from an
+SSE2-baseline scalar walk to explicit AVX2 (n=2955: 4.24s -> 1.52s),
+and the aarch64 packed path is 2.25-3.19x its predecessor. Wide fronts
+are now several times cheaper per flop, while the fill penalty of a
+larger nemin is unchanged. The break-even therefore moved in favour of
+amalgamation, by a factor of the same order as the regression that
+sank it. That is a real reason to re-measure, not a re-litigation.
+Recording the pre-registered criterion BEFORE running, so a repeat of
+the 2026-05-16 result is reported as a confirmation, not buried.
+
+* 20:30 :nemin:sweep:measured:
+Ran the sweep. nemin=8 beats the shipped 16 on BOTH axes on structured
+KKTs (geomean 0.925 time / 0.678 nnz; clnlbeam_like 0.925/0.579,
+chain12000 0.815/0.640) and is neutral on 61 parity fixtures
+(0.986/0.89). Every arm ABOVE 16 loses everywhere — the 2026-05-16
+rejection survives the kernel rewrite intact, so the reviewer's stated
+direction is dead twice over. But nemin=8 fails my pre-registered
+criterion: parity geomean is 1.4% not 5%, and CERI651A_0000 regresses
+16% (2/15 wins, 178->207us, not noise), DEGENLPB_0046 12%, BQPGASIM 10%.
+Honoring the criterion: no default change.
+
+* 20:55 :amalgamation:cost-model:design:
+The real defect is that the merge rule is size-only and never asks what
+a merge COSTS. nrow = col_counts[first_col].max(ncol), so past the
+natural row count each extra column adds a triangle of pure fill.
+clnlbeam col_counts=2: 16 fronts of 4 flops become one of 1496 (23x)
+and the rule sees only "1 < 16". Added merge_flop_budget: Option<u128>,
+merge iff dflops <= budget, flops = S(nrow)-S(nrow-ncol). Default None
+= bit-identical to today.
+
+First probe (budgets 1000..1e6) was indistinguishable from off on every
+fixture. Diagnosis: the guard is per-merge but the damage is cumulative
+— growing a chain from width 15 to 16 costs only 252 flops, so every
+step passes individually. The useful range is two orders lower than a
+naive Omega/tau estimate. Re-swept 5..500: clean interior optimum at
+30-60, structured geomean 0.945/0.549 and 0.935/0.619, and it dominates
+nemin where it counts (sparseqp: 0.493x fill at the same 0.947x time
+nemin=8 needed 0.676x for). No speed regressions on parity.
+
+* 21:20 :amalgamation:accuracy:rejected:
+Killed it on the axis I had not thought to check. Residuals (single
+unrefined solve, b=1): HATFLDG_0003..0006 go 7.1e-15 -> up to 7.4e-08
+(seven digits), VESUVIOU_0030 1.9e-06 -> 5.4e-03 (2789x), MEYER3NE_0220
+30x. Inertia unchanged everywhere and on HATFLDG/VESUVIOU the fill is
+IDENTICAL to default — so it is not a fill effect. Thinner supernodes
+shrink Bunch-Kaufman's pivot candidate pool inside each front. Checked
+the nemin arms for the same defect and they have it (VESUVIOU 2789x at
+nemin=8, MEYER3NE 83x at nemin=4), so it is a property of the direction,
+not of my rule. 2-7% time + 11-45% fill does not buy seven digits.
+Rejected; knob stays default-off as reproduction apparatus.
+
+* 21:40 :pounce:redirect:priority:
+jrk pointed at pounce#552 comment 5232409020 — the MA57 table re-measured
+against released 0.15.0. clnlbeam 8.05x -> 3.54x and it is NO LONGER the
+worst case; dtoc1nd is, at 3.77x, and it is a DENSE-front matrix
+(nnz/dim 23.0, fronts of 33-64 columns). Ratio ordering is no longer the
+nnz/dim ordering, so "the gap tracks sparsity" is dead as an intuition.
+This retires the whole chain-KKT framing that queue item 2 sat inside —
+amalgamation was aimed at a problem that has largely receded. Also note
+their other named upstream item, warm-path scaling, is the one we
+falsified this morning. Next target is the 33-64 column medium-front
+regime.

--- a/dev/journal/2026-08-09-05.org
+++ b/dev/journal/2026-08-09-05.org
@@ -97,3 +97,38 @@ amalgamation was aimed at a problem that has largely receded. Also note
 their other named upstream item, warm-path scaling, is the one we
 falsified this morning. Next target is the 33-64 column medium-front
 regime.
+
+* 22:10 :issue-153:dtoc1nd:medium-front:first-probe:
+jrk filed #153 tracking this. Ranking: (1) warm-path scaling, (2)
+dtoc1nd dense-front gap, (3) nemin. Answered (3) as a rejection on the
+issue, and split (1)'s premise: warm-STARTING the equilibration is
+falsified (this morning), but CACHING/reusing the scaling vector across
+factorizations — which is what #153 actually proposes — is untested and
+is the better lever precisely because the loop never converges and
+always burns all 10 passes, so reuse saves the whole cost.
+
+First probe on (2). My initial hypothesis was that 33-64 column fronts
+fall through the 0.15.0 gates. Checked before measuring: simd_work =
+n_elim * rowspan * ncol, so a 48-column front with rowspan ~150 gives
+~230k against PACKED_SIMD_MIN_WORK=1024. The gate passes by two orders
+of magnitude. Hypothesis refuted before writing any code.
+
+What the throughput curve says instead (bench_dense_front, nofma serial,
+30 reps, dense front of order n):
+
+  n=32    0.77 GFLOP/s      n=192   3.13
+  n=48    1.42             n=256   3.51
+  n=64    1.85             n=512   4.40
+  n=96    2.95             n=1024  5.05
+  n=128   3.45
+
+The dtoc1nd regime (33-64 columns) runs at 1.4-1.9 GFLOP/s, ~2.7x below
+the n=1024 rate and far below what AVX2 can do on the trailing update
+alone. So the medium-front deficit is real and local, but it is NOT the
+packed kernel being switched off — it is running, and the cost is
+elsewhere in the front (pivot search is O(n^2) scan per pivot, plus
+per-front fixed cost). Caveat: this bench factors a square front
+(nrow=ncol=n); real dtoc1nd fronts are trapezoidal, so the ncol axis
+matches but the rowspan does not. Asked jrk on #153 for dtoc1nd's
+loop-time-weighted front histogram bucketed 9-32/33-64/65-128/>128
+before committing to a mechanism.

--- a/dev/research/amalgamation-cost-model-2026-08-09.md
+++ b/dev/research/amalgamation-cost-model-2026-08-09.md
@@ -1,0 +1,257 @@
+# Amalgamation after the 0.15.0 kernel work: `nemin` re-sweep and a cost-model merge rule
+
+Post-release queue item 2 (`dev/plans/release-0.15.0-checklist.md` §4)
+was "amalgamation `nemin` sweep — 90% of clnlbeam's supernodes are ≤8
+columns". This note reports the re-measurement and concludes that the
+item's premise points the wrong way: **raising `nemin` is already
+falsified on that exact family, and the measured win is in the opposite
+direction.** It then identifies what is actually wrong with the merge
+rule and proposes a fix.
+
+## 1. Why re-measure something already in tried-and-rejected
+
+`nemin` has been swept three times (2026-04-19, 2026-05-03 Phase A and
+Phase B, 2026-05-16 issue #10 lever 5). The most recent sweep targeted
+clnlbeam by name and found `nemin ∈ {32, 64, 128}` at geomean
+1.032 / 1.356 / 1.989 × the `nemin=16` baseline, with `factor_nnz`
+inflating 1.23–1.33×. `nemin ∈ {256, MAX}` hung. Issue #10 closed as
+"hardware floor".
+
+That rejection rests on one sentence: *"chain-link merges blow trailing
+fill faster than the wider panel can amortize."* The amortization rate
+is exactly what 0.15.0 changed — the trailing update went from an
+SSE2-baseline scalar tile walk to explicit AVX2/NEON (n=2955:
+4.24 s → 1.52 s x86; 2.25–3.19× on NEON), and per-supernode fixed
+overhead fell twice over (pack-buffer pooling, env-read caching:
+−5.7% / −9.0%). Both terms of the trade moved, in opposite directions.
+Re-measuring is warranted; re-litigating the conclusion without new
+measurement would not be.
+
+**Pre-registered criterion, fixed before the first run:** a `nemin`
+default change ships only if it wins ≥5% geomean with a ≥8/10 paired
+sign test on ≥2 fixture classes and regresses no fixture by >2%.
+
+## 2. Method
+
+`crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs`. Paired
+alternating A/B per `dev/decisions.md` 2026-08-09: every arm is timed
+once per pair, in order, so drift hits all arms equally; `min_us` per
+arm; sign test over pairs. Symbolic is computed once per arm and only
+the numeric phase is timed, isolating the lever. Inertia and the true
+∞-norm relative residual are reported per arm — `nemin` changes
+numerics, so byte-parity does not apply.
+
+Fixtures: 61 CUTEst KKT snapshots in `tests/data/parity/**` (n = 3 …
+5314), plus four structured KKTs built in earlier sessions
+(clnlbeam_like n=100000, grid250 n=62500, sparseqp_kkt n=26000,
+chain12000_kkt n=12000). 10–15 pairs each. x86_64, 4 cores, AVX2.
+
+## 3. Result
+
+Geomean vs `nemin = 16`:
+
+| arm | 61 parity fixtures |        | 4 structured KKTs |        |
+|-----|--------------------|--------|-------------------|--------|
+|     | time               | nnz    | time              | nnz    |
+| 1   | 1.21               | 0.67   | 1.330             | 0.373  |
+| 4   | 1.02               | 0.83   | 0.986             | 0.506  |
+| 8   | **0.986**          | 0.89   | **0.925**         | 0.678  |
+| 16  | 1.000              | 1.000  | 1.000             | 1.000  |
+| 32  | 1.02               | 1.19   | 1.125             | 1.600  |
+| 64  | 1.15               | 1.65   | 1.533             | 2.742  |
+
+Three things are settled by this table.
+
+1. **The queue item's direction is dead.** Every arm above 16 loses on
+   time and inflates fill, on every fixture class. The 2026-05-16
+   rejection survives the kernel rewrite intact — the faster kernel did
+   not buy back the fill. Reported here as a confirmation, not a
+   discovery.
+2. **`nemin = 8` is better than the shipped default on both axes**, and
+   most clearly where it matters: clnlbeam_like 0.925× time at 0.579×
+   fill, chain12000 0.815× at 0.640×, sparseqp 0.950× at 0.676×. Inertia
+   is identical across all arms on all fixtures; residuals are equal or
+   better.
+3. **It does not clear the pre-registered bar.** The parity geomean is
+   1.4%, not 5%, and individual fixtures regress well past 2%:
+   CERI651A_0000 1.163 (2/15 wins, 178 → 207 µs — a real effect, not
+   noise), DEGENLPB_0046 1.119, BQPGASIM_0012 1.100, HS85_0176 1.056.
+   By the criterion set before the run, **the default does not change.**
+
+The criterion was written as a speed criterion and is therefore
+under-specified: it has nothing to say about the uniform 10–42% fill
+reduction, which is a deterministic symbolic quantity — identical on
+every platform, and not subject to the timing noise that has twice
+produced wrong conclusions on this container. That is a real result on
+an axis the criterion did not cover, and it is the reason the next
+section exists rather than the note ending here.
+
+## 4. What is actually wrong: the merge rule has no fill guard
+
+`find_supernodes` (`src/symbolic/supernode.rs:340-374`) accepts a merge
+on either of two conditions:
+
+```rust
+let trivial_chain = parent_ncol == 1 && col_counts[p_first] + 1 == col_counts[child_last];
+let size_based    = child_ncol < params.nemin && parent_ncol < params.nemin;
+```
+
+`trivial_chain` is the structurally free merge: the row patterns already
+match, so it costs nothing. `size_based` asks only whether two
+supernodes are *small*. It never asks what the merge costs. The whole
+`nemin` sweep is therefore a search for one global number that stands in
+for a per-merge decision, which is why every sweep finds a different
+optimum per matrix family and why no single value has ever satisfied the
+corpus.
+
+The cost is exactly computable at the point of decision. A supernode's
+front is `nrow = col_counts[first_col].max(ncol)`
+(`supernode.rs:399`), so merging child into parent gives
+`nrow_m = col_counts[s_first].max(ncol_c + ncol_p)`. The
+`.max(ncol)` is where the damage happens: once the merged width exceeds
+the natural row count, every additional column adds a triangle of pure
+fill that no pattern justifies.
+
+clnlbeam is the extreme case. Its chain links have `col_counts = 2`. At
+`nemin = 16`, sixteen 1-column fronts of `nrow = 2` (LDLᵀ ≈ 4 flops
+each, 64 total) merge into one `ncol = 16, nrow = 16` front:
+`Σ_{j=1}^{16} j² = 1496` flops, a 23× inflation, and the measured
+`factor_nnz` per column moves 2.0 → 9.5, matching the model's 4.25×
+prediction to within the model's own crudeness. The size rule cannot see
+any of this; it sees only `1 < 16` and `1 < 16`.
+
+But pure fill minimisation is equally wrong: `nemin = 1` has the lowest
+fill of every arm (0.373× on the structured set) and is the **slowest**
+(1.330×), because 99999 one-column fronts pay 99999 lots of per-front
+overhead. The objective is neither fill nor front count. It is time, and
+time is roughly
+
+```
+  T  ≈  τ · flops  +  Ω · n_fronts
+```
+
+so a merge is worth taking exactly when the flops it adds cost less than
+the one front's overhead it removes:
+
+```
+  Δflops · τ  <  Ω        ⟺        Δflops  <  Ω/τ  ≡  MERGE_FLOP_BUDGET
+```
+
+with `flops(ncol, nrow) = Σ_{k=0}^{ncol-1} (nrow-k)² = S(nrow) - S(nrow-ncol)`,
+`S(x) = x(x+1)(2x+1)/6`.
+
+`Ω/τ` is a single number with a physical meaning — the flop-equivalent
+of one front's fixed overhead — and it is a *hardware* constant, not a
+per-matrix tuning parameter. That is the substantive difference from
+`nemin`: one calibration should serve the corpus, and when the kernel
+gets faster (τ falls) or the per-front overhead falls (Ω), the rule
+adapts by recalibration rather than by re-deriving a shape heuristic.
+It also subsumes `trivial_chain`, whose Δflops is ≈ 0 by construction.
+
+## 5. Measured: the cost model works, and then fails on accuracy
+
+Implemented as `SupernodeParams::merge_flop_budget: Option<u128>`
+(`None` = today's rule exactly). Budget sweep, same harness.
+
+Structured KKTs, geomean vs the shipped default:
+
+| budget | time  | nnz   |
+|--------|-------|-------|
+| 5      | 1.018 | 0.492 |
+| 15     | 0.967 | 0.507 |
+| 30     | 0.945 | 0.549 |
+| 60     | 0.935 | 0.619 |
+| 125    | 0.960 | 0.723 |
+| 250    | 0.970 | 0.827 |
+| 500    | 0.986 | 0.919 |
+| 1000+  | 1.003 | 1.000 |
+
+A clean interior optimum at 30–60, and it dominates the `nemin` sweep on
+the axis that motivated it: on sparseqp, budget 30 holds fill at 0.493×
+for the same 0.947× time that `nemin = 8` bought at 0.676× fill. The
+per-front adaptivity is doing real work. Above ~500 the guard becomes a
+no-op — each incremental merge is individually cheap even when the chain
+of merges is ruinous, which is why the first probe (1000 … 1e6) was
+indistinguishable from `off` and why the useful range is two orders of
+magnitude lower than a naive Ω/τ estimate suggests.
+
+On the 61 parity fixtures: 0.980–0.997× time, 0.866–0.940× fill. No
+speed regression of the kind that sank `nemin = 8`.
+
+**And then the residuals.** Reported per arm by the harness (single
+unrefined `Solver::solve`, `b = 1`, so the ∞-norm residual is also the
+relative one). Degradations >10× at budget ∈ {15, 30, 60, 125}:
+
+| fixture | default | guarded | factor |
+|---------|---------|---------|--------|
+| HATFLDG_0003..0006 | 7.1e-15 | up to 7.4e-08 | up to 9e6× |
+| VESUVIOU_0030 | 1.9e-06 | 5.4e-03 | 2789× |
+| MEYER3NE_0220 | 2.7e-08 | 8.0e-07 | 30× |
+
+Seven digits on HATFLDG, from machine precision to 1e-8. Inertia is
+unchanged everywhere, and on HATFLDG/VESUVIOU the fill is *identical* to
+the default — so this is not a fill effect. Thinner supernodes give
+Bunch–Kaufman a smaller candidate pool inside each front, and on
+ill-conditioned fixtures it takes worse pivots.
+
+The same defect is in the `nemin` lever, which is what makes this a
+property of the direction rather than of this particular rule:
+`nemin = 8` degrades VESUVIOU_0030 by the same 2789× and MEYER3NE_0220
+by 16×; `nemin = 4` degrades MEYER3NE_0220 by 83×.
+
+**Conclusion: neither lever ships.** "Correctness before performance,
+always" is a hard constraint in `CLAUDE.md`, and 2–7% of factor time plus
+11–45% of fill does not buy seven digits of residual. The direction is
+closed for both the global constant and the cost model — not because the
+speed and memory wins are absent, but because they are paid for on an
+axis neither the queue item nor my own pre-registered criterion thought
+to check.
+
+## 6. Plan
+
+`merge_flop_budget` stays in the tree as an opt-in knob, defaulting to
+`None` = today's rule exactly, so the default path is bit-identical and
+no corpus gate is needed to carry it. It is the apparatus that produced
+§5 and lets anyone reproduce it. It is **not recommended for use**: the
+doc comment carries the accuracy result, and flipping the default would
+need the full corpus run (inertia 100%, Phase 2.8.1 partitions, residual
+envelope) that this container does not have — and would have to answer
+the residual question first, which no amount of corpus timing does.
+
+Nothing else here ships. Post-release queue item 2 is closed.
+
+## 7. What this redirects to
+
+Published after this work was done, `pounce#552`'s re-measurement against
+a released 0.15.0 moves the target
+([comment 5232409020](https://github.com/jkitchin/pounce/issues/552#issuecomment-5232409020)):
+
+| matrix | 0.15.0 | MA57 | ratio was | ratio now |
+|--------|-------:|-----:|----------:|----------:|
+| dtoc1nd | 13.67 | 3.63 | 4.85× | **3.77×** |
+| clnlbeam | 25.74 | 7.27 | 8.05× | 3.54× |
+| marine_1600 | 35.50 | 13.50 | 3.05× | 2.63× |
+| rocket_12800 | 19.11 | 8.79 | 2.87× | 2.17× |
+| steering_12800 | 27.44 | 18.96 | 2.53× | 1.45× |
+| dtoc2 | 109.01 | 84.21 | 1.70× | 1.29× |
+
+clnlbeam — the matrix this whole queue item was aimed at, and the
+nominated upstream target at 8.05× — is more than halved and **is no
+longer the worst case**. `dtoc1nd` is, and it is a *dense-front* matrix:
+nnz/dim = 23.0, fronts of 33–64 columns. The ratio ordering is no longer
+the nnz/dim ordering, so "the gap tracks sparsity" is dead as a guiding
+intuition.
+
+Amalgamation was a chain-KKT lever aimed at a chain-KKT problem that has
+substantially receded. The medium-front regime (33–64 columns) is where
+the worst remaining ratio lives, and it is a different mechanism — one
+the 0.15.0 packed kernel touches only above `PACKED_SIMD_MIN_WORK`. That
+is the next target, not this one.
+
+Note also that the other item pounce names as upstream — warm-path
+scaling, "57–81% of the warm prologue" — was falsified earlier the same
+day: the ∞-norm equilibration converges linearly at ratio ½ and never
+reaches its tolerance, so the iteration count is fixed at the cap and no
+warm start can reduce it
+(`dev/research/scaling-warm-start-2026-08-09.md`). Cheapening it is a
+conditioning trade, not a free win.

--- a/dev/research/scaling-warm-start-2026-08-09.md
+++ b/dev/research/scaling-warm-start-2026-08-09.md
@@ -1,0 +1,124 @@
+# Scaling warm-start (post-0.15.0 item 1) — hypothesis FALSIFIED, with a better diagnosis
+
+Session 2026-08-09-04. Motivation: the PR #150 review profiled six real
+KKT matrices and found the **warm** prologue at 15–39% of factorization
+with ∞-norm equilibration at 63–81% of that — re-derived from scratch on
+every call. On `rocket_12800` scaling alone is 34% of the whole factor.
+The reviewer's clean observation: across calls 0→2 the prologue *does*
+warm for everything else (`permute` collapses 4443→539 µs on clnlbeam,
+25647→1584 µs on dtoc2) while `scaling` stays flat (3909 / 19850 µs).
+
+Hypothesis: KKT values drift smoothly across IPM iterations, so seeding
+the iteration with the previous factorization's converged `d` should cut
+the iteration count and hence the cost.
+
+**The hypothesis is false, and the reason is more useful than the fix
+would have been.**
+
+## Measurement
+
+`examples/probe_kr_warmstart.rs` (checked in): run the exact iteration
+from `scaling::infnorm::compute_infnorm`, perturb every value by ±5%
+(standing in for one IPM step), then re-run cold vs warm-started from
+the previous `d`, counting iterations.
+
+| fixture | n | cold iters | **warm iters** | cold-vs-warm max rel diff |
+|---|---:|---:|---:|---:|
+| clnlbeam-like (tridiagonal) | 100,000 | 2 | **2** | 2.2e-16 |
+| grid250 (Laplacian) | 62,500 | 2 | **2** | 0 (bit-identical) |
+| chain12000 (hicks-like) | 12,000 | 10 | **10** | 5.1e-2 |
+| sparseqpL (banded KKT) | 105,000 | 10 | **10** | 5.1e-2 |
+| HYDCAR20 | 198 | 10 | **10** | 6.3e-2 |
+| twirism1_kkt | 745 | 10 | **10** | 5.1e-2 |
+
+Zero iteration reduction anywhere. Two regimes, neither helped:
+
+- **Already minimal (2 iterations).** Nothing to save.
+- **Capped at 10 without converging.** The 5e-2 cold-vs-warm spread is
+  the tell: both runs are on the *same* matrix, so if either had
+  converged they would agree to ~`tol`. They differ by 5%, so neither
+  is near a fixed point.
+
+## Why: the tolerance is unreachable by construction
+
+Per-iteration `max_dev` on the capped matrices (`KR_TRACE=1`):
+
+```
+HYDCAR20            twirism1_kkt
+iter  1: 7.28e+1    iter  1: 1.05e+2
+iter  2: 9.82e-1    iter  2: 9.90e-1
+iter  3: 8.52e-1    iter  3: 9.02e-1
+iter  4: 6.06e-1    iter  4: 6.87e-1
+iter  5: 3.73e-1    iter  5: 4.41e-1
+iter  6: 2.08e-1    iter  6: 2.52e-1
+iter  7: 1.10e-1    iter  7: 1.35e-1
+iter  8: 5.66e-2    iter  8: 7.01e-2
+iter  9: 2.87e-2    iter  9: 3.57e-2
+iter 10: 1.45e-2    iter 10: 1.80e-2
+```
+
+Clean linear convergence at ratio ≈ 1/2 per iteration — the known rate
+for Ruiz-style ∞-norm equilibration (`d ← d / sqrt(row_max)`), which is
+what `compute_infnorm` implements regardless of the "Knight-Ruiz" label
+in the module doc. From `max_dev ≈ 1e-2` at the cap, reaching
+`tol = 1e-8` needs ~20 more iterations, i.e. **~30 total**.
+
+So `max_iter = 10` with `tol = 1e-8` means: on any matrix not already
+near-equilibrated, the tolerance is unreachable and the loop *always*
+runs the full 10 passes. Warm-starting cannot reduce a fixed iteration
+count. The in-code comment — "Most matrices converge in 2–4 iterations;
+a few pathological ones need all 10" — understates it: on this fixture
+set 4 of 6 hit the cap, and they do not "need" 10, they are *truncated*
+at 10.
+
+## What this means for the optimization
+
+The cost is **10 fixed passes over the matrix** on the hard class. To
+make scaling cheaper you must do fewer passes, which is a
+conditioning/speed trade, not a free win:
+
+| cap | max_dev reached (HYDCAR20) | relative equilibration quality |
+|---:|---:|---|
+| 10 (today) | 1.4e-2 | baseline |
+| 5 | 3.7e-1 | **26× worse** |
+| 3 | 8.5e-1 | 60× worse |
+
+Halving the cap would buy roughly half of a 63–81% share of a 15–39%
+prologue — call it 5–15% of factor time — at the cost of a 26× worse
+equilibration on exactly the ill-conditioned matrices the scaling
+exists to rescue. That is a bad trade on its face and would have to be
+justified by corpus residual/inertia data, not by timing alone.
+
+## Options, ranked
+
+1. **Do nothing (recommended for now).** The measurement says the
+   planned free win does not exist. Item (3) should be re-scoped or
+   dropped rather than implemented as designed.
+2. **Warm-start for *quality*, not speed.** Seeding from the previous
+   `d` makes the truncated iteration a *continued* one across the IPM:
+   same 10 passes, but each factorization starts further along, so the
+   scaling improves monotonically over the solve. Free conditioning,
+   zero speed change, and it could reduce downstream iterative-
+   refinement work — which is where it would actually pay. Speculative
+   until measured against refinement counts.
+3. **A faster-converging algorithm.** Ruiz's 1/2-linear rate is the
+   binding constraint. A Newton/accelerated variant (true Knight-Ruiz)
+   would reach tolerance in far fewer passes. Real work, and it changes
+   numerics substantially.
+4. **Lower the cap.** Cheapest to implement, worst risk/benefit; needs
+   corpus residual data before it could be considered.
+
+## Constraint on all of them
+
+Every option changes numerical output — different `d` → different
+`D·A·D` → potentially different pivots. Unlike everything in 0.15.0,
+the `golden_bits` / parity apparatus does **not** gate this. The gate is
+a full corpus run (inertia 100%, Phase 2.8.1 partitions, residuals),
+which the dev container does not have.
+
+## Reproducer
+
+```sh
+cargo run --release --example probe_kr_warmstart -- <matrix.mtx> [drift]
+KR_TRACE=1 cargo run --release --example probe_kr_warmstart -- <matrix.mtx>
+```

--- a/dev/sessions/2026-08-09-03.md
+++ b/dev/sessions/2026-08-09-03.md
@@ -1,0 +1,164 @@
+# Session 2026-08-09-03
+
+## Goal
+
+Post-0.15.0 optimization queue item 2: the `nemin` amalgamation sweep
+(`dev/plans/release-0.15.0-checklist.md` §4.2), motivated by the PR #150
+review — 90% of clnlbeam's supernodes are ≤8 columns and they are 35.9%
+of its factorization loop.
+
+## Accomplished
+
+**Both amalgamation levers measured and rejected. Nothing ships; the
+default path is bit-identical to 0.15.0.**
+
+Harness: `crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs` —
+paired alternating A/B per `decisions.md` 2026-08-09 (all arms timed once
+per pair, `min_us`, sign test), symbolic computed once per arm so only
+the numeric phase is timed, inertia + true ∞-norm residual reported per
+arm. 61 CUTEst KKT parity fixtures (n = 3 … 5314) + 4 structured KKTs
+(clnlbeam_like n=100000, grid250, sparseqp_kkt, chain12000_kkt).
+x86_64, 4 cores, AVX2. Criterion pre-registered before the first run.
+
+### 1. The queue item's direction is dead, and re-confirmed
+
+Geomean vs shipped `nemin=16`, time / factor_nnz:
+
+| arm | 1 | 4 | 8 | 32 | 64 |
+|---|---|---|---|---|---|
+| 61 parity | 1.21/0.67 | 1.02/0.83 | 0.986/0.89 | 1.02/1.19 | 1.15/1.65 |
+| 4 structured | 1.33/0.37 | 0.99/0.51 | 0.925/0.68 | 1.13/1.60 | 1.53/2.74 |
+
+Every arm above 16 loses on time and inflates fill on every class. This
+re-confirms the 2026-05-16 rejection (issue #10 lever 5) after the one
+development that could have overturned it — that rejection turned
+entirely on "the wider panel cannot amortize the fill", and the 0.15.0
+kernel rewrite is exactly what changed the amortization rate. It did not
+buy the fill back.
+
+### 2. `nemin=8` wins but fails its pre-registered criterion
+
+Better on both axes on structured KKTs (clnlbeam_like 0.925× time at
+0.579× fill; chain12000 0.815/0.640). But the criterion was ≥5% geomean
+with ≥8/10 sign test on ≥2 classes and no fixture regressing >2%: parity
+geomean is 1.4%, and CERI651A_0000 regresses 16% (178→207 µs, 2/15 wins
+— an effect, not noise), DEGENLPB_0046 12%, BQPGASIM_0012 10%.
+
+### 3. Cost-model merge guard: implemented, works, rejected on accuracy
+
+The size rule (`child_ncol < nemin && parent_ncol < nemin`) never asks
+what a merge costs. Front height is `col_counts[first_col].max(ncol)`,
+so past the natural row count every extra column adds a triangle of pure
+fill — clnlbeam's `col_counts=2` chain links inflate 23× at `nemin=16`
+and the rule sees only `1 < 16`.
+
+Added `SupernodeParams::merge_flop_budget: Option<u128>` (default `None`
+= historical rule exactly): merge only if `Δflops ≤ budget`, with
+`flops(ncol,nrow) = Σ_{k<ncol}(nrow−k)² = S(nrow) − S(nrow−ncol)`.
+Mirrored into `predict_merges` so `Renumber` does not bias the postorder
+toward merges the guard then rejects.
+
+It works on its own axes: clean interior optimum at budget 30–60
+(structured 0.935–0.945× time, 0.549–0.619× fill), no parity speed
+regressions (0.980–0.997 time, 0.866–0.940 nnz), and it dominates
+`nemin` where it counts — sparseqp holds 0.493× fill at the same 0.947×
+time `nemin=8` needed 0.676× fill for.
+
+**Then the residuals** (single unrefined solve, `b=1`):
+
+| fixture | default | guarded | factor |
+|---|---|---|---|
+| HATFLDG_0003..0006 | 7.1e-15 | up to 7.4e-08 | up to 9e6× |
+| VESUVIOU_0030 | 1.9e-06 | 5.4e-03 | 2789× |
+| MEYER3NE_0220 | 2.7e-08 | 8.0e-07 | 30× |
+
+Seven digits on HATFLDG. Inertia unchanged everywhere and on
+HATFLDG/VESUVIOU **the fill is identical to the default**, so this is
+not a fill effect: thinner supernodes shrink Bunch–Kaufman's pivot
+candidate pool inside each front. `nemin` has the same defect (VESUVIOU
+2789× at 8, MEYER3NE 83× at 4), so it is a property of the direction,
+not of this rule.
+
+"Correctness before performance, always." 2–7% of factor time and 11–45%
+of fill does not buy seven digits of residual. Neither ships. The knob
+stays default-off as the reproduction apparatus with the accuracy result
+in its doc comment.
+
+### Also
+
+- Cherry-picked the scaling-warm-start research (e2ba443) onto this
+  branch after #151 merged.
+- Fixed five exhaustive `SupernodeParams` literals in
+  `feral-diagnostics` — a workspace member the root `--all-targets`
+  build does not cover. (The pre-commit config *does* have a
+  `-p feral-diagnostics --all-targets` clippy hook, which caught it
+  before push; the earlier python-bindings breakage had no equivalent.)
+- Answered issue #153 with the rejection and a correction to its item 1
+  premise: https://github.com/jkitchin/feral/issues/153#issuecomment-5232463822
+
+## Benchmark Results
+
+The corpus bench (`cargo run --bin bench --release`) is not runnable
+here — `data/matrices` holds 2 files in this container, not the 154k
+corpus. The default path is unchanged and bit-identical, so the release
+gates are unaffected by this session. Local suite:
+
+```
+cargo test --release
+84/84 test binaries, 802 passed, 0 failed
+cargo fmt --check / cargo clippy -- -D warnings / clippy -p feral-diagnostics: pass
+```
+
+Medium-front throughput probe for the next item (`bench_dense_front`,
+nofma serial, 30 reps, dense front of order n):
+
+```
+n=32   0.77 GFLOP/s     n=192   3.13
+n=48   1.42             n=256   3.51
+n=64   1.85             n=512   4.40
+n=96   2.95             n=1024  5.05
+n=128  3.45
+```
+
+## Decisions Made
+
+None. No default behavior changed; nothing was added to
+`dev/decisions.md` because nothing was decided about the shipped path.
+
+## Abandoned Approaches
+
+Both appended to `dev/tried-and-rejected.md` (2026-08-09 entry):
+
+1. `nemin` retune (up **or** down) — up re-confirmed as a loss, down
+   fails its pre-registered criterion and degrades residuals.
+2. Cost-model merge guard — works on time and fill, rejected on
+   accuracy.
+
+## Next Session Should
+
+Issue #153 re-ranks the queue, and item 3 (`nemin`) is now closed by this
+session. Remaining, in the issue's order:
+
+1. **Scaling reuse across factorizations** — note this is *not* the
+   warm-start that was falsified this morning. That result (the ∞-norm
+   equilibration converges linearly at ratio ½, never reaches `tol=1e-8`,
+   and always burns all 10 passes) is what makes *reuse* attractive: it
+   saves the entire cost, up to 34% of factorization on rocket_12800.
+   Changes numerics; needs a staleness check and — per this session's
+   result — residual gates from the start, not added at the end.
+   Inertia agreement is not sufficient evidence of safety.
+2. **dtoc1nd's dense-front gap** (33–64 column fronts, now the worst
+   downstream ratio at 3.77× vs MA57). First probe done: the hypothesis
+   that these fronts fall through `PACKED_SIMD_MIN_WORK` is **refuted** —
+   a 48-column front with rowspan ~150 gives `simd_work ≈ 230k` against
+   a threshold of 1024, so the packed SIMD path is fully engaged. The
+   deficit is real (1.4–1.9 GFLOP/s vs 5.05 at n=1024) but sits
+   elsewhere in the front: pivot search is an O(n²) scan per pivot, plus
+   per-front fixed cost. Requested dtoc1nd's loop-time-weighted front
+   histogram (9–32 / 33–64 / 65–128 / >128) on #153 before picking a
+   mechanism.
+3. Permute-cache off-by-one (first-solve latency only), `nrow`
+   underestimate (#128) sensitivity on the sibling rule.
+
+Also outstanding: the `claude/feral-scaling-research` branch is now
+subsumed (its commit is on this branch) and can be deleted.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5068,3 +5068,89 @@ evidence that a cache would help — the cost may be iteration-count-bound
 rather than starting-point-bound. Measure the iteration count before
 building the cache. Full analysis and the ranked alternatives:
 dev/research/scaling-warm-start-2026-08-09.md.
+
+---
+
+## 2026-08-09 — Amalgamation retune after 0.15.0: `nemin` lower, and a cost-model merge guard
+
+**What.** Post-release queue item 2 (`dev/plans/release-0.15.0-checklist.md`
+§4.2), motivated by the PR #150 review: 90% of clnlbeam's supernodes are
+≤8 columns and they are 35.9% of its loop. Two levers measured, both
+rejected. Harness:
+`crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs` (paired
+alternating A/B per decisions.md 2026-08-09, `min_us`, sign test), 61
+parity fixtures + 4 structured KKTs, x86_64 AVX2.
+
+**Lever 1 — retune `nemin`. Rejected on its own pre-registered
+criterion.** The criterion, fixed before the first run: ships only if
+≥5% geomean with ≥8/10 sign test on ≥2 fixture classes and no fixture
+regressing >2%.
+
+Geomean vs `nemin=16`, time / nnz — 61 parity, then 4 structured:
+
+| arm | 1 | 4 | 8 | 32 | 64 |
+|---|---|---|---|---|---|
+| parity | 1.21/0.67 | 1.02/0.83 | 0.986/0.89 | 1.02/1.19 | 1.15/1.65 |
+| structured | 1.33/0.37 | 0.99/0.51 | 0.925/0.68 | 1.13/1.60 | 1.53/2.74 |
+
+`nemin=8` is genuinely better on both axes on the structured set, but
+the parity geomean is 1.4% (not 5%) and individual fixtures regress well
+past 2%: CERI651A_0000 1.163 (2/15 wins, 178→207 µs — an effect, not
+noise), DEGENLPB_0046 1.119, BQPGASIM_0012 1.100, HS85_0176 1.056.
+
+This also **re-confirms the 2026-05-16 rejection** (issue #10 lever 5)
+after the kernel rewrite that was its only plausible escape hatch: every
+arm above 16 loses on time and inflates fill on every class. The faster
+trailing update did not buy back the fill. The queue item's stated
+direction — raise `nemin` to fuse small supernodes — is dead twice over.
+
+**Lever 2 — cost-model merge guard. Implemented, measured, rejected on
+accuracy.** The size rule (`child_ncol < nemin && parent_ncol < nemin`)
+never asks what a merge costs. Front height is
+`col_counts[first_col].max(ncol)`, so past the natural row count every
+extra column is a triangle of pure fill; clnlbeam's `col_counts=2` chain
+links inflate 23× at `nemin=16` and the rule cannot see it. Added
+`SupernodeParams::merge_flop_budget: Option<u128>` — merge only if
+`Δflops ≤ budget`, with
+`flops(ncol,nrow) = Σ_{k<ncol}(nrow-k)² = S(nrow)-S(nrow-ncol)`.
+
+It works on the axes it was designed for. Clean interior optimum at
+budget 30–60 (structured geomean 0.945/0.549 and 0.935/0.619), no speed
+regressions on parity (0.980–0.997 time, 0.866–0.940 nnz), and it
+dominates `nemin` where it counts: sparseqp holds 0.493× fill at the
+same 0.947× time that `nemin=8` needed 0.676× fill for.
+
+**Then the residuals.** Single unrefined solve, `b=1`, so ∞-norm
+residual is also relative. Degradations >10× at budgets 15–125:
+
+| fixture | default | guarded |
+|---|---|---|
+| HATFLDG_0003..0006 | 7.1e-15 | up to 7.4e-08 |
+| VESUVIOU_0030 | 1.9e-06 | 5.4e-03 |
+| MEYER3NE_0220 | 2.7e-08 | 8.0e-07 |
+
+Seven digits on HATFLDG. Inertia unchanged everywhere, and on
+HATFLDG/VESUVIOU **the fill is identical to the default** — so this is
+not a fill effect. Thinner supernodes shrink Bunch-Kaufman's pivot
+candidate pool inside each front and it takes worse pivots on
+ill-conditioned matrices. `nemin` has the same defect (VESUVIOU 2789× at
+`nemin=8`, MEYER3NE 83× at `nemin=4`), which is what makes it a property
+of the direction rather than of this rule.
+
+**Why rejected.** "Correctness before performance, always" is a hard
+constraint. 2–7% of factor time and 11–45% of fill does not buy seven
+digits of residual. Neither my pre-registered criterion nor the queue
+item thought to check the axis that decided it — recorded here because
+the next person to have this idea will not think to check it either.
+
+The knob stays in-tree defaulting to `None` (bit-identical default path)
+as the reproduction apparatus, with the accuracy result in its doc
+comment. Research note:
+`dev/research/amalgamation-cost-model-2026-08-09.md`.
+
+**Also redirects the target.** pounce#552's re-measurement against a
+released 0.15.0 (comment 5232409020) shows clnlbeam more than halved
+(8.05× → 3.54× vs MA57) and **no longer the worst case** — `dtoc1nd` is,
+at 3.77×, and it is a dense-front matrix (nnz/dim 23.0, fronts of 33–64
+columns). Amalgamation is a chain-KKT lever aimed at a problem that has
+largely receded.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5018,3 +5018,53 @@ and the delayed-pivot cascade (per-factor-cost-cluster mechanism A).
 Any retry of eager-path SIMD must first show a front-level profile
 where the update loops are >30% of eager time AND not already
 vectorized in the disassembly.
+
+## 2026-08-09 — Warm-starting the ∞-norm scaling iteration across factorizations
+
+**What was tried.** The PR #150 review ranked "scaling warm-start" as the
+largest remaining line item: the warm prologue is 15-39% of
+factorization, ∞-norm equilibration is 63-81% of that, and it is the one
+prologue component that does NOT warm across calls (permute collapses
+4443->539 us on clnlbeam; scaling stays flat at 3909 us). Hypothesis:
+seed `compute_infnorm`'s iteration with the previous factorization's `d`
+instead of `1.0`, since IPM values drift smoothly, and cut the iteration
+count.
+
+**Symptoms / numbers.** Zero iteration reduction on every fixture
+measured (`examples/probe_kr_warmstart.rs`, ±5% value perturbation
+standing in for one IPM step):
+
+| fixture | cold iters | warm iters |
+|---|---:|---:|
+| clnlbeam-like n=100000 | 2 | 2 |
+| grid250 n=62500 | 2 | 2 |
+| chain12000 | 10 | 10 |
+| sparseqpL n=105000 | 10 | 10 |
+| HYDCAR20 | 10 | 10 |
+| twirism1_kkt | 10 | 10 |
+
+**Why it failed.** Two regimes, neither reachable by warm-starting.
+Matrices either converge in 2 iterations already (nothing to save), or
+they hit `max_iter = 10` WITHOUT converging. The per-iteration trace
+shows clean linear convergence at ratio ~1/2 — the known rate for
+Ruiz-style ∞-norm equilibration (`d <- d/sqrt(row_max)`), which is what
+`compute_infnorm` implements despite the "Knight-Ruiz" label. At the cap
+`max_dev` is still ~1.4e-2 against `tol = 1e-8`; reaching that tolerance
+needs ~30 iterations. So the tolerance is unreachable by construction and
+the loop always runs the full 10 passes — a fixed cost that no starting
+point can reduce. The 5e-2 cold-vs-warm spread on the same matrix
+confirms neither run is near a fixed point.
+
+**Correction to the code's own comment.** `compute_infnorm` says "Most
+matrices converge in 2-4 iterations; a few pathological ones need all
+10." On this fixture set 4 of 6 hit the cap, and they do not *need* 10 —
+they are *truncated* at 10 and never converge.
+
+**What was kept.** `examples/probe_kr_warmstart.rs` as the reproducer and
+the convergence-trace tool. No production code changed.
+
+**Lesson.** "Component X doesn't warm across calls" is not by itself
+evidence that a cache would help — the cost may be iteration-count-bound
+rather than starting-point-bound. Measure the iteration count before
+building the cache. Full analysis and the ranked alternatives:
+dev/research/scaling-warm-start-2026-08-09.md.

--- a/examples/probe_kr_warmstart.rs
+++ b/examples/probe_kr_warmstart.rs
@@ -1,0 +1,133 @@
+//! Measures the headroom for Knight-Ruiz warm-starting (post-0.15.0 item 1).
+//!
+//! KR currently starts from `d = 1` on every factorization. In an IPM the
+//! KKT values drift smoothly, so the previous factorization's converged `d`
+//! should be a near-fixed-point. This probe quantifies that: it runs KR
+//! cold, perturbs the values the way an IPM iteration would, then runs KR
+//! both cold and warm-started and reports the iteration counts and how far
+//! apart the two answers land.
+//!
+//! Usage: cargo run --release --example probe_kr_warmstart -- <mtx> [drift]
+
+use feral::sparse::csc::CscMatrix;
+
+/// KR iteration, instrumented, with a caller-supplied starting `d`.
+/// Mirrors `scaling::infnorm::compute_infnorm` exactly.
+fn kr(matrix: &CscMatrix, d0: Option<&[f64]>) -> (Vec<f64>, usize) {
+    kr_traced(matrix, d0, false)
+}
+
+fn kr_traced(matrix: &CscMatrix, d0: Option<&[f64]>, trace: bool) -> (Vec<f64>, usize) {
+    let n = matrix.n;
+    let mut d = match d0 {
+        Some(v) => v.to_vec(),
+        None => vec![1.0f64; n],
+    };
+    let max_iter = 10;
+    let tol = 1e-8;
+    let mut row_max = vec![0.0f64; n];
+    let mut iters = 0;
+    for _ in 0..max_iter {
+        iters += 1;
+        for r in row_max.iter_mut() {
+            *r = 0.0;
+        }
+        for j in 0..n {
+            let dj = d[j];
+            let mut col_max = row_max[j];
+            for k in matrix.col_ptr[j]..matrix.col_ptr[j + 1] {
+                let i = matrix.row_idx[k];
+                let v = (d[i] * matrix.values[k] * dj).abs();
+                if i != j && v > row_max[i] {
+                    row_max[i] = v;
+                }
+                if v > col_max {
+                    col_max = v;
+                }
+            }
+            row_max[j] = col_max;
+        }
+        let mut max_dev = 0.0f64;
+        for i in 0..n {
+            let m = row_max[i];
+            if m > 0.0 {
+                d[i] /= m.sqrt();
+                let dev = (m - 1.0).abs();
+                if dev > max_dev {
+                    max_dev = dev;
+                }
+            }
+        }
+        if trace {
+            eprintln!("      iter {iters:>2}: max_dev = {max_dev:.6e}");
+        }
+        if max_dev < tol {
+            break;
+        }
+    }
+    (d, iters)
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: <mtx> [drift]");
+    let drift: f64 = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.05);
+    let m = feral::read_mtx(std::path::Path::new(&path))
+        .unwrap()
+        .to_csc()
+        .unwrap();
+
+    // Factorization 1: cold KR on the original values.
+    let (d1, it1) = kr(&m, None);
+
+    // Simulate one IPM step: perturb every value multiplicatively. A
+    // deterministic pseudo-random walk stands in for the barrier update.
+    let mut m2 = m.clone();
+    let mut s = 0x2545_F491_4F6C_DD1Du64;
+    for v in m2.values.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        let u = (s >> 11) as f64 / (1u64 << 53) as f64; // [0,1)
+        *v *= 1.0 + drift * (2.0 * u - 1.0);
+    }
+
+    // Factorization 2: cold vs warm-started from d1.
+    let (d_cold, it_cold) = kr(&m2, None);
+    let (d_warm, it_warm) = kr(&m2, Some(&d1));
+
+    // How far apart are the two converged answers?
+    let mut max_rel = 0.0f64;
+    for i in 0..m.n {
+        let a = d_cold[i];
+        let b = d_warm[i];
+        if a != 0.0 {
+            let r = ((a - b) / a).abs();
+            if r > max_rel {
+                max_rel = r;
+            }
+        }
+    }
+    let identical = d_cold
+        .iter()
+        .zip(&d_warm)
+        .all(|(a, b)| a.to_bits() == b.to_bits());
+
+    println!(
+        "{}: n={} nnz={} drift={:.3}",
+        path.rsplit('/').next().unwrap(),
+        m.n,
+        m.values.len(),
+        drift
+    );
+    println!("  KR iters: first-factor cold={it1}  next-factor cold={it_cold}  next-factor WARM={it_warm}");
+    println!(
+        "  cold-vs-warm converged d: max rel diff = {max_rel:.3e}, bit-identical = {identical}"
+    );
+    if std::env::var("KR_TRACE").is_ok() {
+        eprintln!("    convergence trajectory (cold, perturbed matrix):");
+        let _ = kr_traced(&m2, None, true);
+    }
+}

--- a/src/symbolic/supernode.rs
+++ b/src/symbolic/supernode.rs
@@ -54,6 +54,50 @@ pub struct SupernodeParams {
     /// `core_analyse.f90:644-685` is the reference.
     pub amalgamation_strategy: AmalgamationStrategy,
 
+    /// Opt-in cost-model guard on amalgamation. `None` (the default)
+    /// reproduces the historical size-only merge rule exactly.
+    ///
+    /// The size rule (`child_ncol < nemin && parent_ncol < nemin`) asks
+    /// only whether two supernodes are *small*, never what merging them
+    /// costs. On chain-shaped KKTs that is badly wrong: a front's height
+    /// is `col_counts[first_col].max(ncol)`, so once the merged width
+    /// exceeds the natural row count every extra column adds a triangle
+    /// of pure fill. clnlbeam's chain links have `col_counts = 2`, so at
+    /// `nemin = 16` sixteen 4-flop fronts merge into one 1496-flop front
+    /// — a 23x inflation the size rule cannot see.
+    ///
+    /// When `Some(budget)`, a merge is additionally required to add no
+    /// more than `budget` flops to the factorization:
+    ///
+    /// ```text
+    ///   flops(ncol, nrow) = sum_{k<ncol} (nrow-k)^2
+    ///   dflops = flops(merged) - flops(child) - flops(parent) <= budget
+    /// ```
+    ///
+    /// `budget` is the flop-equivalent of one front's fixed overhead
+    /// (`Omega/tau` in `T ~ tau*flops + Omega*n_fronts`), so it is a
+    /// hardware constant rather than a per-matrix shape heuristic:
+    /// merging is worth it exactly when the flops it adds cost less than
+    /// the one front's overhead it removes. It subsumes the
+    /// `trivial_chain` rule, whose `dflops` is ~0 by construction.
+    ///
+    /// **Not recommended.** Measured (2026-08-09): budget 30–60 buys
+    /// 5.5–6.5% factor time and 38–45% fill on structured KKTs, and
+    /// costs up to **seven digits of residual** on ill-conditioned
+    /// fixtures — HATFLDG 7.1e-15 → 7.4e-08, VESUVIOU_0030 1.9e-06 →
+    /// 5.4e-03 — with fill and inertia *unchanged* on exactly those
+    /// matrices. Thinner supernodes give Bunch-Kaufman a smaller pivot
+    /// candidate pool inside each front. The same effect is present in
+    /// `nemin` at 4 and 8, so it is a property of the direction, not of
+    /// this rule.
+    ///
+    /// Kept as the reproduction apparatus for that result and as a
+    /// memory knob for callers who know their problems are well
+    /// conditioned. Changing it changes fill and numerics, so the
+    /// default stays `None`. See
+    /// `dev/research/amalgamation-cost-model-2026-08-09.md`.
+    pub merge_flop_budget: Option<u128>,
+
     /// Phase 2.13b per-stage symbolic profiler. When `Some`, the
     /// `symbolic_factorize_with_method` driver records elapsed time
     /// per stage (ordering, etree, postorder, col_counts, renumber,
@@ -114,6 +158,7 @@ impl Default for SupernodeParams {
         Self {
             nemin: 16,
             preprocess: OrderingPreprocess::Auto,
+            merge_flop_budget: None,
             small_leaf: SmallLeafParams::default(),
             amalgamation_strategy: AmalgamationStrategy::default(),
             symbolic_profiler: None,
@@ -371,7 +416,26 @@ pub fn find_supernodes(
             };
             let root_cap_exceeded = parent_is_root && merged_ncol > root_cap;
 
-            if (trivial_chain || size_based) && !root_cap_exceeded {
+            // Cost-model guard (opt-in; `None` leaves the historical
+            // rule bit-identical). Front heights follow the same model
+            // the rest of this function uses for `nrow`
+            // (`col_counts[first_col].max(ncol)`, see step 3), so the
+            // estimate is self-consistent with what the merge actually
+            // produces.
+            let budget_ok = match params.merge_flop_budget {
+                None => true,
+                Some(budget) => {
+                    let nrow_c = col_counts[s_first].max(child_ncol);
+                    let nrow_p = col_counts[p_first].max(parent_ncol);
+                    let nrow_m = col_counts[s_first].max(merged_ncol);
+                    let added = front_flops(merged_ncol, nrow_m)
+                        .saturating_sub(front_flops(child_ncol, nrow_c))
+                        .saturating_sub(front_flops(parent_ncol, nrow_p));
+                    added <= budget
+                }
+            };
+
+            if (trivial_chain || size_based) && budget_ok && !root_cap_exceeded {
                 merged_into[root_s] = Some(root_p);
                 // Transfer columns to parent and update first column.
                 // Adjacency invariant guarantees s_first < p_first,
@@ -609,6 +673,25 @@ pub(crate) fn find_fundamental_supernodes(
     }
 }
 
+/// Dense-LDLᵀ flop count for a trapezoidal front of `ncol` eliminated
+/// columns and `nrow` total rows:
+/// `Σ_{k=0}^{ncol-1} (nrow-k)² = S(nrow) - S(nrow-ncol)` with
+/// `S(x) = x(x+1)(2x+1)/6`.
+///
+/// Used only by the opt-in `SupernodeParams::merge_flop_budget` guard,
+/// where the absolute scale is irrelevant — only differences between
+/// candidate merges matter. `u128` because `S(x)` is cubic and `nrow`
+/// reaches the thousands on wide Schur complements.
+fn front_flops(ncol: usize, nrow: usize) -> u128 {
+    // `nrow >= ncol` holds for every front the caller constructs
+    // (`nrow` is built with `.max(ncol)`), but clamp rather than
+    // underflow if that ever stops being true.
+    let s = |x: u128| x * (x + 1) * (2 * x + 1) / 6;
+    let nrow = nrow as u128;
+    let ncol = (ncol as u128).min(nrow);
+    s(nrow) - s(nrow - ncol)
+}
+
 /// Predict desired merges (Phase 2.12) for the SSIDS-style column
 /// renumbering. Runs the same fundamental-supernode detection and
 /// SSIDS size rule as `find_supernodes`, but **does not enforce
@@ -657,7 +740,26 @@ pub(crate) fn predict_merges(
         // 2. Size-based: both < nemin
         let size_based = child_ncol < params.nemin && parent_ncol < params.nemin;
 
-        if trivial_chain || size_based {
+        // Same cost-model guard as `find_supernodes`. It has to be
+        // mirrored here or the `Renumber` strategy would bias the
+        // postorder towards merges that the guard then rejects,
+        // producing a column numbering optimized for a merge set that
+        // never happens.
+        let budget_ok = match params.merge_flop_budget {
+            None => true,
+            Some(budget) => {
+                let merged_ncol = child_ncol + parent_ncol;
+                let nrow_c = col_counts[s_first].max(child_ncol);
+                let nrow_p = col_counts[p_first].max(parent_ncol);
+                let nrow_m = col_counts[s_first].max(merged_ncol);
+                front_flops(merged_ncol, nrow_m)
+                    .saturating_sub(front_flops(child_ncol, nrow_c))
+                    .saturating_sub(front_flops(parent_ncol, nrow_p))
+                    <= budget
+            }
+        };
+
+        if (trivial_chain || size_based) && budget_ok {
             // Mark every column of this child supernode as "biased
             // late" — its subtree should be emitted adjacent to its
             // parent in the merge-biased postorder.
@@ -675,6 +777,102 @@ mod tests {
     use super::*;
     use crate::sparse::csc::CscMatrix;
     use crate::symbolic::column_counts::column_counts;
+
+    /// Oracle: hand-summed `Σ_{k=0}^{ncol-1} (nrow-k)²`. Written out
+    /// term by term so the closed form is checked against arithmetic
+    /// done independently of it.
+    #[test]
+    fn front_flops_matches_hand_summation() {
+        assert_eq!(front_flops(1, 2), 4); // 2²
+        assert_eq!(front_flops(2, 2), 5); // 2² + 1²
+        assert_eq!(front_flops(3, 5), 50); // 5² + 4² + 3²
+        assert_eq!(front_flops(4, 4), 30); // 4² + 3² + 2² + 1²
+                                           // Σ_{j=1}^{16} j² = 16·17·33/6 = 1496 — the clnlbeam case in
+                                           // dev/research/amalgamation-cost-model-2026-08-09.md §4.
+        assert_eq!(front_flops(16, 16), 1496);
+        assert_eq!(front_flops(0, 9), 0);
+        // Brute-force agreement over a range, independent of the closed form.
+        for nrow in 0..40usize {
+            for ncol in 0..=nrow {
+                let brute: u128 = (0..ncol).map(|k| ((nrow - k) as u128).pow(2)).sum();
+                assert_eq!(front_flops(ncol, nrow), brute, "ncol={ncol} nrow={nrow}");
+            }
+        }
+    }
+
+    /// The clnlbeam pathology in miniature: a chain whose `col_counts`
+    /// are 2, so amalgamating under the size rule builds fronts far
+    /// wider than the pattern justifies. `merge_flop_budget = Some(0)`
+    /// must reject exactly those merges, while `None` must reproduce
+    /// the historical rule bit-for-bit.
+    #[test]
+    fn merge_flop_budget_rejects_fill_inflating_chain_merges() {
+        let n = 12;
+        let mut rows = Vec::new();
+        let mut cols = Vec::new();
+        let mut vals = Vec::new();
+        for i in 0..n {
+            rows.push(i);
+            cols.push(i);
+            vals.push(2.0);
+            if i + 1 < n {
+                rows.push(i + 1);
+                cols.push(i);
+                vals.push(-1.0);
+            }
+        }
+        let m = CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("csc");
+        let pat = m.symmetric_pattern();
+        let etree = EliminationTree::from_pattern(&pat);
+        let counts = column_counts(&pat, &etree);
+
+        let base = SupernodeParams {
+            nemin: 16,
+            ..Default::default()
+        };
+        let guarded = SupernodeParams {
+            nemin: 16,
+            merge_flop_budget: Some(0),
+            ..Default::default()
+        };
+
+        let unguarded = find_supernodes(&etree, &counts, &base);
+        let capped = find_supernodes(&etree, &counts, &guarded);
+
+        // Column coverage is a conservation law: the guard changes how
+        // columns are grouped, never how many there are.
+        let total = |s: &[Supernode]| s.iter().map(|x| x.ncol).sum::<usize>();
+        assert_eq!(total(&unguarded), n);
+        assert_eq!(total(&capped), n);
+
+        // nemin=16 > n, so the size rule merges the whole chain into one
+        // wide front; the budget must refuse and leave it fragmented.
+        assert!(
+            capped.len() > unguarded.len(),
+            "budget=0 did not suppress any merge: {} vs {} supernodes",
+            capped.len(),
+            unguarded.len()
+        );
+        let widest_capped = capped.iter().map(|s| s.ncol).max().unwrap_or(0);
+        let widest_unguarded = unguarded.iter().map(|s| s.ncol).max().unwrap_or(0);
+        assert!(
+            widest_capped < widest_unguarded,
+            "budget=0 left a front as wide as the unguarded rule ({widest_capped})"
+        );
+
+        // A budget far above any merge this fixture can propose must be
+        // indistinguishable from the historical rule.
+        let generous = SupernodeParams {
+            nemin: 16,
+            merge_flop_budget: Some(u128::MAX),
+            ..Default::default()
+        };
+        let wide_open = find_supernodes(&etree, &counts, &generous);
+        assert_eq!(wide_open.len(), unguarded.len());
+        for (a, b) in wide_open.iter().zip(unguarded.iter()) {
+            assert_eq!((a.first_col, a.ncol, a.nrow), (b.first_col, b.ncol, b.nrow));
+        }
+    }
 
     #[test]
     fn test_supernodes_tridiagonal() {


### PR DESCRIPTION
Closes the `nemin` amalgamation item (#153 item 3, post-0.15.0 queue item 2)
as a **rejection**. The default path is bit-identical to 0.15.0 — the only
behavioural addition is an opt-in knob that defaults to today's rule exactly.

This PR is mostly evidence. The one code change that could affect output is
off by default and is documented as not recommended.

## Why this was re-opened at all

`nemin` is already in `dev/tried-and-rejected.md` three times, most recently
2026-05-16 (issue #10 lever 5) sweeping **clnlbeam by name** at 32/64/128.
That rejection turned on a single sentence — *"chain-link merges blow trailing
fill faster than the wider panel can amortize"* — and the amortization rate is
exactly what 0.15.0 changed (SSE2-baseline scalar walk → explicit AVX2/NEON,
plus two cuts to per-supernode fixed cost). Both terms of the trade moved, in
opposite directions, so re-measuring was warranted. The acceptance criterion
was written down **before** the first run.

## What was measured

`crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs`: paired alternating
A/B per `decisions.md` 2026-08-09 (every arm timed once per pair so drift hits
all arms equally, `min_us`, sign test), symbolic computed once per arm so only
the numeric phase is timed, inertia and true ∞-norm residual reported per arm.
61 CUTEst KKT parity fixtures (n = 3 … 5314) + 4 structured KKTs. x86_64 AVX2.

### 1. The queue item's direction is dead, and re-confirmed post-SIMD

Geomean vs shipped `nemin=16`, time / factor_nnz:

| arm | 1 | 4 | 8 | 32 | 64 |
|---|---|---|---|---|---|
| 61 parity | 1.21/0.67 | 1.02/0.83 | 0.986/0.89 | 1.02/1.19 | 1.15/1.65 |
| 4 structured | 1.33/0.37 | 0.99/0.51 | 0.925/0.68 | 1.13/1.60 | 1.53/2.74 |

Every arm above 16 loses on time and inflates fill on every class. The faster
kernel did not buy the fill back.

### 2. `nemin=8` wins on both axes and still fails its own criterion

Structured KKTs 0.925× time at 0.678× fill (clnlbeam_like 0.925/0.579).
Criterion was ≥5% geomean with ≥8/10 sign test on ≥2 classes and no fixture
regressing >2%. Parity geomean is **1.4%**, and CERI651A_0000 regresses 16%
(178→207 µs, 2/15 wins — an effect, not noise), DEGENLPB_0046 12%,
BQPGASIM_0012 10%.

### 3. The rule's real defect, fixed — and it still loses

`child_ncol < nemin && parent_ncol < nemin` asks only whether two supernodes
are *small*, never what merging them costs. Front height is
`col_counts[first_col].max(ncol)`, so past the natural row count every extra
column adds a triangle of pure fill. clnlbeam's `col_counts = 2` chain links
inflate **23×** at `nemin=16` and the rule sees only `1 < 16`.

`SupernodeParams::merge_flop_budget: Option<u128>` — merge only if
`Δflops ≤ budget`, `flops(ncol,nrow) = Σ_{k<ncol}(nrow−k)² = S(nrow)−S(nrow−ncol)`.
Mirrored into `predict_merges` so `Renumber` cannot bias the postorder toward
merges the guard then rejects.

It works on the axes it was built for — clean interior optimum at budget
30–60 (structured 0.935–0.945× time, 0.549–0.619× fill), no parity speed
regressions, and it **dominates `nemin`** where it counts: sparseqp holds
0.493× fill at the same 0.947× time `nemin=8` needed 0.676× fill for.

**Then the residuals** (single unrefined solve, `b = 1`):

| fixture | default | guarded | factor |
|---|---|---|---|
| HATFLDG_0003..0006 | 7.1e-15 | up to 7.4e-08 | up to 9e6× |
| VESUVIOU_0030 | 1.9e-06 | 5.4e-03 | 2789× |
| MEYER3NE_0220 | 2.7e-08 | 8.0e-07 | 30× |

Seven digits on HATFLDG. **Inertia unchanged everywhere, and on
HATFLDG/VESUVIOU the fill is identical to the default** — so this is not a
fill effect. Thinner supernodes shrink Bunch–Kaufman's pivot candidate pool
inside each front. `nemin` carries the same defect (VESUVIOU 2789× at 8,
MEYER3NE 83× at 4), which makes it a property of the direction rather than of
this rule.

"Correctness before performance, always": 2–7% of factor time and 11–45% of
fill does not buy seven digits of residual.

## What actually lands

- `SupernodeParams::merge_flop_budget: Option<u128>`, **default `None` =
  historical rule exactly**. Kept as the reproduction apparatus and as a
  memory knob for callers who know their problems are well conditioned; the
  doc comment carries the accuracy numbers and says it is not recommended.
- The sweep harness, the research note, the `tried-and-rejected` entry, the
  session checkpoint, and the journal.
- Five exhaustive `SupernodeParams` literals in `feral-diagnostics` updated.
- Cherry-picked e2ba443 (scaling-warm-start falsification, docs only) from
  `claude/feral-scaling-research`, which is now subsumed and can be deleted.

## Verification

```
cargo test --release        84/84 test binaries, 802 passed, 0 failed
cargo fmt --check           pass
cargo clippy -- -D warnings pass
cargo clippy -p feral-diagnostics --all-targets  pass
python/ cargo check --all-targets                pass
```

New unit tests: `front_flops` against hand summation **and** brute force over
a range; `Some(u128::MAX)` structurally identical to `None`; `Some(0)`
suppresses exactly the fill-inflating chain merges.

The corpus bench is not runnable in this container (`data/matrices` holds 2
files, not 154k). It is not needed here: the default path is unchanged and
bit-identical, so the release gates are unaffected.

## Note for reviewers on #153

Two items in that issue change on the strength of this work — details in
[the comment](https://github.com/jkitchin/feral/issues/153#issuecomment-5232463822):

- **Item 3 (`nemin`) is closed as a rejection**, not "still worth doing".
- **Item 1's premise needs splitting.** Warm-*starting* the equilibration is
  falsified (linear convergence at ratio ½, tolerance unreachable, always
  burns all 10 passes). **Caching/reusing** the scaling vector — what #153
  actually proposes — is untested and is the better lever *because* of that
  result: reuse saves the entire cost rather than trimming iterations.
- Opening hypothesis for **item 2** refuted before writing code: 33–64 column
  fronts do **not** fall through `PACKED_SIMD_MIN_WORK` (`simd_work ≈ 230k`
  vs a threshold of 1024). The deficit is real (1.4–1.9 GFLOP/s vs 5.05 at
  n=1024) but is the pivot scan and per-front cost, not a disabled kernel.

If there is one thing worth a second opinion, it is the residual measurement
that decided this: unrefined single solve with `b = 1`. If you think refined
residuals would change the verdict, that is a cheap re-run and I would rather
be corrected than ship a wrong rejection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F87aJtwLT34CTG8KLj5fqm)_