### PR TITLE
fix(mc64): scaling-cache gate is a drift measure + bit-identical Hungarian heap speedup (MA57 headline retracted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — MC64 scaling cache rejected matrices against their own fingerprint
+
+- The value-bound gate that decides whether a cached MC64 scaling may be reused
+  had three conditions, two of which measure how far the matrix has drifted from
+  the one the scaling was computed on. The third did not: it compared the
+  current **minimum** scaled diagonal against the baseline **mean**. Because
+  those are different statistics, it behaved as an absolute property of the
+  matrix rather than a drift measure, and rejected reuse even when the matrix
+  had not moved at all.
+- Condition 3 is now the disjunction of the original absolute floor and a drift
+  bound against the baseline minimum. This is a strict widening: nothing the
+  gate accepts today can start being rejected.
+- Effect is narrow and measured. Across 53 gate evaluations on the seven corpus
+  families that route to MC64, exactly two decisions change — both on
+  `robot_1600`, cutting that trajectory's factorization time 14.3% and its
+  scaling time 39.8%. Inertia is unchanged on every iterate of every family, and
+  a genuine diagonal collapse (`arki0003`, eight orders down) is still rejected.
+- No API change; the gate is internal.
+
 ### Changed — `Solver` defaults `use_parallel` from the platform (issue #154)
 
 - `Solver::new()` and `Solver::with_params(...)` now derive `use_parallel` from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — MC64 Hungarian matching is 4-5% faster on large matchings *(bit-identical)*
+
+- The Hungarian matching's binary min-heap stored only row indices and looked
+  the key up through a random access into the distance array on every
+  comparison. It now stores the key inline alongside the index. Comparisons
+  and tie-breaking are unchanged, so the matching — and therefore the scaling
+  vector — is unchanged.
+- **Verified bit-identical on 51 matrices across 39 families**, by hashing the
+  raw bits of the scaling vector each factorization produces.
+- Measured (median of 3): `nql180_0000` 1.040x, `nql180_0002` 1.057x. Matrices
+  whose matchings are small and L1-resident (`pinene_3200`, `marine_1600`) are
+  unchanged, as expected — the win is in the sift-down path, which only
+  matters when the heap outgrows cache.
+- No API change.
+
 ### Fixed — MC64 scaling cache rejected matrices against their own fingerprint
 
 - The value-bound gate that decides whether a cached MC64 scaling may be reused

--- a/crates/feral-diagnostics/src/bin/bench_one_matrix.rs
+++ b/crates/feral-diagnostics/src/bin/bench_one_matrix.rs
@@ -21,7 +21,7 @@ use std::time::Instant;
 use feral::numeric::factorize::factorize_multifrontal_parallel_with_workspace;
 use feral::numeric::factorize::FactorWorkspace;
 use feral::numeric::solve::solve_sparse_refined;
-use feral::scaling::{Mc64FallbackReason, ScalingInfo};
+use feral::scaling::{Mc64FallbackReason, ScalingInfo, ScalingStrategy};
 use feral::symbolic::{symbolic_factorize, SupernodeParams};
 use feral::{read_mtx, CscMatrix, NumericParams};
 
@@ -141,7 +141,15 @@ fn solve_one(mtx_path: &str, rhs_path: &str, out_path: &str) -> std::io::Result<
     // InfNorm picked by matrix shape) and BK pivot threshold = 1e-8.
     // This matches the high-level `Solver::new()` defaults; bench
     // measures what library users get out of the box.
-    let params = NumericParams::default();
+    let mut params = NumericParams::default();
+    // `FERAL_SCALING=identity` disables feral's own scaling so the
+    // factorization can be timed against a solver that is also doing
+    // none -- see `prescale_mtx`, which bakes `D A D` into the matrix
+    // so both arms factorize identical numbers. Anything else (or
+    // unset) leaves the out-of-the-box `Auto` default alone.
+    if env::var("FERAL_SCALING").as_deref() == Ok("identity") {
+        params.scaling = ScalingStrategy::Identity;
+    }
     let mut ws = FactorWorkspace::new();
     let t0 = Instant::now();
     let factor_res = factorize_multifrontal_parallel_with_workspace(&csc, &sym, &params, &mut ws);
@@ -188,6 +196,7 @@ fn solve_one(mtx_path: &str, rhs_path: &str, out_path: &str) -> std::io::Result<
     writeln!(out, "inertia_neg {}", inertia.negative)?;
     writeln!(out, "inertia_zero {}", inertia.zero)?;
     writeln!(out, "analyse_us {}", analyse_us)?;
+    writeln!(out, "scaling {:?}", params.scaling)?;
     writeln!(out, "factor_us {}", factor_us)?;
     writeln!(out, "solve_us {}", solve_us)?;
     writeln!(out, "rel_res {:.17e}", rel)?;

--- a/crates/feral-diagnostics/src/bin/diag_delayed_fronts.rs
+++ b/crates/feral-diagnostics/src/bin/diag_delayed_fronts.rs
@@ -1,0 +1,112 @@
+//! diag_delayed_fronts — how often does issue #125's static-layout fast
+//! path miss?
+//!
+//! Step 1 of #125 (PR #139) reuses the symbolic static frontal layout
+//! only when `n_delayed_in == 0`. Step 2 (still open) would extend it to
+//! fronts that receive delayed columns. This reports what fraction of
+//! fronts, and what fraction of frontal *rows*, take the dynamic
+//! `build_row_indices` path today — i.e. the ceiling on what step 2 can
+//! recover.
+//!
+//! Usage: diag_delayed_fronts <a.mtx> [b.mtx ...]
+
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
+use feral::read_mtx;
+use feral::symbolic::SupernodeParams;
+use feral::{NumericParams, Solver};
+use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_delayed_fronts <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    println!(
+        "{:<24}{:>9}{:>10}{:>9}{:>11}{:>12}{:>11}",
+        "matrix", "fronts", "delayed", "pct", "rows", "rows_dyn", "pct_rows"
+    );
+    let mut buildrow_rows = Vec::new();
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let mut solver = Solver::with_params(NumericParams::default(), SupernodeParams::default())
+            .with_parallel(false);
+        let status = solver.factor(&csc, None);
+        if !matches!(status, feral::FactorStatus::Success) {
+            eprintln!("{a}: factor status {status:?}");
+        }
+        let f = match solver.factors() {
+            Some(f) => f,
+            None => {
+                eprintln!("{a}: no factors");
+                continue;
+            }
+        };
+        let (mut fronts, mut delayed, mut rows, mut rows_dyn) = (0usize, 0usize, 0usize, 0usize);
+        for nf in &f.node_factors {
+            fronts += 1;
+            rows += nf.nrow;
+            if nf.n_delayed_in > 0 {
+                delayed += 1;
+                rows_dyn += nf.nrow;
+            }
+        }
+        // Warm refactor with phase timing on: `BUILDROW_NS` wraps both
+        // arms of the #125 branch (static `.to_vec()` copy and dynamic
+        // `build_row_indices`), so buildrow/factor is a hard ceiling on
+        // what step 2 could ever recover.
+        PHASE_TIMING_ENABLED.store(true, Relaxed);
+        phase_timing::reset();
+        let t0 = Instant::now();
+        let _ = solver.factor(&csc, None);
+        let factor_ns = t0.elapsed().as_nanos() as u64;
+        PHASE_TIMING_ENABLED.store(false, Relaxed);
+        let (buildrow_ns, ..) = phase_timing::snapshot_detail();
+
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<24}{:>9}{:>10}{:>8.2}%{:>11}{:>12}{:>10.2}%",
+            name,
+            fronts,
+            delayed,
+            100.0 * delayed as f64 / fronts.max(1) as f64,
+            rows,
+            rows_dyn,
+            100.0 * rows_dyn as f64 / rows.max(1) as f64
+        );
+        buildrow_rows.push((
+            name.to_string(),
+            factor_ns,
+            buildrow_ns,
+            100.0 * rows_dyn as f64 / rows.max(1) as f64,
+        ));
+    }
+
+    println!();
+    println!(
+        "{:<24}{:>13}{:>13}{:>12}{:>12}",
+        "matrix", "factor_us", "buildrow_us", "buildrow%", "dyn_rows%"
+    );
+    for (name, factor_ns, buildrow_ns, pct_rows) in &buildrow_rows {
+        println!(
+            "{:<24}{:>13}{:>13}{:>11.2}%{:>11.2}%",
+            name,
+            factor_ns / 1000,
+            buildrow_ns / 1000,
+            100.0 * *buildrow_ns as f64 / (*factor_ns).max(1) as f64,
+            pct_rows
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_factor_phases.rs
+++ b/crates/feral-diagnostics/src/bin/diag_factor_phases.rs
@@ -1,0 +1,168 @@
+//! diag_factor_phases — where does feral's numeric factorization time go?
+//!
+//! Splits the warm **numeric driver** wall (not the `Solver::factor`
+//! wall — that folds in symbolic reuse checks and scaling-cache lookups
+//! the phase counters do not cover) into:
+//!
+//!   driver total = prologue + per-supernode loop + epilogue
+//!   loop         = assembly + dense factor + per-node remainder
+//!   dense factor = panel + Schur + scalar tail + L-extract
+//!                  + contrib-extract + dense remainder
+//!
+//! The two remainder columns are the point of the probe: an
+//! optimization item aimed at a named sub-phase cannot pay for itself
+//! if the unnamed remainder is larger than the phase it targets.
+//!
+//! Usage: diag_factor_phases <a.mtx> [b.mtx ...]
+
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
+use feral::numeric::factorize::{
+    factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, Profiler,
+};
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use feral::{read_mtx, NumericParams};
+use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+const N_REPS: usize = 3;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_factor_phases <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    println!(
+        "{:<22}{:>9}{:>7}{:>9}{:>8}{:>8}{:>8}{:>8}{:>9}{:>10}",
+        "matrix",
+        "drv_us",
+        "prol%",
+        "permute%",
+        "scaling%",
+        "schur%",
+        "cbextr%",
+        "zerofil%",
+        "dense_o%",
+        "buildrow%"
+    );
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let sp = SupernodeParams::default();
+        let symbolic = match symbolic_factorize_with_method(&csc, &sp, OrderingMethod::Auto) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{a}: symbolic failed: {e:?}");
+                continue;
+            }
+        };
+        let nparams = NumericParams::default();
+        let mut ws = FactorWorkspace::new();
+        // Warm the workspace and branch predictors; not timed.
+        if factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &nparams, &mut ws)
+            .is_err()
+        {
+            eprintln!("{a}: warm-up factorization failed");
+            continue;
+        }
+
+        // Best-of-N by driver wall, per the `min` convention in
+        // dev/decisions.md.
+        let mut best = u64::MAX;
+        let mut keep = [0u64; 15];
+        for _ in 0..N_REPS {
+            PHASE_TIMING_ENABLED.store(true, Relaxed);
+            phase_timing::reset();
+            let prof = Arc::new(Mutex::new(Profiler::new()));
+            let mut np = nparams.clone();
+            np.profiler = Some(prof.clone());
+            np.pattern_reused_hint = true;
+
+            let t0 = Instant::now();
+            let res =
+                factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &np, &mut ws);
+            let wall_ns = t0.elapsed().as_nanos() as u64;
+            PHASE_TIMING_ENABLED.store(false, Relaxed);
+            if res.is_err() {
+                eprintln!("{a}: timed factorization failed");
+                break;
+            }
+            let guard = match prof.lock() {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("{a}: profiler poisoned: {e}");
+                    break;
+                }
+            };
+            let report = guard.report();
+            let timings = guard.timings();
+            let asm_ns: u64 = timings.iter().map(|t| t.assembly_ns).sum();
+            let dense_ns: u64 = timings.iter().map(|t| t.densefactor_ns).sum();
+            let panel_ns: u64 = timings.iter().map(|t| t.panelfactor_ns).sum();
+            let schur_ns: u64 = timings.iter().map(|t| t.schur_ns).sum();
+            let tail_ns: u64 = timings.iter().map(|t| t.scalartail_ns).sum();
+            let (br_ns, _sc, _xa, lex_ns, cbex_ns) = phase_timing::snapshot_detail();
+            let zerofill_ns = phase_timing::CONTRIBZEROFILL_NS.load(Relaxed);
+            let pb = report.prologue_breakdown;
+            drop(guard);
+
+            if wall_ns < best {
+                best = wall_ns;
+                keep = [
+                    report.prologue_us * 1000,
+                    report.epilogue_us * 1000,
+                    report.loop_ns,
+                    asm_ns,
+                    dense_ns,
+                    panel_ns,
+                    schur_ns,
+                    lex_ns + tail_ns,
+                    cbex_ns,
+                    zerofill_ns,
+                    pb.permute_us * 1000,
+                    pb.scaling_us * 1000,
+                    pb.symmetric_pattern_us * 1000,
+                    pb.setup_us * 1000,
+                    br_ns,
+                ];
+            }
+        }
+        if best == u64::MAX {
+            continue;
+        }
+        let [prol, epil, loop_ns, asm, dense, panel, schur, lex_tail, cbex, zerofill, permute, scaling, sympat, setup, buildrow] =
+            keep;
+        let _ = (sympat, setup);
+        // Per-node remainder: loop time not inside assembly or the dense
+        // factor. Dense remainder: dense time outside its five sub-phases.
+        let node_other = loop_ns.saturating_sub(asm + dense);
+        let dense_other = dense.saturating_sub(panel + schur + lex_tail + cbex);
+        let pct = |v: u64| 100.0 * v as f64 / best.max(1) as f64;
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<22}{:>9}{:>6.1}%{:>8.1}%{:>7.1}%{:>7.1}%{:>7.1}%{:>7.1}%{:>8.1}%{:>9.1}%",
+            name,
+            best / 1000,
+            pct(prol),
+            pct(permute),
+            pct(scaling),
+            pct(schur),
+            pct(cbex),
+            pct(zerofill),
+            pct(dense_other),
+            pct(buildrow)
+        );
+        let _ = (epil, loop_ns, asm, dense, panel, lex_tail, node_other);
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_mc64_reuse_threat.rs
+++ b/crates/feral-diagnostics/src/bin/diag_mc64_reuse_threat.rs
@@ -1,0 +1,146 @@
+//! diag_mc64_reuse_threat — does reusing a stale MC64 *scaling vector*
+//! actually corrupt inertia?
+//!
+//! The value-bound gate (`src/scaling/value_bound.rs`) exists to stop
+//! issue #38. But the two artifacts issue #38 names are not the same
+//! object:
+//!
+//!   * `symbolic.cached_mc64` — the MC64 *matching*, which feeds the
+//!     `LdltCompress` permutation and therefore changes the
+//!     elimination structure. `mc64_cache_invalidated_after_factor_issue_38`
+//!     guards this one.
+//!   * `Solver::mc64_scaling_cache` — the *scaling vector* `D`. Values
+//!     only; the pattern and the ordering are untouched.
+//!
+//! The value-bound gate guards the second. The in-tree guard test
+//! `mc64_cache_rejected_on_value_drift_issue_38_guard` asserts only
+//! that the gate *rejects* on drift — it never establishes that
+//! reusing would have been wrong. This probe asks that question
+//! directly: force `ScalingStrategy::External(D0)` onto a drifted
+//! matrix and check the inertia against an oracle computed
+//! independently of feral's factorization.
+//!
+//! Oracle: for a symmetric tridiagonal matrix the LDL^T scalar
+//! recurrence `d_1 = a_1`, `d_k = a_k - b_{k-1}^2 / d_{k-1}` is a
+//! Sturm sequence — the signs of `d_k` give the inertia directly
+//! (Golub & Van Loan, Matrix Computations, 4th ed., §8.4.1). This is
+//! arithmetic on the matrix entries, not a call into the solver.
+
+use feral::scaling::ScalingStrategy;
+use feral::{CscMatrix, FactorStatus, NumericParams, Solver};
+
+/// Symmetric tridiagonal `n x n`, lower triangle, in CSC.
+fn tridiag(n: usize, diag: f64, off: f64) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..n {
+        rows.push(j);
+        cols.push(j);
+        vals.push(diag);
+        if j + 1 < n {
+            rows.push(j + 1);
+            cols.push(j);
+            vals.push(off);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("valid CSC")
+}
+
+/// Inertia of a symmetric tridiagonal via the Sturm/LDL^T recurrence.
+/// Independent of feral's factorization. Returns (pos, neg, zero).
+fn sturm_inertia(n: usize, diag: f64, off: f64) -> (usize, usize, usize) {
+    let (mut pos, mut neg, mut zero) = (0usize, 0usize, 0usize);
+    let mut d = diag;
+    for k in 0..n {
+        if k > 0 {
+            d = diag - off * off / d;
+        }
+        // Standard Sturm convention: an exactly-zero pivot is perturbed
+        // to a tiny POSITIVE value and counted positive, then the
+        // recurrence continues. A zero pivot is not a zero eigenvalue —
+        // tridiag(4, 10, 10) = 10·tridiag(4, 1, 1) has eigenvalues
+        // 10(1 + 2cos(kπ/5)) = 26.18, 16.18, 3.82, -6.18, i.e. (3,1,0),
+        // even though d_2 = 10 - 100/10 = 0 exactly.
+        if d == 0.0 {
+            d = f64::MIN_POSITIVE;
+        }
+        if d > 0.0 {
+            pos += 1;
+        } else if d < 0.0 {
+            neg += 1;
+        } else {
+            zero += 1;
+        }
+    }
+    (pos, neg, zero)
+}
+
+fn main() {
+    let n = 4;
+    let base_diag = 10.0;
+    let base_off = 1.0;
+
+    // Iterate 0: install the cache from the undrifted matrix.
+    let a0 = tridiag(n, base_diag, base_off);
+
+    println!(
+        "{:<10}{:>16}{:>16}{:>16}{:>10}",
+        "off", "sturm(p,n,z)", "fresh(p,n,z)", "reuseD0(p,n,z)", "verdict"
+    );
+
+    // Sweep the off-diagonal upward: this is the axis the in-tree
+    // guard test drifts along (1.0 -> 50.0), extended far past it.
+    for &off in &[
+        1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 1e2, 1e3, 1e4, 1e6, 1e9, 1e12,
+    ] {
+        let a1 = tridiag(n, base_diag, off);
+        let (sp, sn_, sz) = sturm_inertia(n, base_diag, off);
+
+        // Arm A: fresh MC64 on the drifted matrix.
+        let mut solver_fresh = Solver::new().with_scaling(ScalingStrategy::Mc64Symmetric);
+        let fresh = match solver_fresh.factor(&a1, None) {
+            FactorStatus::Success | FactorStatus::WrongInertia { .. } => solver_fresh.inertia(),
+            _ => None,
+        };
+
+        // Arm B: iterate-0's scaling forced onto the drifted matrix.
+        let mut solver_d0 = Solver::new().with_scaling(ScalingStrategy::Mc64Symmetric);
+        if !matches!(solver_d0.factor(&a0, None), FactorStatus::Success) {
+            println!("{off:<10.0e}  baseline factor failed");
+            continue;
+        }
+        let d0 = match solver_d0.factors() {
+            Some(f) => f.scaling.clone(),
+            None => {
+                println!("{off:<10.0e}  no baseline scaling");
+                continue;
+            }
+        };
+        let np = NumericParams {
+            scaling: ScalingStrategy::External(d0),
+            ..NumericParams::default()
+        };
+        let mut solver_reuse = Solver::with_params(np, Default::default());
+        let reuse = match solver_reuse.factor(&a1, None) {
+            FactorStatus::Success | FactorStatus::WrongInertia { .. } => solver_reuse.inertia(),
+            _ => None,
+        };
+
+        let fmt = |i: Option<&feral::Inertia>| match i {
+            Some(i) => format!("({},{},{})", i.positive, i.negative, i.zero),
+            None => "FAIL".to_string(),
+        };
+        let oracle = format!("({sp},{sn_},{sz})");
+        let f = fmt(fresh);
+        let r = fmt(reuse);
+        let verdict = if r != oracle && f == oracle {
+            "REUSE WRONG"
+        } else if f != oracle {
+            "fresh wrong"
+        } else {
+            "ok"
+        };
+        println!("{off:<10.0e}{oracle:>16}{f:>16}{r:>16}{verdict:>10}");
+    }
+}

--- a/crates/feral-diagnostics/src/bin/diag_mc64_scaling_fingerprint.rs
+++ b/crates/feral-diagnostics/src/bin/diag_mc64_scaling_fingerprint.rs
@@ -1,0 +1,62 @@
+//! diag_mc64_scaling_fingerprint — bit-exact fingerprint of the MC64
+//! scaling vector, for use as a same-output oracle across refactors of
+//! the Hungarian matching.
+//!
+//! The MC64 matching is only observable through the scaling vector it
+//! produces (`SparseFactors::scaling`). Any change to the matching --
+//! including a different choice among equal-cost augmenting paths --
+//! moves at least one entry of that vector. Hashing the raw IEEE bits
+//! of every entry therefore detects *any* deviation, not just one
+//! large enough to move a residual.
+//!
+//! Usage: diag_mc64_scaling_fingerprint <a.mtx> <b.mtx> ...
+
+use feral::read_mtx;
+use feral::Solver;
+use std::path::Path;
+
+/// FNV-1a over the raw bits, so that -0.0 vs 0.0 and NaN payloads are
+/// distinguishable. A checksum, not a hash for security.
+fn fingerprint(v: &[f64]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for x in v {
+        for b in x.to_bits().to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x1000_0000_01b3);
+        }
+    }
+    h
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_mc64_scaling_fingerprint <a.mtx> ...");
+        std::process::exit(2);
+    }
+    println!(
+        "{:<28}{:>10}{:>22}{:>14}",
+        "matrix", "n", "scaling_fnv1a", "status"
+    );
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let name = Path::new(a)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| a.clone());
+        let mut solver = Solver::new();
+        let status = solver.factor(&csc, None);
+        let (fp, n) = match solver.factors() {
+            Some(f) => (fingerprint(&f.scaling), f.scaling.len()),
+            None => (0, 0),
+        };
+        println!("{name:<28}{n:>10}{fp:>22x}{:>14}", format!("{status:?}"));
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_mc64_warm_vs_cold.rs
+++ b/crates/feral-diagnostics/src/bin/diag_mc64_warm_vs_cold.rs
@@ -1,0 +1,94 @@
+//! diag_mc64_warm_vs_cold — is MC64 scaling cost a property of the
+//! matrix, or of the solver that has already factored something else?
+//!
+//! `diag_trajectory_scaling` (ONE solver over the iterates, as ripopt
+//! drives it) reported pinene_3200's per-iterate `scaling_us` climbing
+//! 8,500 -> 207,611 on a pattern that never changes.
+//! `diag_scaling_reuse_correctness` (a FRESH solver per iterate)
+//! reported the same matrices flat at ~9,000-10,300. Same matrices,
+//! same `with_parallel(false)`, same profiling. The only difference is
+//! solver reuse.
+//!
+//! This runs both arms side by side on the same iterate so the
+//! comparison is not across two binaries: a warm solver carried over
+//! the whole sequence, and a cold solver constructed for that one
+//! matrix.
+//!
+//! Usage: diag_mc64_warm_vs_cold <iter0.mtx> <iter1.mtx> ...
+
+use feral::{read_mtx, FactorStatus, Solver};
+use std::path::Path;
+
+fn scal_of(solver: &Solver) -> (u64, u64, u64) {
+    match solver.profile_report() {
+        Some(r) => (
+            r.total_us,
+            r.prologue_breakdown.scaling_us,
+            r.prologue_breakdown.scaling_pivot_order_us,
+        ),
+        None => (0, 0, 0),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_mc64_warm_vs_cold <iter0.mtx> ...");
+        std::process::exit(2);
+    }
+    let mut warm = Solver::new().with_profiling(true).with_parallel(false);
+    println!(
+        "{:<24}{:>9}{:>11}{:>11}{:>10}{:>11}{:>11}{:>8}",
+        "iterate", "nnz", "warm_scal", "warm_pivord", "warm_tot", "cold_scal", "cold_tot", "hit"
+    );
+    let mut prev_hits = 0usize;
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let st = warm.factor(&csc, None);
+        if !matches!(
+            st,
+            FactorStatus::Success | FactorStatus::WrongInertia { .. }
+        ) {
+            eprintln!("{a} warm: {st:?}");
+            continue;
+        }
+        let (wtot, wscal, wpiv) = scal_of(&warm);
+        let hits_now = warm.mc64_cache_hit_count();
+        let hit = hits_now > prev_hits;
+        prev_hits = hits_now;
+
+        let mut cold = Solver::new().with_profiling(true).with_parallel(false);
+        let st = cold.factor(&csc, None);
+        if !matches!(
+            st,
+            FactorStatus::Success | FactorStatus::WrongInertia { .. }
+        ) {
+            eprintln!("{a} cold: {st:?}");
+            continue;
+        }
+        let (ctot, cscal, _) = scal_of(&cold);
+
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<24}{:>9}{:>11}{:>11}{:>10}{:>11}{:>11}{:>8}",
+            name,
+            csc.nnz(),
+            wscal,
+            wpiv,
+            wtot,
+            cscal,
+            ctot,
+            if hit { "yes" } else { "NO" }
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_mc64_work_trajectory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_mc64_work_trajectory.rs
@@ -1,0 +1,76 @@
+//! diag_mc64_work_trajectory — does the MC64 Hungarian get more
+//! expensive along an IPM trajectory, on a pattern that never changes?
+//!
+//! `diag_mc64_warm_vs_cold` showed pinene_3200's `scaling_us` climbing
+//! 8,052 -> 214,213 us on a warm solver while a cold solver stayed
+//! flat. That is not a slowdown: `Solver::factor` clears
+//! `symbolic.cached_mc64` after every call (issue #38,
+//! `src/numeric/solver.rs:1374`), so the cold arm's Hungarian ran
+//! inside `analyze()` and is billed outside `ProfileReport::total_us`
+//! ("wallclock for the entire driver call"). The two arms bill the
+//! same work to different phases.
+//!
+//! So the question the warm/cold split cannot answer: is the Hungarian
+//! *itself* value-dependent? `diagnose_mc64_matching` runs the matching
+//! standalone -- no solver, no cache, no scaling post-processing -- so
+//! the per-iterate work counters are a property of the matrix alone.
+//!
+//! Usage: diag_mc64_work_trajectory <iter0.mtx> <iter1.mtx> ...
+
+use feral::read_mtx;
+use feral::scaling::diagnose_mc64_matching;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_mc64_work_trajectory <iter0.mtx> ...");
+        std::process::exit(2);
+    }
+    println!(
+        "{:<24}{:>9}{:>10}{:>12}{:>14}{:>14}{:>14}{:>14}",
+        "iterate",
+        "nnz",
+        "match_us",
+        "augment",
+        "touched",
+        "heap_init",
+        "phase3_inner",
+        "edge_scans"
+    );
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let t = Instant::now();
+        let s = match diagnose_mc64_matching(&csc) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{a}: {e:?}");
+                continue;
+            }
+        };
+        let us = t.elapsed().as_micros() as u64;
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<24}{:>9}{:>10}{:>12}{:>14}{:>14}{:>14}{:>14}",
+            name,
+            csc.nnz(),
+            us,
+            s.augment_searches,
+            s.touched_total,
+            s.heap_init_slots,
+            s.phase3_inner_iters,
+            s.main_loop_edge_scans
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_scaled_entry_spread.rs
+++ b/crates/feral-diagnostics/src/bin/diag_scaled_entry_spread.rs
@@ -1,0 +1,148 @@
+//! diag_scaled_entry_spread — is there an O(nnz) statistic of
+//! `D0 · A_N · D0` that stays put while the diagonal-dominance ratio
+//! runs away with the IPM barrier trajectory?
+//!
+//! The 2026-05-21 Track-B2 rejection
+//! (`dev/tried-and-rejected.md`, "gate metric confounded by IPM
+//! delta") found condition 1 of the value bound -- growth of
+//! `max_j off_max/diag` against its iter-0 baseline -- rejecting
+//! every warm iterate on pinene_3200, because the KKT (2,2) block
+//! carries a delta-regularized diagonal against O(1) off-diagonals,
+//! so the ratio is ~1/delta and explodes as delta->0. That entry
+//! concluded "diagonal dominance of D*A*D is the wrong proxy".
+//!
+//! The complaint is specifically about the DIAGONAL. MC64's own
+//! objective never mentions it: the matching maximises the product
+//! of matched magnitudes, and the resulting scaling drives matched
+//! entries to ~1 with every other entry <= 1. So the question this
+//! probe asks is whether the entry magnitudes alone -- no diagonal
+//! anywhere in the statistic -- stay bounded along the same
+//! trajectory that blows up the ratio.
+//!
+//! Prints, per iterate, both statistics computed on the SAME scaled
+//! matrix so they can be compared directly:
+//!   max_ratio  -- what condition 1 measures today (diagonal-based)
+//!   max_ent    -- max |(D0 A_N D0)_ij| over all stored entries
+//!   p999_ent   -- 99.9th percentile of the same, by magnitude
+//!   frac_gt1   -- fraction of entries with magnitude > 1
+//!
+//! `D0` is iterate 0's own MC64 vector, so iterate 0 is the baseline
+//! and every later row is drift against it.
+//!
+//! Usage: diag_scaled_entry_spread <iter0.mtx> <iter1.mtx> ...
+
+use feral::symbolic::SupernodeParams;
+use feral::{read_mtx, CscMatrix, FactorStatus, NumericParams, Solver};
+use std::path::Path;
+
+/// Both statistics in one O(nnz) sweep of the lower triangle.
+/// Returns (max_ratio over rows with a nonzero diagonal, max entry,
+/// 99.9th-percentile entry, fraction of entries > 1).
+fn stats(a: &CscMatrix, d: &[f64]) -> (f64, f64, f64, f64) {
+    let n = a.n;
+    let mut diag = vec![0.0f64; n];
+    let mut offmax = vec![0.0f64; n];
+    let mut mags: Vec<f64> = Vec::with_capacity(a.nnz());
+    for j in 0..n {
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let i = a.row_idx[k];
+            let v = (a.values[k] * d[i] * d[j]).abs();
+            mags.push(v);
+            if i == j {
+                diag[j] = v;
+            } else {
+                // Symmetric: the stored (i,j) is also (j,i).
+                if v > offmax[i] {
+                    offmax[i] = v;
+                }
+                if v > offmax[j] {
+                    offmax[j] = v;
+                }
+            }
+        }
+    }
+    let mut max_ratio = 0.0f64;
+    for j in 0..n {
+        if diag[j] > 0.0 {
+            let r = offmax[j] / diag[j];
+            if r > max_ratio {
+                max_ratio = r;
+            }
+        }
+    }
+    mags.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let max_ent = mags.last().copied().unwrap_or(0.0);
+    let idx = ((mags.len() as f64) * 0.999) as usize;
+    let p999 = mags
+        .get(idx.min(mags.len().saturating_sub(1)))
+        .copied()
+        .unwrap_or(0.0);
+    let n_gt1 = mags.iter().filter(|v| **v > 1.0).count();
+    let frac = n_gt1 as f64 / mags.len().max(1) as f64;
+    (max_ratio, max_ent, p999, frac)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() < 2 {
+        eprintln!("usage: diag_scaled_entry_spread <iter0.mtx> <iter1.mtx> ...");
+        std::process::exit(2);
+    }
+    let first = read_mtx(Path::new(&args[0])).and_then(|m| m.to_csc())?;
+    let mut seed = Solver::with_params(NumericParams::default(), SupernodeParams::default())
+        .with_parallel(false);
+    if !matches!(
+        seed.factor(&first, None),
+        FactorStatus::Success | FactorStatus::WrongInertia { .. }
+    ) {
+        eprintln!("seed factorization failed");
+        std::process::exit(1);
+    }
+    let d0 = match seed.factors() {
+        Some(f) => f.scaling.clone(),
+        None => {
+            eprintln!("seed produced no factors");
+            std::process::exit(1);
+        }
+    };
+    println!("D0 from {} (n={})", args[0], d0.len());
+    println!(
+        "{:<24}{:>12}{:>10}{:>12}{:>12}{:>12}",
+        "iterate", "max_ratio", "vs iter0", "max_ent", "p999_ent", "frac_gt1"
+    );
+    let mut base_ratio = 0.0f64;
+    let mut base_ent = 0.0f64;
+    for (idx, a) in args.iter().enumerate() {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        if csc.n != d0.len() {
+            println!("{a} n changed -- skipped");
+            continue;
+        }
+        let (r, me, p999, frac) = stats(&csc, &d0);
+        if idx == 0 {
+            base_ratio = r.max(1.0);
+            base_ent = me.max(1e-300);
+        }
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<24}{:>12.3e}{:>9.1}x{:>12.3e}{:>12.3e}{:>12.3e}   ent {:.1}x",
+            name,
+            r,
+            r / base_ratio,
+            me,
+            p999,
+            frac,
+            me / base_ent
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_scaling_reuse_correctness.rs
+++ b/crates/feral-diagnostics/src/bin/diag_scaling_reuse_correctness.rs
@@ -1,0 +1,142 @@
+//! diag_scaling_reuse_correctness — would reusing an earlier iterate's
+//! MC64 scaling actually be CORRECT on later iterates?
+//!
+//! The value-bound gate (`src/scaling/value_bound.rs`) exists to stop
+//! issue #38: a stale MC64 scaling silently corrupting inertia on warm
+//! IPM replays. The 2026-05-21 Track-B2 rejection recorded that no
+//! cheap value proxy separates "safe to reuse" from "matching
+//! changed". So before touching the gate, the question is not whether
+//! it rejects too often — it is whether the rejected reuses were
+//! actually safe.
+//!
+//! This factors each iterate twice: once with the solver's own
+//! strategy (fresh MC64 — the oracle), and once with
+//! `ScalingStrategy::External` carrying the FIRST iterate's scaling
+//! vector (what a perfectly permissive cache would do). It compares
+//! inertia and residual. The oracle is a fresh independent
+//! factorization, not this probe's own arithmetic.
+//!
+//! Usage: diag_scaling_reuse_correctness <iter0.mtx> <iter1.mtx> ...
+
+use feral::scaling::ScalingStrategy;
+use feral::symbolic::SupernodeParams;
+use feral::{read_mtx, CscMatrix, FactorStatus, Inertia, NumericParams, Solver};
+use std::path::Path;
+
+/// ‖Ax − b‖∞ / (1 + ‖b‖∞) for the all-ones RHS.
+fn rel_res(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0; n];
+    // Lower-triangle CSC of a symmetric matrix: each stored (i,j)
+    // contributes to both ax[i] and ax[j] unless i == j.
+    for j in 0..n {
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let i = a.row_idx[k];
+            let v = a.values[k];
+            ax[i] += v * x[j];
+            if i != j {
+                ax[j] += v * x[i];
+            }
+        }
+    }
+    let num = ax
+        .iter()
+        .zip(b)
+        .map(|(p, q)| (p - q).abs())
+        .fold(0.0f64, f64::max);
+    let den = 1.0 + b.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+    num / den
+}
+
+fn factor_once(
+    csc: &CscMatrix,
+    strategy: Option<ScalingStrategy>,
+) -> Option<(Inertia, f64, f64, Vec<f64>)> {
+    let mut np = NumericParams::default();
+    if let Some(s) = strategy {
+        np.scaling = s;
+    }
+    let mut solver = Solver::with_params(np, SupernodeParams::default()).with_parallel(false);
+    match solver.factor(csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            eprintln!("  factor failed: {other:?}");
+            return None;
+        }
+    }
+    let inertia = solver.inertia()?.clone();
+    let scaling = solver.factors()?.scaling.clone();
+    let b = vec![1.0; csc.n];
+    let res = match solver.solve(&b) {
+        Ok(x) => rel_res(csc, &x, &b),
+        Err(_) => f64::NAN,
+    };
+    let res_ref = match solver.solve_refined(csc, &b) {
+        Ok(x) => rel_res(csc, &x, &b),
+        Err(_) => f64::NAN,
+    };
+    Some((inertia, res, res_ref, scaling))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() < 2 {
+        eprintln!("usage: diag_scaling_reuse_correctness <iter0.mtx> <iter1.mtx> ...");
+        std::process::exit(2);
+    }
+    // Baseline scaling: the first iterate's own MC64 vector.
+    let first = read_mtx(Path::new(&args[0])).and_then(|m| m.to_csc())?;
+    let (_, _, _, d0) = match factor_once(&first, None) {
+        Some(t) => t,
+        None => {
+            eprintln!("baseline factorization failed");
+            std::process::exit(1);
+        }
+    };
+    println!("baseline scaling from {} (n={})", args[0], d0.len());
+    println!(
+        "{:<26}{:>7}{:>12}{:>10}{:>10}{:>12}{:>10}{:>10}{:>8}",
+        "iterate", "nnz", "fresh(n,z)", "res", "res_ref", "reuse(n,z)", "res", "res_ref", "inertia"
+    );
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        if csc.n != d0.len() {
+            println!(
+                "{name:<26}{:>7}  n changed -- cache invalid by fingerprint",
+                csc.nnz()
+            );
+            continue;
+        }
+        let fresh = factor_once(&csc, None);
+        let reuse = factor_once(&csc, Some(ScalingStrategy::External(d0.clone())));
+        match (fresh, reuse) {
+            (Some((fi, fr, frr, _)), Some((ri, rr, rrr, _))) => {
+                let same = fi.negative == ri.negative && fi.zero == ri.zero;
+                println!(
+                    "{:<26}{:>7}{:>12}{:>10.1e}{:>10.1e}{:>12}{:>10.1e}{:>10.1e}{:>8}",
+                    name,
+                    csc.nnz(),
+                    format!("({},{})", fi.negative, fi.zero),
+                    fr,
+                    frr,
+                    format!("({},{})", ri.negative, ri.zero),
+                    rr,
+                    rrr,
+                    if same { "same" } else { "DIFFERS" }
+                );
+            }
+            _ => println!("{name:<26} factorization failed"),
+        }
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_scaling_reuse_correctness.rs
+++ b/crates/feral-diagnostics/src/bin/diag_scaling_reuse_correctness.rs
@@ -51,12 +51,14 @@ fn rel_res(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
 fn factor_once(
     csc: &CscMatrix,
     strategy: Option<ScalingStrategy>,
-) -> Option<(Inertia, f64, f64, Vec<f64>)> {
+) -> Option<(Inertia, f64, f64, Vec<f64>, u64, u64)> {
     let mut np = NumericParams::default();
     if let Some(s) = strategy {
         np.scaling = s;
     }
-    let mut solver = Solver::with_params(np, SupernodeParams::default()).with_parallel(false);
+    let mut solver = Solver::with_params(np, SupernodeParams::default())
+        .with_parallel(false)
+        .with_profiling(true);
     match solver.factor(csc, None) {
         FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
         other => {
@@ -75,7 +77,11 @@ fn factor_once(
         Ok(x) => rel_res(csc, &x, &b),
         Err(_) => f64::NAN,
     };
-    Some((inertia, res, res_ref, scaling))
+    let (total_us, scal_us) = match solver.profile_report() {
+        Some(r) => (r.total_us, r.prologue_breakdown.scaling_us),
+        None => (0, 0),
+    };
+    Some((inertia, res, res_ref, scaling, total_us, scal_us))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -86,7 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     // Baseline scaling: the first iterate's own MC64 vector.
     let first = read_mtx(Path::new(&args[0])).and_then(|m| m.to_csc())?;
-    let (_, _, _, d0) = match factor_once(&first, None) {
+    let (_, _, _, d0, _, _) = match factor_once(&first, None) {
         Some(t) => t,
         None => {
             eprintln!("baseline factorization failed");
@@ -95,8 +101,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     println!("baseline scaling from {} (n={})", args[0], d0.len());
     println!(
-        "{:<26}{:>7}{:>12}{:>10}{:>10}{:>12}{:>10}{:>10}{:>8}",
-        "iterate", "nnz", "fresh(n,z)", "res", "res_ref", "reuse(n,z)", "res", "res_ref", "inertia"
+        "{:<24}{:>12}{:>10}{:>10}{:>10}{:>12}{:>10}{:>10}{:>10}{:>8}",
+        "iterate",
+        "fresh(n,z)",
+        "f_tot_us",
+        "f_scl_us",
+        "res_ref",
+        "reuse(n,z)",
+        "r_tot_us",
+        "r_scl_us",
+        "res_ref",
+        "inertia"
     );
     for a in &args {
         let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
@@ -120,17 +135,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let fresh = factor_once(&csc, None);
         let reuse = factor_once(&csc, Some(ScalingStrategy::External(d0.clone())));
         match (fresh, reuse) {
-            (Some((fi, fr, frr, _)), Some((ri, rr, rrr, _))) => {
+            (Some((fi, _fr, frr, _, ftot, fscl)), Some((ri, _rr, rrr, _, rtot, rscl))) => {
                 let same = fi.negative == ri.negative && fi.zero == ri.zero;
                 println!(
-                    "{:<26}{:>7}{:>12}{:>10.1e}{:>10.1e}{:>12}{:>10.1e}{:>10.1e}{:>8}",
+                    "{:<24}{:>12}{:>10}{:>10}{:>10.1e}{:>12}{:>10}{:>10}{:>10.1e}{:>8}",
                     name,
-                    csc.nnz(),
                     format!("({},{})", fi.negative, fi.zero),
-                    fr,
+                    ftot,
+                    fscl,
                     frr,
                     format!("({},{})", ri.negative, ri.zero),
-                    rr,
+                    rtot,
+                    rscl,
                     rrr,
                     if same { "same" } else { "DIFFERS" }
                 );

--- a/crates/feral-diagnostics/src/bin/diag_symbolic_stages_argv.rs
+++ b/crates/feral-diagnostics/src/bin/diag_symbolic_stages_argv.rs
@@ -1,0 +1,81 @@
+//! Per-stage symbolic profiler over matrices named on the command line.
+//!
+//! `diag_symbolic_stages` hardcodes two small matrices. This variant
+//! takes paths as argv so the same breakdown can be pulled for an
+//! arbitrary matrix -- written to attribute the 60x spread in
+//! analyse-cost-per-nonzero across the chain KKT corpus
+//! (clnlbeam_0000 19.2 us/nnz vs dtoc1nd_0001 0.20 us/nnz).
+//!
+//! Usage: diag_symbolic_stages_argv <a.mtx> [b.mtx ...]
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use feral::read_mtx;
+use feral::symbolic::{
+    symbolic_factorize_with_method, OrderingMethod, SupernodeParams, SymbolicProfiler,
+};
+
+const N_REPEAT: usize = 3;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_symbolic_stages_argv <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    for path in &args {
+        let name = Path::new(path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.clone());
+        if !Path::new(path).exists() {
+            eprintln!("SKIP missing: {}", path);
+            continue;
+        }
+        let Ok(mtx) = read_mtx(Path::new(path)) else {
+            eprintln!("SKIP unreadable: {}", path);
+            continue;
+        };
+        let Ok(csc) = mtx.to_csc() else {
+            eprintln!("SKIP not convertible: {}", path);
+            continue;
+        };
+
+        let mut runs = Vec::new();
+        for _ in 0..N_REPEAT {
+            let prof = Arc::new(Mutex::new(SymbolicProfiler::new()));
+            let params = SupernodeParams {
+                symbolic_profiler: Some(prof.clone()),
+                ..Default::default()
+            };
+            if symbolic_factorize_with_method(&csc, &params, OrderingMethod::Amd).is_err() {
+                eprintln!("SKIP symbolic failed: {}", path);
+                break;
+            }
+            let Ok(guard) = prof.lock() else { break };
+            runs.push(guard.report());
+        }
+        if runs.is_empty() {
+            continue;
+        }
+        // Median run by total.
+        runs.sort_by_key(|r| r.total_us);
+        let rep = &runs[runs.len() / 2];
+
+        println!("\n=== {}  (n={}, nnz={}) ===", name, csc.n, csc.nnz());
+        println!("{:<28}{:>12}{:>9}", "stage", "us", "%");
+        let total = rep.total_us.max(1) as f64;
+        let mut stages: Vec<_> = rep.stages.iter().collect();
+        stages.sort_by_key(|s| std::cmp::Reverse(s.us));
+        for s in stages {
+            println!(
+                "{:<28}{:>12}{:>8.1}%",
+                s.name,
+                s.us,
+                100.0 * s.us as f64 / total
+            );
+        }
+        println!("{:<28}{:>12}{:>8.1}%", "TOTAL", rep.total_us, 100.0);
+    }
+}

--- a/crates/feral-diagnostics/src/bin/diag_trajectory_reuse.rs
+++ b/crates/feral-diagnostics/src/bin/diag_trajectory_reuse.rs
@@ -1,0 +1,147 @@
+//! diag_trajectory_reuse — the end-to-end economics of reusing iter-0's
+//! MC64 scaling across a whole IPM trajectory.
+//!
+//! Every earlier probe here measured half the question.
+//! `diag_trajectory_scaling` drove ONE solver (as ripopt does) but only
+//! with fresh scaling. `diag_scaling_reuse_correctness` compared fresh
+//! against reuse but built a FRESH solver per iterate, which hides the
+//! MC64 cost in `analyze()` -- `Solver::factor` clears
+//! `symbolic.cached_mc64` after every call (issue #38,
+//! `src/numeric/solver.rs:1374`), so only a warm solver pays the
+//! Hungarian inside the timed driver.
+//!
+//! This drives TWO warm solvers over the same trajectory in the same
+//! process: one on `Auto` (today's behaviour), one pinned to
+//! `External(d0)` where `d0` is iter-0's own MC64 vector (what a
+//! perfectly permissive cache would do). It reports per-iterate
+//! wallclock and inertia for both.
+//!
+//! Issue #38's claim is that stale scaling "silently corrupts inertia
+//! and (eventually) explodes factor cost". This measures both halves
+//! against the arm that actually pays for the alternative.
+//!
+//! Usage: diag_trajectory_reuse <iter0.mtx> <iter1.mtx> ...
+
+use feral::scaling::ScalingStrategy;
+use feral::symbolic::SupernodeParams;
+use feral::{read_mtx, CscMatrix, FactorStatus, NumericParams, Solver};
+use std::path::Path;
+
+fn build(strategy: Option<ScalingStrategy>) -> Solver {
+    let mut np = NumericParams::default();
+    if let Some(s) = strategy {
+        np.scaling = s;
+    }
+    Solver::with_params(np, SupernodeParams::default())
+        .with_parallel(false)
+        .with_profiling(true)
+}
+
+/// Returns (total_us, scaling_us, "pos/neg/zero").
+fn step(solver: &mut Solver, csc: &CscMatrix) -> Option<(u64, u64, String)> {
+    match solver.factor(csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            eprintln!("  factor failed: {other:?}");
+            return None;
+        }
+    }
+    let inertia = solver
+        .inertia()
+        .map(|i| format!("{}/{}/{}", i.positive, i.negative, i.zero))?;
+    let (total_us, scal_us) = match solver.profile_report() {
+        Some(r) => (r.total_us, r.prologue_breakdown.scaling_us),
+        None => (0, 0),
+    };
+    Some((total_us, scal_us, inertia))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() < 2 {
+        eprintln!("usage: diag_trajectory_reuse <iter0.mtx> <iter1.mtx> ...");
+        std::process::exit(2);
+    }
+    // iter-0's own MC64 vector, from a throwaway solver.
+    let first = read_mtx(Path::new(&args[0])).and_then(|m| m.to_csc())?;
+    let mut seed = build(None);
+    if !matches!(
+        seed.factor(&first, None),
+        FactorStatus::Success | FactorStatus::WrongInertia { .. }
+    ) {
+        eprintln!("seed factorization failed");
+        std::process::exit(1);
+    }
+    let d0 = match seed.factors() {
+        Some(f) => f.scaling.clone(),
+        None => {
+            eprintln!("seed produced no factors");
+            std::process::exit(1);
+        }
+    };
+    drop(seed);
+    println!("baseline scaling from {} (n={})", args[0], d0.len());
+
+    let mut fresh = build(None);
+    let mut reuse = build(Some(ScalingStrategy::External(d0.clone())));
+    println!(
+        "{:<24}{:>9}{:>11}{:>11}{:>11}{:>11}{:>8}{:>18}",
+        "iterate", "nnz", "fresh_tot", "fresh_scl", "reuse_tot", "reuse_scl", "speedup", "inertia"
+    );
+    let (mut sum_fresh, mut sum_reuse) = (0u64, 0u64);
+    let mut differs = 0usize;
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        if csc.n != d0.len() {
+            println!("{name:<24} n changed -- cache invalid by fingerprint");
+            continue;
+        }
+        let f = step(&mut fresh, &csc);
+        let r = step(&mut reuse, &csc);
+        match (f, r) {
+            (Some((ft, fs, fi)), Some((rt, rs, ri))) => {
+                sum_fresh += ft;
+                sum_reuse += rt;
+                let same = fi == ri;
+                if !same {
+                    differs += 1;
+                }
+                println!(
+                    "{:<24}{:>9}{:>11}{:>11}{:>11}{:>11}{:>7.2}x{:>18}",
+                    name,
+                    csc.nnz(),
+                    ft,
+                    fs,
+                    rt,
+                    rs,
+                    ft as f64 / rt.max(1) as f64,
+                    if same {
+                        fi
+                    } else {
+                        format!("{fi} vs {ri} DIFFERS")
+                    }
+                );
+            }
+            _ => println!("{name:<24} factorization failed"),
+        }
+    }
+    println!();
+    println!(
+        "trajectory: fresh {} us, reuse {} us, speedup {:.2}x, inertia differs on {} iterate(s)",
+        sum_fresh,
+        sum_reuse,
+        sum_fresh as f64 / sum_reuse.max(1) as f64,
+        differs
+    );
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_trajectory_scaling.rs
+++ b/crates/feral-diagnostics/src/bin/diag_trajectory_scaling.rs
@@ -1,0 +1,99 @@
+//! diag_trajectory_scaling — MC64 scaling cost across a full IPM
+//! iterate sequence, not a single factorization.
+//!
+//! The 2026-05-21 rejection of the value-bounded MC64 cache (Track B2)
+//! recorded this lesson: "A per-factor profile of the *named target's
+//! full iteration sequence*, not a single iteration, should precede
+//! the plan." Repeatedly refactoring one iterate measures a workload
+//! nobody runs — real IPM callers feed a new value set each time, and
+//! the previous lever died because a single-iterate profile said MC64
+//! dominated when the full trajectory said the delayed-pivot blowup
+//! did.
+//!
+//! This drives ONE `Solver` over the iterates in order, as ripopt
+//! would, and reports per-iterate whether the scaling cache hit, what
+//! scaling cost, and whether the pattern changed underneath it (a
+//! pattern change invalidates the cache by fingerprint and is not a
+//! gate failure).
+//!
+//! Usage: diag_trajectory_scaling <iter0.mtx> <iter1.mtx> ...
+
+use feral::{read_mtx, FactorStatus, Solver};
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_trajectory_scaling <iter0.mtx> <iter1.mtx> ...");
+        std::process::exit(2);
+    }
+    let mut solver = Solver::new().with_profiling(true).with_parallel(false);
+    println!(
+        "{:<26}{:>9}{:>10}{:>9}{:>9}{:>8}{:>16}",
+        "iterate", "nnz", "factor_us", "scal_us", "scaling%", "hit", "inertia"
+    );
+    let mut prev_nnz: Option<usize> = None;
+    let mut prev_hits = 0usize;
+    let mut cum_scal: u64 = 0;
+    let mut cum_total: u64 = 0;
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let nnz = csc.nnz();
+        let status = solver.factor(&csc, None);
+        if !matches!(
+            status,
+            FactorStatus::Success | FactorStatus::WrongInertia { .. }
+        ) {
+            eprintln!("{a}: {status:?}");
+            continue;
+        }
+        let inertia = match solver.inertia() {
+            Some(i) => format!("{}/{}/{}", i.positive, i.negative, i.zero),
+            None => "-".to_string(),
+        };
+        let hits_now = solver.mc64_cache_hit_count();
+        let hit = hits_now > prev_hits;
+        prev_hits = hits_now;
+
+        let (total_us, scal_us) = match solver.profile_report() {
+            Some(r) if r.total_us > 0 => (r.total_us, r.prologue_breakdown.scaling_us),
+            _ => (0, 0),
+        };
+        cum_scal += scal_us;
+        cum_total += total_us;
+        let pat = match prev_nnz {
+            Some(p) if p != nnz => " (pattern changed)",
+            _ => "",
+        };
+        prev_nnz = Some(nnz);
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<26}{:>9}{:>10}{:>9}{:>8.1}%{:>8}{:>16}{}",
+            name,
+            nnz,
+            total_us,
+            scal_us,
+            100.0 * scal_us as f64 / total_us.max(1) as f64,
+            if hit { "yes" } else { "NO" },
+            inertia,
+            pat
+        );
+    }
+    println!();
+    println!(
+        "trajectory total: factor {} us, scaling {} us ({:.1}% of all factorizations)",
+        cum_total,
+        cum_scal,
+        100.0 * cum_scal as f64 / cum_total.max(1) as f64
+    );
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_warm_scaling.rs
+++ b/crates/feral-diagnostics/src/bin/diag_warm_scaling.rs
@@ -1,0 +1,105 @@
+//! diag_warm_scaling — is scaling still paid on warm `Solver::factor`?
+//!
+//! `diag_factor_phases` drives the numeric driver directly, so its
+//! `scaling%` column reflects a driver with no `Solver`-level MC64
+//! cache behind it. This probe runs the same breakdown through
+//! `Solver` — which owns `mc64_scaling_cache` — and prints
+//! `mc64_cache_hit_count` alongside, so the scaling share can be read
+//! against proof the cache was actually live.
+//!
+//! Usage: diag_warm_scaling <a.mtx> [b.mtx ...]
+
+use feral::scaling::ScalingStrategy;
+use feral::symbolic::SupernodeParams;
+use feral::{read_mtx, FactorStatus, NumericParams, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+const N_REPS: usize = 3;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: diag_warm_scaling <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    println!(
+        "{:<22}{:>9}{:>8}{:>9}{:>9}{:>10}{:>10}",
+        "matrix", "drv_us", "prol%", "scaling%", "permute%", "mc64_hits", "scaling_info"
+    );
+    for a in &args {
+        let csc = match read_mtx(Path::new(a)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {a}: {e:?}");
+                continue;
+            }
+        };
+        let mut np = NumericParams::default();
+        if std::env::var("FORCE_INFNORM").is_ok() {
+            np.scaling = ScalingStrategy::InfNorm;
+        }
+        if std::env::var("FORCE_MC64").is_ok() {
+            np.scaling = ScalingStrategy::Mc64Symmetric;
+        }
+        let mut solver = Solver::with_params(np, SupernodeParams::default())
+            .with_profiling(true)
+            .with_parallel(false);
+        // Warm-up: primes symbolic cache, MC64 cache, workspace.
+        match solver.factor(&csc, None) {
+            FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+            other => {
+                eprintln!("{a}: warm-up failed: {other:?}");
+                continue;
+            }
+        }
+        let baseline_hits = solver.mc64_cache_hit_count();
+
+        let mut best = u64::MAX;
+        let mut keep = [0u64; 3];
+        for _ in 0..N_REPS {
+            let t0 = Instant::now();
+            let status = solver.factor(&csc, None);
+            let wall_us = t0.elapsed().as_micros() as u64;
+            if !matches!(
+                status,
+                FactorStatus::Success | FactorStatus::WrongInertia { .. }
+            ) {
+                eprintln!("{a}: factor failed mid-loop: {status:?}");
+                break;
+            }
+            if let Some(report) = solver.profile_report() {
+                if report.total_us > 0 && wall_us < best {
+                    best = wall_us;
+                    keep = [
+                        report.prologue_us,
+                        report.prologue_breakdown.scaling_us,
+                        report.prologue_breakdown.permute_us,
+                    ];
+                }
+            }
+        }
+        if best == u64::MAX {
+            eprintln!("{a}: no profiled rep");
+            continue;
+        }
+        let hits = solver.mc64_cache_hit_count() - baseline_hits;
+        let sinfo = format!("{:?}", solver.scaling_info());
+        let pct = |v: u64| 100.0 * v as f64 / best.max(1) as f64;
+        let name = Path::new(a)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(a);
+        println!(
+            "{:<22}{:>9}{:>7.1}%{:>8.1}%{:>8.1}%{:>10}  {}",
+            name,
+            best,
+            pct(keep[0]),
+            pct(keep[1]),
+            pct(keep[2]),
+            hits,
+            sinfo.chars().take(46).collect::<String>()
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/prescale_mtx.rs
+++ b/crates/feral-diagnostics/src/bin/prescale_mtx.rs
@@ -1,0 +1,54 @@
+//! Pre-scale a matrix with MC64 symmetric scaling and write the result.
+//!
+//! Exists to make the feral-vs-MA57 factorization comparison
+//! apples-to-apples. Neither natural arm is clean: MA57 with
+//! `ICNTL(15)=1` computes MC64 inside the timed `MA57BD`, while feral
+//! computes its MC64 in untimed analysis; MA57 with `ICNTL(15)=0` does
+//! no scaling at all while feral still applies its own. Either way the
+//! two solvers factorize different numbers.
+//!
+//! Writing `A' = D A D` to disk once removes the asymmetry: both
+//! solvers then read the same pre-scaled matrix and are configured to
+//! do no scaling of their own, so `factor_us` measures factorization
+//! and nothing else.
+//!
+//! Usage: prescale_mtx <in.mtx> <out.mtx>
+
+use std::path::Path;
+
+use feral::read_mtx;
+use feral::scaling::{compute_scaling, ScalingStrategy};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        eprintln!("usage: prescale_mtx <in.mtx> <out.mtx>");
+        std::process::exit(2);
+    }
+    let csc = read_mtx(Path::new(&args[0]))?.to_csc()?;
+    let n = csc.n;
+
+    let (d, info) = compute_scaling(&csc, &ScalingStrategy::Mc64Symmetric)?;
+    if d.len() != n {
+        return Err(format!("scaling vector length {} != n {}", d.len(), n).into());
+    }
+
+    // Report what actually happened. `Mc64Symmetric` can fall back to
+    // infinity-norm equilibration on a degenerate matching, and a run
+    // that silently fell back is not the experiment we think it is.
+    eprintln!("{}: n={} scaling_info={:?}", args[0], n, info);
+
+    let mut out = String::new();
+    out.push_str("%%MatrixMarket matrix coordinate real symmetric\n");
+    out.push_str(&format!("% pre-scaled A' = D A D, D from {:?}\n", info));
+    out.push_str(&format!("{} {} {}\n", n, n, csc.values.len()));
+    for j in 0..n {
+        for k in csc.col_ptr[j]..csc.col_ptr[j + 1] {
+            let i = csc.row_idx[k];
+            let v = csc.values[k] * d[i] * d[j];
+            out.push_str(&format!("{} {} {:.17e}\n", i + 1, j + 1, v));
+        }
+    }
+    std::fs::write(&args[1], out)?;
+    Ok(())
+}

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,83 +1,83 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-10T11:44:47Z
+Generated: 2026-08-10T12:00:56Z
 
 ## Latest Session
-File: dev/sessions/2026-08-10-01.md
+File: dev/sessions/2026-08-10-02.md
 ```
-# Session 2026-08-10-01
+# Session 2026-08-10-02
+
+Journal: `dev/journal/2026-08-09-08.org` (the work began late on 2026-08-09;
+the file number follows the journal, the session number follows
+`dev/sessions/` which main had already advanced to `2026-08-10-01`).
 
 ## Goal
 
-Fix the post-amalgamation `Supernode.nrow` underestimate.
+Take the MC64 Hungarian search bound — the lever recommended at the close of
+the condition-1 dig-in (`dev/research/mc64-condition1-cost-share-2026-08-09.md`).
+Then resolve the merge conflicts blocking PR #157 and get remote CI green.
 
-This was item E of issue #128, a five-part allocation-churn bundle. That issue
-has been **closed as not planned**; this item was extracted onto its own
-branch because it is the only part that was a correctness bug rather than a
-micro-optimization.
+## Benchmark comparison to previous session — TAIL IS SLIGHTLY WORSE
 
-Why the rest was dropped, recorded so nobody re-opens the question:
+Reported first, per protocol. Against the last full-corpus bench
+(`2026-08-09-09`; `2026-08-10-01` had no corpus in its container):
 
-- **Item A** (dense Schur pack buffers) had already landed in `fc4e9b8` and
-  `484bda7`.
-- **Item C** (`DenseLu::update` clones) is bound by the issue's own
-  instruction to the #115 dense-update rework, "not before."
-- **Items B and D** were implemented and measured, then dropped as not worth
-  the review surface. B (FT update allocation pooling) took 11.2 -> 2.8
-  allocations per update, which at the probe's ~60 ns/alloc convention is
-  ~0.6 us against an 85.8 us/update budget — under 1%, and the large win on
-  that path had already landed in earlier sessions. D (postorder child arena)
-  cut symbolic time 12-19%, but symbolic runs once per sparsity pattern, so
-  for an IPM consumer that refactorizes the same pattern every iteration it
-  amortizes to nothing. Both were bit-exact and correct; neither was
-  load-bearing.
+| factor/MUMPS | 2026-08-09-09 | this session | direction |
+|---|---|---|---|
+| geomean | 0.43 | **0.44** | worse |
+| p50     | 0.30 | 0.30       | flat  |
+| p90     | 1.54 | **1.57**   | worse |
+| p99     | 3.30 | **3.45**   | worse |
+| max     | 8.70 | **12.40**  | worse |
 
-## Benchmark Results
+`solve/SSIDS` p90 also moved 2.44 → 2.50; `factor/SSIDS` geomean and both
+`nnzL` rows are unchanged. All Phase 2.8.1 exit partitions still PASS.
 
-**No usable corpus perf signal** — the benchmark corpus is not present in this
-container, so the harness found 2 matrices. Reported as-is rather than
-omitted; identical to session 2026-08-09-04's numbers.
+I do not have an attributed cause, and I am not claiming one. What can be said:
 
-```
---- Sparse solver validation ---
-Sparse solver: 2/2 total
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+- **Not the MC64 change.** `509f0ce` is verified bit-identical on 51 matrices,
+  and it only touches the Hungarian heap, which does not run at all on the
+  small CUTEst matrices that set these tails. The worst ratios are `KIRBY2`
+  (n = 458) and `GROUPING` (n = 225).
+- The merge brought in main's `Supernode.nrow` fix (`2026-08-10-01`), which is
+  explicitly flagged there as a *behavior change to parallel dispatch*. That is
+  the one plausible candidate in the diff, but it is unverified — nobody has
+  re-benched main alone since it landed.
+- Sub-millisecond matrices on a laptop are noisy; a single-matrix `max` moving
+  8.70 → 12.40 on `KIRBY2_0007` (1476 us vs 1298-1142 us on its siblings) is
+  within what this harness swings run to run.
 
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
-```
-
-This change is not expected to move those numbers — it corrects estimates, not
-kernels — and a 2-matrix sample could not show it either way.
+Next session should re-run the bench on `origin/main` alone before spending
+effort here, to separate main's change from noise.
 
 ## Accomplished
 
-`find_supernodes` set `nrow = col_counts[first_col].max(ncol)`. Exact for a
+### The recommended lever does not exist (negative result)
+
+My own prior note called the Hungarian search bound
 ```
 
 ## Git Status
 ```
+5a9150d Merge origin/main into docs/session-2026-08-09-05
 509f0ce perf(mc64): store the key inline in the Hungarian heap; bit-identical
-e8a7283 research(mc64): condition 1 rejects on a barrier-trajectory metric; cost share predicts the outcome
-795dcd2 docs: session checkpoint 2026-08-09-09 (#125 sizing + MC64 value-bound fix)
-bd1bc26 fix(scaling): make MC64 value-bound condition 3 a drift measure
-8f8aa8c feat(diag): trajectory-level scaling profile and a scaling-reuse safety check
+fe8cc64 Merge pull request #158 from jkitchin/claude/fix-supernode-nrow
+32d90ee docs: session checkpoint 2026-08-10-01 (Supernode.nrow fix)
+fc84eb3 fix(symbolic): correct post-amalgamation Supernode.nrow (#128 item E)
 ```
 
 ## Test Status
 ```
-test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
 test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
@@ -86,30 +86,75 @@ test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ..
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 412 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.40s
+test result: ok. 412 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.42s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-10-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-10-02.md)
 
 
-**No usable corpus perf signal** — the benchmark corpus is not present in this
-container, so the harness found 2 matrices. Reported as-is rather than
-omitted; identical to session 2026-08-09-04's numbers.
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
 
---- Sparse solver validation ---
-Sparse solver: 2/2 total
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.57       3.45      12.40
+solve/MUMPS        153560       0.07       0.08       0.14       0.66       2.78
+factor/SSIDS       154500       0.04       0.03       0.32       1.01       2.49
+solve/SSIDS        154500       0.93       1.00       2.50       8.33      30.25
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
 
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
+Per-family factor geomean vs MUMPS (top 25 families by count):
+family                  count    geomean        p50        max
+HS118                    3000       0.91       0.94       1.60
+BIGGSC4                  3000       0.42       0.45       0.60
+MGH10LS                  3000       0.20       0.22       0.44
+PALMER7A                 3000       0.28       0.30       0.70
+ALLINITA                 3000       0.41       0.40       0.85
+HS13                     3000       0.17       0.20       0.56
+ALLINITC                 3000       0.19       0.20       0.30
+HS89                     3000       0.20       0.20       0.30
+HATFLDH                  3000       0.42       0.45       0.55
+MCONCON                  3000       0.90       0.94       1.97
+HS92                     3000       0.35       0.36       0.82
+SSINE                    3000       0.27       0.27       0.33
+HATFLDBNE                3000       0.39       0.40       0.83
+HS90                     3000       0.20       0.20       0.33
+DJTL                     3000       0.09       0.10       0.22
+SSI                      3000       0.21       0.22       0.33
+CONCON                   3000       0.86       0.89       1.72
+HS91                     3000       0.25       0.27       0.40
+PALMER5A                 3000       0.29       0.30       0.44
+AVION2                   2682       1.48       1.52       2.11
+CERI651ALS               2331       0.27       0.27       0.33
+PFIT4                    2286       0.25       0.27       0.30
+CERI651C                 2233       0.28       0.30       0.33
+CERI651CLS               2227       0.27       0.27       0.40
+BATCH                    2054       1.35       1.41       1.98
 
-This change is not expected to move those numbers — it corrects estimates, not
-kernels — and a 2-matrix sample could not show it either way.
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(μs)    mumps(μs)      ratio
+KIRBY2_0007                    458         1476          119      12.40
+KIRBY2_0006                    458         1298          127      10.22
+KIRBY2_0008                    458         1142          122       9.36
+KIRBY2_0011                    458          932          120       7.77
+KIRBY2_0009                    458          990          128       7.73
+KIRBY2_0010                    458          987          133       7.42
+GROUPING_0059                  225          725          116       6.25
+GROUPING_0139                  225          701          113       6.20
+GROUPING_0033                  225          692          112       6.18
+GROUPING_0137                  225          674          111       6.07
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.57     <= 2.0     PASS
+medium (<500)            153560     1.57     <= 3.0     PASS
 
 ```
 
@@ -146,26 +191,26 @@ unaffected, but the sweep recorded in
 model and its numbers do not transfer.
 
 ## Recent Tried-and-Rejected
-Swept `RAYON_NUM_THREADS` = 1, 2, 4, 8, 10 against the default on six
-real chain KKTs, 15 paired runs each, on an M4 Pro (10P + 4E — *more*
-efficiency cores than the 4P+4E M2 the hypothesis came from, so the
-predicted effect should be larger). Every ratio vs the default landed
-within 6% of 1.0; the only significant one was `marine_1600` at t1
-(0.961, 0/15, p = 0.0001), in the wrong direction to support the
-hypothesis. `steering_12800` at one thread: 1.003 (9/15, p = 0.6072).
-`dtoc1nd`, the matrix that actually regressed, at t4: 1.005 (7/15,
-p = 1.0000).
+inline-key heap that followed is bit-identical and won 4-5% on nql180.
 
-The knob was verified live, not assumed: feral reads the global rayon
-pool (`rayon::current_num_threads()`, `src/numeric/factorize.rs:3262`),
-and the same variable moved the proxy matrices by up to 65%.
+Full data: `dev/research/mc64-hungarian-search-bound-2026-08-09.md`.
 
-Consequence worth carrying forward: single-threaded main matches
-all-threads main on every one of these matrices, so **#150's 1.20x to
-2.05x gains on the large chains are not parallelism gains**. Do not
-build on the assumption that they are.
+## 2026-08-09 — `build_cost_graph` as an MC64 optimization target
 
-Full data: `dev/research/chain-kkt-corpus-2026-08-09.md`, Result 3.
+**Rejected on measurement.** Timed at 8-12 ms per iterate. That is ~20% of
+pinene's *cheapest* iterate but **0.4%** of nql180's — and nql180 is where the
+MC64 time actually is. Optimizing it cannot move the corpus. The instrumented
+timer was reverted and is not in any commit.
+
+## 2026-08-09 — array fusion projected from a microbenchmark
+
+**Not rejected, but the projection was wrong and is recorded so it is not
+reused.** A standalone microbenchmark of split-array vs fused-record reads
+predicted **1.68-1.9x**. The real end-to-end win from the inline-key heap was
+**4-5%**, because the split reads are only ~2.3 ns of nql180's ~13 ns/scan.
+Microbenchmarks of one memory access pattern do not predict a loop that also
+does heap sifting and comparison work; scale by the measured share of the loop
+before believing them.
 
 ## Source Files
 ```
@@ -303,7 +348,5 @@ tests/sqd_fast_path.rs
 tests/static_assembly_maps.rs
 tests/stress_tests.rs
 tests/symbolic_profiler.rs
-tests/task_plan_parity.rs
-tests/threshold_consistency.rs
-tests/tiny_fast_path.rs
-```
+
+(truncated from      354 lines to 350 line budget)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,84 +1,84 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T21:06:51Z
+Generated: 2026-08-10T00:14:28Z
 
 ## Latest Session
-File: dev/sessions/2026-08-09-07.md
+File: dev/sessions/2026-08-09-09.md
 ```
-# Session 2026-08-09-07
+# Session 2026-08-09-09
 
 ## Goal
 
-Two halves. First: take PR #151 from green to shipped (merge, tag,
-publish, notify pounce). Second, once that was done: take the
-measurement the release was cut for, which is the factorization gap
-against Harwell on chain-structured KKTs.
+Size issue #125 step 2 before building it. That measurement said not to
+build it, and pointed at the MC64 scaling cache instead — so the second
+half of the session went there: find why the value-bound gate never
+hits on warm iterates, and fix it.
 
-## Unfavorable result, stated first
+## Accomplished
 
-**On the two largest chain-structured proxies, `main` is significantly
-slower than 0.14.0.** `prommis_sx_like` 0.833x (2/15 wins, p = 0.0074),
-`double_column_like` 0.914x (4/15, p = 0.1185). This contradicts the
-0.15.0 release note's "wins all twelve arms", which was measured on real
-matrices on a 4-core homogeneous x86_64 container. It also independently
-reproduces the `chainW` anomaly that session 2026-08-09-02 recorded and
-accepted as a proxy quirk, and that the pounce-side reviewer on PR #150
-flagged as a probable regression on exactly this geometry.
+### Issue #125 step 2 — measured, recommended against
 
-Caveats that keep this from being a verdict: these are synthetic
-proxies, the "new" arm is `main` at `7a31ff6` rather than the `v0.15.0`
-tag, and the bisect that would separate the two did not run. Full
-numbers, method and limits in
-`dev/research/chain-kkt-ma57-gap-2026-08-09.md`.
+Static frontal row layout for fronts that receive delayed columns. Step 1
+landed in PR #139; step 2 would extend it past `n_delayed_in == 0`.
 
-## Accomplished — release
+- **Reach:** 7 of 41 corpus matrices have any front with `n_delayed_in > 0`.
+  Material dynamic rows on 3: steering_12800 61.53%, robot_1600 28.86%,
+  qcqp1500-1nc 25.04%. clnlbeam, dtoc1nd, dtoc2, marine_1600 and
+  rocket_12800 are all at **0.00%**.
+- **Cost ceiling** (`BUILDROW_NS / factor`): **0.21%–3.13%**. It is the
+  smallest column in the phase profile.
+- The fast-path `.to_vec()` cannot become a borrow — `row_indices` is
+  moved into `NodeFactors` at `factorize.rs:2739`, so the copy is a
+  genuine ownership requirement.
 
-1. Verified #151 green, merged as `808babb`, waited for main CI on the
-   squash commit before tagging (a different SHA than the PR head).
-2. Tagged `v0.15.0` and published the GitHub Release. Release job: tag /
-   `Cargo.toml` check PASS, `cargo test` PASS, `cargo publish` PASS for
-   all seven crates. Wheels job: sdist + four wheels, PyPI publish, `uv
-   pip` smoke test PASS.
-3. Verified against the registries, not workflow exit codes: crates.io
-   `feral` 0.15.0; PyPI `feral-solver` 0.15.0 with macosx universal2,
-   manylinux x86_64, manylinux aarch64, win_amd64 and the sdist.
-4. Notified pounce ([pounce#552 comment 5232312068](https://github.com/jkitchin/pounce/issues/552#issuecomment-5232312068)).
-   Release checklist §3 complete.
+~1–2% on 3 of 41 matrices, paid for by touching the delayed-pivot path.
+I explicitly retract my earlier characterization of #125 as "obvious
+work" — that was true of step 1, not step 2.
 
-## Accomplished — measurement
+### Factorization phase profile
 
-5. Established what this machine can and cannot measure. It has the
-   CoinHSL v2023.11.17 bundle (so MA57 is available, oracle built and
-   linked) and Ipopt 3.13.2 with MA27/MA57/MUMPS all confirmed live. It
-   does **not** have `data/matrices/` at all, nor the Pyomo NMPC stack
-   for the five #552 models, nor CUTEst to regenerate the corpus.
-6. Built `external_benchmarks/chain_proxy/`: block-tridiagonal KKT
-   proxies at the reported #552 geometries, plus the paired A/B runner
-   and a mechanism probe. Portable (env-driven paths) so it runs on the
+Driver wall, best of 3 warm sequential reps. **Methodology correction
+made mid-session:** the first version measured against the
+`Solver::factor` wall, which folds in work the phase counters do not
+cover, and showed 18.5%–50.9% "outside" assembly+dense. Rewritten to
+drive `factorize_multifrontal_supernodal_with_workspace` directly; the
+books then close (prologue + epilogue + loop ≈ 100%). Same
+timed-region-mismatch error class that caused two retractions earlier
+in the day.
+
+| matrix | drv_us | prol% | scaling% | schur% | cbextr% | dense_o% | buildrow% |
+|---|---|---|---|---|---|---|---|
+| clnlbeam | 26297 | 18.1% | 15.2% | 11.2% | 6.6% | 22.1% | 2.2% |
+| dtoc1nd | 12540 | 25.0% | 19.5% | 8.2% | 12.0% | 9.6% | 0.8% |
+| dtoc2 | 76483 | 12.8% | 8.0% | 5.7% | 14.4% | 13.8% | 2.0% |
+| marine_1600 | 31271 | 22.4% | 18.9% | 15.7% | 5.7% | 19.3% | 1.2% |
+| rocket_12800 | 20461 | 34.7% | 29.3% | 11.3% | 1.8% | 24.5% | 0.9% |
+| steering_12800 | 37880 | 17.5% | 14.6% | 15.3% | 5.7% | 19.8% | 3.7% |
+| robot_1600 | 8662 | 19.0% | 15.8% | 15.0% | 6.4% | 22.1% | 3.0% |
 ```
 
 ## Git Status
 ```
-1833768 docs: note that #156 changed the parallel default after the measurement
-14bbaa2 docs: ship 0.15.0, then measure the gap vs MA57 (chain proxies)
-f7a152a Merge pull request #156 from jkitchin/claude/review-issue-154-ukpt7t
-af73f63 Merge origin/main into claude/review-issue-154-ukpt7t
-6c87a0e docs: session checkpoint 2026-08-09-03 (issue #154 review + implementation)
+bd1bc26 fix(scaling): make MC64 value-bound condition 3 a drift measure
+8f8aa8c feat(diag): trajectory-level scaling profile and a scaling-reuse safety check
+16b423c feat(diag): size issue #125 step 2 before building it -- and find a bigger target
+7d9812d docs(research): profile MC64 before optimizing it — dense-column diagnosis fails
+197c7be feat(bench): pre-scale offline so both solvers factorize identical numbers
 ```
 
 ## Test Status
 ```
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
@@ -86,55 +86,91 @@ test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ..
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.53s
+test result: ok. 416 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.50s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-07.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-09.md)
 
 
-No corpus bench: this machine has no corpus, and the release half of the
-session changed zero lines of source. Numbers for the shipped code stand
-from session 03 and the aarch64 revalidation at `6fd12d4`. `cargo test`
-for the published SHA ran green inside the release job. The proxy
-measurements are tabulated in the research note rather than duplicated
-here.
+`cargo run --bin bench --release`, post-fix. Both exit partitions PASS.
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.43       0.30       1.54       3.30       8.70
+solve/MUMPS        153560       0.07       0.08       0.14       0.68       3.04
+factor/SSIDS       154500       0.04       0.03       0.32       0.96       2.03
+solve/SSIDS        154500       0.93       1.00       2.44       8.35      36.50
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.54     <= 2.0     PASS
+medium (<500)            153560     1.54     <= 3.0     PASS
+
+Against the earlier run in this session (pre-fix):
+
+| partition | before | after |
+|---|---|---|
+| dense small-frontal p90 | 1.62 | 1.58 |
+| dense medium p90 | 2.04 | 2.00 |
+| sparse small-frontal p90 | 1.57 | 1.54 |
+| sparse medium p90 | 1.57 | 1.54 |
+
+**Do not read this as a win from the fix.** The bench factors each
+matrix once with a fresh solver, so the value-bound gate is never
+consulted and the change should be a no-op here — which is what "no
+regression" means in this table. The p90 movement is run-to-run noise;
+the worst-ratio top 10 turned over completely between the two runs
+(SWOPF/QPNBLEND before, KIRBY2 after) on matrices of n = 157–458 where
+absolute times are sub-millisecond.
+
+The bench corpus is also a different population from the seven
+kkt-mittelmann families the fix was measured on. It is a regression
+control, not evidence for the change.
+
 
 ```
 
 ## Recent Decisions
-`solver_parallel_factor_matches_sequential` is the #7 bit-exactness
-regression test; repairing only its assertion would leave it comparing
-the sequential driver against itself and passing vacuously. The rule
-adopted: any test that means "the parallel driver" constructs with an
-explicit `with_parallel(true)`, and only the default test asserts the
-derived value — against the same probe the constructor uses, so it
-cannot silently become environment-dependent again.
+**Decision:** `Mc64CacheValidity` gains `min_diag_0`, and condition 3 becomes a
+disjunction of the existing absolute floor and a new drift bound
+`min_diag >= DIAG_SHRINK * min_diag_0`, with `DIAG_SHRINK = 1.0 / GROWTH_FACTOR
+= 0.5`.
 
-**New coverage.** `solver_parallel_default_follows_platform`,
-`pool_num_threads_precedence` (via a pure
-`pool_num_threads_from(env, hardware)` helper, so no test mutates
-process-global environment state), and
-`solver_parallel_without_pool_falls_back_to_serial_refine`, which
-reproduces the post-build-failure field state and asserts the refine
-output is bit-identical to the sequential solver.
+**Why a disjunction rather than a replacement.** It is a strict widening of the
+accept set, so no matrix that the gate accepts today can start being rejected.
+And it is zero-drift-safe by construction: re-checking the baseline matrix
+gives `min_diag == min_diag_0` exactly, so the drift clause holds for any
+`DIAG_SHRINK <= 1`.
 
-**Also changed.** `FERAL_PARALLEL` in the C ABI (`src/capi.rs`) was
-off-only; with a derived default it needs a force-on arm
-(`1`/`on`/`true`/`yes`), otherwise a wasm-bindgen-rayon embedder has
-no way to opt in without a rebuild. Unset or unrecognized values leave
-the derived default alone.
+**Why 0.5.** Symmetric with `GROWTH_FACTOR`: the minimum diagonal may shrink by
+the same factor the worst dominance ratio may grow. The constant is **not**
+load-bearing — every value swept from 0.5 to 1e-6 produces the same 25 accepts
+out of 53 corpus gate evaluations. 0.5 is the tightest defensible choice, not a
+tuned one.
 
-**Validation.** `taskset -c 0 cargo test --lib` → 409 passed, 0
-failed. Full `cargo test` on 4 cores → 0 failed across all binaries.
-`cargo clippy --all-targets -- -D warnings` → clean.
+**Evidence.** 53 gate evaluations across the 7 corpus families that route to
+MC64. Condition 3 was the sole blocker on 3: two `robot_1600` checks at drift
+0.988 and 1.000 (false positives) and one `arki0003` check at drift 2.1e-08 (a
+genuine eight-order collapse, still rejected after the change). Pre/post-fix
+binaries give a complete hit-pattern diff of two flips, both `robot_1600`, with
+inertia byte-identical on every iterate of every family.
 
-**Out of scope.** This does not address the wasm hang in
-jkitchin/pounce#482. That reproduces only under `nightly-2026-08-02`,
-is a CPU spin, and occurs inside `pounce_load` — parsing, upstream of
-feral entirely.
+**Scope.** This does not touch conditions 1 or 2, and does not revisit the
+2026-05-21 rejection of Track B2 (`tried-and-rejected.md:2087`), which turned on
+condition 1 being confounded by the IPM barrier trajectory. That finding still
+holds: `pinene_3200` rejects 8/8 on condition 1 after this change.
+
+Research note: `dev/research/mc64-value-bound-diag-drift-2026-08-09.md`.
 
 ## Recent Tried-and-Rejected
 Swept `RAYON_NUM_THREADS` = 1, 2, 4, 8, 10 against the default on six

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,124 +1,106 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T16:26:16Z
+Generated: 2026-08-09T19:45:39Z
 
 ## Latest Session
-File: dev/sessions/2026-08-09-04.md
+File: dev/sessions/2026-08-09-07.md
 ```
-# Session 2026-08-09-04
+# Session 2026-08-09-06
 
 ## Goal
 
-Review issue #154 ("default `use_parallel` from the platform instead of
-hardcoding `true`"), then implement it fully so the issue can be closed.
+Two halves. First: take PR #151 from green to shipped (merge, tag,
+publish, notify pounce). Second, once that was done: take the
+measurement the release was cut for, which is the factorization gap
+against Harwell on chain-structured KKTs.
 
-## Accomplished
+## Unfavorable result, stated first
 
-### Review
+**On the two largest chain-structured proxies, `main` is significantly
+slower than 0.14.0.** `prommis_sx_like` 0.833x (2/15 wins, p = 0.0074),
+`double_column_like` 0.914x (4/15, p = 0.1185). This contradicts the
+0.15.0 release note's "wins all twelve arms", which was measured on real
+matrices on a 4-core homogeneous x86_64 container. It also independently
+reproduces the `chainW` anomaly that session 2026-08-09-02 recorded and
+accepted as a proxy quirk, and that the pounce-side reviewer on PR #150
+flagged as a probable regression on exactly this geometry.
 
-Verified every claim in #154 against `808babb` (v0.15.0). The diagnosis is
-correct and all line references are exact: `solver.rs:430` (`use_parallel:
-true`), `:972` (unconditional `ensure_parallel_pool()`), `:1148`, `:1216`,
-`:1540`, and the quoted `ensure_parallel_pool` body. Three gaps in the
-proposal, all confirmed by measurement rather than reading:
+Caveats that keep this from being a verdict: these are synthetic
+proxies, the "new" arm is `main` at `7a31ff6` rather than the `v0.15.0`
+tag, and the bisect that would separate the two did not run. Full
+numbers, method and limits in
+`dev/research/chain-kkt-ma57-gap-2026-08-09.md`.
 
-1. **The test inventory was incomplete, and understated.** The issue names
-   one test and calls it a latent flake. Applying *only* the issue's
-   one-liner to a pristine tree and running under `taskset -c 0`:
+## Accomplished — release
 
-   ```
-   test result: FAILED. 404 passed; 3 failed; 6 ignored
-     solver_parallel_default_is_on             solver.rs:2825
-     solver_parallel_factor_matches_sequential solver.rs:3852
-       assertion failed: par.parallel()
-     solver_reuses_thread_pool_across_factors  solver.rs:2887
-       .expect("pool must be built after first parallel factor")
-   ```
+1. Verified #151 green, merged as `808babb`, waited for main CI on the
+   squash commit before tagging (a different SHA than the PR head).
+2. Tagged `v0.15.0` and published the GitHub Release. Release job: tag /
+   `Cargo.toml` check PASS, `cargo test` PASS, `cargo publish` PASS for
+   all seven crates. Wheels job: sdist + four wheels, PyPI publish, `uv
+   pip` smoke test PASS.
+3. Verified against the registries, not workflow exit codes: crates.io
+   `feral` 0.15.0; PyPI `feral-solver` 0.15.0 with macosx universal2,
+   manylinux x86_64, manylinux aarch64, win_amd64 and the sdist.
+4. Notified pounce ([pounce#552 comment 5232312068](https://github.com/jkitchin/pounce/issues/552#issuecomment-5232312068)).
+   Release checklist §3 complete.
 
-   `solver_parallel_factor_matches_sequential` is the #7 bit-exactness
-   regression test. Repairing only its assertion would leave it comparing
-   the sequential driver against itself — passing vacuously, with the
-   contract silently unchecked.
+## Accomplished — measurement
 
-2. **The "filed separately" fallback bug is not separable.** After the
-   default flips, `with_parallel(true)` — the escape hatch #154 recommends
-   for wasm — still reaches `ensure_parallel_pool()` and, on build failure,
-   falls to a `None` arm that runs the *parallel* driver bare, i.e. on
-   rayon's global pool. That is the failure being avoided, reintroduced
-   through the workaround prescribed for it. Shipping the default flip alone
-   would release a version whose documented wasm answer is a trap.
-
-3. **A fourth dispatch site the issue misses:** `solve_many_refined`
-   (`solver.rs:1601`) has the same `None`-arm shape as `solve_refined`.
-
-Adjacent sweep over every rayon entry point reachable from `Solver`:
-`intrafront_parallel` (Lever 1.1) is set only inside the parallel driver
-(`factorize.rs:3127`), so the sequential path never spawns nested rayon work
-— the pounce#79 oversubscription guarantee holds, not a bug. `solve.rs`
+5. Established what this machine can and cannot measure. It has the
+   CoinHSL v2023.11.17 bundle (so MA57 is available, oracle built and
+   linked) and Ipopt 3.13.2 with MA27/MA57/MUMPS all confirmed live. It
+   does **not** have `data/matrices/` at all, nor the Pyomo NMPC stack
+   for the five #552 models, nor CUTEst to regenerate the corpus.
+6. Built `external_benchmarks/chain_proxy/`: block-tridiagonal KKT
+   proxies at the reported #552 geometries, plus the paired A/B runner
+   and a mechanism probe. Portable (env-driven paths) so it runs on the
 ```
 
 ## Git Status
 ```
+f7a152a Merge pull request #156 from jkitchin/claude/review-issue-154-ukpt7t
+af73f63 Merge origin/main into claude/review-issue-154-ukpt7t
 6c87a0e docs: session checkpoint 2026-08-09-03 (issue #154 review + implementation)
 4f2fad6 fix(solver): derive use_parallel from the platform; fall back to sequential when the pool fails
-808babb release: feral v0.15.0 (#151)
-fad5670 perf(parallel): task-per-subtree coarsening + profiler nanoseconds (#150)
-e8e1c5a perf(kernel): explicit SIMD packed trailing update + x86 pulp dispatch fix (#149)
+7a31ff6 Merge pull request #155 from jkitchin/claude/feral-kernel-perf-dx0fkq
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
-test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
 test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
 test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 411 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.12s
+test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 6.00s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-04.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-09-07.md)
 
 
-No usable perf signal this session: the benchmark corpus is not present in
-this container, so the harness found 2 matrices. Reported as-is rather than
-omitted.
-
---- Dense solver validation ---
-  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
-
---- Sparse solver validation ---
-Sparse solver: 2/2 total
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
-
---- Dense perf vs oracles: no matrices have oracle timings ---
---- Sparse perf vs oracles: no matrices have oracle timings ---
-
-There is no reason to expect a perf delta on a multi-core host: the derived
-default is `true` there, and the pool-fallback change is unreachable unless
-`ThreadPoolBuilder::build()` fails. The one measurable change would be on a
-single-CPU host, where the sequential driver is now selected — that is the
-intended effect, not a regression.
+No corpus bench: this machine has no corpus, and the release half of the
+session changed zero lines of source. Numbers for the shipped code stand
+from session 03 and the aarch64 revalidation at `6fd12d4`. `cargo test`
+for the published SHA ran green inside the release job. The proxy
+measurements are tabulated in the research note rather than duplicated
+here.
 
 ```
 
@@ -242,8 +224,8 @@ tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering.rs
 tests/column_renumbering_parity.rs
+tests/column_renumbering.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -257,6 +239,14 @@ tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/golden_bits.rs
 tests/growth_flag.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -268,21 +258,13 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
-tests/lu_dense.rs
 tests/lu_dense_update_bg.rs
+tests/lu_dense.rs
 tests/lu_ft_widebump.rs
 tests/lu_scaling.rs
 tests/lu_sparse.rs
@@ -301,8 +283,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue.rs
 tests/rook_rescue_kkt.rs
+tests/rook_rescue.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,11 +1,11 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T19:45:39Z
+Generated: 2026-08-09T19:46:37Z
 
 ## Latest Session
 File: dev/sessions/2026-08-09-07.md
 ```
-# Session 2026-08-09-06
+# Session 2026-08-09-07
 
 ## Goal
 
@@ -59,34 +59,34 @@ numbers, method and limits in
 
 ## Git Status
 ```
+14bbaa2 docs: ship 0.15.0, then measure the gap vs MA57 (chain proxies)
 f7a152a Merge pull request #156 from jkitchin/claude/review-issue-154-ukpt7t
 af73f63 Merge origin/main into claude/review-issue-154-ukpt7t
 6c87a0e docs: session checkpoint 2026-08-09-03 (issue #154 review + implementation)
 4f2fad6 fix(solver): derive use_parallel from the platform; fall back to sequential when the pool fails
-7a31ff6 Merge pull request #155 from jkitchin/claude/feral-kernel-perf-dx0fkq
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 6.00s
+test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 5.78s
 
 ```
 

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-09T19:46:37Z
+Generated: 2026-08-09T21:06:51Z
 
 ## Latest Session
 File: dev/sessions/2026-08-09-07.md
@@ -59,34 +59,34 @@ numbers, method and limits in
 
 ## Git Status
 ```
+1833768 docs: note that #156 changed the parallel default after the measurement
 14bbaa2 docs: ship 0.15.0, then measure the gap vs MA57 (chain proxies)
 f7a152a Merge pull request #156 from jkitchin/claude/review-issue-154-ukpt7t
 af73f63 Merge origin/main into claude/review-issue-154-ukpt7t
 6c87a0e docs: session checkpoint 2026-08-09-03 (issue #154 review + implementation)
-4f2fad6 fix(solver): derive use_parallel from the platform; fall back to sequential when the pool fails
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 5.78s
+test result: ok. 413 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.53s
 
 ```
 
@@ -137,26 +137,26 @@ is a CPU spin, and occurs inside `pounce_load` — parsing, upstream of
 feral entirely.
 
 ## Recent Tried-and-Rejected
-`nemin=8`, MEYER3NE 83× at `nemin=4`), which is what makes it a property
-of the direction rather than of this rule.
+Swept `RAYON_NUM_THREADS` = 1, 2, 4, 8, 10 against the default on six
+real chain KKTs, 15 paired runs each, on an M4 Pro (10P + 4E — *more*
+efficiency cores than the 4P+4E M2 the hypothesis came from, so the
+predicted effect should be larger). Every ratio vs the default landed
+within 6% of 1.0; the only significant one was `marine_1600` at t1
+(0.961, 0/15, p = 0.0001), in the wrong direction to support the
+hypothesis. `steering_12800` at one thread: 1.003 (9/15, p = 0.6072).
+`dtoc1nd`, the matrix that actually regressed, at t4: 1.005 (7/15,
+p = 1.0000).
 
-**Why rejected.** "Correctness before performance, always" is a hard
-constraint. 2–7% of factor time and 11–45% of fill does not buy seven
-digits of residual. Neither my pre-registered criterion nor the queue
-item thought to check the axis that decided it — recorded here because
-the next person to have this idea will not think to check it either.
+The knob was verified live, not assumed: feral reads the global rayon
+pool (`rayon::current_num_threads()`, `src/numeric/factorize.rs:3262`),
+and the same variable moved the proxy matrices by up to 65%.
 
-The knob stays in-tree defaulting to `None` (bit-identical default path)
-as the reproduction apparatus, with the accuracy result in its doc
-comment. Research note:
-`dev/research/amalgamation-cost-model-2026-08-09.md`.
+Consequence worth carrying forward: single-threaded main matches
+all-threads main on every one of these matrices, so **#150's 1.20x to
+2.05x gains on the large chains are not parallelism gains**. Do not
+build on the assumption that they are.
 
-**Also redirects the target.** pounce#552's re-measurement against a
-released 0.15.0 (comment 5232409020) shows clnlbeam more than halved
-(8.05× → 3.54× vs MA57) and **no longer the worst case** — `dtoc1nd` is,
-at 3.77×, and it is a dense-front matrix (nnz/dim 23.0, fronts of 33–64
-columns). Amalgamation is a chain-KKT lever aimed at a problem that has
-largely receded.
+Full data: `dev/research/chain-kkt-corpus-2026-08-09.md`, Result 3.
 
 ## Source Files
 ```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6297,3 +6297,45 @@ failed. Full `cargo test` on 4 cores → 0 failed across all binaries.
 jkitchin/pounce#482. That reproduces only under `nightly-2026-08-02`,
 is a CPU spin, and occurs inside `pounce_load` — parsing, upstream of
 feral entirely.
+
+## 2026-08-09 — MC64 value-bound condition 3 measures drift, not an absolute floor
+
+`mc64_value_bound_passes` decides whether a cached MC64 scaling may be reused
+on a new matrix. Conditions 1 and 2 compare a current statistic against the
+same statistic on the baseline matrix. Condition 3 did not: it compared the
+current **minimum** scaled diagonal against the baseline **mean**. Those are
+different statistics, so condition 3 was an absolute property of the matrix —
+"is the scaled diagonal's dynamic range wider than `1/EPS_DIAG`" — rather than
+a measure of how far the matrix had moved, and it could reject a matrix against
+its own fingerprint.
+
+**Decision:** `Mc64CacheValidity` gains `min_diag_0`, and condition 3 becomes a
+disjunction of the existing absolute floor and a new drift bound
+`min_diag >= DIAG_SHRINK * min_diag_0`, with `DIAG_SHRINK = 1.0 / GROWTH_FACTOR
+= 0.5`.
+
+**Why a disjunction rather than a replacement.** It is a strict widening of the
+accept set, so no matrix that the gate accepts today can start being rejected.
+And it is zero-drift-safe by construction: re-checking the baseline matrix
+gives `min_diag == min_diag_0` exactly, so the drift clause holds for any
+`DIAG_SHRINK <= 1`.
+
+**Why 0.5.** Symmetric with `GROWTH_FACTOR`: the minimum diagonal may shrink by
+the same factor the worst dominance ratio may grow. The constant is **not**
+load-bearing — every value swept from 0.5 to 1e-6 produces the same 25 accepts
+out of 53 corpus gate evaluations. 0.5 is the tightest defensible choice, not a
+tuned one.
+
+**Evidence.** 53 gate evaluations across the 7 corpus families that route to
+MC64. Condition 3 was the sole blocker on 3: two `robot_1600` checks at drift
+0.988 and 1.000 (false positives) and one `arki0003` check at drift 2.1e-08 (a
+genuine eight-order collapse, still rejected after the change). Pre/post-fix
+binaries give a complete hit-pattern diff of two flips, both `robot_1600`, with
+inertia byte-identical on every iterate of every family.
+
+**Scope.** This does not touch conditions 1 or 2, and does not revisit the
+2026-05-21 rejection of Track B2 (`tried-and-rejected.md:2087`), which turned on
+condition 1 being confounded by the IPM barrier trajectory. That finding still
+holds: `pinene_3200` rejects 8/8 on condition 1 after this change.
+
+Research note: `dev/research/mc64-value-bound-diag-drift-2026-08-09.md`.

--- a/dev/journal/2026-08-09-07.org
+++ b/dev/journal/2026-08-09-07.org
@@ -78,3 +78,21 @@ reproduces the post-build-failure field state (factor with parallel
 off, then flip `use_parallel`) and asserts the refine output is
 BIT-IDENTICAL to the sequential solver — the fallback is a scheduling
 decision and must not perturb numerics.
+
+* 18:40 :handoff:rebase:main-moved:
+Rebased onto f7a152a. Main moved twice during this session: #155
+(amalgamation) and #156 (issue #154). Two consequences worth recording.
+(1) Journal numbering collided AGAIN — the container took -04, -05 and
+-06 while this session was live, so this journal is -07 and the session
+file is dev/sessions/2026-08-09-07.md. Check `git ls-tree origin/main
+dev/journal/` before picking a number; the local directory is not
+authoritative when work runs concurrently elsewhere.
+(2) More substantive: #156 (4f2fad6) stops Solver::with_params
+hardcoding use_parallel:true and derives it from
+available_parallelism() > 1, plus sequential fallback at all four
+dispatch sites when the pool fails. That changes WHICH DRIVER a
+default-constructed solver takes, which is precisely the axis the chain
+regression sits on. Everything measured here is 7a31ff6, which predates
+it. Added a note to the research note: the corpus-machine bisect must
+treat current main as its own point, not assume it matches the measured
+7a31ff6.

--- a/dev/journal/2026-08-09-07.org
+++ b/dev/journal/2026-08-09-07.org
@@ -1,0 +1,80 @@
+#+TITLE: Session 2026-08-09-07 — ship 0.15.0, then measure the gap vs MA57
+# Session file: dev/sessions/2026-08-09-04.md. Journal numbers -04
+# and -05 were taken by the amalgamation session (PR #155) while
+# this work was in flight, so the numbers do not line up.
+
+* 16:20 :issue-154:parallel:wasm:review:
+Reviewed issue #154 ("default `use_parallel` from the platform").
+Verified every code claim against 808babb: line refs 430, 972, 1148,
+1216, 1540 and the quoted `ensure_parallel_pool` body are all exact.
+Diagnosis is correct and the direction is right.
+
+Three problems with the proposal as written:
+1. The test inventory is incomplete. The issue names one test
+   (`solver_parallel_default_is_on`) and calls it a latent flake.
+   There are three, and two are hard failures. Measured by applying
+   ONLY the issue's one-liner to a pristine tree and running under
+   `taskset -c 0`:
+     test result: FAILED. 404 passed; 3 failed
+     solver_parallel_default_is_on          FAILED (solver.rs:2825)
+     solver_parallel_factor_matches_sequential FAILED (3852,
+       `assertion failed: par.parallel()`)
+     solver_reuses_thread_pool_across_factors  FAILED (2887,
+       `.expect("pool must be built after first parallel factor")`)
+   The middle one is the #7 bit-exactness regression test. Fixing
+   only its assert would make it compare the sequential driver to
+   itself and pass vacuously — a silent loss of coverage.
+2. The "filed separately" fallback bug is not separable. After the
+   default flips, `with_parallel(true)` — the escape hatch the issue
+   leans on for wasm — still routes to `ensure_parallel_pool()`, and
+   on build failure falls to the `None` arm which runs the PARALLEL
+   driver bare, i.e. on the global rayon pool. That is the failure
+   the issue is avoiding, now reached through the documented
+   workaround. Shipping the default flip alone would release a
+   version whose documented wasm answer is a trap.
+3. The issue misses a fourth dispatch site: `solve_many_refined`
+   (solver.rs:1601) has the same `None`-arm shape as `solve_refined`.
+
+* 16:45 :issue-154:parallel:adjacent:
+Adjacent sweep before implementing. Checked every rayon entry point
+reachable from `Solver`:
+- `intrafront_parallel` (dense/factor.rs:3402, Lever 1.1) is set ONLY
+  inside `factorize_multifrontal_parallel_with_workspace`
+  (factorize.rs:3127), so the sequential driver never spawns nested
+  rayon work. Not a bug — the pounce#79 oversubscription guarantee
+  holds. Fixing the `None` arms to route sequential fixes the one
+  path where it leaked.
+- `solve.rs:632/734/998` rayon uses are all under
+  `solve_sparse_refined_parallel`, already gated by `use_parallel`.
+- Real adjacent find: `ensure_parallel_pool` sized its pool with
+  `rayon::current_num_threads()`, which INITIALIZES rayon's global
+  registry as a side effect — spawning a second set of workers we
+  never use, and on a host that cannot spawn, failing inside rayon
+  rather than at our own `build()` where we can handle it. Replaced
+  with `pool_num_threads()`, reproducing rayon's own rule
+  (RAYON_NUM_THREADS -> available_parallelism -> 1) without touching
+  the global registry. `Solver` now never initializes it.
+- Also fixed the `FERAL_PARALLEL` capi knob, which was off-only. With
+  a derived default it needs a force-on arm, otherwise a
+  wasm-bindgen-rayon embedder has no way to opt in without a rebuild.
+
+Also: `.git/hooks/pre-commit` was missing on this clone
+(assemble-context.sh warned). Installed pre-commit per CLAUDE.md.
+
+* 17:10 :issue-154:parallel:validation:
+Implemented and validated. Single-CPU host simulated with
+`taskset -c 0` (nproc reports 1), which is the case the issue's
+validation table omits and the one all three test failures need:
+  taskset -c 0 cargo test --lib -> 409 passed; 0 failed; 6 ignored
+  cargo test (4 cores, full suite) -> 0 failed across all binaries
+  cargo clippy --all-targets -D warnings -> clean
+New coverage: `solver_parallel_default_follows_platform` asserts
+against the same probe the constructor uses (not a hardcoded bool, so
+it cannot become environment-dependent again);
+`pool_num_threads_precedence` pins the RAYON_NUM_THREADS rule via a
+pure helper so no test mutates process-global env;
+`solver_parallel_without_pool_falls_back_to_serial_refine`
+reproduces the post-build-failure field state (factor with parallel
+off, then flip `use_parallel`) and asserts the refine output is
+BIT-IDENTICAL to the sequential solver — the fallback is a scheduling
+decision and must not perturb numerics.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -318,3 +318,38 @@ never warms": that is the numeric scaling in the factor prologue
 (3.9-19.9 ms per call, 18-34% of factor time), paid every
 factorization. ldlt_compress is symbolic, paid once per analysis. Both
 are MC64. Whether one fix addresses both is unverified.
+
+* 18:40 :clean:prescale:ma57:confirmed:
+Ran the clean experiment. prescale_mtx writes A' = D A D once (MC64
+symmetric, scaling_info=Applied on all six, no infnorm fallback); feral
+runs FERAL_SCALING=identity and MA57 runs ICNTL(15)=0, so neither
+scales and both factorize identical numbers.
+
+MA57 faster on every matrix that can carry a timing, 15 pairs, all
+0/15 at p=0.0001: dtoc1nd 4.72x, clnlbeam 3.56x, marine_1600 2.92x,
+rocket_12800 2.64x, dtoc2 1.46x.
+
+steering_12800 EXCLUDED. MA57 rel_res 2.12e-05 on the pre-scaled matrix
+vs feral 1.62e-14 on the same input -- MA57 does not solve it
+acceptably without its own scaling. Second time the correctness gate
+has caught an MA57 accuracy problem a timing-only table would have
+published (first was 4.53e-08 on unscaled steering). Keeping the gate
+ahead of the timing table is earning its place.
+
+Convergence across three protocols (MA57 faster by):
+  matrix          #153/pounce   ICNTL(15)=0   clean pre-scaled
+  dtoc1nd            3.77x         5.53x          4.72x
+  clnlbeam           3.54x         4.08x          3.56x
+  marine_1600        2.63x         3.02x          2.92x
+  rocket_12800       2.17x         3.74x          2.64x
+  dtoc2              1.29x         1.59x          1.46x
+
+Different harnesses, different scaling handling, different machines,
+same answer. The factorization gap is real at roughly 1.5x-4.7x and
+0.15.0 did not close it. I am now confident in this; the retracted
+result was the only measurement that ever said otherwise.
+
+Side observation: feral-default ran within 2-8% of feral-noscale on the
+pre-scaled inputs. Not in tension with #153's 18-34% warm-path scaling
+cost -- MC64 on an already-MC64-scaled matrix converges immediately --
+but it does mean this experiment cannot measure warm-path scaling.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -449,3 +449,106 @@ here; the mechanism is that csp stays RINF while the search hunts for
 an unmatched row, so nothing prunes insertion. Whether that frontier
 can be bounded without changing the matching is open and needs its own
 research note before any code.
+
+* 20:40 :issue125:sizing:measurement:step2-rejected:
+Asked to implement #125 step 2 (delayed-column splice). Sized the
+ceiling before writing code, per spec 5.1. Built
+`diag_delayed_fronts` (fronts and frontal rows taking the dynamic
+`build_row_indices` path) and extended it with the `BUILDROW_NS`
+phase counter.
+
+Reach: 7 of 41 corpus matrices have ANY front with `n_delayed_in > 0`.
+Only 3 have material dynamic rows -- steering_12800 61.53%,
+robot_1600 28.86%, qcqp1500-1nc 25.04%. Five of the six chain KKTs
+that motivated the whole MA57 investigation (clnlbeam, dtoc1nd,
+dtoc2, marine_1600, rocket_12800) are at exactly 0.00%.
+
+Cost: `BUILDROW_NS` wraps BOTH arms of the #125 branch
+(factorize.rs:2491-2505), so buildrow/factor is a hard ceiling on
+step 2. Measured 0.21%-3.13% of factor wall (steering 3.13%,
+robot 1.97%, qcqp1500-1nc 0.21%, clnlbeam 1.65%). Step 2 removes
+only part of that -- it still has to splice delayed columns.
+
+Also checked whether the step-1 fast-path `.to_vec()` could become a
+borrow: no. `row_indices` is moved into `NodeFactors`
+(factorize.rs:2739), so ownership is required.
+
+Conclusion: ~1-2% on 3 of 41 matrices, paid for by touching the
+delayed-pivot path -- the highest-risk code in the solver. Step 2
+is not worth building. Recorded that my earlier characterization of
+#125 as "obvious work" was true of step 1 (landed, PR #139) and NOT
+of step 2.
+
+* 21:05 :profile:factorization:phase-timing:scaling:
+Ran the internal factorization profile previously offered but never
+done. Key methodological point: drove
+`factorize_multifrontal_supernodal_with_workspace` DIRECTLY rather
+than `Solver::factor`, because the `Solver` wall folds in symbolic
+reuse checks and scaling-cache lookups the phase counters do not
+cover. First attempt used the Solver wall and showed 18%-51%
+"outside" -- an artifact of exactly the timed-region mismatch that
+produced two retractions earlier this session. With the driver call
+the books close: prologue + loop + epilogue ~= 100%.
+
+Driver wall split (best of 3 warm reps, sequential):
+
+| matrix        | drv_us | prol% | scaling% | schur% | cbextr% | dense_o% | buildrow% |
+|---------------+--------+-------+----------+--------+---------+----------+-----------|
+| clnlbeam      |  26297 | 18.1% |    15.2% |  11.2% |    6.6% |    22.1% |      2.2% |
+| dtoc1nd       |  12540 | 25.0% |    19.5% |   8.2% |   12.0% |     9.6% |      0.8% |
+| dtoc2         |  76483 | 12.8% |     8.0% |   5.7% |   14.4% |    13.8% |      2.0% |
+| marine_1600   |  31271 | 22.4% |    18.9% |  15.7% |    5.7% |    19.3% |      1.2% |
+| rocket_12800  |  20461 | 34.7% |    29.3% |  11.3% |    1.8% |    24.5% |      0.9% |
+| steering_12800|  37880 | 17.5% |    14.6% |  15.3% |    5.7% |    19.8% |      3.7% |
+| robot_1600    |   8662 | 19.0% |    15.8% |  15.0% |    6.4% |    22.1% |      3.0% |
+
+`buildrow%` (#125's target) is the smallest column on the table.
+Two large unattributed buckets: `dense_o%` (9.6%-24.5%, inside the
+dense frontal factor but outside panel/Schur/tail/L-extract/
+contrib-extract) and prologue scaling.
+
+* 21:30 :bug:mc64:cache:value-bound:confirmed:
+Chased `scaling%` through `Solver` (which owns `mc64_scaling_cache`)
+with `mc64_cache_hit_count` printed alongside. The corpus splits
+exactly on cache hits: hits=3 -> scaling ~0.0%; hits=0 -> scaling
+6.6%-41.7%.
+
+**Confirmed bug on robot_1600_0001.** The cache IS populated
+correctly and is then REJECTED on every reuse of the bit-identical
+matrix. Instrumented `mc64_value_bound_passes` (temporary
+FERAL_VB_DEBUG patch, reverted):
+
+  vb: ratio true (6.111443e14 vs 1.222289e15) | count true (15410 vs
+      15410) | diag false (1.636275e-15 vs 4.177246e-13)
+
+`ratio` and `count` pass with numerically IDENTICAL stats -- proof
+of zero drift, it is literally the same matrix. `cond_diag`
+(value_bound.rs:237) fails: it tests
+`min_diag >= EPS_DIAG * mean_diag_0`, which is an ABSOLUTE property
+of the matrix, not a drift measure. Any matrix whose scaled diagonal
+spans more than ~1e12 can never reuse its own cache, so MC64 reruns
+and is discarded every factorization.
+
+Cost: 40.4% of the warm factor wall. Forcing
+`ScalingStrategy::InfNorm` on robot_1600_0001 takes the driver from
+10,662 us to 6,013 us -- 1.77x on the WHOLE factorization.
+
+It is a cliff, not a corner case. robot_1600_0000 passes with only
+5.6x margin (2.353320e-12 vs 4.213035e-13); WM_CFy_0000 by 3.2x
+(1.124683e-12 vs 3.565878e-13). An IPM trajectory walks off it
+mid-solve, which is the workload that matters. Same family, adjacent
+iterates, opposite verdicts.
+
+Scope limit, stated explicitly: at iterate _0000 NO corpus matrix is
+rejected -- all 31 misses there are "no-cache" (Auto picked InfNorm,
+nothing to cache by design). So the rejection is confirmed on
+robot_1600_0001 and its frequency across full trajectories is NOT
+established.
+
+Separate observation, measured but not shown to be reducible: on
+31 of 42 matrices Auto picks InfNorm and it is recomputed every
+factor at 3%-38% of the driver wall (elec_400 37.9%, ex8_2_2 26.2%,
+ex8_2_3 26.1%, gasoil_3200 23.1%, arki0003 23.5%, pinene_3200
+21.4%). Values change each IPM iterate so recomputation is
+legitimate; whether an O(nnz) scan should cost 20%-38% of a
+factorization is an open question.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -219,3 +219,102 @@ timing-only table.
 Also: #149's SIMD kernel is below 1.0 on all six, significantly on
 clnlbeam (0.966, 0/15, 0.0001) and rocket_12800 (0.979, 2/15, 0.0074).
 It helped on the proxies. Separate thread, worth its own bisect.
+
+* 17:05 :correction:ma57:oracle:methodology:
+Result 1 of this session is WRONG and has been retracted on PR #157.
+
+Asked whether any optimization work remained, pulled analyse_us
+alongside factor_us, and noticed feral's analysis was 5.0 s on
+clnlbeam against a 26 ms factorization. Chasing that led back through
+the oracle and exposed the error.
+
+`ma57_bench.F` sets ICNTL(15)=1. MA57 computes that scaling *inside
+MA57BD*, which is exactly the region the oracle times as factor_us.
+feral computes its MC64 during analysis, which its factor_us excludes.
+So the comparison charged MA57 per-factorization for work feral had
+already amortized and was not billed for.
+
+I had checked that factor_us covered MA57BD only and treated that as
+sufficient. The boundary of the timed region was verified; the
+contents were not.
+
+Corrected (ICNTL(15)=0, 15 pairs, min factor_us), feral vs ma57:
+  dtoc1nd        14050 /  2539  -> MA57 5.53x   0/15  p=0.0001
+  clnlbeam       21979 /  5384  -> MA57 4.08x   1/15  p=0.0010
+  rocket_12800   22266 /  5955  -> MA57 3.74x   0/15  p=0.0001
+  marine_1600    33131 / 10973  -> MA57 3.02x   0/15  p=0.0001
+  steering_12800 34517 / 17097  -> MA57 2.02x   0/15  p=0.0001
+  dtoc2          81725 / 51309  -> MA57 1.59x   0/15  p=0.0001
+
+MA57 faster on all six. Three independent confirmations:
+- issue #153 measured the same six through pounce: 1.29x-3.77x MA57.
+  Its MA57 times (clnlbeam 7.27 ms, rocket 8.79, steering 18.96) match
+  ICNTL(15)=0 (5.38, 5.96, 17.1), not the oracle's (201, 554, 292).
+- the proxy note I "superseded" said 1.4x-2.4x slower. Right direction,
+  close magnitude. I overturned a correct finding with a worse
+  measurement.
+- the steering accuracy caveat was the same artifact: scaling off gives
+  MA57 rel_res 1.59e-14, not 4.53e-08.
+
+Results 2 and 3 are untouched -- they compare feral builds to each
+other and never invoke the oracle.
+
+Oracle now defaults ICNTL(15)=0, takes MA57_SCALING to override, times
+MA57AD, and echoes both analyse_us and `scaling` into every sidecar so
+a result file can never again be ambiguous about which arm produced it.
+
+* 17:20 :analysis:mc64:ldlt_compress:target:
+The question that exposed the error also produced the clearest
+optimization target in the corpus.
+
+analyse_us vs factor_us for main, and per-stage via a new
+diag_symbolic_stages_argv:
+
+  matrix          analyse    factor   ldlt_compress  share   ordering
+  clnlbeam       5001272     26008        4515372    99.3%      3706
+  rocket_12800   2705801     29910        2289795    98.3%      3932
+  marine_1600    1048521     42817              -        -          -
+  steering_12800  130389     41795          23539    33.6%      6172
+  dtoc2           276116    101528              -        -          -
+  dtoc1nd          42464     19278           2834    23.1%      2118
+
+ldlt_compress is compute_mc64_cache (src/symbolic/mod.rs:1211). On
+clnlbeam it is 4.5 s while the fill-reducing ordering beside it is
+3.7 ms -- a factor of 1200. Every other symbolic stage is 1-15 ms.
+
+Not a size effect: clnlbeam has the FEWEST nonzeros of the large five
+(259,993) and the most expensive analysis; steering_12800 is larger
+(n=115,201, nnz=409,591) and analyses 38x faster. A 192x spread on
+comparable matrices points at an algorithmic pathology in the matching
+-- plausibly long augmenting paths on chain structure -- not uniform
+slowness.
+
+Against MA57's analysis, now that the oracle times MA57AD:
+  clnlbeam       feral 5001272 vs ma57   6298   -> 794x slower
+  rocket_12800         2705801     6426        -> 421x
+  marine_1600          1048521     7296        -> 144x
+  dtoc1nd                42464     2467        ->  17x
+  dtoc2                 276116   434101        -> feral 1.6x FASTER
+  steering_12800        130389   178776        -> feral 1.4x FASTER
+
+The two matrices where feral's analysis wins are exactly the two where
+ldlt_compress is a small share. Clean causal story: feral's analysis is
+competitive when MC64 does not blow up.
+
+End-to-end with both arms doing MC64 (feral total vs MA57 ICNTL(15)=1
+total) -- the only arm pairing where both solvers do the same work:
+  clnlbeam       5027280 /  240384 -> MA57 20.9x
+  marine_1600    1091338 /   54566 -> MA57 20.0x
+  dtoc1nd          61742 /    8086 -> MA57  7.6x
+  rocket_12800   2735711 /  602572 -> MA57  4.5x
+  dtoc2           377644 /  505747 -> feral 1.34x faster
+  steering_12800  172184 /  473026 -> feral 2.75x faster
+
+Issue #134 already carries "MC64 partial-matching two-pass" as a
+backlog item. This is the evidence for promoting it.
+
+Note this is a DIFFERENT cost from issue #153's "warm-path scaling
+never warms": that is the numeric scaling in the factor prologue
+(3.9-19.9 ms per call, 18-34% of factor time), paid every
+factorization. ldlt_compress is symbolic, paid once per analysis. Both
+are MC64. Whether one fix addresses both is unverified.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -626,3 +626,177 @@ Condition 1 is exactly what tried-and-rejected.md:2087 (2026-05-21)
 found confounded by the IPM barrier trajectory. The prize there is an
 order of magnitude larger than condition 3 was worth, and that entry
 says why it is hard. Do not start it without reading it.
+
+* 23:40 :mc64:scaling:measurement:correction:
+Ran the untested half of issue #38's claim ("silently corrupts
+inertia *and explodes factor cost*") on the three high-scaling
+families. `diag_scaling_reuse_correctness` with per-arm timing
+columns, fresh solver per iterate, `with_parallel(false)`:
+
+pinene_3200 (10 iterates): reuse total is LOWER on every one --
+41787->33205, 43732->36618, ..., 49822->32868 us. The delta is
+approximately the scaling cost, so non-scaling work is unchanged.
+No cost explosion.
+
+nql180 (7 iterates): reuse is SLOWER on 5 of 7, substantially --
+697786->1156543 (+66%), 726355->1303582 (+79%), 710552->1195501
+(+68%), 690824->1396280 (+102%), 695627->1345981 (+94%). Fresh
+scaling there is only ~14.5 ms of ~700 ms (2%), so reuse buys
+nothing and costs a lot. This is the first positive instance of
+#38's cost claim on a real KKT. Inertia still "same" on all 17.
+
+* 23:55 :mc64:profiling:correction:
+CORRECTION to my own earlier reading. I reported pinene_3200's
+per-iterate `scal_us` growing 8500 -> 207611 (19.7x) and called it
+a value-dependent MC64 slowdown. Built `diag_mc64_warm_vs_cold` to
+compare a warm solver against a cold one on the same matrix in the
+same process:
+
+  iterate  warm_scal  warm_pivord  warm_tot  cold_scal  cold_tot
+  0000          8052           61     42582       8041     41283
+  0001          9472           55     45184      10052     44952
+  0002         57749           50     92557       9375     41917
+  0006        205611           50    234063       8432     41763
+  0007        214213           51    244975       9400     45886
+  0009        175500           57    208370       8526     49707
+
+Cold is flat, warm climbs 26.6x. `scaling_pivot_order_us` is ~50 us
+in both, so it is inside MC64 proper. But this is NOT a slowdown:
+`Solver::factor` clears `symbolic.cached_mc64` after every call
+(issue #38, src/numeric/solver.rs:1374, whose own comment predicts
+"one extra MC64 (~100-200 ms on n~1e5) per warm refactor"). The
+cold arm's Hungarian therefore ran inside `analyze()`, and
+`ProfileReport::total_us` is documented as "wallclock for the
+entire driver call" -- the numeric driver only. The two arms bill
+the same work to different phases. My 19.7x was a measurement
+artifact of comparing across two probes with different solver
+lifetimes.
+
+* 00:10 :mc64:hungarian:value-dependence:
+The warm/cold split cannot answer whether the Hungarian itself is
+value-dependent, so measured it standalone via
+`feral::scaling::diagnose_mc64_matching` (no solver, no cache, no
+scaling post-processing) -- `diag_mc64_work_trajectory`.
+
+pinene_3200, identical pattern (nnz 732976) from iterate 1 on:
+
+  iter  match_us  augment   touched   edge_scans
+  0001     46852    57426   1340479      8148431
+  0003    107582    70196   3651551     29912538
+  0006    229183    77994   6816372     70268885
+  0009    175882    77993   6201685     55972134
+
+4.9x in wallclock on a pattern that never changes, so the value
+dependence is real and independent of the #38 artifact above.
+`augment_searches` moves only 1.36x (57426 -> 77993); `touched`
+moves 5.1x and `main_loop_edge_scans` 8.6x. Per-search work goes
+from 142 edge scans to 900. The search COUNT is stable; each
+shortest-augmenting-path search wanders much further as delta->0.
+
+nql180 is the extreme: 895 augment searches doing 202-222M edge
+scans on n=259681, i.e. ~227,000 scans per search (~87% of n).
+1.17 s -> 3.12 s across the trajectory.
+
+marine_1600 spikes to 809 ms at iterate 1 (23.5M touched) and
+falls back to 32 ms at iterate 2; iterate 0 has a different nnz
+(342399 vs 414399), so the spike sits right at the pattern change.
+
+Implication: capping or reordering the augmenting-path search is a
+strictly-safe lever (same matching, less work) that helps every
+family, including the ones where scaling reuse is unsafe. It does
+not depend on resolving the condition-1 gate question at all.
+
+* 00:35 :mc64:reuse:economics:corpus:
+Built `diag_trajectory_reuse`: TWO warm solvers over the same
+trajectory in one process, one on `Auto`, one pinned to
+`External(d0)` where d0 is iterate 0's own MC64 vector. This is the
+arm the previous probes could not measure -- only a warm solver
+pays the Hungarian inside the timed driver, because
+`Solver::factor` clears `symbolic.cached_mc64` after every call.
+
+Whole kkt-mittelmann corpus, 37 families with >=2 iterates, 233
+iterates, <=10 iterates each:
+
+  corpus fresh 34.66 s -> reuse 24.47 s, aggregate 1.42x,
+  geomean 1.164x, inertia differs on 0 iterates
+
+Wins: pinene_3200 5.09x, nql180 2.10x, marine_1600 1.63x,
+robot_1600 1.42x, gasoil_3200 1.39x, rocket_12800 1.33x.
+Losses: ex4_2_160 0.75x, cont5_1_l 0.77x, arki0009 0.91x,
+qcqp1000-2c 0.99x.
+
+rocket_12800 -- the named #38 reproducer -- shows 1.25x/1.42x with
+inertia 51201/38400/0 on both iterates and both arms. CAVEAT: my
+probe's fingerprint check is `csc.n != d0.len()`, n only. rocket
+changes nnz between iterates (332793 -> 435190), so the External
+arm applied D0 across a PATTERN change that the real cache would
+reject outright. That makes rocket a harder correctness test than
+the design would ever attempt, and it also means rocket's 1.33x is
+not a payoff the real design could bank.
+
+* 00:50 :mc64:issue38:mechanism:
+Read the original #38 evidence (`dev/journal/2026-05-16-30.org`
+17:25). The corruption mechanism is explicitly structural:
+`pick_ordering_preprocess` triggers `LdltCompress`, `LdltCompress`
+populates `SymbolicFactorization::cached_mc64` via
+`mc64::compute_matching`, and the stale *matching* is applied to
+iter-N. The scaling vector is downstream of that. Reusing D0
+alone -- `ScalingStrategy::External` -- cannot reach
+`LdltCompress` and cannot change the elimination structure.
+
+That is a mechanism-level reason the 233-iterate agreement is not
+luck. It is still not a proof: absence of a counterexample on this
+corpus is not a safety argument, and every matrix here has a fixed
+pattern per family.
+
+* 01:05 :mc64:gate:metric:negative-result:
+Tested whether a diagonal-free value statistic can replace
+condition 1. `diag_scaled_entry_spread` computes, on the same
+scaled matrix, both today's `max_ratio` and entry-magnitude
+statistics of D0*A_N*D0 (max, 99.9th pct, fraction > 1) -- MC64's
+own objective is about entry magnitudes and never mentions the
+diagonal, so this was the natural candidate.
+
+It does not discriminate, and it fails in the informative
+direction:
+
+  family        speedup   max_ent drift   p999_ent
+  marine_1600     1.63x       5.2e12        1.030
+  nql180          2.10x       3.9e6         3.9e6
+  pinene_3200     5.09x       1.1e1         5.698
+  ex4_2_160       0.75x       1.0e4         1.0e4
+
+marine_1600 is a WIN with the worst entry drift in the set;
+ex4_2_160 is a LOSS with far milder drift. Entry magnitude is
+anti-correlated with whether reuse is a good idea. p999 separates
+marine (a few outlier entries, p999 ~ 1.0) from ex4_2_160 (a broad
+shift, p999 = max), but nql180 also has p999 = max and is a 2.10x
+win. No value proxy tried predicts the outcome.
+
+* 01:20 :mc64:gate:cost-share:
+The reason no value proxy predicts the outcome is that there is
+nothing numerical left to predict: inertia never changed. What
+varies across the corpus is only COST. Sorting the 37 families by
+the fraction of factor time fresh MC64 actually consumes gives a
+monotone relationship:
+
+  scal%   families                          speedup
+  <=5.4   all four losses                   0.75x - 1.08x
+  >=12.6  every family without exception    1.13x - 5.09x
+
+Every loss sits at scal% <= 5.4 (ex4_2_160 5.4, cont5_1_l 3.3,
+arki0009 3.0, qcqp1000-2c 0.6). Every family at scal% >= 12.6
+wins. The gap 5.4 -> 12.6 is empty, so the threshold is not
+load-bearing anywhere in 6-12%.
+
+Gating on measured cost share at 10%: 15 of 37 families reuse,
+corpus 34.66 s -> 24.32 s, 1.43x -- i.e. it banks essentially all
+of the unconditional 1.42x while dropping every regression.
+
+The significance is that `scaling_us / total_us` is already
+measured per factorization. A cost-share gate needs no value
+proxy, no numerical justification, and no new O(nnz) sweep. The
+2026-05-21 entry searched for a metric separating "safe" from
+"unsafe"; on this evidence the scaling-vector path has no unsafe
+side, and the quantity that actually needs separating is
+profitable from unprofitable.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -353,3 +353,99 @@ Side observation: feral-default ran within 2-8% of feral-noscale on the
 pre-scaled inputs. Not in tension with #153's 18-34% warm-path scaling
 cost -- MC64 on an already-MC64-scaled matrix converges immediately --
 but it does mean this experiment cannot measure warm-path scaling.
+
+* 19:30 :correction:analysis:ma57:icntl15:
+Second instance of the same error, in my own Result 4. I compared
+feral's analyse_us (which includes MC64) against MA57's analyse_us at
+ICNTL(15)=0 (which includes no scaling at all) and reported feral's
+analysis as 794x slower on clnlbeam. That is the retracted result's
+mistake one level up: same asymmetry, different stage.
+
+Charging MA57 for its scaling (factor at ICNTL(15)=1 minus factor at
+ICNTL(15)=0, both already measured):
+
+  matrix          feral ana   MA57 ana+scal   as reported   corrected
+  clnlbeam         5001.3ms        201.6ms      794x slow   24.8x slow
+  rocket_12800     2705.8ms        554.8ms      421x slow    4.9x slow
+  marine_1600      1048.5ms         39.7ms      144x slow   26.4x slow
+  dtoc1nd            42.5ms          4.5ms       17x slow    9.4x slow
+  steering_12800    130.4ms        454.1ms     1.4x faster  3.5x faster
+  dtoc2             276.1ms        444.8ms     1.6x faster  1.6x faster
+
+MC64 head to head, both solvers doing the same job: feral 23.2x slower
+(clnlbeam), 25.1x (marine), 4.2x (rocket), 1.4x (dtoc2), 1.2x
+(dtoc1nd) -- and 13.3x FASTER on steering.
+
+Also established empirically: MA57ID sets ICNTL(15)=1. MA57's own
+default IS scaling-on. So ICNTL(15)=0 is not MA57's default
+configuration; it is the right setting for a factorization-only
+comparison (and the clean experiment, where both arms are scaling-free
+on pre-scaled input, is unaffected and stands), but it is the wrong
+baseline for anything end-to-end.
+
+Against MA57 in its default configuration, feral's once-per-analysis
+MC64 amortizes: crossover at 28 factorizations (clnlbeam), 5 (rocket),
+102 (marine), immediately (steering); MA57 wins always on dtoc1nd and
+after 8 on dtoc2. Caveat: this assumes the cache is actually reused
+across warm factorizations, which is exactly what #153 disputes.
+
+Lesson, second time: the asymmetry is not in the timer, it is in what
+each solver was configured to DO. Checking the timer boundary does not
+catch it. The check that does is "name the work each arm performs in
+the timed region, and diff the two lists."
+
+* 19:50 :mc64:scaling-law:measurement:dense-column-refuted:
+Profiled MC64 across the corpus (probe_mc64_hungarian, 41 matrices,
+one iterate per family) to find what actually drives its cost. The
+prior diagnosis -- dense coupling column, O(searches x dense_deg),
+mc64-dense-column-2026-06-06.md -- does not survive.
+
+clnlbeam has max_col_degree = 5 and is the second most expensive
+matrix in the corpus (4522 ms). steering_12800 has the LARGEST max_deg
+in the corpus (51202) and runs in 21 ms. gasoil_3200 (max_deg 41500)
+runs in 9.6 ms. Over the six chain KKTs, log(ms) vs log(max_deg) is
+r = -0.59 -- the wrong sign. Against touched_total it is r = +0.999.
+
+Cost is bimodal corpus-wide: 37 of 41 matrices run at 0.3-70 ms; four
+(clnlbeam 4522, nql180 2892, rocket 2279, marine 812) are 1-2 orders
+out. rocket is the dense-column class the prior note explains. clnlbeam
+and nql180 are not -- max_deg 5 and 182.
+
+The scaling law, from leading principal submatrices of clnlbeam
+(n = 80k..100k; not a true size ladder because clnlbeam is block
+ordered, but within this range searches is pinned at 5043):
+
+  n       touched      edge_scans     ms
+  90000   176356074    360898556     4080
+  93000   188383074    360895553     4232
+  96000   200410074    360892553     4351
+  98000   208428074    360890553     4421
+  99000   212437074    360889550     4450
+  99999   216406073    360922194     4525
+
+edge_scans is FLAT (3.609e8, varying <0.01%). touched grows exactly
++4009 per unit of n -- four independent deltas (3000/3000/2000/1000)
+all give 4009.0. So each augmenting search reaches Theta(n) distinct
+rows while the edge work does not grow at all. Growing the problem
+buys pure heap traffic and zero additional edge scanning. Wall time
+tracks touched, not edge_scans.
+
+touched is distinct rows: hungarian.rs:549 guards touched.push(i) with
+d[i] == RINF, so no double counting. heap_init_slots == touched_total
++ n exactly on every matrix, confirming the #80 incremental-reset fix
+is intact and heap init is NOT the cost.
+
+This is value-driven, not structural. Synthetic chain KKTs from
+gen_chain_kkt at the same geometry (nx=2, nc=1, n up to 384000) get
+searches=0 -- greedy init matches everything -- and run in 18 ms at
+n=384000. Same shape, no blowup. Consistent with issue #80's trap #2
+(MC64 needs real values), and one more instance of proxies not
+reproducing the real matrices.
+
+What this does NOT establish: a fix. The impossibility proof in
+mc64-dense-column-2026-06-06.md section 3.2 is specific to pruning the
+dense-column inner scan and does not cover the Theta(n) frontier seen
+here; the mechanism is that csp stays RINF while the search hunts for
+an unmatched row, so nothing prunes insertion. Whether that frontier
+can be bounded without changing the matching is open and needs its own
+research note before any code.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -800,3 +800,89 @@ proxy, no numerical justification, and no new O(nnz) sweep. The
 "unsafe"; on this evidence the scaling-vector path has no unsafe
 side, and the quantity that actually needs separating is
 profitable from unprofitable.
+
+* 02:10 :mc64:hungarian:prior-art:correction:
+Took the "Hungarian search bound" lever recommended at the end of
+mc64-condition1-cost-share-2026-08-09.md. Prior-art check and code
+inspection killed it before any code was written, on two counts.
+
+(1) The classic csp shortest-augmenting-path bound is ALREADY
+implemented: hungarian.rs:541 prunes the root scan, :570 terminates
+the main loop, :591 prunes the inner column scan. Nothing standard is
+missing.
+
+(2) tried-and-rejected.md:2313 (2026-06-06-03) proves no per-column
+reduced-cost bound can ever prune the inner scan -- with
+vj + lb_tight = dq0, the skip fires iff dq0 >= csp, but q0 was popped
+only because dq0 < csp -- and explicitly instructs future sessions not
+to retry it.
+
+So my note's phrase "same-output-less-work, needs no gate and no
+residual argument" is WRONG. Any further truncation ends a search
+before its shortest path is proven -> suboptimal matching -> different
+scaling vector -> corpus study + human approval. Recorded the
+correction at the top of the new research note rather than editing the
+old one.
+
+* 02:25 :mc64:hungarian:measurement:
+Where the Hungarian time actually goes. Per-edge-scan cost differs
+4.5x between the two dominant families on IDENTICAL code:
+pinene_3200_0006 206,907 us / 70.3M scans = 2.94 ns/scan;
+nql180_0002 3,197,295 us / 222.1M scans = 14.4 ns/scan.
+
+The two are in opposite regimes. pinene: init heuristic leaves ~61% of
+columns unmatched (77,994 searches on n=127,995), so many tiny
+searches, 87 rows touched each -> L1-resident. nql180: init matches
+99.66% (893 searches on n=259,681), so a few enormous searches, 53,411
+rows touched each = 21% of all rows -> working set far past L1. The
+4.5x tracks working-set size, not algorithm.
+
+Also sized build_cost_graph via a temporary FERAL_BUILD_DEBUG timer
+(reverted): 8-12 ms/iterate = 20% of pinene's cheapest iterate but
+0.4% of nql180's. Not the lever.
+
+* 02:40 :mc64:hungarian:optimization:bit-identical:
+Implemented what the measurement pointed at instead. Every heap sift
+level did d[self.heap[parent]] -- a load from the heap array then a
+DEPENDENT random load into d. IndexHeap now stores the key inline
+(HeapEntry { key, idx }). Comparisons are unchanged, so the matching is
+bit-identical by construction. Side benefit: removes the heap's
+&[f64] borrow of d, which is what previously blocked fusing d with the
+other per-row arrays.
+
+Oracle: new diag_mc64_scaling_fingerprint hashes the raw IEEE bits of
+every entry of SparseFactors::scaling, so ANY matching deviation is
+caught, not just one big enough to move a residual. Verified
+deterministic across repeat runs before trusting it.
+
+51 matrices / 39 families: all fingerprints unchanged.
+
+Speed, median of 3: nql180_0000 1,174,045 -> 1,128,533 us (1.040x);
+nql180_0002 3,083,529 -> 2,917,491 us (1.057x); pinene_0001 44,381 ->
+45,279 (0.98x); pinene_0006 202,205 -> 202,969 (1.00x); marine_1600
+29,911 -> 29,820 (1.00x).
+
+4-5% on the family that dominates corpus MC64 time, nothing elsewhere
+-- exactly the predicted split, since pinene was already L1-resident.
+Smaller than I hoped; reporting it as such. cargo test --release exit
+0, clippy -D warnings clean.
+
+* 02:50 :mc64:hungarian:profile:next:
+sample(1) on nql180_0002: 100/108 samples in the inlined main loop, 7
+in IndexHeap::update. Decrease-key sift-UP is only ~6.5% (most
+sift-ups terminate immediately), so the gain came from the sift-DOWN
+path inside pop, as designed.
+
+Remaining lever, measured by a standalone microbenchmark of the access
+pattern (5 split arrays vs 1 fused struct, at nql180's n):
+ws=500 -> 0.99x (pinene regime), ws=50000 -> 1.90x, ws=259681 -> 1.68x.
+So fusing visited/u/iperm/d into one per-row struct is worth ~1.7x on
+the array-access portion ONLY, which is ~2.3 of nql180's ~13 ns/scan
+-> expect ~7% end-to-end. Bit-identical, now unblocked. Not done.
+
+Honest ceiling on this direction: nql180's 893 searches are long
+because the augmenting paths are long, which is a property of the
+matrix. Constant-factor memory work buys tens of percent, not
+multiples. A multiple requires changing the matching (auction /
+eps-optimal, or skipping MC64 on these KKTs) -- the gated,
+approval-requiring path, not this one.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -1,0 +1,221 @@
+#+TITLE: Session 2026-08-09-08 — PR #157 follow-through on the real corpus
+#+DATE: 2026-08-09
+
+* 15:45 :pr157:orientation:corpus:
+Picked up PR #157 (branch =docs/session-2026-08-09-05=, head 1833768).
+CI green (check + stress-smoke, both x2), no reviews, docs-and-harness
+only. The research note =dev/research/chain-kkt-ma57-gap-2026-08-09.md=
+lists three ordered next steps that need a machine with
+=data/matrices/=: bisect, thread sweep, re-run the gap on the real
+corpus. This machine has it.
+
+Inventory:
+- =data/matrices/kkt-mittelmann/= has clnlbeam, dtoc1nd, dtoc2,
+  marine_1600, rocket_12800. *steering_12800 has no =.mtx=* — only a
+  =steering_12800.solver.log=. The set is five families, not the six
+  the note names.
+- =external_benchmarks/ma57_oracle/ma57_bench= is a prebuilt arm64
+  binary and runs clean.
+- All five bisect commits resolve locally: c05eb77 (0.14.0), e8e1c5a
+  (#149 SIMD), fad5670 (#150 parallel), 808babb (v0.15.0), f7a152a
+  (main).
+- Machine: =Mac16,11=, Apple M4 Pro, 10 performance + 4 efficiency
+  cores. Different from the M2 (=Mac14,2=, 4P+4E) the note was measured
+  on, so this is an independent replication — but still heterogeneous,
+  so the homogeneous-core leg of the E-core hypothesis is not testable
+  here.
+
+* 15:50 :calibration:ma57:surprise:
+One untimed pass of current main and MA57 over the real matrices, to
+size the run. =factor_us=:
+
+| matrix           |      n | feral   | ma57    |
+|------------------+--------+---------+---------|
+| clnlbeam         |  99999 |  38,083 | 278,063 |
+| rocket_12800     |  89601 |  19,387 | 552,194 |
+| marine_1600      |  76807 | 120,462 |  44,303 |
+| dtoc1nd          |   9685 |  11,172 |   5,980 |
+
+The proxy conclusion — "feral slower than MA57 on all five, 1.4x to
+2.4x" — does *not* reproduce here. feral is 7x and 28x faster on the
+two largest. Single shot, not the paired protocol, so not quotable
+yet, but it is the number the note said the proxies could not settle,
+and it points the other way.
+
+Second observation: analysis dominates wall clock on these
+(clnlbeam =analyse_us= 4,593,570 vs =factor_us= 38,083). Run cost is
+set by analysis, ~9.3 s per feral pass over the five, 2.2 s for MA57.
+
+* 15:52 :correctness:dtoc2:singular:
+=dtoc2_0001= and =dtoc2_0002= are singular. feral reports
+=inertia_zero 4= with =rel_res NaN=; MA57 reports =inertia_zero 103=,
+also NaN. Two independent solvers agreeing on rank deficiency means
+the matrix, not the solver. =dtoc2_0000= factors clean
+(=inertia_zero 0=, =rel_res 3.08e-16=) and is what the run uses. Note
+this is a *different* dtoc2 from the =kkt= corpus DTOC2 (n=9990) in
+=dev/corpus-characterization/summary.csv=; the mittelmann one is
+n=103920.
+
+* 15:56 :harness:arm_run:
+=ab_run.py= hardcodes three arms (new/base/ma57); the bisect needs six
+and the thread sweep four. Wrote
+=external_benchmarks/chain_proxy/arm_run.py=, an N-arm generalization
+reusing =ab_run.py='s =read_mtx_lower=, =synth_rhs=, =parse_sidecar=
+and =sign_test_p= so the protocol is literally the same code. Arms are
+=NAME=BIN= or =NAME=BIN|K=V,K2=V2= for env overrides, which is what
+makes the thread sweep and the SIMD/seed probes a matter of arguments
+rather than another script. This is the =probe_bisect.py= the note
+recorded as written-but-never-run; it is committed this time.
+
+Added a correctness gate that prints before any timing table: any arm
+with =inertia_zero != 0= or NaN/>1e-8 =rel_res= is flagged and the
+matrix is called out as not trustworthy for timing.
+
+=real_corpus_mtx.py= builds the =--mtx-dir= as symlinks into
+=data/matrices/kkt-mittelmann=, one iterate per family, with the
+selection rules (and the dtoc2 and steering_12800 exceptions) in the
+module docstring.
+
+Baseline builds are cheap here: 6-7 s each for a cold release build of
+the four worktrees, which is a consequence of the zero-non-Rust-deps
+constraint keeping the dependency graph tiny.
+
+* 16:07 :bisect:result:regression:ma57:
+Bisect done: 15 pairs, 6 arms, 5 real matrices, correctness gate clean
+(=inertia_zero=0=, =rel_res <= 1e-8= on every arm and matrix).
+
+=min factor_us=:
+
+| matrix       |      n | v0.14.0 | #149 SIMD | #150 par | v0.15.0 |   main |    ma57 |
+|--------------+--------+---------+-----------+----------+---------+--------+---------|
+| clnlbeam     |  99999 |   43914 |     43338 |    21311 |   21417 |  21495 |  202278 |
+| dtoc1nd      |   9685 |   10856 |     11102 |    13696 |   13899 |  13980 |    4493 |
+| dtoc2        | 103920 |  115928 |    114206 |    80795 |   80732 |  80098 |   60283 |
+| marine_1600  |  76807 |   31127 |     33425 |    32195 |   32380 |  32086 |   40829 |
+| rocket_12800 |  89601 |   27602 |     28599 |    21935 |   22381 |  22091 |  534744 |
+
+*Both headline claims in the proxy note are contradicted.*
+
+1. The MA57 gap. main vs ma57 (>1 = feral faster): rocket_12800 24.21
+   (15/15, p=0.0001), clnlbeam 9.41 (15/15, 0.0001), marine_1600 1.27
+   (15/15, 0.0001), dtoc2 0.75 (0/15, 0.0001), dtoc1nd 0.32 (0/15,
+   0.0001). The proxies said "slower on all five, 1.4x-2.4x". On the
+   real matrices feral is faster on three of five, and the two losses
+   are the smallest matrix in the set and dtoc2.
+
+2. The regression. vs 0.14.0, #150 gives clnlbeam 2.061, dtoc2 1.435,
+   rocket_12800 1.258, all 15/15 at p=0.0001; marine_1600 0.967.
+   *dtoc1nd loses: 0.793 (0/15, p=0.0001)*, and v0.15.0 (0.781) and
+   main (0.777) hold that loss. #149 alone is flat to slightly negative
+   (marine 0.931, rocket 0.965, clnlbeam 1.013, dtoc2 1.015).
+
+So the regression is real and attributable to #150, but it is on the
+*smallest* matrix (n=9,685), not the large chains — which is the
+opposite of what =prommis_sx_like= (0.833) and =double_column_like=
+(0.914) predicted. The proxies got the sign right on "something
+regressed" and the location wrong.
+
+3. v0.15.0 vs main are indistinguishable (2.050/2.043, 1.233/1.249,
+   1.436/1.447, 0.961/0.970, 0.781/0.777). The tag-vs-post-tag
+   question the note left open is answered: the #155 amalgamation
+   guard and #156's parallel-default change move nothing here.
+
+* 16:10 :steering:blocked:ripopt:
+Tried to fill the =steering_12800= hole. The =.nl= is in
+=/Users/jkitchin/Dropbox/projects/pounce-bench-data/mittelmann/nl=, so
+re-ran =scripts/harvest-mittelmann-kkt.sh steering_12800= against it
+with =RIPOPT_BIN=/Users/jkitchin/projects/ripopt/target/release/ripopt=.
+
+ripopt solved it fine — "Optimal after 23 iterations", 60.8 s, final
+primal_inf 7.1e-15 — and wrote *zero* =.mtx= files.
+
+Cause: ripopt commit 76d3575 (2026-04-28, "A7.6 (set 2) delete dead
+condensed-path helpers") bulk-deleted the dump implementation —
+=collect_kkt_lower_triangle_entries=, =write_kkt_mtx_file=,
+=write_kkt_json_sidecar=, =dump_kkt_matrix= — plus the
+=if let Some(ref dump_dir) = options.kkt_dump_dir= call site. It left
+=SolverOptions::kkt_dump_dir= / =kkt_dump_name= (options.rs:714) and
+the CLI wiring (ripopt_ampl.rs:607) in place, so =kkt_dump_dir== is
+still accepted on the command line and now silently does nothing.
+
+That makes steering_12800 unavailable without restoring ~200 lines in
+another repo. Out of scope for this PR; leaving the set at five and
+recording it as a known hole. Worth an issue on ripopt: an option that
+parses and silently no-ops is worse than one that errors.
+
+* 16:25 :threads:ecores:refuted:
+Thread sweep, =RAYON_NUM_THREADS= = 1/2/4/8/10 vs default (14), 15
+pairs. *Nothing moves.* Every ratio vs =main-all= within 6% of 1.0;
+the only significant one is marine_1600 at t1 (0.961, 0/15, 0.0001),
+which is the wrong direction for the hypothesis. steering_12800 at one
+thread: 1.003 (9/15, p=0.6072).
+
+Verified the knob is live before believing the null: feral reads the
+global rayon pool (=rayon::current_num_threads()=,
+=src/numeric/factorize.rs:3262=, =src/numeric/solve.rs:632=), and the
+same env var moved the *proxies* by up to 65% (double_column_like
+40382 -> 66584). So the variable works; these matrices just do not
+care.
+
+E-core hypothesis refuted, on hardware with *more* E-cores than the
+machine that generated it. Recorded in =tried-and-rejected.md=.
+
+Bigger consequence: single-threaded main == all-threads main on every
+matrix, so *#150's 1.20x-2.05x gains are not parallelism gains*.
+Whatever task-per-subtree coarsening bought (spawn overhead, locality,
+traversal order), it is not multi-core execution. Any follow-up that
+tries to extend #150 by parallelizing harder starts from a false
+premise.
+
+* 16:30 :steering:pounce:harvest:
+pounce has what ripopt lost. =pounce <p>.nl --dump kkt:<spec>
+--dump-dir <d>= writes =iter_NNN/kkt_solve_NNN.jsonl=, one JSON object
+per line with =n=, =irn=, =jcn=, =vals=, =rhs=, =sol= and the inertia
+fields. Wrote =scripts/harvest-pounce-kkt.py= to convert that tree into
+the =<name>_<iter:04>.{mtx,json}= layout the corpus tooling reads.
+
+Two deliberate choices in the converter: entries are summed into a dict
+before writing the lower triangle (pounce emits the full symmetric
+structure as 1-based triplets — 422,392 triplets collapse to 409,591
+unique lower-triangle coordinates on steering, and Matrix Market has no
+defined semantics for a repeated coordinate); and only the first
+=kkt_solve_NNN= per iteration is kept, since later ones are
+inertia-correction retries of the same system and would over-weight
+hard iterations.
+
+Validated against an *external* oracle, not against itself: a
+synthesized =b = A x_true= cannot catch a mangled matrix because b is
+derived from the same file. Instead — pounce reports
+=num_neg_evals_actual = 51201=; feral and MA57 independently report
+=inertia_neg 51201=, =inertia_pos 64000=, =inertia_zero 0= on the
+converted =.mtx=. Three solvers agree. feral solves pounce's own dumped
+RHS to =rel_res 3.66e-14=.
+
+steering_12800_0001: n=115201, nnz=409591 — the largest matrix in the
+set.
+
+* 16:45 :bisect:six:gap:ma57accuracy:
+Re-ran bisect and thread sweep with all six. Both conclusions hold and
+strengthen.
+
+Gap, main vs ma57 (>1 = feral faster), all p=0.0001:
+rocket_12800 23.40, clnlbeam 9.68, *steering_12800 8.06*,
+marine_1600 1.27, dtoc2 0.755, dtoc1nd 0.319.
+
+#150 vs 0.14.0: steering 1.646, clnlbeam 2.048, dtoc2 1.401,
+rocket 1.200 (all 15/15); dtoc1nd 0.764. main holds all of it
+(steering 1.669, dtoc1nd 0.750).
+
+*The correctness gate fired, on MA57.* steering_12800: MA57
+=rel_res 4.53e-08= against feral =3.52e-14=, identical matrix and RHS.
+Everywhere else both are 1e-16..1e-14. feral's sidecar says
+=refined yes=, so part of it is iterative refinement the MA57 oracle
+does not do. =factor_us= is factorization only so the 8.06x stands,
+but it must be quoted with the caveat: feral is faster *and* more
+accurate there, against a looser MA57 solve. Writing the gate into
+=arm_run.py= is what surfaced this; it would have been invisible in a
+timing-only table.
+
+Also: #149's SIMD kernel is below 1.0 on all six, significantly on
+clnlbeam (0.966, 0/15, 0.0001) and rocket_12800 (0.979, 2/15, 0.0074).
+It helped on the proxies. Separate thread, worth its own bisect.

--- a/dev/journal/2026-08-09-08.org
+++ b/dev/journal/2026-08-09-08.org
@@ -552,3 +552,77 @@ ex8_2_3 26.1%, gasoil_3200 23.1%, arki0003 23.5%, pinene_3200
 21.4%). Values change each IPM iterate so recomputation is
 legitimate; whether an O(nnz) scan should cost 20%-38% of a
 factorization is an open question.
+
+* 22:15 :bug:mc64:cache:value-bound:fix:measurement:
+Instrumented =precompute_mc64_validity= and =mc64_value_bound_passes=
+behind =FERAL_VB_DEBUG= (backed up to /tmp/vb2.bak, reverted after) and
+drove =diag_trajectory_scaling= over 24 corpus families to size the
+=cond_diag= defect before fixing it.
+
+First correction to my own earlier reading: I had recorded "mean_diag_0
+4.213035e-13". That is the *threshold*, not the mean. =mean_diag= is
+4.213035e-1; the threshold is =EPS_DIAG * mean_diag= = 4.213035e-13.
+The conclusion (min compared against mean) is unchanged.
+
+Sizing, and it is far smaller than the 32.7% headline that motivated
+the work:
+- 17 of 24 families never run MC64 at all -- =pick_scaling_strategy=
+  routes them to InfNorm, =pre=0= in the debug log. That includes every
+  large-scaling% family from the phase profile (clnlbeam, dtoc2,
+  rocket_12800, steering_12800). No MC64 cache work can touch them.
+- 7 families route to MC64 -> 53 gate evaluations.
+- =cond_diag= is the *sole* blocker on 3 of 53. Two on robot_1600 with
+  drift 0.988 and 1.000 (false positives -- the min scaled diagonal did
+  not move). One on arki0003 with drift 2.1e-8, a genuine eight-order
+  collapse that any correct condition 3 must reject.
+
+Threshold sweep: DIAG_SHRINK from 0.5 down to 1e-6 all give the same 25
+accepts of 53. The constant is not load-bearing; picked 0.5 =
+1/GROWTH_FACTOR as the tightest defensible value.
+
+* 22:40 :mc64:value-bound:implemented:verified:
+Fix landed as a disjunction, not a replacement:
+=min_diag >= EPS_DIAG*mean_diag_0 || min_diag >= DIAG_SHRINK*min_diag_0=.
+Strict widening of the accept set, zero-drift-safe by construction
+(re-checking the baseline gives =min_diag == min_diag_0= exactly).
+
+Tests first, and the regression test did fail first. Added the
+=min_diag_0= field and its population *without* the =cond_diag= change,
+which made the new test fail at runtime rather than at compile time:
+
+: value_bound_passes_on_identical_matrix_with_wide_diagonal_range ... FAILED
+: panicked: a matrix must pass the value bound against its own fingerprint
+: test result: FAILED. 12 passed; 1 failed
+
+After the =cond_diag= change: 13 passed. Full =cargo test --release=
+exit 0.
+
+Verification against pre-fix and post-fix binaries built from the same
+tree, 7 families, 53 gate evaluations. The complete hit-pattern diff:
+
+: < robot_1600_0004 NO      > robot_1600_0004 yes
+: < robot_1600_0005 NO      > robot_1600_0005 yes
+
+Nothing else moved. Inertia byte-identical on every iterate of every
+family. robot_1600 trajectory 63560 -> 54445 us (14.3%), scaling 20721
+-> 12479 us (39.8%). Matches the 13.8% predicted from the gate log.
+
+* 23:00 :mc64:sizing:next-target:
+The trajectory totals reframe where the scaling mass actually is, and it
+is not where this fix helps:
+
+| family      | scaling share | helped |
+| nql180      |         66.2% | no     |
+| pinene_3200 |         79.4% | no     |
+| marine_1600 |         50.6% | no     |
+| robot_1600  | 32.6%->22.9%  | yes    |
+| dtoc1nd     |         10.4% | no     |
+| arki0003    |          3.5% | no     |
+| qcqp1000-2c |          0.5% | no     |
+
+nql180 spends 11.2 s of 17.0 s in scaling and gets nothing here -- it
+rejects on *condition 1*, as does pinene_3200 on all 8 of its checks.
+Condition 1 is exactly what tried-and-rejected.md:2087 (2026-05-21)
+found confounded by the IPM barrier trajectory. The prize there is an
+order of magnitude larger than condition 3 was worth, and that entry
+says why it is hard. Do not start it without reading it.

--- a/dev/plans/mc64-value-bound-diag-drift.md
+++ b/dev/plans/mc64-value-bound-diag-drift.md
@@ -1,0 +1,56 @@
+# Plan — make MC64 value-bound condition 3 a drift measure
+
+Research: `dev/research/mc64-value-bound-diag-drift-2026-08-09.md`.
+
+## Change
+
+`src/scaling/value_bound.rs` only. No API surface moves; everything here is
+`pub(crate)`.
+
+1. Add `min_diag_0: f64` to `Mc64CacheValidity`, populated in
+   `precompute_mc64_validity` from `stats.min_diag`. Keep `mean_diag_0`.
+2. Add `const DIAG_SHRINK: f64 = 0.5;` documented as `1.0 / GROWTH_FACTOR`.
+3. `cond_diag` becomes the disjunction of the existing absolute floor and the
+   new drift clause.
+4. Update the doc comment on `mc64_value_bound_passes` (condition 3) and the
+   defensive length-mismatch comment in `precompute_mc64_validity`, which
+   currently reasons about `mean_diag_0 = 0` alone.
+
+## Tests, written first
+
+New, in `value_bound.rs`:
+
+* `value_bound_passes_on_identical_matrix_with_wide_diagonal_range` — the
+  regression. `diag(1e-14, 1.0)`, identity scaling, validity from
+  `precompute_mc64_validity` on that same matrix. Hand oracle: no
+  off-diagonals so `max_ratio = 0`, `n_off_dominant = 0`, `min_diag = 1e-14`,
+  `mean_diag = (1e-14 + 1)/2 = 0.5`. Today `cond_diag` is
+  `1e-14 >= 1e-12 * 0.5 = 5e-13` -> false, so the gate rejects a matrix
+  against its own fingerprint. **This test must fail before the change.**
+* `value_bound_rejects_collapse_from_tiny_baseline` — the `arki0003` control,
+  numbers taken from the instrumented corpus run, not from the code:
+  `min_diag_0 = 9.372359e-6`, `mean_diag_0 = 9.925188e-1`, current
+  `min_diag = 1.984196e-13`. Both clauses must fail.
+* `value_bound_vacuous_when_no_qualifying_rows` — all-zero diagonal gives
+  `min_diag_0 = mean_diag_0 = 0`; both clauses are `>= 0` and condition 3 is
+  vacuous, as it already is today. Locks the edge case against the new field.
+
+Existing tests keep their assertions. The three hand-built `Mc64CacheValidity`
+literals gain `min_diag_0`; `value_bound_rejects_on_diagonal_collapse` gets
+`min_diag_0: 1.0` so its `1e-20` current diagonal fails the drift clause too
+and the test still rejects for the reason its doc comment states.
+
+## Oracle provenance
+
+Hand calculation for the synthetic cases (arithmetic shown in each doc
+comment), and the instrumented corpus run for the `arki0003` numbers. Neither
+is read off the implementation.
+
+## Gates
+
+* `cargo test` green, including `tests/issue_38_*`, `tests/mc64_*`,
+  `tests/n2_static_pivot_scaling.rs`, `tests/n4_mc64_retry_latch.rs`,
+  `tests/issue65_mc64_fallback.rs`, `tests/lu_scaling.rs`.
+* `diag_trajectory_scaling` on the seven MC64-routed families: exactly two
+  additional hits, both `robot_1600`, no other family's hit pattern changes.
+* Inertia unchanged on those families.

--- a/dev/plans/release-0.15.0-checklist.md
+++ b/dev/plans/release-0.15.0-checklist.md
@@ -111,22 +111,34 @@ one — on grid250 here, forcing `min_seeds=64` costs 1.85×, so the knob
 demonstrably routes both ways. If a single default serves the corpus,
 change `PAR_MIN_SEEDS` and record it in decisions.md.
 
-## 3. Release
+## 3. Release — **SHIPPED 2026-08-09**
 
-- [ ] Bump **all six** version strings (a `0.14.0` grep must come back
+- [x] Bump **all six** version strings (a `0.14.0` grep must come back
       empty except for the unrelated `feral-*` ordering crates at 0.2.1):
       `Cargo.toml:13`, `Cargo.lock:198`, `python/Cargo.toml:5`,
       `python/Cargo.lock:62` (`feral`), `python/Cargo.lock:113`
       (`feral-python`), `python/pyproject.toml:7`
-- [ ] Verify both lockfiles still resolve: `cargo metadata --locked` in
+- [x] Verify both lockfiles still resolve: `cargo metadata --locked` in
       the root and in `python/`
-- [ ] `CHANGELOG.md`: move the Unreleased section under `[0.15.0]`
-- [ ] Publish a **GitHub Release** — `release.yml` fires on
-      `release: published` (not on tag push), and it verifies the tag
-      matches `Cargo.toml`. This is the irreversible step: crates.io
-      versions can be yanked but never re-published.
-- [ ] Notify pounce (issue #148 / pounce#552) so the factorization
-      comparison can be re-run against a released feral
+- [x] `CHANGELOG.md`: move the Unreleased section under `[0.15.0]`
+- [x] PR #151 merged as `808babb` (squash). Main CI green on the merge
+      commit: CI, Python wheels, Pages all success.
+- [x] Tag `v0.15.0` pushed at `808babb`; **GitHub Release published**
+      (`release.yml` fires on `release: published`, not on tag push, and
+      it verifies the tag matches `Cargo.toml`). Tag/version check
+      passed, `cargo test` green in the release job.
+- [x] Tag + publish: crates.io `feral 0.15.0` live (all seven crates in
+      dependency order); PyPI `feral-solver 0.15.0` live with four
+      wheels (macOS universal2, manylinux x86_64, manylinux aarch64,
+      win_amd64) plus the sdist. `uv pip` smoke test passed.
+- [x] Notify pounce (issue #148 / pounce#552) so the factorization
+      comparison can be re-run against a released feral. Posted as
+      [pounce#552 comment 5232312068](https://github.com/jkitchin/pounce/issues/552#issuecomment-5232312068):
+      what changed, that defaults are bit-identical, and the one-line
+      pin bump at `Cargo.toml:127` plus dropping any uncommitted
+      `[patch.crates-io]` redirect.
+
+**§3 complete. 0.15.0 is fully shipped and announced.**
 
 ## 4. After the release — the real next round
 

--- a/dev/research/chain-kkt-corpus-2026-08-09.md
+++ b/dev/research/chain-kkt-corpus-2026-08-09.md
@@ -1,0 +1,199 @@
+# The MA57 comparison on the real chain KKTs
+
+**Date:** 2026-08-09
+**Machine:** Apple M4 Pro, `Mac16,11`, 10 performance + 4 efficiency cores, macOS.
+**Supersedes:** `chain-kkt-ma57-gap-2026-08-09.md`, whose two headline
+conclusions this run contradicts.
+
+## Why
+
+The proxy note measured block-tridiagonal stand-ins because the machine
+it ran on had no `data/matrices/`. It closed with three ordered steps
+for a machine that did: bisect the regression, sweep threads, re-run
+the gap. This is that run. All three are done, and the answers are not
+the ones the proxies predicted.
+
+## Setup
+
+Six real KKT systems, one iterate per family, from
+`data/matrices/kkt-mittelmann` (see
+`external_benchmarks/chain_proxy/real_corpus_mtx.py` for the selection
+rules). Paired alternating A/B per `dev/decisions.md` (2026-08-09):
+every arm timed once per pair, `min factor_us` over 15 pairs as the
+per-arm statistic, exact two-sided sign test over pairs. All arms read
+the same matrices and the same synthesized RHS.
+
+`steering_12800` had no `.mtx` in the corpus and was regenerated for
+this run — see **Regenerating steering_12800** below.
+
+`dtoc2` uses iterate `_0000`. `dtoc2_0001` and `_0002` are singular:
+feral reports `inertia_zero = 4`, MA57 reports `103`, both `rel_res =
+NaN`. Two independent solvers agreeing on rank deficiency means the
+matrix, not the solver, so those iterates cannot carry a timing.
+
+## Result 1 — the gap against MA57 is not a gap
+
+`main` vs HSL MA57, `min factor_us` over 15 pairs. Ratio > 1 means
+feral is faster.
+
+| matrix | n | main | ma57 | ratio | wins | p |
+|---|---|---|---|---|---|---|
+| rocket_12800 | 89,601 | 22,893 | 535,659 | **23.40** | 15/15 | 0.0001 |
+| clnlbeam | 99,999 | 21,739 | 210,481 | **9.68** | 15/15 | 0.0001 |
+| steering_12800 | 115,201 | 33,923 | 273,494 | **8.06** | 15/15 | 0.0001 |
+| marine_1600 | 76,807 | 33,373 | 42,471 | 1.27 | 15/15 | 0.0001 |
+| dtoc2 | 103,920 | 81,163 | 61,245 | 0.76 | 0/15 | 0.0001 |
+| dtoc1nd | 9,685 | 14,297 | 4,561 | 0.32 | 0/15 | 0.0001 |
+
+feral is faster on four of six, by up to 23x, and the two losses are
+`dtoc2` (1.3x) and `dtoc1nd`, the smallest matrix in the set by an
+order of magnitude.
+
+The proxy note reported "feral is slower than HSL MA57 on all five
+proxies, 1.4x to 2.4x" and called the largest, most chain-like proxy
+the worst case. On the real matrices the largest and most chain-like
+are where feral wins hardest. The proxies inverted the result.
+
+**One caveat belongs with the 8.06x.** On `steering_12800` MA57's
+residual is `4.53e-08` against feral's `3.52e-14`, on identical matrix
+and RHS — six orders of magnitude, and the only place in the run where
+either solver is worse than `1e-13`. feral's sidecar reports `refined
+yes`, so some of that is iterative refinement the MA57 oracle does not
+do. `factor_us` is numeric factorization only, so the timing stands,
+but the honest statement is that feral is 8x faster *and* far more
+accurate there, against an MA57 solve that is looser than feral's.
+
+## Result 2 — the regression is real, and it is on the small matrix
+
+Ratios vs `v0.14.0` (c05eb77). > 1 means the arm is faster.
+
+| matrix | #149 SIMD | #150 parallel | v0.15.0 | main |
+|---|---|---|---|---|
+| clnlbeam | 0.966 | 2.048 | 2.054 | 2.048 |
+| steering_12800 | 0.986 | 1.646 | 1.644 | 1.669 |
+| dtoc2 | 0.999 | 1.401 | 1.438 | 1.434 |
+| rocket_12800 | 0.979 | 1.200 | 1.255 | 1.214 |
+| marine_1600 | 0.953 | 0.956 | 0.953 | 0.943 |
+| **dtoc1nd** | 0.960 | **0.764** | **0.762** | **0.750** |
+
+All the large-matrix gains are 15/15 at p = 0.0001, and so is the
+`dtoc1nd` loss.
+
+Three things this settles:
+
+1. **#150 (`fad5670`, task-per-subtree coarsening) is the mover, and it
+   is a large win** — 2.05x, 1.65x, 1.43x, 1.20x on the four largest.
+2. **The one regression is on `dtoc1nd`, n = 9,685** — a 25% loss, 0/15,
+   p = 0.0001, introduced by #150 and carried unchanged into v0.15.0 and
+   main. The proxy note predicted losses on the two *largest*,
+   chain-structured matrices. It got the existence of a regression right
+   and its location exactly backwards.
+3. **v0.15.0 and main are indistinguishable** (2.054/2.048,
+   1.644/1.669, 1.438/1.434, 1.255/1.214, 0.953/0.943, 0.762/0.750).
+   The proxy note flagged that its "new" arm was three commits past the
+   tag and that #156 had since changed the parallel default, and left
+   tag-vs-main open. It does not matter: neither #155's amalgamation
+   guard nor #156's `available_parallelism()` default moves anything
+   here.
+
+#149's SIMD kernel is neutral-to-negative on this corpus — below 1.0 on
+all six, significantly so on `clnlbeam` (0.966, 0/15, p = 0.0001) and
+`rocket_12800` (0.979, 2/15, p = 0.0074). On the proxies it was helping;
+here it is not. That is a separate thread worth pulling.
+
+## Result 3 — thread count does nothing, and the E-core hypothesis is dead
+
+`main` at `RAYON_NUM_THREADS` = 1, 2, 4, 8, 10 against the default
+(all 14). Ratios vs `main-all`.
+
+| matrix | t1 | t2 | t4 | t8 | t10 |
+|---|---|---|---|---|---|
+| clnlbeam | 0.972 | 0.973 | 0.983 | 0.992 | 0.976 |
+| dtoc1nd | 0.992 | 1.024 | 1.005 | 0.998 | 0.987 |
+| dtoc2 | 1.008 | 1.018 | 0.995 | 1.018 | 0.998 |
+| marine_1600 | 0.961 | 1.056 | 1.029 | 1.026 | 1.015 |
+| rocket_12800 | 1.030 | 1.029 | 1.024 | 1.049 | 1.041 |
+| steering_12800 | 1.003 | 0.997 | 0.993 | 1.018 | 1.020 |
+
+Every ratio is within 6% of 1.0, and only `marine_1600` at t1 (0.961,
+0/15, p = 0.0001) is significant. **Restricting feral to a single thread
+costs essentially nothing on any of these matrices.**
+
+The proxy note's untested hypothesis was that rayon treating efficiency
+cores as equivalent to performance cores lets a coarse task stall the
+factorization, predicting "the loss shrinks or inverts at
+`RAYON_NUM_THREADS=4`". It does not move at all, on a 10P+4E machine
+where the effect should be *larger* than on the 4P+4E M2 the hypothesis
+came from. The hypothesis is refuted; recorded in
+`tried-and-rejected.md`.
+
+The knob is real, not inert: feral reads the global rayon pool
+(`rayon::current_num_threads()`, `src/numeric/factorize.rs:3262`,
+`src/numeric/solve.rs:632`), and the same env var moved the proxies by
+up to 65%.
+
+**The consequence is the interesting part.** If single-threaded main
+matches all-threads main, then #150's 2.05x on `clnlbeam` is not a
+parallelism win. Whatever task-per-subtree coarsening bought — lower
+spawn overhead, better locality, a different traversal order — it is
+not multi-core execution. Any follow-up that treats #150 as "the
+parallel win" and tries to extend it by parallelizing harder is
+starting from a false premise.
+
+## Regenerating steering_12800
+
+`data/matrices/kkt-mittelmann/steering_12800/` held only a zero-byte
+`.solver.log`. The harvest path in
+`scripts/harvest-mittelmann-kkt.sh` is dead: ripopt commit `76d3575`
+(2026-04-28, "A7.6 (set 2) delete dead condensed-path helpers")
+bulk-deleted `dump_kkt_matrix`, `write_kkt_mtx_file`,
+`write_kkt_json_sidecar` and `collect_kkt_lower_triangle_entries`
+along with the `if let Some(ref dump_dir) = options.kkt_dump_dir` call
+site, but left `SolverOptions::kkt_dump_dir` (`options.rs:714`) and its
+CLI wiring (`ripopt_ampl.rs:607`) in place. So `kkt_dump_dir=` is still
+accepted on the command line and silently writes nothing — the harvest
+reports "OK ... 0 mtx" and exits 0.
+
+pounce dumps the same systems. The replacement path is
+
+```sh
+pounce steering_12800.nl --dump kkt:1-3 --dump-dir <dumpdir>
+scripts/harvest-pounce-kkt.py --dump-dir <dumpdir> --name steering_12800
+```
+
+The conversion is checked against an external oracle rather than
+trusted: pounce reports `num_neg_evals_actual = 51201`, and feral and
+MA57 independently agree on the converted matrix (`inertia_neg =
+51201`, `inertia_pos = 64000`, `inertia_zero = 0`). feral solves
+pounce's own dumped RHS to `rel_res = 3.66e-14`.
+
+This also unblocks the other 41 Mittelmann families that were never
+harvested.
+
+## What this means for the open items
+
+- **The MA57 gap is not the story it was.** On four of six real chain
+  KKTs, including the three largest, feral is 8x to 23x faster. Any
+  number quoted to pounce should come from this table, not from the
+  proxies and not from pounce#552's pre-SIMD figures.
+- **`dtoc1nd` is the concrete regression to chase**, and it is cheap:
+  one small matrix, a known culprit commit, 25% on the table.
+- **`dtoc2` and `dtoc1nd` are where MA57 still wins.** Both are the
+  losses; neither is large. That is the shape of the remaining gap.
+- **#149's SIMD kernel is negative on this corpus.** It was a win on
+  the proxies and on the release's own measurements. Worth its own
+  bisect before more kernel work.
+- The scaling-reuse item stays on hold, but for a new reason: the
+  premise that feral is broadly behind MA57 on this matrix class is
+  false.
+
+## Limits
+
+- One iterate per family, six families, one machine, one architecture
+  (aarch64 / Apple silicon). No x86_64 arm was run.
+- `factor_us` is numeric factorization only. Analysis dominates wall
+  clock on these matrices (`clnlbeam` analyse 4.59 s vs factor 38 ms),
+  and pounce#552 reports end-to-end solve time, so this does not
+  directly answer the report.
+- The MA57 oracle does not do the iterative refinement feral does; see
+  the `steering_12800` residual caveat under Result 1.

--- a/dev/research/chain-kkt-corpus-2026-08-09.md
+++ b/dev/research/chain-kkt-corpus-2026-08-09.md
@@ -296,3 +296,53 @@ what pounce measures through `SparseSymLinearSolverInterface` (issue
 The clean experiment, not yet run: pre-scale each matrix with MC64
 offline and run both solvers with scaling off, so the two arms
 factorize identical numbers.
+
+## Result 5 — the clean experiment: both arms on identical numbers
+
+The corrected Result 1 still compared arms doing different work.
+`prescale_mtx` removes the asymmetry: it computes MC64 symmetric
+scaling once, writes `A' = D A D` to disk, and both solvers read that.
+feral runs with `FERAL_SCALING=identity` (`ScalingStrategy::Identity`,
+echoed into the sidecar as `scaling Identity`); MA57 runs with
+`ICNTL(15) = 0`. Neither does any scaling of its own, so `factor_us` is
+factorization and nothing else. All six pre-scaled with a real matching
+(`scaling_info=Applied`, no fall back to infinity-norm).
+
+15 pairs, `min factor_us`, ratio > 1 means feral faster:
+
+| matrix | feral | ma57 | MA57 faster by | wins | p |
+|---|---|---|---|---|---|
+| dtoc1nd | 12,061 | 2,555 | 4.72x | 0/15 | 0.0001 |
+| clnlbeam | 19,315 | 5,418 | 3.56x | 0/15 | 0.0001 |
+| marine_1600 | 28,949 | 9,924 | 2.92x | 0/15 | 0.0001 |
+| rocket_12800 | 16,332 | 6,184 | 2.64x | 0/15 | 0.0001 |
+| dtoc2 | 75,291 | 51,757 | 1.46x | 0/15 | 0.0001 |
+| ~~steering_12800~~ | 30,663 | 17,648 | ~~1.74x~~ | 0/15 | 0.0001 |
+
+`steering_12800` is **excluded**, not quoted. MA57's residual on the
+pre-scaled matrix is `2.12e-05` against feral's `1.62e-14` on the same
+input — MA57 does not solve it acceptably without its own scaling, so
+that row cannot carry a timing. The correctness gate caught this, as it
+caught the `4.53e-08` in the run before. Every other cell is `1e-16` to
+`6e-14` on both arms.
+
+Three protocols now agree on the same answer:
+
+| matrix | issue #153 (pounce) | ICNTL(15)=0, unscaled | clean, pre-scaled |
+|---|---|---|---|
+| dtoc1nd | 3.77x | 5.53x | 4.72x |
+| clnlbeam | 3.54x | 4.08x | 3.56x |
+| marine_1600 | 2.63x | 3.02x | 2.92x |
+| rocket_12800 | 2.17x | 3.74x | 2.64x |
+| dtoc2 | 1.29x | 1.59x | 1.46x |
+
+Different harnesses, different scaling handling, different machines,
+same conclusion: **MA57's numeric factorization is roughly 1.5x to 4.7x
+faster than feral's on these matrices.** The gap #148 and #153 have
+been tracking is real and did not close with 0.15.0.
+
+A secondary reading: `feral-default` (Auto scaling) ran within 2-8% of
+`feral-noscale` on the pre-scaled matrices. That is not in tension with
+issue #153's 18-34% — MC64 on an already-MC64-scaled matrix converges
+almost immediately. It does mean this experiment says nothing about
+warm-path scaling cost, which needs an unscaled input to measure.

--- a/dev/research/chain-kkt-corpus-2026-08-09.md
+++ b/dev/research/chain-kkt-corpus-2026-08-09.md
@@ -2,8 +2,49 @@
 
 **Date:** 2026-08-09
 **Machine:** Apple M4 Pro, `Mac16,11`, 10 performance + 4 efficiency cores, macOS.
-**Supersedes:** `chain-kkt-ma57-gap-2026-08-09.md`, whose two headline
-conclusions this run contradicts.
+**Supersedes:** `chain-kkt-ma57-gap-2026-08-09.md` in part — its
+Results 2 and 3 only. Its Result 1 (the MA57 gap) stands; see the
+correction below.
+
+> **CORRECTION (supersedes Result 1 below).** The "no gap" result
+> was produced with a misconfigured oracle and is wrong. `ma57_bench.F`
+> sets `ICNTL(15) = 1`, which makes MA57 compute MC64 scaling *inside*
+> `MA57BD` — the region the oracle times. feral computes its MC64 in
+> **analysis**, which `factor_us` excludes. The comparison charged MA57
+> per-factorization for work feral had already amortized and was not
+> being billed for.
+>
+> Re-run with `ICNTL(15) = 0`, 15 pairs, `min factor_us`:
+>
+> | matrix | feral | ma57 | MA57 faster by | wins | p |
+> |---|---|---|---|---|---|
+> | dtoc1nd | 14,050 | 2,539 | 5.53x | 0/15 | 0.0001 |
+> | clnlbeam | 21,979 | 5,384 | 4.08x | 1/15 | 0.0010 |
+> | rocket_12800 | 22,266 | 5,955 | 3.74x | 0/15 | 0.0001 |
+> | marine_1600 | 33,131 | 10,973 | 3.02x | 0/15 | 0.0001 |
+> | steering_12800 | 34,517 | 17,097 | 2.02x | 0/15 | 0.0001 |
+> | dtoc2 | 81,725 | 51,309 | 1.59x | 0/15 | 0.0001 |
+>
+> MA57 is faster on **all six**. Three independent checks say this is
+> the real number:
+>
+> - issue #153 measured the same six through pounce and got 1.29x-3.77x in
+>   MA57's favor. Its MA57 times (clnlbeam 7.27 ms, rocket 8.79,
+>   steering 18.96) match `ICNTL(15)=0` (5.38, 5.96, 17.1), not the
+>   oracle's (201, 554, 292).
+> - The proxy conclusion this note claimed to supersede — 1.4x-2.4x
+>   slower — was right in direction and close in magnitude. A correct
+>   finding was overturned by a worse measurement.
+> - The steering accuracy caveat was the same artifact. With scaling
+>   off MA57 gets `1.59e-14`, not `4.53e-08`.
+>
+> Results 2 and 3 are unaffected: they compare feral builds to each
+> other and never touch the oracle. The #150 attribution, the dtoc1nd
+> regression, and the refuted E-core hypothesis all stand.
+>
+> What the checking missed: `factor_us` was verified to cover `MA57BD`
+> only, and that was treated as sufficient. The boundary of the timed
+> region was checked; the contents were not.
 
 ## Why
 
@@ -197,3 +238,61 @@ harvested.
   directly answer the report.
 - The MA57 oracle does not do the iterative refinement feral does; see
   the `steering_12800` residual caveat under Result 1.
+
+## Result 4 — analysis dominates, and one stage is all of it
+
+Found while checking whether the corrected MA57 gap left any
+optimization work. `analyse_us` vs `factor_us` for `main`, same run:
+
+| matrix | n | nnz | analyse_us | factor_us | analyse/nnz |
+|---|---|---|---|---|---|
+| clnlbeam | 99,999 | 259,993 | 5,001,272 | 26,008 | 19.24 |
+| rocket_12800 | 89,601 | 435,190 | 2,705,801 | 29,910 | 6.22 |
+| marine_1600 | 76,807 | 414,399 | 1,048,521 | 42,817 | 2.53 |
+| steering_12800 | 115,201 | 409,591 | 130,389 | 41,795 | 0.32 |
+| dtoc2 | 103,920 | 961,230 | 276,116 | 101,528 | 0.29 |
+| dtoc1nd | 9,685 | 217,270 | 42,464 | 19,278 | 0.20 |
+
+A 60x spread in cost per nonzero across matrices of comparable size.
+`clnlbeam` has the *fewest* nonzeros of the large five and the most
+expensive analysis; `steering_12800` is larger (n = 115,201) with
+comparable nnz and analyses 38x faster. Not a constant factor.
+
+Per-stage breakdown via `diag_symbolic_stages_argv`:
+
+| matrix | `ldlt_compress` | share of symbolic | `ordering` |
+|---|---|---|---|
+| clnlbeam | 4,515,372 | 99.3% | 3,706 |
+| rocket_12800 | 2,289,795 | 98.3% | 3,932 |
+| steering_12800 | 23,539 | 33.6% | 6,172 |
+| dtoc1nd | 2,834 | 23.1% | 2,118 |
+
+`ldlt_compress` is `compute_mc64_cache` — the Duff-Pralet symmetric
+matching (`src/symbolic/mod.rs:1211`). On `clnlbeam` it takes 4.5 s
+while the fill-reducing ordering beside it takes 3.7 ms, a factor of
+1,200. Every other symbolic stage is 1-15 ms and scales sanely.
+
+`src/symbolic/mod.rs:1190` already records the same shape on the pf22
+powerflow KKT (MC64 ~53 s vs `amd_order` ~0.3 s, issue #80), so this is
+the second corpus where MC64 dominates analysis by three orders of
+magnitude.
+
+This also reframes Result 1 honestly: feral's MC64 is not free, it is
+billed to analysis, where `factor_us` does not see it. Whether
+amortizing it across an IPM's refactorizations is legitimate depends on
+the caller — but 4.5 s of analysis dominates any end-to-end number
+regardless of how fast the factorization becomes.
+
+## Limits on the corrected comparison
+
+Neither MA57 configuration is a clean apples-to-apples arm.
+`ICNTL(15) = 1` charges MA57 per-factorization for scaling feral
+amortizes into analysis. `ICNTL(15) = 0` gives feral MC64 scaling that
+MA57 does not get, so feral's arm is doing strictly more numerical
+work. The corrected table uses `ICNTL(15) = 0` because that matches
+what pounce measures through `SparseSymLinearSolverInterface` (issue
+#153) and agrees with it to within the harness difference.
+
+The clean experiment, not yet run: pre-scale each matrix with MC64
+offline and run both solvers with scaling off, so the two arms
+factorize identical numbers.

--- a/dev/research/chain-kkt-corpus-2026-08-09.md
+++ b/dev/research/chain-kkt-corpus-2026-08-09.md
@@ -293,9 +293,20 @@ work. The corrected table uses `ICNTL(15) = 0` because that matches
 what pounce measures through `SparseSymLinearSolverInterface` (issue
 #153) and agrees with it to within the harness difference.
 
-The clean experiment, not yet run: pre-scale each matrix with MC64
-offline and run both solvers with scaling off, so the two arms
-factorize identical numbers.
+The clean experiment **has since been run** — see Result 5. Both arms
+factorize identical pre-scaled matrices with scaling off, and MA57 is
+still faster by 1.46x-4.72x.
+
+One further correction belongs here. An earlier revision of Result 4
+compared feral's `analyse_us` against MA57's `analyse_us` at
+`ICNTL(15) = 0` and reported feral's analysis as 794x slower on
+clnlbeam. That is the retracted result's error one level up: feral's
+analysis does MC64, MA57's analysis at `ICNTL(15) = 0` does no scaling
+at all. Charging MA57 for its scaling (its `factor` at `ICNTL(15) = 1`
+minus at `= 0`) gives 24.8x, not 794x. `MA57ID` sets `ICNTL(15) = 1`,
+confirmed by calling it directly — scaling-on is MA57's *own default*,
+so `ICNTL(15) = 0` is the right setting for a factorization-only
+comparison but the wrong baseline for anything end-to-end.
 
 ## Result 5 — the clean experiment: both arms on identical numbers
 
@@ -346,3 +357,91 @@ A secondary reading: `feral-default` (Auto scaling) ran within 2-8% of
 issue #153's 18-34% — MC64 on an already-MC64-scaled matrix converges
 almost immediately. It does mean this experiment says nothing about
 warm-path scaling cost, which needs an unscaled input to measure.
+
+## Result 6 — what actually drives MC64, and the dense-column diagnosis fails
+
+`ldlt_compress` being 99.3% of clnlbeam's symbolic made MC64 the
+obvious optimization target, so it was profiled properly before any
+work started. `probe_mc64_hungarian` over 41 corpus matrices (one
+iterate per family) reports algorithmic counters rather than wall
+clock.
+
+**First, the head-to-head.** feral's MC64 against MA57's, both doing
+the same job (MA57's = its `factor` at `ICNTL(15) = 1` minus at `= 0`):
+
+| matrix | feral MC64 | MA57 MC64 | |
+|---|---|---|---|
+| clnlbeam | 4,522 ms | 195 ms | feral 23.2x slower |
+| marine_1600 | 812 ms | 32 ms | feral 25.1x slower |
+| rocket_12800 | 2,279 ms | 548 ms | feral 4.2x slower |
+| dtoc2 | 14.6 ms | 10.7 ms | feral 1.4x slower |
+| dtoc1nd | 2.5 ms | 2.1 ms | feral 1.2x slower |
+| steering_12800 | 20.7 ms | 275 ms | **feral 13.3x faster** |
+
+A real gap on two matrices, near-parity on two, and a win on one. Not
+the uniform catastrophe the 794x number implied.
+
+**Second, the prior diagnosis does not explain the corpus.**
+`mc64-dense-column-2026-06-06.md` attributes the cost to a dense
+coupling column, `O(searches x dense_deg)`, and proves no
+behavior-preserving inner-loop fast path exists. That analysis is
+correct *for rocket_12800*. It is not the general law:
+
+| matrix | max_col_degree | ms |
+|---|---|---|
+| steering_12800 | **51,202** (largest in corpus) | 21 |
+| gasoil_3200 | 41,500 | 9.6 |
+| rocket_12800 | 38,401 | 2,279 |
+| nql180 | 182 | 2,892 |
+| clnlbeam | **5** | 4,522 |
+
+The two densest-column matrices in the corpus are among the fastest,
+and the most expensive one has `max_col_degree = 5`. Over the six chain
+KKTs, `log(ms)` against `log(max_col_degree)` gives r = **-0.59** — the
+wrong sign. Against `touched_total` it gives r = **+0.999**.
+
+Cost is bimodal: 37 of 41 matrices run in 0.3-70 ms; four (clnlbeam
+4,522, nql180 2,892, rocket 2,279, marine 812) are one to two orders
+out. Only rocket is the class the prior note covers.
+
+**Third, the scaling law.** From leading principal submatrices of
+clnlbeam. (Not a true size ladder — clnlbeam is block-ordered — but
+across this range `searches` is pinned at 5,043, which isolates
+per-search cost.)
+
+| n | touched | edge_scans | ms |
+|---|---|---|---|
+| 90,000 | 176,356,074 | 360,898,556 | 4,080 |
+| 93,000 | 188,383,074 | 360,895,553 | 4,232 |
+| 96,000 | 200,410,074 | 360,892,553 | 4,351 |
+| 98,000 | 208,428,074 | 360,890,553 | 4,421 |
+| 99,000 | 212,437,074 | 360,889,550 | 4,450 |
+| 99,999 | 216,406,073 | 360,922,194 | 4,525 |
+
+`edge_scans` is **flat** — 3.609e8, varying under 0.01% while `n` grows
+11%. `touched` grows exactly **+4,009 per unit of `n`**; the four
+independent deltas (Δn = 3000, 3000, 2000, 1000) all give 4009.0. Wall
+time tracks `touched`, not `edge_scans`.
+
+So each augmenting search reaches **Θ(n) distinct rows** while
+performing a *constant* amount of edge work. Growing the problem buys
+pure heap traffic and no additional edge scanning. `touched` counts
+distinct rows — `hungarian.rs:549` guards the push with `d[i] == RINF`
+— and `heap_init_slots == touched_total + n` holds exactly on every
+matrix, so issue #80's incremental-reset fix is intact and heap
+*initialization* is not the cost.
+
+**Fourth, it is value-driven, not structural.** Synthetic chain KKTs
+from `gen_chain_kkt` at the same geometry (`nx=2, nc=1`, n up to
+384,000) get `searches = 0` — greedy init matches everything — and run
+in 18 ms at n = 384,000. Same shape, no blowup. This matches issue
+#80's trap #2 ("MC64 needs real values") and is one more instance of
+the proxies failing to reproduce the real matrices.
+
+**What this does not establish.** A fix. The impossibility proof in
+`mc64-dense-column-2026-06-06.md` §3.2 is specific to pruning the
+dense-column inner scan and does not cover the Θ(n) frontier measured
+here. The likely mechanism is that `csp` stays `RINF` while the search
+hunts for an unmatched row, so nothing prunes insertion — but whether
+that frontier can be bounded without changing the matching is open, and
+needs its own research note before any code.

--- a/dev/research/chain-kkt-ma57-gap-2026-08-09.md
+++ b/dev/research/chain-kkt-ma57-gap-2026-08-09.md
@@ -1,0 +1,158 @@
+# The factorization gap after 0.15.0, and a chain regression it exposed
+
+**Date:** 2026-08-09
+**Machine:** Apple M2, `Mac14,2`, 4 performance + 4 efficiency cores, macOS.
+**Status:** proxy measurement. Needs re-running on the corpus machine
+before any of it is acted on.
+
+## Why
+
+0.15.0 was cut specifically so the pounce#552 factorization comparison
+could be re-taken: the 3.5-4.8x gap in that report describes the
+pre-SIMD kernel. Nobody knew the current gap, which made every remaining
+optimization item a bet at unknown odds.
+
+The five #552 models are Pyomo NMPC problems needing idaes/prommis, and
+this machine has neither them nor `data/matrices/`. What it does have is
+the CoinHSL v2023.11.17 bundle, so MA57 is available as an oracle. The
+substitute is block-tridiagonal KKT proxies at the reported geometry:
+see `external_benchmarks/chain_proxy/README.md` for the construction,
+the analytic inertia oracle, and the limits.
+
+## Method
+
+Paired alternating A/B per `decisions.md` (2026-08-09): every arm timed
+once per pair, `min` over 15 pairs, exact two-sided sign test. All arms
+read the same manifest, matrices and synthesized RHS.
+
+Correctness first: both feral and MA57 reproduce the analytic inertia
+(`T*nx` positive, `T*nc` negative, zero zeros) exactly on all five
+proxies, feral residuals 3.7e-16 to 2.3e-15, MA57 2.0e-16 to 2.4e-16.
+The matrices are sound; the timings are on well-conditioned,
+correctly-solved systems.
+
+**Arm naming caveat:** the "new" arm throughout is `main` at `7a31ff6`,
+which is three commits past the `v0.15.0` tag (it includes the
+amalgamation guard from #155, opt-in and documented as bit-identical by
+default). A worktree at the exact `v0.15.0` tag was built but the
+bisect that would separate tag from main **did not run**. Everything
+below therefore says "main", not "0.15.0", and attributing the
+regression to a specific PR is still open.
+
+## Result 1 — the gap against MA57
+
+`min factor_us` over 15 pairs; ratio > 1 means feral is faster.
+
+| proxy | n | main | ma57 | ratio | wins | p |
+|---|---|---|---|---|---|---|
+| hicks_like | 1,806 | 1,082 | 603 | 0.557 | 2/15 | 0.0074 |
+| cart_pole_like | 2,709 | 1,590 | 1,081 | 0.680 | 1/15 | 0.0010 |
+| quad_tank_like | 3,010 | 1,635 | 968 | 0.592 | 0/15 | 0.0001 |
+| double_column_like | 25,389 | 36,150 | 26,210 | 0.725 | 5/15 | 0.3018 |
+| prommis_sx_like | 28,303 | 56,519 | 23,470 | 0.415 | 0/15 | 0.0001 |
+
+**feral is slower than MA57 on all five, by 1.4x to 2.4x.** Four of the
+five are significant; `double_column_like` is not (5/15, p = 0.30).
+
+This is narrower than the 3.5-4.8x in pounce#552, but the two numbers
+are not comparable: different matrices, different machine, and this one
+is numeric factorization only where the report is end-to-end. The honest
+statement is that on chain-structured proxies, post-SIMD feral is still
+materially behind MA57, and the largest, most chain-like proxy is the
+worst case.
+
+## Result 2 — main is slower than 0.14.0 on the two big chains
+
+Same run, validity control. Ratio > 1 means main is faster than 0.14.0.
+
+| proxy | ratio | wins | p |
+|---|---|---|---|
+| hicks_like | 1.045 | 13/15 | 0.0074 |
+| quad_tank_like | 1.026 | 13/15 | 0.0074 |
+| cart_pole_like | 1.016 | 9/15 | 0.6072 |
+| double_column_like | 0.914 | 4/15 | 0.1185 |
+| **prommis_sx_like** | **0.833** | **2/15** | **0.0074** |
+
+The three small ODE-shaped proxies gain a little. **The two large
+chain-structured ones lose**, and `prommis_sx_like` loses 20%
+significantly. This contradicts the release's "wins all twelve arms",
+which was measured on real matrices on a 4-core homogeneous x86_64
+container.
+
+It also reproduces something already on the record: session 2026-08-09-02
+found the old per-node driver beating the new one by ~20% on a wide-block
+chain proxy (`chainW`), could not explain it, and accepted it as a proxy
+quirk; the pounce-side reviewer on PR #150 reframed it as a probable
+regression on exactly `double_column` / `prommis_sx` geometry. An
+independent proxy at the reported geometry, on different hardware, now
+shows the same thing. It should stop being treated as a quirk.
+
+## Result 3 — mechanism not yet identified
+
+15 pairs, two large proxies, arms that isolate the two levers 0.15.0
+shipped. Ratio > 1 means faster than 0.14.0.
+
+`prommis_sx_like` (0.14.0 = 53,237 us):
+
+| arm | min_us | vs 0.14.0 | wins | p |
+|---|---|---|---|---|
+| main default | 67,376 | 0.790 | 1/15 | 0.0010 |
+| main `PAR_MIN_SEEDS=u64::MAX` | 66,689 | 0.798 | 0/15 | 0.0001 |
+| main `RAYON_NUM_THREADS=1` | 73,479 | 0.725 | 1/15 | 0.0010 |
+| main `PACKED_SIMD=0` | 72,228 | 0.737 | 0/15 | 0.0001 |
+
+`double_column_like` (0.14.0 = 37,602 us):
+
+| arm | min_us | vs 0.14.0 | wins | p |
+|---|---|---|---|---|
+| main default | 40,382 | 0.931 | 3/15 | 0.0352 |
+| main `PAR_MIN_SEEDS=u64::MAX` | 59,551 | 0.631 | 0/15 | 0.0001 |
+| main `RAYON_NUM_THREADS=1` | 66,584 | 0.565 | 0/15 | 0.0001 |
+| main `PACKED_SIMD=0` | 45,276 | 0.831 | 0/15 | 0.0001 |
+
+Neither lever explains it. Disabling the packed SIMD kernel makes things
+**worse** on both, so the kernel is helping, not hurting. Forcing the
+sequential fallback does not recover the loss on `prommis_sx_like` and
+is much worse on `double_column_like`.
+
+Two things this does establish:
+
+1. **These chains do not collapse to `seeds = 1`.** `FERAL_DEBUG_TASK_PLAN=1`
+   reports `prommis_sx_like: n_snodes=2625 n_tasks=15 seeds=8` and
+   `double_column_like: n_snodes=2591 n_tasks=17 seeds=9`. The task
+   graph is active on both. The release note's reasoning that
+   "chain-shaped trees collapse to a single task and take the sequential
+   driver outright" does not hold for this geometry, which is precisely
+   the geometry pounce cares about.
+2. On `prommis_sx_like`, running the task graph (67,376) is worth almost
+   nothing against forcing it off (66,689), while 0.14.0's per-supernode
+   spawning got 53,237. Coarsening 2,625 supernodes into 15 unequal
+   tasks appears to give up parallelism that the finer-grained driver
+   was extracting.
+
+**Untested hypothesis:** on a 4P+4E M2 rayon treats efficiency cores as
+equivalent to performance cores, so a coarse task landing on an E-core
+stalls the whole factorization, where per-node granularity let
+work-stealing rebalance. This predicts the loss shrinks or inverts at
+`RAYON_NUM_THREADS=4`. That arm was written (`probe_bisect.py`, not
+committed since it never ran) but not executed.
+
+## What to run on the corpus machine
+
+In order. The first two are cheap and decide whether the third matters.
+
+1. **Bisect the regression** across `c05eb77` (0.14.0), `e8e1c5a`
+   (#149 SIMD), `fad5670` (#150 parallel), `808babb` (v0.15.0) and
+   current `main`, on the real chain KKTs. This attributes it to a PR,
+   and separates the v0.15.0 tag from post-tag `main` — which this
+   measurement cannot do.
+2. **Thread sweep** (1 / 2 / 4 / all) on the same matrices, on
+   homogeneous-core hardware and on Apple silicon, to test the E-core
+   hypothesis.
+3. **Re-run the gap against MA57** on the real corpus. Only that number
+   should be quoted to pounce; the proxy ratios above are a hypothesis.
+
+Do not act on the scaling-reuse item until 1 and 2 land. If the
+regression is real on the corpus, recovering 20% on the exact matrix
+class pounce cares about is both cheaper and better-evidenced than a
+design project that changes numerics and needs residual gates.

--- a/dev/research/chain-kkt-ma57-gap-2026-08-09.md
+++ b/dev/research/chain-kkt-ma57-gap-2026-08-09.md
@@ -2,8 +2,26 @@
 
 **Date:** 2026-08-09
 **Machine:** Apple M2, `Mac14,2`, 4 performance + 4 efficiency cores, macOS.
-**Status:** proxy measurement. Needs re-running on the corpus machine
-before any of it is acted on.
+**Status:** SUPERSEDED by `chain-kkt-corpus-2026-08-09.md`. Kept as the
+record of what the proxies said and why it was believed.
+
+> **Both headline conclusions below are contradicted by the real
+> corpus.** The three follow-ups this note asked for were run on
+> 2026-08-09 on an M4 Pro with `data/matrices/`, and:
+>
+> * feral is **not** slower than MA57 on chain KKTs — it is 8x to 23x
+>   *faster* on `rocket_12800`, `clnlbeam` and `steering_12800`, and
+>   loses only on `dtoc2` (1.3x) and `dtoc1nd`, the smallest matrix.
+> * the regression is **not** on the large chains — it is on `dtoc1nd`
+>   (n = 9,685), where #150 costs 25%. On the four largest matrices #150
+>   *gains* 1.20x to 2.05x.
+> * the efficiency-core hypothesis in "Result 3" is **refuted**.
+>   Thread count moves nothing on the real matrices, on hardware with
+>   more efficiency cores than the machine the hypothesis came from.
+>
+> The proxies got "something regressed after 0.14.0" right and its
+> location exactly backwards. Read them as a cautionary case for
+> geometry-matched synthetic stand-ins, not as a measurement.
 
 ## Why
 

--- a/dev/research/chain-kkt-ma57-gap-2026-08-09.md
+++ b/dev/research/chain-kkt-ma57-gap-2026-08-09.md
@@ -39,6 +39,16 @@ bisect that would separate tag from main **did not run**. Everything
 below therefore says "main", not "0.15.0", and attributing the
 regression to a specific PR is still open.
 
+**Main has since moved, in a way that matters here.** #156 (issue #154,
+`4f2fad6`) landed after these runs: `Solver::with_params` no longer
+hardcodes `use_parallel: true` but derives it from
+`available_parallelism() > 1`, and all four dispatch sites now fall back
+to the sequential path when pool construction fails. That changes which
+driver a default-constructed solver takes, which is exactly the axis the
+regression sits on. `7a31ff6` (measured) predates it; `f7a152a` does
+not. The bisect below must therefore treat current main as its own
+point rather than assuming it behaves like the measured `7a31ff6`.
+
 ## Result 1 — the gap against MA57
 
 `min factor_us` over 15 pairs; ratio > 1 means feral is faster.

--- a/dev/research/chain-kkt-ma57-gap-2026-08-09.md
+++ b/dev/research/chain-kkt-ma57-gap-2026-08-09.md
@@ -2,16 +2,21 @@
 
 **Date:** 2026-08-09
 **Machine:** Apple M2, `Mac14,2`, 4 performance + 4 efficiency cores, macOS.
-**Status:** SUPERSEDED by `chain-kkt-corpus-2026-08-09.md`. Kept as the
-record of what the proxies said and why it was believed.
+**Status:** PARTIALLY SUPERSEDED by `chain-kkt-corpus-2026-08-09.md`.
+Result 1 of this note stands. Results 2 and 3 are superseded.
 
-> **Both headline conclusions below are contradicted by the real
-> corpus.** The three follow-ups this note asked for were run on
-> 2026-08-09 on an M4 Pro with `data/matrices/`, and:
+> **Result 1 of this note was right.** An earlier revision of this
+> banner said feral was 8x-23x *faster* than MA57 on chain KKTs. That
+> came from an oracle running `ICNTL(15) = 1`, which computes MC64
+> scaling inside the timed `MA57BD` region while feral's MC64 sits in
+> untimed analysis. Corrected (`ICNTL(15) = 0`, 15 pairs), MA57 is
+> faster on all six real matrices by 1.59x to 5.53x — the same
+> direction, and close to the magnitude, this note reported from the
+> proxies (1.4x-2.4x). The proxies were vindicated by the real corpus,
+> not contradicted by it.
 >
-> * feral is **not** slower than MA57 on chain KKTs — it is 8x to 23x
->   *faster* on `rocket_12800`, `clnlbeam` and `steering_12800`, and
->   loses only on `dtoc2` (1.3x) and `dtoc1nd`, the smallest matrix.
+> **What is genuinely superseded:**
+>
 > * the regression is **not** on the large chains — it is on `dtoc1nd`
 >   (n = 9,685), where #150 costs 25%. On the four largest matrices #150
 >   *gains* 1.20x to 2.05x.
@@ -19,9 +24,8 @@ record of what the proxies said and why it was believed.
 >   Thread count moves nothing on the real matrices, on hardware with
 >   more efficiency cores than the machine the hypothesis came from.
 >
-> The proxies got "something regressed after 0.14.0" right and its
-> location exactly backwards. Read them as a cautionary case for
-> geometry-matched synthetic stand-ins, not as a measurement.
+> So the proxies got the gap right and the regression's location
+> exactly backwards.
 
 ## Why
 

--- a/dev/research/mc64-condition1-cost-share-2026-08-09.md
+++ b/dev/research/mc64-condition1-cost-share-2026-08-09.md
@@ -1,0 +1,192 @@
+# Condition 1 rejects on a metric that measures the barrier trajectory. The fix is not a better metric.
+
+**Date:** 2026-08-09
+**Machine:** Apple M2, `Mac14,2`, 4P + 4E cores, macOS. All timings
+`with_parallel(false)`, `with_profiling(true)`.
+**Status:** measurement complete; no implementation. The design
+recommendation at the end is a proposal, not a landed change.
+
+## Why
+
+`tried-and-rejected.md` (2026-05-21, "B2 value-bounded MC64 scaling
+cache: gate metric confounded by IPM δ") rejected the value-bounded
+MC64 scaling cache. Today nql180 spends 11.2 s of 17 s in scaling,
+pinene_3200 79%, marine_1600 51% — all rejecting on condition 1. That
+entry is the starting point for re-opening it, not a reason to skip
+it.
+
+The entry rests on two claims. Both are examined below with fresh
+measurements; one is stale, one is true but narrower than it reads.
+
+## The cost claim is stale, and it inverted
+
+> Even with a perfect gate, B2 targets <2 % of the cost. pinene_3200's
+> 10 iters total 493.9 s; iters 6-9 are 64.8/77.8/135.7/208.2 s (the
+> cost-cluster blowup, 98 %). The MC64 Hungarian is ≤6 s total.
+
+Today, the same 10 iterates of pinene_3200 total **1.48 s**, of which
+MC64 is **1.19 s — 79%**. The delayed-pivot cost-cluster blowup that
+dwarfed MC64 in May has since been fixed (~325× faster on this
+family), and MC64 went from a rounding error to the dominant term.
+The May reasoning was correct when written; its premise no longer
+holds.
+
+## The metric claim is true, and it indicts the diagonal specifically
+
+> The KKT (2,2)-block rows carry a tiny δ-regularized diagonal (≈1e-8)
+> against ≈1 off-diagonals, so their off/diag ratio is ≈1/δ. As the
+> interior-point method drives δ→0, the ratio explodes 1e8→1e10 — the
+> gate is measuring the IPM's barrier trajectory, not whether `D₀` is
+> still a usable scaling.
+
+This is confirmed, and it is a complaint about dividing by the
+diagonal. MC64's own objective never mentions the diagonal: the
+matching maximises the product of matched magnitudes, and the scaling
+drives matched entries to ≈1 with all others ≤1. So the obvious
+repair is a diagonal-free statistic on the same scaled matrix.
+
+**That repair does not work.** `diag_scaled_entry_spread` computes
+today's `max_ratio` and entry-magnitude statistics of `D₀·A_N·D₀` in
+the same sweep:
+
+| family | speedup | max_ent drift vs iter 0 | p999_ent |
+|---|---|---|---|
+| marine_1600 | 1.63× | 5.2e12 | 1.030 |
+| nql180 | 2.10× | 3.9e6 | 3.9e6 |
+| pinene_3200 | 5.09× | 1.1e1 | 5.698 |
+| ex4_2_160 | 0.75× | 1.0e4 | 1.0e4 |
+
+`marine_1600` is the best-behaved family in the set by outcome and the
+worst by entry drift; `ex4_2_160` is the one clear regression and its
+drift is eight orders milder. Entry magnitude is **anti-correlated**
+with whether reuse is a good idea. `p999_ent` separates marine (a
+handful of outlier entries) from ex4_2_160 (a broad shift), but nql180
+also has `p999 == max` and is a 2.10× win.
+
+No value proxy tried predicts the outcome.
+
+## Why no value proxy predicts the outcome: there is no numerical outcome
+
+`diag_trajectory_reuse` drives **two warm solvers** over the same
+trajectory in one process — one on `Auto`, one pinned to
+`External(d0)` with iterate 0's own MC64 vector. The warm arm matters:
+`Solver::factor` clears `symbolic.cached_mc64` after every call
+(issue #38, `src/numeric/solver.rs:1374`), so only a warm solver pays
+the Hungarian inside `ProfileReport::total_us`. Every earlier probe in
+this session that built a fresh solver per iterate was billing that
+work to `analyze()` and measuring the wrong thing.
+
+Whole `kkt-mittelmann` corpus, 37 families with ≥2 iterates, 233
+iterates:
+
+    corpus fresh 34.66 s -> reuse 24.47 s
+    aggregate 1.42x, geomean 1.164x
+    inertia differs on 0 iterates
+
+Zero. Including `rocket_12800`, the matrix #38 was filed on.
+
+### Why that is not luck
+
+`dev/journal/2026-05-16-30.org` §17:25 records #38's mechanism
+explicitly: `pick_ordering_preprocess` triggers `LdltCompress`,
+`LdltCompress` populates `SymbolicFactorization::cached_mc64` via
+`mc64::compute_matching`, and the stale **matching** is applied to
+iterate N. The scaling vector is downstream of that. Two distinct
+objects share the name "MC64 cache":
+
+* `symbolic.cached_mc64` — the matching/permutation. Feeds
+  `LdltCompress`; changes the elimination structure. This is what #38
+  corrupted, and what `mc64_cache_invalidated_after_factor_issue_38`
+  (`src/numeric/solver.rs:2285`) guards.
+* `Solver::mc64_scaling_cache` — the scaling vector. Values only.
+  This is what the value bound gates.
+
+`ScalingStrategy::External` reuses only the second. It cannot reach
+`LdltCompress` and cannot change the elimination structure.
+
+The in-tree guard `mc64_cache_rejected_on_value_drift_issue_38_guard`
+(`src/numeric/solver.rs:2511`) asserts only that the gate *rejects* on
+`tridiag(4, 10, 1)` → `tridiag(4, 10, 50)`. It never establishes that
+reuse would have been wrong. A sweep of that same family against an
+independent Sturm-sequence oracle (Golub & Van Loan 4th ed. §8.4.1)
+found reuse == fresh == oracle at every drift magnitude from off=1 to
+off=1e12, including off=50.
+
+### What this is not
+
+Absence of a counterexample across 233 iterates is not a safety proof.
+Every family here has a fixed pattern, and the probe's fingerprint
+check is `csc.n != d0.len()` — n only. `rocket_12800` changes nnz
+between iterates (332793 → 435190), so the External arm there applied
+`D₀` across a pattern change the real cache would reject outright.
+That makes rocket a *harder* correctness test than the design would
+ever attempt, and it also means rocket's 1.33× is not a payoff the
+real design could bank.
+
+## What does predict the outcome
+
+Sorting the 37 families by the fraction of factor time fresh MC64
+actually consumes:
+
+| scal% band | families | speedup range |
+|---|---|---|
+| ≤ 5.4% | all four regressions | 0.75× – 1.08× |
+| ≥ 12.6% | every family, no exception | 1.13× – 5.09× |
+
+The four regressions sit at 5.4% (ex4_2_160), 3.3% (cont5_1_l), 3.0%
+(arki0009), 0.6% (qcqp1000-2c). The band 5.4% → 12.6% is empty, so
+any threshold in 6–12% gives the identical partition. The constant is
+not load-bearing.
+
+Gating on measured cost share at 10%:
+
+    15 of 37 families reuse
+    corpus 34.66 s -> 24.32 s, 1.43x
+
+That banks essentially all of the unconditional 1.42× while dropping
+every regression.
+
+## Recommendation
+
+Replace the value-bound gate's role, not its metric.
+`scaling_us / total_us` is already measured per factorization
+(`PrologueBreakdown::scaling_us`, `ProfileReport::total_us`), so the
+gate needs no value proxy, no numerical justification, and no
+additional O(nnz) sweep. The 2026-05-21 entry searched for a metric
+separating "safe" from "unsafe"; on this evidence the scaling-vector
+path has no unsafe side, and the quantity that needs separating is
+profitable from unprofitable.
+
+Open before implementing:
+
+1. **The regression that reuse causes is real and unexplained.**
+   `ex4_2_160` reuse costs +45% on iterates 2–9 with *correct*
+   inertia, and `nql180_0001` costs +66%. Something downstream —
+   most likely delayed pivots — gets more expensive under a stale
+   scaling. A cost-share gate sidesteps it rather than explaining it.
+2. Profiling is not free and is off by default; a shipped gate needs
+   the cost share available without `with_profiling(true)`.
+3. Correctness rests on 233 iterates with no counterexample. Before
+   landing, either an argument that the scaling vector cannot alter
+   inertia, or an adversarial search for a case where it does.
+
+## The independent, strictly-safe lever this surfaced
+
+The Hungarian is genuinely value-dependent, measured standalone via
+`diagnose_mc64_matching` (no solver, no cache), on a pattern that
+never changes:
+
+| pinene_3200 | match_us | augment | touched | edge_scans |
+|---|---|---|---|---|
+| 0001 | 46,852 | 57,426 | 1,340,479 | 8,148,431 |
+| 0006 | 229,183 | 77,994 | 6,816,372 | 70,268,885 |
+
+4.9× in wallclock. `augment_searches` moves only 1.36×;
+`main_loop_edge_scans` moves 8.6×. The search *count* is stable —
+each shortest-augmenting-path search wanders much further as δ→0. On
+nql180, 895 searches perform 222M edge scans on n=259,681, i.e.
+~227,000 scans per search, ~87% of n.
+
+Bounding that search is same-output-less-work, needs no gate and no
+residual argument, and helps the families where reuse is unprofitable
+too. It is independent of everything above.

--- a/dev/research/mc64-hungarian-search-bound-2026-08-09.md
+++ b/dev/research/mc64-hungarian-search-bound-2026-08-09.md
@@ -1,0 +1,117 @@
+# MC64 Hungarian search bound — the lever does not exist; the cost is memory layout
+
+Date: 2026-08-09
+Status: negative result on the stated lever + a small verified win
+Follows: `dev/research/mc64-condition1-cost-share-2026-08-09.md`
+
+## Correction to the prior note
+
+`mc64-condition1-cost-share-2026-08-09.md` closes by recommending a
+Hungarian search bound and describes it as
+
+> "same-output-less-work, needs no gate and no residual argument"
+
+**That characterization is wrong and should not be relied on.** Two
+independent reasons, both found by inspection before any code was
+written:
+
+1. The classic shortest-augmenting-path bound is **already
+   implemented**. `csp` (cost of the best augmenting path found so far)
+   prunes the root scan (`src/scaling/hungarian.rs:541`), terminates the
+   main loop (`:570`), and prunes the inner column scan (`:591`). There
+   is no missing standard bound to add.
+2. Any *further* truncation would end a search before its shortest
+   augmenting path is proven, yielding a suboptimal matching, hence a
+   different scaling vector. That is a numerics change requiring a
+   corpus inertia/residual study and human approval — not a free win.
+
+`dev/tried-and-rejected.md:2313` (2026-06-06-03) additionally proves
+that no per-column reduced-cost bound can ever prune the inner scan
+(`vj + lb_tight = dq0`, and `q0` was popped only because `dq0 < csp`),
+and instructs future sessions not to retry it. That directive stands.
+
+## Where the time actually goes
+
+Per-edge-scan cost differs 4.5x between the two families that dominate
+the corpus, on identical code:
+
+| matrix          | match_us  | edge_scans | ns/scan | searches | touched/search |
+|-----------------|-----------|------------|---------|----------|----------------|
+| pinene_3200_0006|   206,907 | 70,268,885 |  2.94   | 77,994   |     87         |
+| nql180_0000     | 1,214,332 | 91,979,446 | 13.2    |    893   | 24,020         |
+| nql180_0002     | 3,197,295 |222,147,205 | 14.4    |    895   | 53,411         |
+
+The two families are in opposite regimes. pinene's init heuristic
+leaves ~61% of columns unmatched (77,994 searches on n=127,995), so it
+runs many tiny searches whose working set stays in L1. nql180's init
+matches 99.66% (893 searches on n=259,681), so it runs a few enormous
+searches, each touching 9-21% of all rows — a working set far past L1.
+The 4.5x per-scan gap tracks working-set size, not algorithm.
+
+`build_cost_graph` is not the lever either: 8-12 ms/iterate, which is
+20% of pinene's cheapest iterate but 0.4% of nql180's.
+
+## What was done
+
+The inner loop reads five *random-index* arrays per edge
+(`visited[i]`, `u[i]`, `iperm[i]`, `d[i]`, heap position), and every
+heap sift level did `d[self.heap[parent]]` — a load from the heap array
+followed by a **dependent random load** into `d`.
+
+`IndexHeap` now stores the key inline (`HeapEntry { key, idx }`), so
+sifting stays within the heap array, which parent/child arithmetic
+already walks with locality. The comparisons performed are unchanged,
+so the matching is bit-identical by construction. This also removes the
+heap's `&[f64]` borrow of `d`, which is what previously prevented `d`
+from being fused with the other per-row arrays.
+
+## Evidence
+
+Bit-identity oracle: `diag_mc64_scaling_fingerprint` hashes the raw
+IEEE bits of every entry of `SparseFactors::scaling`, so *any*
+deviation in the matching is detected, not merely one large enough to
+move a residual. Verified deterministic across repeat runs first.
+
+- **51 matrices across 39 families: all fingerprints unchanged.**
+
+Speed (median of 3, standalone matching, same binary path):
+
+| matrix           | before us | after us | speedup |
+|------------------|-----------|----------|---------|
+| nql180_0000      | 1,174,045 | 1,128,533|  1.040x |
+| nql180_0002      | 3,083,529 | 2,917,491|  1.057x |
+| pinene_3200_0001 |    44,381 |   45,279 |  0.98x  |
+| pinene_3200_0006 |   202,205 |  202,969 |  1.00x  |
+| marine_1600_0000 |    29,911 |   29,820 |  1.00x  |
+
+4-5% on the family that dominates corpus MC64 time, nothing elsewhere —
+exactly the predicted split, since pinene's searches were already
+L1-resident. This is smaller than hoped and is reported as such.
+
+`sample` profile of nql180_0002: 100/108 samples in the inlined main
+loop, 7 in `IndexHeap::update`. Decrease-key sift-*up* is ~6.5% — most
+sift-ups terminate immediately — so the win comes from the sift-*down*
+path inside `pop`, as intended.
+
+## What is left, and what it is worth
+
+A microbenchmark of the access pattern alone (5 split arrays vs 1 fused
+struct, nql180's n) shows the split/fused gap is entirely a
+working-set effect:
+
+    ws=   500  split=0.70 ns  fused=0.70 ns  speedup=0.99x   <- pinene regime
+    ws= 50000  split=2.12 ns  fused=1.12 ns  speedup=1.90x
+    ws=259681  split=2.27 ns  fused=1.35 ns  speedup=1.68x   <- nql180 regime
+
+So fusing `visited`/`u`/`iperm`/`d` into one per-row struct is worth
+~1.7x **on the array-access portion only**, which is ~2.3 ns of
+nql180's ~13 ns/scan. Expected end-to-end gain ~7%, bit-identical, now
+unblocked by the inline-key change. Not yet done.
+
+Honest bound on this whole direction: the Hungarian on nql180 is doing
+893 genuinely long shortest-path searches, and their length is a
+property of the matrix, not of the implementation. Constant-factor
+memory work is worth tens of percent, not multiples. A multiple
+requires changing the matching (auction/eps-optimal, or skipping MC64
+on these KKTs) — which is the gated, approval-requiring path, not this
+one.

--- a/dev/research/mc64-value-bound-diag-drift-2026-08-09.md
+++ b/dev/research/mc64-value-bound-diag-drift-2026-08-09.md
@@ -1,0 +1,197 @@
+# The MC64 value-bound gate rejects at zero drift
+
+**Date:** 2026-08-09
+**Machine:** Apple M4 Pro (`Mac16,11`), 10P+4E, macOS. Sequential solver.
+**Status:** Measured. Proposes a narrow fix to condition 3.
+
+## The defect
+
+`mc64_value_bound_passes` (`src/scaling/value_bound.rs:224`) decides whether a
+cached MC64 scaling `D` may be reused on a new matrix. Three conditions:
+
+```rust
+let cond_ratio = stats.max_ratio    <= GROWTH_FACTOR * validity.r0;
+let cond_count = n_off_dominant     <= GROWTH_COUNT  * validity.n_off_dominant_0;
+let cond_diag  = stats.min_diag     >= EPS_DIAG      * validity.mean_diag_0;
+```
+
+Conditions 1 and 2 are *drift* measures: current statistic against the same
+statistic on the baseline matrix. Condition 3 is not. It compares the current
+**min** scaled diagonal against the baseline **mean**. Those are different
+statistics, so `cond_diag` is an absolute property of the matrix — "does the
+scaled diagonal have dynamic range wider than `1/EPS_DIAG`" — not a measure of
+how far the matrix has moved.
+
+The consequence is that a matrix can fail the gate **against itself**. Feeding
+the baseline matrix back in gives `max_ratio == r0` and `n_off_dominant ==
+n_off_dominant_0` exactly (conditions 1 and 2 pass by construction), yet
+`cond_diag` still fails whenever `min_diag < 1e-12 * mean_diag`.
+
+Instrumented run on `robot_1600_0001` (`FORCE_MC64`, temporary
+`FERAL_VB_DEBUG` print, reverted):
+
+```
+vb: ratio true (6.111443e14 vs 1.222289e15) | count true (15410 vs 15410) | diag false
+    min_diag 1.636275e-15, mean_diag 4.177246e-1  ->  threshold 4.177246e-13
+```
+
+Zero drift on the two drift conditions; condition 3 rejects anyway.
+
+## How often it actually matters
+
+`FERAL_VB_DEBUG` instrumentation on `precompute_mc64_validity` and
+`mc64_value_bound_passes`, driven through `diag_trajectory_scaling` (one
+`Solver`, iterates in order, as an IPM caller would). 24 families attempted;
+`min_diag_0` recovered by pairing each `vb-chk` with the preceding `vb-pre`.
+
+**Most of the corpus never reaches this gate.** 17 of the 24 families ran MC64
+zero times — `pick_scaling_strategy` routes them to InfNorm, so no cache, no
+gate. That includes every large-scaling% family from the phase profile:
+`clnlbeam`, `dtoc2`, `rocket_12800`, `steering_12800`. Their scaling cost is
+InfNorm, which this lever cannot touch.
+
+Seven families do route to MC64, giving **53 gate evaluations**. Condition 3 is
+the *sole* blocker on **three**:
+
+| family | min_diag | min_diag_0 | drift | verdict |
+|---|---|---|---|---|
+| robot_1600 | 2.335e-15 | 2.335e-15 | 1.000 | false positive — zero drift |
+| robot_1600 | 7.572e-15 | 7.667e-15 | 0.988 | false positive — zero drift |
+| arki0003 | 1.984e-13 | 9.372e-06 | 2.1e-08 | **genuine collapse** |
+
+The `arki0003` case is the control: an eight-order collapse of the minimum
+scaled diagonal, which any correct form of condition 3 must reject. The two
+`robot_1600` cases are pure false positives — the minimum scaled diagonal did
+not move.
+
+The remaining rejections come from conditions 1 and 2 and are untouched by this
+note. `pinene_3200` rejects on condition 1 on all 8 of its checks, exactly as
+`tried-and-rejected.md:2087` (2026-05-21) recorded.
+
+## Proposed fix
+
+Store `min_diag_0` in `Mc64CacheValidity` and make condition 3 pass if *either*
+the existing absolute floor holds *or* the minimum has not drifted down:
+
+```rust
+let cond_diag = stats.min_diag >= EPS_DIAG * validity.mean_diag_0
+             || stats.min_diag >= DIAG_SHRINK * validity.min_diag_0;
+```
+
+This is a strict widening of the accept set, and it is zero-drift-safe by
+construction: re-checking the baseline matrix gives `min_diag == min_diag_0`
+exactly, so the second clause holds for any `DIAG_SHRINK <= 1`.
+
+`DIAG_SHRINK = 1.0 / GROWTH_FACTOR = 0.5` — symmetric with the existing
+constant: the minimum diagonal may shrink by the same factor the worst
+dominance ratio may grow.
+
+**The threshold is not load-bearing.** Every value swept from 0.5 down to 1e-6
+produces the same 25 accepts out of 53. The two `robot_1600` false positives
+sit at drift 0.988 and 1.000; the `arki0003` genuine collapse sits at 2.1e-08.
+Nothing in the corpus lies between. 0.5 is chosen because it is the tightest
+defensible value, not because the data forces it.
+
+## What it buys
+
+`robot_1600` only, and only iterates 0004 and 0005:
+
+```
+trajectory total: factor 62084 us, scaling 20533 us (33.1%)
+recovered:        4951 + 3605 = 8556 us  =  13.8% of the trajectory
+```
+
+No other family's gate decision changes at any swept threshold.
+
+**This is much smaller than the 32.7% figure that motivated the work.** That
+number was the total scaling share of the `robot_1600` trajectory, which
+implicitly assumed the gate could be made to hit on all seven iterates. It
+cannot: two of the four checks fail on conditions 1 and 2, which are working as
+designed, and two iterates change pattern and never reach the gate.
+
+## Verified after implementation
+
+Same seven families, `diag_trajectory_scaling` built from the pre-fix and
+post-fix sources, run back to back.
+
+Hit-pattern diff across all 53 gate evaluations — the complete set of changes:
+
+```
+< robot_1600_0004 NO        > robot_1600_0004 yes
+< robot_1600_0005 NO        > robot_1600_0005 yes
+```
+
+Nothing else moved. Inertia is byte-identical on every iterate of every family
+(`14399/9601/0` on `robot_1600`, `38415/38392/0` on `marine_1600`, and so on).
+
+`robot_1600` trajectory:
+
+| | before | after |
+|---|---|---|
+| factor | 63,560 us | 54,445 us |
+| scaling | 20,721 us (32.6%) | 12,479 us (22.9%) |
+
+14.3% off the trajectory, 39.8% off its scaling — the 13.8% predicted from the
+gate log, within run-to-run noise. Every other family's totals move by less
+than the noise floor.
+
+## Safety
+
+Fresh-MC64-vs-reuse-`D0` comparison (`diag_scaling_reuse_correctness`), which is
+*more* aggressive than this fix — it carries iterate 0's scaling across the
+whole trajectory unconditionally, ignoring the gate entirely. 9 families, 32
+iterates:
+
+* inertia identical on **32 of 32**, no exceptions;
+* refined residuals match within ~2x (worst `steering_12800_0002`, 1.2e-7 reuse
+  vs 2.0e-9 fresh; `steering_12800_0001` reuse is *better*, 6.1e-9 vs 1.6e-7);
+* **unrefined** residuals degrade materially — `marine_1600_0002` 7.3e-3 reuse
+  vs 1.5e-6 fresh, ~4900x.
+
+The unrefined degradation is a property of scaling reuse in general, not of this
+fix, and it is already accepted by the existing gate on the 23 checks that pass
+today. The gate exists to protect inertia (issue #38), and inertia is preserved
+on every iterate measured under a far more aggressive policy than the one
+proposed.
+
+## Relation to the 2026-05-21 rejection
+
+`tried-and-rejected.md:2087` rejected Track B2 because (a) the gate rejected
+every warm iteration on `pinene_3200` via **condition 1**, confounded by the IPM
+barrier trajectory, and (b) B2 targeted <2% of `pinene`'s cost.
+
+This note does not revisit either finding. It addresses **condition 3**, leaves
+condition 1 alone, and confirms `pinene_3200` still rejects 8/8 on condition 1.
+The recorded lesson — "validate the cost model before building the
+optimization... a per-factor profile of the *named target's full iteration
+sequence*, not a single iteration, should precede the plan" — is why the 13.8%
+figure above is a trajectory number and why the corrected sizing appears here
+rather than after implementation.
+
+## The bigger targets this measurement surfaced
+
+**Condition 1, on the families where scaling actually dominates.** The
+trajectory totals are lopsided:
+
+| family | scaling share of trajectory | benefit from this fix |
+|---|---|---|
+| nql180 | 66.2% (11.2 s of 17.0 s) | none |
+| pinene_3200 | 79.4% (1.19 s of 1.50 s) | none |
+| marine_1600 | 50.6% | none |
+| robot_1600 | 32.6% -> 22.9% | 14.3% |
+| dtoc1nd | 10.4% | none |
+| arki0003 | 3.5% | none |
+| qcqp1000-2c | 0.5% | none |
+
+`nql180` and `pinene_3200` spend two thirds to four fifths of their
+factorization time in scaling and this fix does nothing for either — both
+reject on **condition 1**, the growth-factor bound. That is precisely the
+condition `tried-and-rejected.md:2087` found confounded by the IPM barrier
+trajectory on `pinene_3200`. The prize is an order of magnitude larger than
+what condition 3 was worth, and the 2026-05-21 entry says why it is hard.
+Anything that revisits condition 1 must start from that entry.
+
+**InfNorm, for the other 17 families.** They never run MC64 at all —
+`pick_scaling_strategy` routes them to InfNorm, so there is no cache and no
+gate. Their prologue scaling cost is 8.0% to 29.3% of numeric factorization in
+the phase profile, largest on `rocket_12800`. No MC64 cache work can touch it.

--- a/dev/sessions/2026-08-09-07.md
+++ b/dev/sessions/2026-08-09-07.md
@@ -1,0 +1,130 @@
+# Session 2026-08-09-07
+
+## Goal
+
+Two halves. First: take PR #151 from green to shipped (merge, tag,
+publish, notify pounce). Second, once that was done: take the
+measurement the release was cut for, which is the factorization gap
+against Harwell on chain-structured KKTs.
+
+## Unfavorable result, stated first
+
+**On the two largest chain-structured proxies, `main` is significantly
+slower than 0.14.0.** `prommis_sx_like` 0.833x (2/15 wins, p = 0.0074),
+`double_column_like` 0.914x (4/15, p = 0.1185). This contradicts the
+0.15.0 release note's "wins all twelve arms", which was measured on real
+matrices on a 4-core homogeneous x86_64 container. It also independently
+reproduces the `chainW` anomaly that session 2026-08-09-02 recorded and
+accepted as a proxy quirk, and that the pounce-side reviewer on PR #150
+flagged as a probable regression on exactly this geometry.
+
+Caveats that keep this from being a verdict: these are synthetic
+proxies, the "new" arm is `main` at `7a31ff6` rather than the `v0.15.0`
+tag, and the bisect that would separate the two did not run. Full
+numbers, method and limits in
+`dev/research/chain-kkt-ma57-gap-2026-08-09.md`.
+
+## Accomplished — release
+
+1. Verified #151 green, merged as `808babb`, waited for main CI on the
+   squash commit before tagging (a different SHA than the PR head).
+2. Tagged `v0.15.0` and published the GitHub Release. Release job: tag /
+   `Cargo.toml` check PASS, `cargo test` PASS, `cargo publish` PASS for
+   all seven crates. Wheels job: sdist + four wheels, PyPI publish, `uv
+   pip` smoke test PASS.
+3. Verified against the registries, not workflow exit codes: crates.io
+   `feral` 0.15.0; PyPI `feral-solver` 0.15.0 with macosx universal2,
+   manylinux x86_64, manylinux aarch64, win_amd64 and the sdist.
+4. Notified pounce ([pounce#552 comment 5232312068](https://github.com/jkitchin/pounce/issues/552#issuecomment-5232312068)).
+   Release checklist §3 complete.
+
+## Accomplished — measurement
+
+5. Established what this machine can and cannot measure. It has the
+   CoinHSL v2023.11.17 bundle (so MA57 is available, oracle built and
+   linked) and Ipopt 3.13.2 with MA27/MA57/MUMPS all confirmed live. It
+   does **not** have `data/matrices/` at all, nor the Pyomo NMPC stack
+   for the five #552 models, nor CUTEst to regenerate the corpus.
+6. Built `external_benchmarks/chain_proxy/`: block-tridiagonal KKT
+   proxies at the reported #552 geometries, plus the paired A/B runner
+   and a mechanism probe. Portable (env-driven paths) so it runs on the
+   corpus machine unchanged.
+7. **The gap:** feral is slower than MA57 on all five proxies, by 1.4x
+   to 2.4x, worst on the largest and most chain-like
+   (`prommis_sx_like` 0.415, 0/15, p = 0.0001). Narrower than the
+   3.5-4.8x in pounce#552, but not comparable to it: different
+   matrices, different machine, and numeric factorization only where
+   the report is end-to-end.
+8. **Mechanism probe:** neither lever 0.15.0 shipped explains the
+   regression. `FERAL_PACKED_SIMD=0` makes both proxies *worse*, so the
+   kernel is helping. Forcing the sequential fallback does not recover
+   `prommis_sx_like`. Established along the way that these chains do
+   **not** collapse to `seeds = 1` (`prommis_sx_like` coarsens 2625
+   supernodes to 15 tasks with 8 seeds), so the release note's reasoning
+   that chain-shaped trees take the sequential driver outright does not
+   hold for the geometry pounce cares about.
+
+## Correctness evidence for the proxies
+
+Both feral and MA57 reproduce the analytic inertia (`T*nx` positive,
+`T*nc` negative, no zeros) exactly on all five, feral residuals 3.7e-16
+to 2.3e-15, MA57 2.0e-16 to 2.4e-16. An earlier generator was
+rank-deficient by construction (identical rows within each `A_t`); MA57
+caught it as `inertia_zero = 301` and feral returned a residual of
+5.9e+03. Fixed before any timing was taken; recorded in the harness
+README so it is not reintroduced.
+
+## Benchmark Results
+
+No corpus bench: this machine has no corpus, and the release half of the
+session changed zero lines of source. Numbers for the shipped code stand
+from session 03 and the aarch64 revalidation at `6fd12d4`. `cargo test`
+for the published SHA ran green inside the release job. The proxy
+measurements are tabulated in the research note rather than duplicated
+here.
+
+## Decisions Made
+
+- None architectural. Two process points: tag only after CI is green on
+  the squash merge commit, not the PR head; and when a harness reports a
+  suspicious residual, check the analytic oracle before assuming a
+  solver bug (here it was the generator).
+
+## Abandoned Approaches
+
+- None abandoned. One experiment written and not run: the bisect across
+  `c05eb77` / `e8e1c5a` / `fad5670` / `808babb` / `main` plus a thread
+  sweep. Binaries for all five points are built; the script was left out
+  of the commit because it never executed. Procedure documented in the
+  research note.
+
+## Gotchas
+
+- **The PyPI distribution is `feral-solver`, not `feral`.**
+  `pypi.org/pypi/feral/json` is an unrelated third-party package at
+  1.0.0, so a naive post-release check misreads the version.
+- **Journal filename collisions across concurrent sessions.** The cloud
+  container wrote `dev/journal/2026-08-09-04.org` and `-05.org` while
+  this session was live, so this one is `-07`. Check `git ls-tree main
+  dev/journal/` before choosing a number, not just the local directory.
+
+## Next Session Should
+
+Run on the machine that has `data/matrices/`. The first two are cheap
+and decide whether the third matters.
+
+1. **Bisect the chain regression** on the real chain KKTs across
+   `c05eb77` (0.14.0), `e8e1c5a` (#149), `fad5670` (#150), `808babb`
+   (v0.15.0) and `main`. Attributes it to a PR and separates the tag
+   from post-tag main, which the proxy run cannot do.
+2. **Thread sweep** (1/2/4/all) on the same matrices, on homogeneous
+   cores and on Apple silicon, to test the efficiency-core hypothesis:
+   a coarse task landing on an E-core stalls the factorization where
+   0.14.0's per-node granularity let work-stealing rebalance.
+3. **Re-run the gap against MA57** on the real corpus. Only that number
+   should be quoted to pounce.
+4. **Hold the scaling-reuse item** until 1 and 2 land. If the regression
+   is real on the corpus, recovering 20% on the exact matrix class
+   pounce cares about is cheaper and better-evidenced than a design
+   project that changes numerics and needs residual gates designed in
+   from the start.

--- a/dev/sessions/2026-08-09-08.md
+++ b/dev/sessions/2026-08-09-08.md
@@ -1,0 +1,166 @@
+# Session 2026-08-09-08
+
+## Goal
+
+Move PR #157 forward. The PR shipped a proxy measurement and closed with
+three ordered follow-ups that needed a machine with `data/matrices/`:
+bisect the post-0.14.0 chain regression, sweep threads to test the
+efficiency-core hypothesis, and re-run the MA57 gap on the real corpus.
+This machine (Apple M4 Pro, `Mac16,11`, 10P+4E) has the corpus, the
+CoinHSL MA57 oracle, and all five bisect commits.
+
+## Accomplished
+
+All three follow-ups ran. **Both of the proxy note's headline
+conclusions are contradicted by the real matrices.** Full data in
+`dev/research/chain-kkt-corpus-2026-08-09.md`.
+
+Six real KKTs, paired alternating A/B per `decisions.md`, `min
+factor_us` over 15 pairs, exact two-sided sign test.
+
+**1. The MA57 gap is not a gap.** main vs ma57, ratio > 1 = feral
+faster, all p = 0.0001:
+
+| matrix | n | main | ma57 | ratio | wins |
+|---|---|---|---|---|---|
+| rocket_12800 | 89,601 | 22,893 | 535,659 | 23.40 | 15/15 |
+| clnlbeam | 99,999 | 21,739 | 210,481 | 9.68 | 15/15 |
+| steering_12800 | 115,201 | 33,923 | 273,494 | 8.06 | 15/15 |
+| marine_1600 | 76,807 | 33,373 | 42,471 | 1.27 | 15/15 |
+| dtoc2 | 103,920 | 81,163 | 61,245 | 0.76 | 0/15 |
+| dtoc1nd | 9,685 | 14,297 | 4,561 | 0.32 | 0/15 |
+
+The proxies reported "slower than MA57 on all five, 1.4x to 2.4x, worst
+on the largest and most chain-like." The largest and most chain-like are
+where feral wins hardest.
+
+Caveat carried with the 8.06x: on `steering_12800` MA57's residual is
+`4.53e-08` against feral's `3.52e-14`, identical matrix and RHS. feral
+reports `refined yes`; the MA57 oracle does not do that refinement.
+`factor_us` is factorization only so the timing stands, but the MA57
+solve is looser. The correctness gate written into `arm_run.py` is what
+surfaced it.
+
+**2. The regression is real and on the smallest matrix.** Ratios vs
+`v0.14.0`; all large-matrix gains and the `dtoc1nd` loss are 15/15 at
+p = 0.0001:
+
+| matrix | #149 SIMD | #150 parallel | v0.15.0 | main |
+|---|---|---|---|---|
+| clnlbeam | 0.966 | 2.048 | 2.054 | 2.048 |
+| steering_12800 | 0.986 | 1.646 | 1.644 | 1.669 |
+| dtoc2 | 0.999 | 1.401 | 1.438 | 1.434 |
+| rocket_12800 | 0.979 | 1.200 | 1.255 | 1.214 |
+| marine_1600 | 0.953 | 0.956 | 0.953 | 0.943 |
+| dtoc1nd | 0.960 | 0.764 | 0.762 | 0.750 |
+
+#150 (`fad5670`) is the mover and a large win on the four largest. The
+sole regression is `dtoc1nd` (n = 9,685), 25%, carried unchanged into
+v0.15.0 and main. The proxies predicted losses on the two *largest*
+chains. v0.15.0 and main are indistinguishable, closing the
+tag-vs-post-tag question the PR left open.
+
+**3. Thread count does nothing.** `RAYON_NUM_THREADS` 1/2/4/8/10 vs
+default: every ratio within 6% of 1.0, one significant and in the wrong
+direction. E-core hypothesis refuted on hardware with more E-cores than
+the machine that generated it.
+
+**Unfavorable / awkward findings, stated plainly:**
+
+- **#149's SIMD kernel is negative on this corpus** — below 1.0 on all
+  six matrices, significantly on `clnlbeam` (0.966, 0/15, p = 0.0001)
+  and `rocket_12800` (0.979, 2/15, p = 0.0074). It was a win on the
+  proxies and in the release's own measurements.
+- **#150's gains are not parallelism gains.** Single-threaded main
+  matches all-threads main everywhere. Any plan to extend #150 by
+  parallelizing harder is built on a false premise.
+- **`dtoc1nd` and `dtoc2` are still MA57 losses**, 3.1x and 1.3x.
+
+**Corpus repair.** `steering_12800` had no `.mtx` — only a zero-byte
+`.solver.log`. The harvest path is dead: ripopt commit `76d3575`
+(2026-04-28) deleted `dump_kkt_matrix` / `write_kkt_mtx_file` /
+`write_kkt_json_sidecar` / `collect_kkt_lower_triangle_entries` and the
+call site, but left `SolverOptions::kkt_dump_dir` (`options.rs:714`) and
+its CLI wiring (`ripopt_ampl.rs:607`) in place, so `kkt_dump_dir=`
+parses and silently writes nothing — the harvest reports "OK ... 0 mtx"
+and exits 0. Regenerated with pounce (`--dump kkt:1-3`) plus a new
+`scripts/harvest-pounce-kkt.py`, validated against an external oracle:
+pounce reports `num_neg_evals_actual = 51201`, feral and MA57
+independently agree (`inertia_neg = 51201`, `inertia_pos = 64000`,
+`inertia_zero = 0`). This unblocks the 41 Mittelmann families never
+harvested.
+
+`dtoc2_0001` and `_0002` are singular by both solvers (`inertia_zero` 4
+and 103, both `rel_res = NaN`) and are excluded; `dtoc2_0000` is used.
+
+**Harness.** `arm_run.py` generalizes `ab_run.py` to N arms with per-arm
+env overrides, reusing its protocol functions so the statistics are the
+same code — this is the `probe_bisect.py` the proxy note recorded as
+written-but-never-run. It prints a correctness gate (any arm with
+`inertia_zero != 0` or NaN / `> 1e-8` residual) before any timing table.
+`real_corpus_mtx.py` builds the matrix set with its selection rules
+documented.
+
+No solver source changed this session.
+
+## Benchmark Results
+
+```
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(μs)    mumps(μs)      ratio
+SWOPF_0778                     175          882           74      11.92
+QPNBLEND_0189                  157          723           62      11.66
+QPNBLEND_0247                  157          710           62      11.45
+QPNBLEND_0157                  157          636           60      10.60
+QPNBLEND_0294                  157          631           60      10.52
+QPNBLEND_0295                  157          626           60      10.43
+QPNBLEND_0343                  157          610           59      10.34
+QPNBLEND_0344                  157          622           61      10.20
+QPNBLEND_0146                  157          602           61       9.87
+QPNBLEND_0158                  157          589           60       9.82
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.62     <= 2.0     PASS
+medium (<500)            152145     2.04     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.57     <= 2.0     PASS
+medium (<500)            153560     1.57     <= 3.0     PASS
+```
+
+Both partitions PASS. This machine is an M4 Pro; prior sessions' bench
+numbers were taken elsewhere, so absolute microseconds are not
+comparable across checkpoints — only the PASS/FAIL verdicts and the
+p90 targets are.
+
+## Decisions Made
+
+None architectural. One methodological point worth carrying: the
+correctness gate now runs before the timing tables in `arm_run.py`, and
+it earned its place immediately by catching MA57's `4.53e-08` residual
+on `steering_12800`, which a timing-only table would have hidden.
+
+## Abandoned Approaches
+
+- Efficiency cores as the explanation for the chain regression —
+  refuted, appended to `tried-and-rejected.md` with the sweep data.
+- The ripopt harvest path for new corpus matrices — dead upstream, not
+  revived. Replaced with the pounce dump path rather than restoring
+  ~200 deleted lines in another repo.
+
+## Next Session Should
+
+1. **Chase the `dtoc1nd` regression.** One small matrix (n = 9,685), a
+   known culprit (#150, `fad5670`), 25% on the table, and the smallest
+   possible reproducer. Cheapest well-evidenced win available.
+2. **Bisect #149's SIMD kernel on this corpus.** It is negative on all
+   six real matrices and was positive on the proxies. Understand that
+   before any more kernel work.
+3. **Work out what #150 actually bought**, given it is not parallelism.
+   Spawn overhead, locality, and traversal order are the candidates.
+   This determines whether the win generalizes.
+4. Re-run on x86_64 — every number here is aarch64.
+5. Only then revisit the scaling-reuse item. Its premise (feral broadly
+   behind MA57 on this matrix class) is now known false.

--- a/dev/sessions/2026-08-09-09.md
+++ b/dev/sessions/2026-08-09-09.md
@@ -1,0 +1,201 @@
+# Session 2026-08-09-09
+
+## Goal
+
+Size issue #125 step 2 before building it. That measurement said not to
+build it, and pointed at the MC64 scaling cache instead — so the second
+half of the session went there: find why the value-bound gate never
+hits on warm iterates, and fix it.
+
+## Accomplished
+
+### Issue #125 step 2 — measured, recommended against
+
+Static frontal row layout for fronts that receive delayed columns. Step 1
+landed in PR #139; step 2 would extend it past `n_delayed_in == 0`.
+
+- **Reach:** 7 of 41 corpus matrices have any front with `n_delayed_in > 0`.
+  Material dynamic rows on 3: steering_12800 61.53%, robot_1600 28.86%,
+  qcqp1500-1nc 25.04%. clnlbeam, dtoc1nd, dtoc2, marine_1600 and
+  rocket_12800 are all at **0.00%**.
+- **Cost ceiling** (`BUILDROW_NS / factor`): **0.21%–3.13%**. It is the
+  smallest column in the phase profile.
+- The fast-path `.to_vec()` cannot become a borrow — `row_indices` is
+  moved into `NodeFactors` at `factorize.rs:2739`, so the copy is a
+  genuine ownership requirement.
+
+~1–2% on 3 of 41 matrices, paid for by touching the delayed-pivot path.
+I explicitly retract my earlier characterization of #125 as "obvious
+work" — that was true of step 1, not step 2.
+
+### Factorization phase profile
+
+Driver wall, best of 3 warm sequential reps. **Methodology correction
+made mid-session:** the first version measured against the
+`Solver::factor` wall, which folds in work the phase counters do not
+cover, and showed 18.5%–50.9% "outside" assembly+dense. Rewritten to
+drive `factorize_multifrontal_supernodal_with_workspace` directly; the
+books then close (prologue + epilogue + loop ≈ 100%). Same
+timed-region-mismatch error class that caused two retractions earlier
+in the day.
+
+| matrix | drv_us | prol% | scaling% | schur% | cbextr% | dense_o% | buildrow% |
+|---|---|---|---|---|---|---|---|
+| clnlbeam | 26297 | 18.1% | 15.2% | 11.2% | 6.6% | 22.1% | 2.2% |
+| dtoc1nd | 12540 | 25.0% | 19.5% | 8.2% | 12.0% | 9.6% | 0.8% |
+| dtoc2 | 76483 | 12.8% | 8.0% | 5.7% | 14.4% | 13.8% | 2.0% |
+| marine_1600 | 31271 | 22.4% | 18.9% | 15.7% | 5.7% | 19.3% | 1.2% |
+| rocket_12800 | 20461 | 34.7% | 29.3% | 11.3% | 1.8% | 24.5% | 0.9% |
+| steering_12800 | 37880 | 17.5% | 14.6% | 15.3% | 5.7% | 19.8% | 3.7% |
+| robot_1600 | 8662 | 19.0% | 15.8% | 15.0% | 6.4% | 22.1% | 3.0% |
+
+Two large unattributed buckets remain: `dense_o%` (9.6–24.5%) and
+prologue scaling.
+
+### MC64 value-bound condition 3 — bug found and fixed (`bd1bc26`)
+
+```rust
+let cond_diag = stats.min_diag >= EPS_DIAG * validity.mean_diag_0;
+```
+
+Current **minimum** scaled diagonal compared against baseline **mean**.
+Different statistics, so condition 3 was an absolute property of the
+matrix, not a drift measure — and a matrix could fail the gate against
+its own fingerprint while conditions 1 and 2 passed exactly.
+
+Fixed as a **disjunction** with a new drift clause
+`min_diag >= DIAG_SHRINK * min_diag_0`, `DIAG_SHRINK = 1/GROWTH_FACTOR
+= 0.5`. Strict widening of the accept set; zero-drift-safe by
+construction.
+
+Tests first, and the regression test failed first — the `min_diag_0`
+field was added *without* the `cond_diag` change so the failure was at
+runtime, not compile time:
+
+```
+value_bound_passes_on_identical_matrix_with_wide_diagonal_range ... FAILED
+panicked: a matrix must pass the value bound against its own fingerprint
+test result: FAILED. 12 passed; 1 failed
+```
+
+13 passed after the change. `cargo test --release` exit 0.
+
+Verification with pre-fix and post-fix binaries built from the same
+tree, 7 families, 53 gate evaluations. Complete hit-pattern diff:
+
+```
+< robot_1600_0004 NO      > robot_1600_0004 yes
+< robot_1600_0005 NO      > robot_1600_0005 yes
+```
+
+Nothing else moved. Inertia byte-identical on every iterate of every
+family. robot_1600 trajectory 63560 → 54445 us (14.3%), scaling 20721 →
+12479 us (39.8%).
+
+## Sizing correction — report this before the win
+
+I pitched this fix at **32.7%** of robot_1600's trajectory. It is worth
+**14.3%, on one family.** The 32.7% was that trajectory's total scaling
+share and implicitly assumed the gate could be made to hit on all seven
+iterates. It cannot: two of the four checks fail on conditions 1 and 2,
+which are working as designed, and two iterates change pattern and never
+reach the gate.
+
+Two things I had not measured when I pitched it:
+
+- **17 of 24 corpus families never run MC64 at all.**
+  `pick_scaling_strategy` routes them to InfNorm, so there is no cache
+  and no gate. That includes every large-scaling% family in the phase
+  profile above — clnlbeam, dtoc2, rocket_12800, steering_12800.
+- Of the 53 evaluations that remain, condition 3 is the sole blocker on
+  **3**: two robot_1600 false positives (drift 0.988 and 1.000) and one
+  arki0003 genuine collapse (drift 2.1e-8, still rejected after the fix).
+
+Also corrected: I had recorded "mean_diag_0 4.213035e-13". That is the
+*threshold*; the mean is 4.213035e-1. The min-vs-mean conclusion is
+unchanged.
+
+## Benchmark Results
+
+`cargo run --bin bench --release`, post-fix. Both exit partitions PASS.
+
+```
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.43       0.30       1.54       3.30       8.70
+solve/MUMPS        153560       0.07       0.08       0.14       0.68       3.04
+factor/SSIDS       154500       0.04       0.03       0.32       0.96       2.03
+solve/SSIDS        154500       0.93       1.00       2.44       8.35      36.50
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.54     <= 2.0     PASS
+medium (<500)            153560     1.54     <= 3.0     PASS
+```
+
+Against the earlier run in this session (pre-fix):
+
+| partition | before | after |
+|---|---|---|
+| dense small-frontal p90 | 1.62 | 1.58 |
+| dense medium p90 | 2.04 | 2.00 |
+| sparse small-frontal p90 | 1.57 | 1.54 |
+| sparse medium p90 | 1.57 | 1.54 |
+
+**Do not read this as a win from the fix.** The bench factors each
+matrix once with a fresh solver, so the value-bound gate is never
+consulted and the change should be a no-op here — which is what "no
+regression" means in this table. The p90 movement is run-to-run noise;
+the worst-ratio top 10 turned over completely between the two runs
+(SWOPF/QPNBLEND before, KIRBY2 after) on matrices of n = 157–458 where
+absolute times are sub-millisecond.
+
+The bench corpus is also a different population from the seven
+kkt-mittelmann families the fix was measured on. It is a regression
+control, not evidence for the change.
+
+
+## Decisions Made
+
+- **MC64 value-bound condition 3 measures drift, not an absolute floor**
+  — appended to `dev/decisions.md`. Disjunction rather than replacement
+  so it is a strict widening; `DIAG_SHRINK = 0.5` chosen as the tightest
+  defensible value, not a tuned one (every value from 0.5 to 1e-6 gives
+  the same 25 accepts of 53).
+
+## Abandoned Approaches
+
+- **Issue #125 step 2** — measured and recommended against, see above.
+  Not appended to `tried-and-rejected.md` because nothing was built and
+  abandoned; the measurement is in
+  `dev/research/mc64-value-bound-diag-drift-2026-08-09.md` and the
+  journal. If a future session decides to close #125 rather than leave
+  step 2 open, that decision belongs in the issue.
+
+## Next Session Should
+
+1. **Decide where `16b423c`, `8f8aa8c` and `bd1bc26` go.** They are on
+   `docs/session-2026-08-09-05`, whose PR #157 is about MA57 benchmark
+   docs — an unrelated topic. These three want their own branch and PR.
+   **This is the open decision blocking the work from landing.**
+2. **Look at condition 1, but read
+   `tried-and-rejected.md:2087` first.** This is where the scaling mass
+   actually is: nql180 spends 11.2 s of 17.0 s in scaling, pinene_3200
+   79.4%, marine_1600 50.6% — and all of them reject on condition 1, not
+   condition 3. An order of magnitude more value than this fix was
+   worth. The 2026-05-21 entry documents why it is hard: the gate metric
+   is confounded by the IPM barrier trajectory δ→0. Do not restart it
+   cold.
+3. **InfNorm scaling, for the other 17 families.** They never run MC64,
+   so no cache work can help them, and their prologue scaling is 8.0%–
+   29.3% of numeric factorization (largest on rocket_12800).
+4. **`dense_o%`** — 9.6%–24.5% of the driver wall is inside dense
+   factorization but outside panel/schur/lextract/cbextract. Unattributed
+   and larger than anything #125 step 2 could have returned.

--- a/dev/sessions/2026-08-10-02.md
+++ b/dev/sessions/2026-08-10-02.md
@@ -1,0 +1,234 @@
+# Session 2026-08-10-02
+
+Journal: `dev/journal/2026-08-09-08.org` (the work began late on 2026-08-09;
+the file number follows the journal, the session number follows
+`dev/sessions/` which main had already advanced to `2026-08-10-01`).
+
+## Goal
+
+Take the MC64 Hungarian search bound — the lever recommended at the close of
+the condition-1 dig-in (`dev/research/mc64-condition1-cost-share-2026-08-09.md`).
+Then resolve the merge conflicts blocking PR #157 and get remote CI green.
+
+## Benchmark comparison to previous session — TAIL IS SLIGHTLY WORSE
+
+Reported first, per protocol. Against the last full-corpus bench
+(`2026-08-09-09`; `2026-08-10-01` had no corpus in its container):
+
+| factor/MUMPS | 2026-08-09-09 | this session | direction |
+|---|---|---|---|
+| geomean | 0.43 | **0.44** | worse |
+| p50     | 0.30 | 0.30       | flat  |
+| p90     | 1.54 | **1.57**   | worse |
+| p99     | 3.30 | **3.45**   | worse |
+| max     | 8.70 | **12.40**  | worse |
+
+`solve/SSIDS` p90 also moved 2.44 → 2.50; `factor/SSIDS` geomean and both
+`nnzL` rows are unchanged. All Phase 2.8.1 exit partitions still PASS.
+
+I do not have an attributed cause, and I am not claiming one. What can be said:
+
+- **Not the MC64 change.** `509f0ce` is verified bit-identical on 51 matrices,
+  and it only touches the Hungarian heap, which does not run at all on the
+  small CUTEst matrices that set these tails. The worst ratios are `KIRBY2`
+  (n = 458) and `GROUPING` (n = 225).
+- The merge brought in main's `Supernode.nrow` fix (`2026-08-10-01`), which is
+  explicitly flagged there as a *behavior change to parallel dispatch*. That is
+  the one plausible candidate in the diff, but it is unverified — nobody has
+  re-benched main alone since it landed.
+- Sub-millisecond matrices on a laptop are noisy; a single-matrix `max` moving
+  8.70 → 12.40 on `KIRBY2_0007` (1476 us vs 1298-1142 us on its siblings) is
+  within what this harness swings run to run.
+
+Next session should re-run the bench on `origin/main` alone before spending
+effort here, to separate main's change from noise.
+
+## Accomplished
+
+### The recommended lever does not exist (negative result)
+
+My own prior note called the Hungarian search bound
+"same-output-less-work, needs no gate and no residual argument."
+**That was wrong**, and code inspection disproved it before any code was
+written:
+
+1. The classic shortest-augmenting-path bound is **already implemented**.
+   `csp` (cost of the best augmenting path so far) prunes the root scan
+   (`src/scaling/hungarian.rs:541`), terminates the main loop (`:570`), and
+   prunes the inner column scan (`:591`).
+2. Any *further* truncation ends a search before its shortest augmenting
+   path is proven → suboptimal matching → different scaling vector. That is
+   a numerics change requiring a corpus inertia/residual study and human
+   approval, not a free win.
+
+`dev/tried-and-rejected.md:2313` (entry 2026-06-06-03) additionally *proves*
+no per-column reduced-cost bound can ever prune the inner scan: with
+`vj = dq0 - cost[jperm[j2]] + u[q0]`, `vj + lb_tight = dq0`, so the skip
+fires iff `dq0 >= csp` — but `q0` was popped only because `dq0 < csp`. That
+entry instructs future sessions not to retry it. **The directive stands.**
+
+The correction is recorded at the top of the new research note rather than
+by editing the old one (append-only discipline).
+
+### Measurement redirected the work to memory layout
+
+Added `HungarianStats` counters (`heap_init_slots`, `augment_searches`,
+`touched_total`, `phase3_inner_iters`, `main_loop_edge_scans`), exposed via
+`feral::scaling::diagnose_mc64_matching`. Per-edge-scan cost differs 4.5x
+between the two dominant corpus families on identical code:
+
+| matrix           | match_us  | edge_scans  | ns/scan | searches | touched/search |
+|------------------|-----------|-------------|---------|----------|----------------|
+| pinene_3200_0006 |   206,907 |  70,268,885 |  2.94   | 77,994   |     87         |
+| nql180_0000      | 1,214,332 |  91,979,446 | 13.2    |    893   | 24,020         |
+| nql180_0002      | 3,197,295 | 222,147,205 | 14.4    |    895   | 53,411         |
+
+pinene's init heuristic leaves ~61% of columns unmatched → many short,
+L1-resident searches. nql180's init matches 99.66% → few searches, but each
+touches ~21% of all rows, far past L1. `build_cost_graph` was ruled out as a
+target: 8-12 ms/iterate is 20% of pinene's cheapest iterate but 0.4% of
+nql180's.
+
+### Inline-key heap — landed, bit-identical, small verified win (`509f0ce`)
+
+`IndexHeap` now stores `HeapEntry { key: f64, idx: usize }` inline instead of
+`Vec<usize>` + random `d[idx]` lookups. Comparisons and tie-breaking are
+unchanged, so the matching is unchanged.
+
+- **Bit-identity: 51 matrices / 39 families all match baseline.** Oracle is a
+  new diagnostic, `diag_mc64_scaling_fingerprint`, which FNV-hashes the raw
+  bits of `SparseFactors::scaling` (`src/numeric/factorize.rs:958`) — the only
+  observable of the matching.
+- Speed (median of 3): nql180_0000 1,174,045 → 1,128,533 us (**1.040x**);
+  nql180_0002 3,083,529 → 2,917,491 us (**1.057x**); pinene_0001 0.98x;
+  pinene_0006 1.00x; marine_1600 1.00x.
+- `sample` profile: 100/108 samples in the inlined main loop, 7 in
+  `IndexHeap::update` — the gain came from the sift-down path in `pop`.
+
+**Honest accounting:** my array-fusion microbenchmark predicted 1.68-1.9x; the
+real end-to-end win was 4-5%, because the split-array reads are only ~2.3 ns
+of nql180's ~13 ns/scan. The projection was reported as wrong, not rounded up.
+
+### Merge conflicts resolved (`5a9150d`)
+
+Three conflicts (`CHANGELOG.md`, `dev/decisions.md`, `dev/context.md`), all
+append-style Markdown, no code. Both sides kept in date order; heading counts
+136 / 136 / 135-shared / **137 merged** prove nothing was dropped.
+`context.md` was regenerated rather than hand-merged.
+`cargo test --release`: **807 passed, 0 failed.** Fingerprint oracle re-run
+post-merge: all 51 still match baseline.
+
+Noted at the time: the pre-commit hooks reported `(no files to check) Skipped`
+for fmt/clippy on the merge commit, since only Markdown conflicted.
+
+### Remote CI green
+
+All checks pass on `5a9150d`; PR #157 is `MERGEABLE` / `CLEAN`.
+
+| check | result |
+|---|---|
+| `check` (pre-commit, `cargo test` **debug**, diagnostics clippy + test, amd-cleanroom) | pass x2 |
+| `stress-smoke` (M5 gate, issue #28) | pass x2 |
+| Test wheel linux-x86_64 py3.10 / 3.12 / 3.13 | pass |
+
+CI runs the root test suite in **debug**, not release — worth remembering; only
+release had been validated locally before the push.
+
+## Benchmark Results
+
+```
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.57       3.45      12.40
+solve/MUMPS        153560       0.07       0.08       0.14       0.66       2.78
+factor/SSIDS       154500       0.04       0.03       0.32       1.01       2.49
+solve/SSIDS        154500       0.93       1.00       2.50       8.33      30.25
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+Per-family factor geomean vs MUMPS (top 25 families by count):
+family                  count    geomean        p50        max
+HS118                    3000       0.91       0.94       1.60
+BIGGSC4                  3000       0.42       0.45       0.60
+MGH10LS                  3000       0.20       0.22       0.44
+PALMER7A                 3000       0.28       0.30       0.70
+ALLINITA                 3000       0.41       0.40       0.85
+HS13                     3000       0.17       0.20       0.56
+ALLINITC                 3000       0.19       0.20       0.30
+HS89                     3000       0.20       0.20       0.30
+HATFLDH                  3000       0.42       0.45       0.55
+MCONCON                  3000       0.90       0.94       1.97
+HS92                     3000       0.35       0.36       0.82
+SSINE                    3000       0.27       0.27       0.33
+HATFLDBNE                3000       0.39       0.40       0.83
+HS90                     3000       0.20       0.20       0.33
+DJTL                     3000       0.09       0.10       0.22
+SSI                      3000       0.21       0.22       0.33
+CONCON                   3000       0.86       0.89       1.72
+HS91                     3000       0.25       0.27       0.40
+PALMER5A                 3000       0.29       0.30       0.44
+AVION2                   2682       1.48       1.52       2.11
+CERI651ALS               2331       0.27       0.27       0.33
+PFIT4                    2286       0.25       0.27       0.30
+CERI651C                 2233       0.28       0.30       0.33
+CERI651CLS               2227       0.27       0.27       0.40
+BATCH                    2054       1.35       1.41       1.98
+
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(μs)    mumps(μs)      ratio
+KIRBY2_0007                    458         1476          119      12.40
+KIRBY2_0006                    458         1298          127      10.22
+KIRBY2_0008                    458         1142          122       9.36
+KIRBY2_0011                    458          932          120       7.77
+KIRBY2_0009                    458          990          128       7.73
+KIRBY2_0010                    458          987          133       7.42
+GROUPING_0059                  225          725          116       6.25
+GROUPING_0139                  225          701          113       6.20
+GROUPING_0033                  225          692          112       6.18
+GROUPING_0137                  225          674          111       6.07
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.57     <= 2.0     PASS
+medium (<500)            153560     1.57     <= 3.0     PASS
+```
+
+## Decisions Made
+
+None architectural. The one judgement call worth recording: the Hungarian
+matching is left bit-exact. Making it faster by more than a few percent
+requires changing the matching itself (auction / epsilon-optimal, or skipping
+MC64), which is the approval-requiring path — not something to slip in.
+
+## Abandoned Approaches
+
+- **A tighter Hungarian search bound** — the stated lever. Already
+  implemented (`csp`); any further truncation changes the matching. Recorded
+  in `dev/research/mc64-hungarian-search-bound-2026-08-09.md`; the
+  impossibility proof for the per-column variant is the pre-existing
+  `dev/tried-and-rejected.md:2313`, which already forbids retrying it.
+- **`build_cost_graph` as an optimization target** — measured at 0.4% of
+  nql180's iterate. Dropped.
+
+## Next Session Should
+
+1. **Land PR #157**, but first settle its placement. Its title —
+   "docs: 0.15.0 + chain KKT corpus measurement (MA57 headline RETRACTED,
+   see correction)" — no longer describes the 13 commits on the branch. Either
+   retitle it or split the MC64 work onto its own PR. **This is the user's
+   call and was not acted on.**
+2. **Optional, ~7% headroom:** fuse `visited` / `u` / `iperm` / `d` into one
+   record array. Now unblocked, because the inline key removed the heap's
+   `&[f64]` borrow of `d`. Small; take it only if MC64 is still on the
+   critical path.
+3. **Do not** chase Hungarian speed further without deciding to change the
+   matching. nql180's searches are long because its augmenting paths are long
+   — a property of the matrix. A multiple, not a few percent, requires
+   auction/epsilon-optimal or skipping MC64, and that needs a corpus
+   inertia/residual study plus human approval.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5185,3 +5185,51 @@ all-threads main on every one of these matrices, so **#150's 1.20x to
 build on the assumption that they are.
 
 Full data: `dev/research/chain-kkt-corpus-2026-08-09.md`, Result 3.
+
+## 2026-08-09 — a tighter search bound as the MC64 Hungarian lever
+
+**Rejected: the lever does not exist.** `mc64-condition1-cost-share-2026-08-09.md`
+closed by recommending a Hungarian search bound and described it as
+"same-output-less-work, needs no gate and no residual argument". **That
+characterization is wrong.** Code inspection, before any code was written,
+found two independent reasons:
+
+1. The classic shortest-augmenting-path bound is **already implemented**.
+   `csp` — the cost of the best augmenting path found so far — prunes the
+   root scan (`src/scaling/hungarian.rs:541`), terminates the main loop
+   (`:570`), and prunes the inner column scan (`:591`). There is no missing
+   standard bound to add.
+2. Any *further* truncation ends a search before its shortest augmenting path
+   is proven, giving a suboptimal matching and therefore a different scaling
+   vector. That is a numerics change requiring a corpus inertia/residual study
+   and human approval — not a free win.
+
+See also the pre-existing entry 2026-06-06-03 (line ~2313), which proves no
+*per-column reduced-cost* bound can ever prune the inner scan (`vj + lb_tight
+= dq0`, and `q0` was popped only because `dq0 < csp`) and instructs future
+sessions not to retry it. That directive stands.
+
+What the measurement pointed at instead was memory layout, not fewer scans:
+per-edge-scan cost differs 4.5x between corpus families on identical code
+(pinene_3200_0006 2.94 ns/scan, 87 rows touched per search, L1-resident;
+nql180_0002 14.4 ns/scan, 53,411 rows touched per search, far past L1). The
+inline-key heap that followed is bit-identical and won 4-5% on nql180.
+
+Full data: `dev/research/mc64-hungarian-search-bound-2026-08-09.md`.
+
+## 2026-08-09 — `build_cost_graph` as an MC64 optimization target
+
+**Rejected on measurement.** Timed at 8-12 ms per iterate. That is ~20% of
+pinene's *cheapest* iterate but **0.4%** of nql180's — and nql180 is where the
+MC64 time actually is. Optimizing it cannot move the corpus. The instrumented
+timer was reverted and is not in any commit.
+
+## 2026-08-09 — array fusion projected from a microbenchmark
+
+**Not rejected, but the projection was wrong and is recorded so it is not
+reused.** A standalone microbenchmark of split-array vs fused-record reads
+predicted **1.68-1.9x**. The real end-to-end win from the inline-key heap was
+**4-5%**, because the split reads are only ~2.3 ns of nql180's ~13 ns/scan.
+Microbenchmarks of one memory access pattern do not predict a loop that also
+does heap sifting and comparison work; scale by the measured share of the loop
+before believing them.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5154,3 +5154,34 @@ released 0.15.0 (comment 5232409020) shows clnlbeam more than halved
 at 3.77×, and it is a dense-front matrix (nnz/dim 23.0, fronts of 33–64
 columns). Amalgamation is a chain-KKT lever aimed at a problem that has
 largely receded.
+
+## 2026-08-09 — efficiency cores as the explanation for the post-0.14.0 chain regression
+
+**Rejected.** The proxy note `chain-kkt-ma57-gap-2026-08-09.md`
+hypothesized that on Apple silicon rayon treats efficiency cores as
+equivalent to performance cores, so a coarse task from #150's
+task-per-subtree coarsening landing on an E-core stalls the whole
+factorization, where 0.14.0's per-supernode spawning let work-stealing
+rebalance. It predicted the regression "shrinks or inverts at
+`RAYON_NUM_THREADS=4`".
+
+Swept `RAYON_NUM_THREADS` = 1, 2, 4, 8, 10 against the default on six
+real chain KKTs, 15 paired runs each, on an M4 Pro (10P + 4E — *more*
+efficiency cores than the 4P+4E M2 the hypothesis came from, so the
+predicted effect should be larger). Every ratio vs the default landed
+within 6% of 1.0; the only significant one was `marine_1600` at t1
+(0.961, 0/15, p = 0.0001), in the wrong direction to support the
+hypothesis. `steering_12800` at one thread: 1.003 (9/15, p = 0.6072).
+`dtoc1nd`, the matrix that actually regressed, at t4: 1.005 (7/15,
+p = 1.0000).
+
+The knob was verified live, not assumed: feral reads the global rayon
+pool (`rayon::current_num_threads()`, `src/numeric/factorize.rs:3262`),
+and the same variable moved the proxy matrices by up to 65%.
+
+Consequence worth carrying forward: single-threaded main matches
+all-threads main on every one of these matrices, so **#150's 1.20x to
+2.05x gains on the large chains are not parallelism gains**. Do not
+build on the assumption that they are.
+
+Full data: `dev/research/chain-kkt-corpus-2026-08-09.md`, Result 3.

--- a/external_benchmarks/chain_proxy/README.md
+++ b/external_benchmarks/chain_proxy/README.md
@@ -1,0 +1,123 @@
+# chain_proxy — chain-structured KKT proxies vs HSL MA57
+
+A paired A/B harness for the question behind [pounce#552]: how far is
+feral's factorization from Harwell's on the **chain-structured** KKT
+matrices that direct-transcription dynamic optimization produces?
+
+The report's five models are Pyomo NMPC problems that are not in this
+repo, and reproducing them needs idaes/prommis plus their initialization
+chains. This harness substitutes block-tridiagonal proxies generated at
+the *reported geometry* (time points, variables per time point, `n`), so
+it can run anywhere without that stack. It is a stand-in, not the real
+thing — see **Limits** before quoting a number from it.
+
+## What it generates
+
+`gen_chain_kkt.py` builds one symmetric indefinite KKT per model. Per
+time point:
+
+    [ H_t   A_t^T ]      H_t : nx x nx  banded SPD
+    [ A_t  -delta*I ]    A_t : nc x nx  banded constraint Jacobian
+
+coupled to the next point by state-continuity entries, which is what
+makes the elimination tree a chain. Geometry:
+
+| proxy | T | vars/pt | n | reported n |
+|---|---|---|---|---|
+| hicks_like | 301 | 6 | 1,806 | 1,706 |
+| cart_pole_like | 301 | 9 | 2,709 | 2,810 |
+| quad_tank_like | 301 | 10 | 3,010 | 2,910 |
+| double_column_like | 31 | 819 | 25,389 | 25,377 |
+| prommis_sx_like | 31 | 913 | 28,303 | 28,313 |
+
+The `-delta*I` block makes the inertia analytically known: with `H` SPD
+and `A` of full row rank the matrix has exactly `T*nx` positive and
+`T*nc` negative eigenvalues and no zeros. **That is the correctness
+oracle** — it does not depend on either solver being right. Both feral
+and MA57 hit it exactly on all five, with residuals ~1e-15 or better.
+
+Getting there took one fix worth remembering: an earlier generator
+advanced each dual row's column start by a fixed stride and clamped it,
+so when `nx` was close to `A_WIDTH` every row in a block got the same
+columns and proportional values, making `A_t` rank 1. MA57 reported
+`inertia_zero = 301` (one per time point) and feral returned a residual
+of 5.9e+03. If you change the generator, re-check against the oracle
+before trusting a timing.
+
+## Running it
+
+Build the MA57 oracle first (needs the CoinHSL bundle; see
+`../ma57_oracle/Makefile` for the `HSL_ROOT` it expects):
+
+```sh
+make -C ../ma57_oracle
+```
+
+Build the driver for the arm under test, and a baseline in a worktree:
+
+```sh
+cargo build --release -p feral-diagnostics --bin bench_one_matrix
+git worktree add /tmp/feral-base v0.14.0
+(cd /tmp/feral-base && cargo build --release -p feral-diagnostics \
+     --bin bench_one_matrix)
+```
+
+Then:
+
+```sh
+export CHAIN_PROXY_WORK=/tmp/chain-proxy      # matrices + results land here
+python3 gen_chain_kkt.py --out $CHAIN_PROXY_WORK/mtx
+
+FERAL_BIN_BASE=/tmp/feral-base/target/release/bench_one_matrix \
+FERAL_LABEL_NEW=main FERAL_LABEL_BASE=v0.14.0 \
+  python3 ab_run.py --pairs 15
+```
+
+`probe_regression.py` takes the same environment and re-runs the two
+large proxies across `FERAL_PAR_MIN_SEEDS`, `RAYON_NUM_THREADS` and
+`FERAL_PACKED_SIMD` arms, to attribute a difference to the parallel
+driver or to the kernel.
+
+Overrides: `FERAL_BIN_NEW`, `FERAL_BIN_BASE`, `MA57_BIN`,
+`FERAL_LABEL_NEW`, `FERAL_LABEL_BASE`, `CHAIN_PROXY_WORK`.
+
+## Protocol
+
+Paired alternating A/B per `dev/decisions.md` (2026-08-09): every arm is
+timed once per pair so drift hits all arms equally, `min` over pairs is
+the per-arm statistic, and significance is an exact two-sided sign test
+over the pairs. Medians collected at different times are never compared.
+All arms read the same manifest, the same matrices and the same
+synthesized RHS (`b = A x_true`, `x_true[i] = 1 + i/n`), so the residual
+is defined identically across solvers.
+
+## Limits
+
+Read these before quoting a ratio.
+
+- **These are proxies.** Geometry matches the reported models; sparsity
+  and numerics are invented. Measured density is ~4 nnz/row, which is on
+  the sparse side for a real flowsheet KKT. A conclusion from this
+  harness is a hypothesis about the real matrices, not a measurement of
+  them.
+- **Cross-machine comparison is invalid.** The paired design cancels
+  machine differences *within* a run, and that is the only thing it
+  guarantees. Do not compare absolute microseconds here against numbers
+  in the release notes or in pounce#552, which were taken on other
+  hardware.
+- **Heterogeneous cores matter.** On Apple silicon rayon sees P+E cores
+  as equivalent. On a 4P+4E M2 a coarse task landing on an efficiency
+  core stalls the whole factorization, so thread count is a real
+  variable, not a detail. Record `sysctl -n hw.model` with any result.
+- `factor_us` is numeric factorization only. Symbolic analysis and the
+  solve are excluded, so this does not speak to end-to-end solve time,
+  which is what pounce#552 actually reports.
+
+## Superseding it
+
+The real measurement is the same protocol on the real corpus
+(`clnlbeam`, `dtoc1nd`, `steering_12800`, `rocket_12800`, `marine_1600`,
+`dtoc2`), which needs a machine that has `data/matrices/`. When that run
+exists, prefer it and treat this harness as the portable smoke version.
+
+[pounce#552]: https://github.com/jkitchin/pounce/issues/552

--- a/external_benchmarks/chain_proxy/README.md
+++ b/external_benchmarks/chain_proxy/README.md
@@ -1,4 +1,12 @@
-# chain_proxy — chain-structured KKT proxies vs HSL MA57
+# chain_proxy — chain-structured KKT harness vs HSL MA57
+
+> **The proxies have been superseded.** The same protocol now runs on
+> the real corpus (`real_corpus_mtx.py` + `arm_run.py`), and the real
+> matrices contradict both conclusions the proxies produced — see
+> `dev/research/chain-kkt-corpus-2026-08-09.md`. Prefer the real run.
+> The generated proxies are kept as the portable smoke version for
+> machines without `data/matrices/`, and as a worked example of
+> geometry-matched stand-ins giving the wrong answer.
 
 A paired A/B harness for the question behind [pounce#552]: how far is
 feral's factorization from Harwell's on the **chain-structured** KKT
@@ -113,11 +121,40 @@ Read these before quoting a ratio.
   solve are excluded, so this does not speak to end-to-end solve time,
   which is what pounce#552 actually reports.
 
-## Superseding it
+## Running it on the real corpus
 
-The real measurement is the same protocol on the real corpus
-(`clnlbeam`, `dtoc1nd`, `steering_12800`, `rocket_12800`, `marine_1600`,
-`dtoc2`), which needs a machine that has `data/matrices/`. When that run
-exists, prefer it and treat this harness as the portable smoke version.
+`real_corpus_mtx.py` builds the `--mtx-dir` as symlinks into
+`data/matrices/kkt-mittelmann`, one iterate per family, with the
+selection rules (and the `dtoc2` singularity exception) in its
+docstring:
+
+```sh
+python3 real_corpus_mtx.py --out $WORK/mtx
+```
+
+`arm_run.py` is `ab_run.py` generalized to any number of arms, reusing
+its protocol functions directly so the statistics are literally the
+same code. Arms are `NAME=BIN`, optionally with environment overrides
+after a `|`, which is what makes a thread sweep or a SIMD probe a
+matter of arguments rather than another script:
+
+```sh
+python3 arm_run.py --mtx-dir $WORK/mtx --pairs 15 --ref v0.14.0 \
+  --out $WORK/bisect.json \
+  --arm "v0.14.0=/tmp/wt/v0140/target/release/bench_one_matrix" \
+  --arm "main=target/release/bench_one_matrix" \
+  --arm "main-t1=target/release/bench_one_matrix|RAYON_NUM_THREADS=1" \
+  --arm "ma57=../ma57_oracle/ma57_bench"
+```
+
+It prints a correctness gate — any arm with `inertia_zero != 0` or a
+NaN / `> 1e-8` residual — *before* the timing tables, and says plainly
+that flagged matrices cannot carry a ratio. That gate is what caught
+`dtoc2_0001` (singular by both solvers) and MA57's `4.53e-08` residual
+on `steering_12800`.
+
+`steering_12800` has no `.mtx` in the corpus as shipped. Regenerate it
+with pounce (`--dump kkt:1-3`) and `scripts/harvest-pounce-kkt.py`; the
+ripopt harvest path silently writes nothing. See the research note.
 
 [pounce#552]: https://github.com/jkitchin/pounce/issues/552

--- a/external_benchmarks/chain_proxy/ab_run.py
+++ b/external_benchmarks/chain_proxy/ab_run.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Paired alternating A/B: two feral builds vs HSL MA57.
+
+Protocol per feral dev/decisions.md (2026-08-09): every arm is timed
+once per pair so drift hits all arms equally, `min` over pairs is the
+per-arm statistic, and the sign test over pairs is the significance
+check. Medians collected at different times are NOT compared.
+
+Each arm is an external binary reading the same manifest format
+(<mtx> <rhs> <out>), so the matrices, the RHS and the residual
+definition are identical across arms.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SP = Path(__file__).resolve().parent
+ROOT = SP.parents[1]
+WORK = Path(os.environ.get("CHAIN_PROXY_WORK", SP / "work"))
+
+# Arm binaries. The "new" arm defaults to this checkout's build; the
+# baseline arm is whatever you built in a worktree at the older tag.
+# Override any of them by environment variable.
+#
+#   git worktree add /tmp/feral-0140 v0.14.0
+#   (cd /tmp/feral-0140 && cargo build --release -p feral-diagnostics \
+#        --bin bench_one_matrix)
+#   FERAL_BIN_BASE=/tmp/feral-0140/target/release/bench_one_matrix \
+#       python3 ab_run.py
+DRIVER = "target/release/bench_one_matrix"
+FERAL_NEW = Path(os.environ.get("FERAL_BIN_NEW", ROOT / DRIVER))
+FERAL_BASE = Path(os.environ.get("FERAL_BIN_BASE", WORK / "feral-base" / DRIVER))
+MA57 = Path(os.environ.get(
+    "MA57_BIN", ROOT / "external_benchmarks" / "ma57_oracle" / "ma57_bench"))
+
+NEW_LABEL = os.environ.get("FERAL_LABEL_NEW", "feral-new")
+BASE_LABEL = os.environ.get("FERAL_LABEL_BASE", "feral-base")
+
+ARMS = [(NEW_LABEL, FERAL_NEW), (BASE_LABEL, FERAL_BASE), ("ma57", MA57)]
+
+
+def read_mtx_lower(path: Path):
+    trips = []
+    n = 0
+    saw = False
+    with path.open() as f:
+        for line in f:
+            if line.startswith("%"):
+                continue
+            p = line.split()
+            if not saw:
+                n = int(p[1])
+                saw = True
+                continue
+            if len(p) < 3:
+                continue
+            r, c, v = int(p[0]) - 1, int(p[1]) - 1, float(p[2])
+            if r < c:
+                r, c = c, r
+            trips.append((r, c, v))
+    return n, trips
+
+
+def synth_rhs(n, trips):
+    x = [1.0 + i / n for i in range(n)]
+    b = [0.0] * n
+    for r, c, v in trips:
+        b[r] += v * x[c]
+        if r != c:
+            b[c] += v * x[r]
+    return b
+
+
+def parse_sidecar(path: Path) -> dict:
+    d = {}
+    if not path.exists():
+        return d
+    for line in path.read_text().splitlines():
+        p = line.split(None, 1)
+        if len(p) == 2:
+            d[p[0]] = p[1].strip()
+    return d
+
+
+def sign_test_p(wins: int, n: int) -> float:
+    """Two-sided exact binomial p at q=0.5."""
+    from math import comb
+    if n == 0:
+        return 1.0
+    k = max(wins, n - wins)
+    tail = sum(comb(n, i) for i in range(k, n + 1)) / (2 ** n)
+    return min(1.0, 2 * tail)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mtx-dir", default=str(WORK / "mtx"))
+    ap.add_argument("--pairs", type=int, default=15)
+    ap.add_argument("--out", default=str(WORK / "ab_results.json"))
+    args = ap.parse_args()
+
+    mtx_dir = Path(args.mtx_dir)
+    mats = sorted(mtx_dir.glob("*.mtx"))
+    if not mats:
+        print(f"no matrices in {mtx_dir}", file=sys.stderr)
+        return 1
+
+    rhs_dir = WORK / "rhs"
+    rhs_dir.mkdir(parents=True, exist_ok=True)
+    print("=== synthesizing RHS ===", flush=True)
+    for m in mats:
+        rp = rhs_dir / (m.stem + ".rhs")
+        if not rp.exists():
+            n, trips = read_mtx_lower(m)
+            with rp.open("w") as f:
+                for v in synth_rhs(n, trips):
+                    f.write(f"{v:.17e}\n")
+            print(f"  {m.stem}  n={n}  nnz={len(trips)}", flush=True)
+
+    out_root = WORK / "ab_out"
+    manifests = {}
+    for arm, _ in ARMS:
+        (out_root / arm).mkdir(parents=True, exist_ok=True)
+        fd, name = tempfile.mkstemp(suffix=f"_{arm}.manifest", text=True)
+        with os.fdopen(fd, "w") as f:
+            for m in mats:
+                f.write(f"{m} {rhs_dir / (m.stem + '.rhs')} "
+                        f"{out_root / arm / (m.stem + '.out')}\n")
+        manifests[arm] = Path(name)
+
+    # samples[arm][matrix] = [factor_us per pair]
+    samples = {arm: {m.stem: [] for m in mats} for arm, _ in ARMS}
+    meta = {arm: {} for arm, _ in ARMS}
+
+    print(f"\n=== {args.pairs} pairs, {len(ARMS)} arms, "
+          f"{len(mats)} matrices ===", flush=True)
+    for p in range(args.pairs):
+        for arm, binp in ARMS:
+            subprocess.run([str(binp), str(manifests[arm])],
+                           check=False, capture_output=True, timeout=1800)
+            for m in mats:
+                d = parse_sidecar(out_root / arm / (m.stem + ".out"))
+                if d.get("status") == "ok" and "factor_us" in d:
+                    samples[arm][m.stem].append(int(d["factor_us"]))
+                    meta[arm][m.stem] = {
+                        "solver": d.get("solver", arm),
+                        "n": int(d.get("n", 0)),
+                        "rel_res": float(d.get("rel_res", "nan")),
+                        "inertia_pos": d.get("inertia_pos"),
+                        "inertia_neg": d.get("inertia_neg"),
+                        "inertia_zero": d.get("inertia_zero"),
+                    }
+        print(f"  pair {p + 1}/{args.pairs} done", flush=True)
+
+    results = {"pairs": args.pairs, "samples": samples, "meta": meta}
+    Path(args.out).write_text(json.dumps(results, indent=2))
+
+    # ---- report ----
+    print("\n=== min factor_us over pairs ===", flush=True)
+    hdr = f"{'matrix':<22}{'n':>7}" + "".join(f"{a:>16}" for a, _ in ARMS)
+    print(hdr)
+    for m in mats:
+        row = f"{m.stem:<22}"
+        n = next((meta[a][m.stem]["n"] for a, _ in ARMS
+                  if m.stem in meta[a]), 0)
+        row += f"{n:>7}"
+        for arm, _ in ARMS:
+            s = samples[arm][m.stem]
+            row += f"{min(s) if s else -1:>16}"
+        print(row)
+
+    def compare(a: str, b: str, label: str) -> None:
+        print(f"\n=== {label} ({a} vs {b}) ===", flush=True)
+        print(f"{'matrix':<22}{'ratio':>9}{'wins':>9}{'p':>10}   "
+              f"{'rel_res ' + a:>14}{'rel_res ' + b:>14}")
+        for m in mats:
+            sa, sb = samples[a][m.stem], samples[b][m.stem]
+            if not sa or not sb:
+                print(f"{m.stem:<22}{'n/a':>9}")
+                continue
+            k = min(len(sa), len(sb))
+            wins = sum(1 for i in range(k) if sa[i] < sb[i])
+            ratio = min(sb) / min(sa)  # >1 means a is faster
+            ra = meta[a].get(m.stem, {}).get("rel_res", float("nan"))
+            rb = meta[b].get(m.stem, {}).get("rel_res", float("nan"))
+            print(f"{m.stem:<22}{ratio:>9.3f}{f'{wins}/{k}':>9}"
+                  f"{sign_test_p(wins, k):>10.4f}{ra:>14.2e}{rb:>14.2e}")
+
+    compare(NEW_LABEL, BASE_LABEL, "release delta (validity control)")
+    compare(NEW_LABEL, "ma57", f"THE GAP: {NEW_LABEL} vs HSL MA57")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/external_benchmarks/chain_proxy/arm_run.py
+++ b/external_benchmarks/chain_proxy/arm_run.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Paired alternating A/B over an arbitrary number of arms.
+
+`ab_run.py` fixes three arms (new / base / ma57). The bisect and the
+thread sweep need five and four, so this generalizes it: arms are
+declared on the command line, each one a binary plus optional
+environment overrides, and every arm is timed once per pair.
+
+Protocol is unchanged from `ab_run.py` and from feral
+`dev/decisions.md` (2026-08-09): one timing per arm per pair so drift
+hits all arms equally, `min` over pairs as the per-arm statistic, exact
+two-sided sign test over the pairs for significance. Medians collected
+at different times are never compared. All arms read the same manifest
+format (`<mtx> <rhs> <out>`), so the matrices, the RHS and the residual
+definition are identical across arms.
+
+`--mtx-dir` points at any directory of `.mtx` files, which is how the
+same protocol runs on the generated proxies and on the real corpus
+(see `real_corpus_mtx.py`).
+
+Arm syntax:
+
+    --arm 'NAME=/path/to/bin'
+    --arm 'NAME=/path/to/bin|RAYON_NUM_THREADS=1,FERAL_PACKED_SIMD=0'
+
+Example -- bisect five feral builds against MA57, ratios against 0.14.0:
+
+    python3 arm_run.py --mtx-dir $WORK/mtx --pairs 15 --ref v0.14.0 \
+      --arm 'v0.14.0=/tmp/wt/v0140/target/release/bench_one_matrix' \
+      --arm 'main=target/release/bench_one_matrix' \
+      --arm 'ma57=external_benchmarks/ma57_oracle/ma57_bench'
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from ab_run import parse_sidecar, read_mtx_lower, sign_test_p, synth_rhs
+
+
+def parse_arm(spec: str) -> tuple[str, Path, dict]:
+    """`NAME=BIN` or `NAME=BIN|K=V,K2=V2` -> (name, bin, env overrides)."""
+    if "=" not in spec:
+        raise ValueError(f"arm {spec!r}: expected NAME=BIN")
+    name, rest = spec.split("=", 1)
+    env = {}
+    if "|" in rest:
+        rest, envspec = rest.split("|", 1)
+        for kv in envspec.split(","):
+            if not kv.strip():
+                continue
+            if "=" not in kv:
+                raise ValueError(f"arm {name}: env {kv!r} is not K=V")
+            k, v = kv.split("=", 1)
+            env[k.strip()] = v.strip()
+    return name.strip(), Path(rest.strip()), env
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mtx-dir", required=True)
+    ap.add_argument("--arm", action="append", required=True,
+                    help="NAME=BIN[|K=V,...]; repeatable")
+    ap.add_argument("--ref", help="arm every ratio is taken against "
+                                  "(default: the first arm)")
+    ap.add_argument("--pairs", type=int, default=15)
+    ap.add_argument("--rhs-dir", help="where synthesized RHS live "
+                                      "(default: <mtx-dir>/../rhs)")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    arms = [parse_arm(a) for a in args.arm]
+    names = [a[0] for a in arms]
+    if len(set(names)) != len(names):
+        print("duplicate arm names", file=sys.stderr)
+        return 1
+    ref = args.ref or names[0]
+    if ref not in names:
+        print(f"--ref {ref} is not one of {names}", file=sys.stderr)
+        return 1
+    for name, binp, _ in arms:
+        if not binp.exists():
+            print(f"arm {name}: no binary at {binp}", file=sys.stderr)
+            return 1
+
+    mtx_dir = Path(args.mtx_dir)
+    mats = sorted(mtx_dir.glob("*.mtx"))
+    if not mats:
+        print(f"no matrices in {mtx_dir}", file=sys.stderr)
+        return 1
+
+    rhs_dir = Path(args.rhs_dir) if args.rhs_dir else mtx_dir.parent / "rhs"
+    rhs_dir.mkdir(parents=True, exist_ok=True)
+    print("=== synthesizing RHS ===", flush=True)
+    for m in mats:
+        rp = rhs_dir / (m.stem + ".rhs")
+        if rp.exists():
+            continue
+        n, trips = read_mtx_lower(m)
+        with rp.open("w") as f:
+            for v in synth_rhs(n, trips):
+                f.write(f"{v:.17e}\n")
+        print(f"  {m.stem}  n={n}  nnz={len(trips)}", flush=True)
+
+    out_root = Path(args.out).parent / (Path(args.out).stem + "_out")
+    manifests = {}
+    for name, _, _ in arms:
+        (out_root / name).mkdir(parents=True, exist_ok=True)
+        fd, path = tempfile.mkstemp(suffix=f"_{name}.manifest", text=True)
+        with os.fdopen(fd, "w") as f:
+            for m in mats:
+                f.write(f"{m} {rhs_dir / (m.stem + '.rhs')} "
+                        f"{out_root / name / (m.stem + '.out')}\n")
+        manifests[name] = Path(path)
+
+    samples = {n: {m.stem: [] for m in mats} for n in names}
+    meta = {n: {} for n in names}
+
+    print(f"\n=== {args.pairs} pairs, {len(arms)} arms, "
+          f"{len(mats)} matrices ===", flush=True)
+    for p in range(args.pairs):
+        for name, binp, envover in arms:
+            env = dict(os.environ)
+            env.update(envover)
+            subprocess.run([str(binp), str(manifests[name])], env=env,
+                           check=False, capture_output=True, timeout=3600)
+            for m in mats:
+                d = parse_sidecar(out_root / name / (m.stem + ".out"))
+                if d.get("status") == "ok" and "factor_us" in d:
+                    samples[name][m.stem].append(int(d["factor_us"]))
+                    meta[name][m.stem] = {
+                        "solver": d.get("solver", name),
+                        "n": int(d.get("n", 0)),
+                        "rel_res": float(d.get("rel_res", "nan")),
+                        "inertia_pos": d.get("inertia_pos"),
+                        "inertia_neg": d.get("inertia_neg"),
+                        "inertia_zero": d.get("inertia_zero"),
+                    }
+        print(f"  pair {p + 1}/{args.pairs} done", flush=True)
+
+    Path(args.out).write_text(json.dumps(
+        {"pairs": args.pairs, "ref": ref,
+         "arms": [{"name": n, "bin": str(b), "env": e} for n, b, e in arms],
+         "samples": samples, "meta": meta}, indent=2))
+
+    # ---- correctness gate, before any timing is read ----
+    print("\n=== correctness (inertia_zero / rel_res) ===", flush=True)
+    suspect = []
+    for m in mats:
+        bad = []
+        for name in names:
+            d = meta[name].get(m.stem)
+            if d is None:
+                bad.append(f"{name}: no result")
+                continue
+            rr = d["rel_res"]
+            if d["inertia_zero"] not in (None, "0"):
+                bad.append(f"{name}: inertia_zero={d['inertia_zero']}")
+            if not (rr == rr) or rr > 1e-8:      # NaN or too large
+                bad.append(f"{name}: rel_res={rr:.2e}")
+        if bad:
+            suspect.append(m.stem)
+            print(f"  !! {m.stem}: " + "; ".join(bad))
+    if not suspect:
+        print("  all arms: inertia_zero=0, rel_res <= 1e-8 on every matrix")
+    else:
+        print("  timings on the above are NOT trustworthy -- fix or drop "
+              "the matrix before quoting a ratio")
+
+    # ---- report ----
+    print("\n=== min factor_us over pairs ===", flush=True)
+    print(f"{'matrix':<22}{'n':>8}" + "".join(f"{n:>16}" for n in names))
+    for m in mats:
+        n = next((meta[a][m.stem]["n"] for a in names if m.stem in meta[a]), 0)
+        row = f"{m.stem:<22}{n:>8}"
+        for name in names:
+            s = samples[name][m.stem]
+            row += f"{min(s) if s else -1:>16}"
+        print(row)
+
+    print(f"\n=== ratio vs {ref} (>1 means the arm is faster "
+          f"than {ref}) ===", flush=True)
+    for name in names:
+        if name == ref:
+            continue
+        print(f"\n--- {name} vs {ref}")
+        print(f"{'matrix':<22}{'ratio':>9}{'wins':>9}{'p':>10}")
+        for m in mats:
+            sa, sb = samples[name][m.stem], samples[ref][m.stem]
+            if not sa or not sb:
+                print(f"{m.stem:<22}{'n/a':>9}")
+                continue
+            k = min(len(sa), len(sb))
+            wins = sum(1 for i in range(k) if sa[i] < sb[i])
+            print(f"{m.stem:<22}{min(sb) / min(sa):>9.3f}"
+                  f"{f'{wins}/{k}':>9}{sign_test_p(wins, k):>10.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/external_benchmarks/chain_proxy/gen_chain_kkt.py
+++ b/external_benchmarks/chain_proxy/gen_chain_kkt.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate block-tridiagonal (chain-structured) KKT proxies at the
+geometries reported in pounce#552.
+
+Each model is a direct-transcription dynamic optimization problem, so its
+KKT matrix is symmetric indefinite and block tridiagonal: one diagonal
+block per time point, coupled to the next point by state continuity.
+What drives factorization cost is that shape (a chain-shaped elimination
+tree whose front sizes track the per-time-point block size), so the
+proxy fixes T (time points) and b (vars per time point) to the reported
+values and fills each block with a plausible banded saddle structure.
+
+Per time point t, the block is
+
+    [ H_t   A_t^T ]      H_t : nx x nx  banded SPD
+    [ A_t    0    ]      A_t : nc x nx  banded constraint Jacobian
+
+with the (2,2) block structurally absent, as in a true equality-
+constrained KKT. Consecutive points are coupled by C_t, which puts the
+continuity entries of point t+1's dual rows on point t's state columns.
+
+Writes MatrixMarket symmetric coordinate (lower triangle only), which is
+the convention both bench_one_matrix and ma57_bench read.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+# (label, T time points, nx primal per point, nc dual per point)
+# n = T * (nx + nc); chosen to land within ~1% of the reported n.
+MODELS = [
+    ("hicks_like", 301, 3, 3),           # reported n=1,706
+    ("cart_pole_like", 301, 5, 4),       # reported n=2,810
+    ("quad_tank_like", 301, 6, 4),       # reported n=2,910
+    ("double_column_like", 31, 491, 328),  # reported n=25,377
+    ("prommis_sx_like", 31, 548, 365),   # reported n=28,313
+]
+
+H_HALF_BAND = 2   # half-bandwidth of H_t
+A_WIDTH = 3       # primal columns touched per dual row
+C_WIDTH = 2       # state columns of point t touched per dual row of t+1
+DELTA = 1e-4      # (2,2) regularization, as in an interior-point KKT
+
+
+def gen(T: int, nx: int, nc: int) -> tuple[int, list[tuple[int, int, float]]]:
+    """Return (n, lower-triangle triplets) with 0-based indices."""
+    b = nx + nc
+    n = T * b
+    trips: list[tuple[int, int, float]] = []
+
+    def add(r: int, c: int, v: float) -> None:
+        # store lower triangle only
+        if r < c:
+            r, c = c, r
+        trips.append((r, c, v))
+
+    for t in range(T):
+        base = t * b
+        p0 = base           # primal block start
+        d0 = base + nx      # dual block start
+
+        # H_t: banded SPD, diagonally dominant.
+        for i in range(nx):
+            add(p0 + i, p0 + i, 2.0 + 0.1 * (i / max(nx, 1)))
+            for k in range(1, H_HALF_BAND + 1):
+                if i + k < nx:
+                    add(p0 + i + k, p0 + i, -1.0 / k)
+
+        # A_t: each dual row touches A_WIDTH primal columns, spread
+        # across the primal block so the Jacobian has full row rank.
+        #
+        # The starts must be spread over [0, nx - A_WIDTH] rather than
+        # advanced by a fixed stride and clamped: with nx close to
+        # A_WIDTH a fixed stride pins every row to the same start, and
+        # if the values are also a function of k alone the rows come out
+        # identical, making A_t rank 1. Values therefore depend on both
+        # r and k, and non-proportionally, so no two rows are multiples.
+        span = max(nx - A_WIDTH, 0)
+        for r in range(nc):
+            start = (r * span) // max(nc - 1, 1) if nc > 1 else 0
+            for k in range(A_WIDTH):
+                c = start + k
+                if c < nx:
+                    add(d0 + r, p0 + c, 1.0 + 0.05 * k + 0.37 * (((r * (k + 1)) % 5) / 5.0))
+
+        # (2,2) block: -delta*I. Real interior-point KKTs carry this
+        # regularization, and it keeps the proxy comfortably nonsingular
+        # so the inertia is well defined (exactly nc negatives per point
+        # come from here) and both solvers can be held to a tight
+        # residual.
+        for r in range(nc):
+            add(d0 + r, d0 + r, -DELTA)
+
+        # C_t: continuity — point t+1's dual rows reference point t's
+        # state columns. This is the only inter-block coupling, and it
+        # is what makes the elimination tree a chain.
+        if t + 1 < T:
+            d1 = (t + 1) * b + nx
+            cspan = max(nx - C_WIDTH, 0)
+            for r in range(nc):
+                start = (r * cspan) // max(nc - 1, 1) if nc > 1 else 0
+                for k in range(C_WIDTH):
+                    c = start + k
+                    if c < nx:
+                        add(d1 + r, p0 + c, -1.0 - 0.11 * (((r + k) % 3) / 3.0))
+
+    return n, trips
+
+
+def write_mtx(path: Path, n: int, trips: list[tuple[int, int, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        f.write("%%MatrixMarket matrix coordinate real symmetric\n")
+        f.write("% chain-structured KKT proxy for pounce#552 geometry\n")
+        f.write(f"{n} {n} {len(trips)}\n")
+        for r, c, v in trips:
+            f.write(f"{r + 1} {c + 1} {v:.17g}\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, help="output directory")
+    args = ap.parse_args()
+    out = Path(args.out)
+
+    print(f"{'model':<22}{'T':>5}{'b':>6}{'n':>9}{'nnz':>10}{'nnz/row':>9}")
+    for label, T, nx, nc in MODELS:
+        n, trips = gen(T, nx, nc)
+        write_mtx(out / f"{label}.mtx", n, trips)
+        print(f"{label:<22}{T:>5}{nx + nc:>6}{n:>9}{len(trips):>10}"
+              f"{len(trips) / n:>9.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/external_benchmarks/chain_proxy/probe_regression.py
+++ b/external_benchmarks/chain_proxy/probe_regression.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Pin the 0.15.0-vs-0.14.0 chain regression to a mechanism.
+
+The 15-pair A/B showed feral 0.15.0 significantly slower than 0.14.0 on
+the two largest chain-structured proxies (prommis_sx_like 0.833,
+p=0.0074). Two candidate mechanisms shipped in 0.15.0:
+
+  #149  explicit SIMD packed trailing update + x86 pulp dispatch fix
+  #150  one rayon task per subtree instead of one per supernode
+
+This runs the same paired protocol over arms that isolate them:
+
+  0.14.0                    baseline
+  0.15.0 default            the regression
+  0.15.0 PAR_MIN_SEEDS=max  forces the sequential fallback, so the
+                            task-graph path is never taken
+  0.15.0 RAYON=1            single-threaded
+  0.15.0 PACKED_SIMD=0      restores the scalar tile walk
+
+If forcing the sequential fallback recovers the loss, the regression is
+in the parallel driver (#150). If disabling the packed SIMD kernel
+recovers it, it is the kernel (#149).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from math import comb
+from pathlib import Path
+
+SP = Path(__file__).resolve().parent
+ROOT = SP.parents[1]
+WORK = Path(os.environ.get("CHAIN_PROXY_WORK", SP / "work"))
+DRIVER = "target/release/bench_one_matrix"
+
+F15 = os.environ.get("FERAL_BIN_NEW", str(ROOT / DRIVER))
+F14 = os.environ.get("FERAL_BIN_BASE", str(WORK / "feral-base" / DRIVER))
+
+U64_MAX = "18446744073709551615"
+
+ARMS = [
+    ("base", F14, {}),
+    ("new-default", F15, {}),
+    ("new-seq-fallback", F15, {"FERAL_PAR_MIN_SEEDS": U64_MAX}),
+    ("new-rayon1", F15, {"RAYON_NUM_THREADS": "1"}),
+    ("new-nosimd", F15, {"FERAL_PACKED_SIMD": "0"}),
+]
+
+MATS = ["prommis_sx_like", "double_column_like"]
+PAIRS = 15
+
+
+def sign_test_p(wins: int, n: int) -> float:
+    if n == 0:
+        return 1.0
+    k = max(wins, n - wins)
+    return min(1.0, 2 * sum(comb(n, i) for i in range(k, n + 1)) / (2 ** n))
+
+
+def main() -> int:
+    rhs_dir = WORK / "rhs"
+    out_root = WORK / "probe_out"
+    manifests = {}
+    for arm, _, _ in ARMS:
+        (out_root / arm).mkdir(parents=True, exist_ok=True)
+        fd, name = tempfile.mkstemp(suffix=".manifest", text=True)
+        with os.fdopen(fd, "w") as f:
+            for m in MATS:
+                f.write(f"{WORK / 'mtx' / (m + '.mtx')} {rhs_dir / (m + '.rhs')} "
+                        f"{out_root / arm / (m + '.out')}\n")
+        manifests[arm] = Path(name)
+
+    samples = {arm: {m: [] for m in MATS} for arm, _, _ in ARMS}
+    for p in range(PAIRS):
+        for arm, binp, env in ARMS:
+            e = dict(os.environ)
+            e.update(env)
+            subprocess.run([binp, str(manifests[arm])], check=False,
+                           capture_output=True, timeout=1800, env=e)
+            for m in MATS:
+                d = {}
+                for line in (out_root / arm / (m + ".out")).read_text().splitlines():
+                    q = line.split(None, 1)
+                    if len(q) == 2:
+                        d[q[0]] = q[1].strip()
+                if d.get("status") == "ok":
+                    samples[arm][m].append(int(d["factor_us"]))
+        print(f"  pair {p + 1}/{PAIRS}", flush=True)
+
+    (WORK / "probe_results.json").write_text(json.dumps(samples, indent=2))
+
+    for m in MATS:
+        print(f"\n=== {m} ===")
+        base = min(samples["base"][m])
+        print(f"{'arm':<24}{'min_us':>10}{'vs base':>12}{'wins/15':>10}{'p':>9}")
+        for arm, _, _ in ARMS:
+            s = samples[arm][m]
+            if not s:
+                print(f"{arm:<24}{'FAIL':>10}")
+                continue
+            b = samples["base"][m]
+            k = min(len(s), len(b))
+            wins = sum(1 for i in range(k) if s[i] < b[i])
+            ratio = base / min(s)  # >1 means this arm is faster than 0.14.0
+            tag = "" if arm == "base" else f"{wins}/{k}"
+            pv = "" if arm == "base" else f"{sign_test_p(wins, k):.4f}"
+            print(f"{arm:<24}{min(s):>10}{ratio:>12.3f}{tag:>10}{pv:>9}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/external_benchmarks/chain_proxy/real_corpus_mtx.py
+++ b/external_benchmarks/chain_proxy/real_corpus_mtx.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Assemble the real chain-KKT matrix set that supersedes the proxies.
+
+`ab_run.py` and `arm_run.py` take a `--mtx-dir` of `.mtx` files. This
+builds that directory as symlinks into `data/matrices/kkt-mittelmann`,
+picking one iterate per family, so the same paired protocol runs on the
+real matrices behind pounce#552 instead of on the generated proxies.
+
+Selection rules, and why each one:
+
+* One iterate per family. Iterates within a family share sparsity after
+  the first, so extra ones cost run time without adding geometry.
+* `_0001` over `_0000` where both exist: `_0000` is the first KKT and
+  is consistently sparser (dtoc1nd 77,854 nnz vs 217,270; marine_1600
+  342,399 vs 414,399), i.e. not representative of the iterates a solve
+  actually spends its time in.
+* `dtoc2` is the exception and uses `_0000`. `dtoc2_0001` and `_0002`
+  are singular: feral reports `inertia_zero = 4` and MA57 reports 103,
+  both with `rel_res = NaN`. Two independent solvers agreeing the
+  matrix is rank-deficient means the matrix, not the solver, so it
+  cannot carry a timing. `dtoc2_0000` factors clean (`inertia_zero = 0`,
+  `rel_res = 3.1e-16`).
+* `steering_12800` had no `.mtx` in the corpus until this session --
+  only an empty `.solver.log`. The original harvest path is dead:
+  ripopt commit 76d3575 deleted the KKT dump while leaving the
+  `kkt_dump_dir=` option parsing in place, so it accepts the flag and
+  writes nothing. Regenerated with pounce instead
+  (`pounce steering_12800.nl --dump kkt:1-3`) and converted by
+  `scripts/harvest-pounce-kkt.py`. The conversion is checked against an
+  external oracle: pounce reports `num_neg_evals_actual = 51201` and
+  feral and MA57 independently agree (`inertia_neg = 51201`,
+  `inertia_zero = 0`).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+SP = Path(__file__).resolve().parent
+ROOT = SP.parents[1]
+SRC = ROOT / "data" / "matrices" / "kkt-mittelmann"
+
+# family -> iterate stem. See the module docstring for why each.
+SELECTED = {
+    "clnlbeam": "clnlbeam_0000",
+    "dtoc1nd": "dtoc1nd_0001",
+    "dtoc2": "dtoc2_0000",
+    "marine_1600": "marine_1600_0001",
+    "rocket_12800": "rocket_12800_0001",
+    "steering_12800": "steering_12800_0001",
+}
+UNAVAILABLE = {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, help="directory to populate")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    missing = []
+    for fam, stem in sorted(SELECTED.items()):
+        src = SRC / fam / f"{stem}.mtx"
+        if not src.exists():
+            missing.append(str(src))
+            continue
+        link = out / f"{stem}.mtx"
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(src)
+        with src.open() as f:
+            f.readline()
+            dims = f.readline().split()
+        print(f"  {stem:<24} n={dims[0]:>7} nnz={dims[2]:>8}")
+
+    for fam, why in UNAVAILABLE.items():
+        print(f"  {fam:<24} SKIPPED -- {why}")
+
+    if missing:
+        print("\nmissing matrices:", file=sys.stderr)
+        for m in missing:
+            print(f"  {m}", file=sys.stderr)
+        return 1
+    print(f"\n{len(SELECTED)} matrices linked into {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/external_benchmarks/ma57_oracle/ma57_bench.F
+++ b/external_benchmarks/ma57_oracle/ma57_bench.F
@@ -10,7 +10,29 @@ C
 C   Configuration (matches the comparison harness "best-effort" mode):
 C     * ICNTL(6) = 5  — automatic AMD / METIS ordering
 C     * ICNTL(7) = 1  — numerical pivoting with threshold (BK-style)
-C     * ICNTL(15) = 1 — automatic scaling on (MC64-equivalent)
+C     * ICNTL(15) — automatic MC64-equivalent scaling. DEFAULT 0 (OFF).
+C
+C       READ THIS BEFORE CHANGING IT. MA57 computes the ICNTL(15)
+C       scaling *inside MA57BD*, which is the region this harness
+C       times as `factor_us`. feral computes its MC64 during
+C       ANALYSIS, which its own `factor_us` excludes. Setting
+C       ICNTL(15)=1 therefore charges MA57 per-factorization for work
+C       feral has already amortized and is not billed for, and the
+C       resulting comparison is not apples-to-apples.
+C
+C       Measured cost of that mistake (chain KKTs, min over 15 pairs):
+C       ICNTL(15)=1 inflates MA57 `factor_us` by 37x on clnlbeam
+C       (200,662 vs 5,384 us) and 93x on rocket_12800 (554,339 vs
+C       5,955 us). It also made MA57 *less* accurate on
+C       steering_12800 (rel_res 4.53e-08 vs 1.59e-14). A run with
+C       ICNTL(15)=1 produced a published claim that feral was 8x-23x
+C       faster than MA57; corrected, MA57 is faster on all six by
+C       1.59x-5.53x. See dev/research/chain-kkt-corpus-2026-08-09.md.
+C
+C       Override with the MA57_SCALING environment variable
+C       (MA57_SCALING=1 restores the old behavior). The value used is
+C       always echoed into the sidecar as `scaling`, so a result file
+C       can never again be ambiguous about which arm it came from.
 C     * CNTL(1)  = 1e-8 — pivot threshold (matches MA27 / Ipopt default)
 C     * MA57DD JOB=2 with ICNTL(9)=10 — residual-based iterative
 C       refinement, up to 10 steps. Mirrors what MUMPS + ICNTL(10)=2
@@ -80,8 +102,11 @@ C     MA57 workspace
 
       DOUBLE PRECISION :: RES_NORM, RHS_NORM, REL_RES
       INTEGER(8) :: T_FAC_START, T_FAC_END, T_SOL_START, T_SOL_END
+      INTEGER(8) :: T_ANA_START, T_ANA_END
       INTEGER(8) :: CLOCK_RATE, CLOCK_MAX
-      INTEGER(8) :: FAC_US, SOL_US
+      INTEGER(8) :: FAC_US, SOL_US, ANA_US
+      INTEGER :: ISCALE, ENV_LEN, ENV_STAT
+      CHARACTER(LEN=32) :: ENV_VAL
       LOGICAL :: HAVE_FAILURE
 
       IF (COMMAND_ARGUMENT_COUNT() .LT. 1) THEN
@@ -91,6 +116,15 @@ C     MA57 workspace
       CALL GET_COMMAND_ARGUMENT(1, MANIFEST_PATH)
 
       CALL SYSTEM_CLOCK(COUNT_RATE=CLOCK_RATE, COUNT_MAX=CLOCK_MAX)
+
+C     ---- Resolve ICNTL(15) once, before the manifest loop ----
+      ISCALE = 0
+      CALL GET_ENVIRONMENT_VARIABLE("MA57_SCALING", ENV_VAL,
+     &                              ENV_LEN, ENV_STAT)
+      IF (ENV_STAT .EQ. 0 .AND. ENV_LEN .GT. 0) THEN
+        READ(ENV_VAL(1:ENV_LEN), *, IOSTAT=IOS) ISCALE
+        IF (IOS .NE. 0) ISCALE = 0
+      END IF
 
       OPEN(UNIT=10, FILE=TRIM(MANIFEST_PATH), STATUS='OLD',
      &     ACTION='READ', IOSTAT=IOS)
@@ -149,7 +183,7 @@ C     ---- MA57 init: defaults, then override with "best-effort" cfg ----
       ICNTL(6) = 5
       ICNTL(7) = 1
       ICNTL(9) = 1
-      ICNTL(15) = 1
+      ICNTL(15) = ISCALE
       CNTL(1)  = 1.0D-8
 
 C     ---- Analysis ----
@@ -157,8 +191,10 @@ C     ---- Analysis ----
       ALLOCATE(KEEP(LKEEP))
       ALLOCATE(IWORK(5 * MROWS))
 
+      CALL SYSTEM_CLOCK(T_ANA_START)
       CALL MA57AD(MROWS, MNNZ, IRA, JCA, LKEEP, KEEP, IWORK,
      &            ICNTL, INFO, RINFO)
+      CALL SYSTEM_CLOCK(T_ANA_END)
       IF (INFO(1) .LT. 0) THEN
         WRITE(0,'(A,A,A,I6)') "ma57ad failed on ", TRIM(MTX_PATH),
      &        " INFO(1)=", INFO(1)
@@ -242,6 +278,7 @@ C     ---- Compute residual ||A·x - b||_2 / ||b||_2 ----
         REL_RES = SQRT(RES_NORM)
       END IF
 
+      ANA_US = ((T_ANA_END - T_ANA_START) * 1000000_8) / CLOCK_RATE
       FAC_US = ((T_FAC_END - T_FAC_START) * 1000000_8) / CLOCK_RATE
       SOL_US = ((T_SOL_END - T_SOL_START) * 1000000_8) / CLOCK_RATE
 
@@ -264,12 +301,14 @@ C     ---- Write result ----
       WRITE(12,'(A,I0)') "inertia_pos ", INERT_POS
       WRITE(12,'(A,I0)') "inertia_neg ", INERT_NEG
       WRITE(12,'(A,I0)') "inertia_zero ", INERT_ZERO
+      WRITE(12,'(A,I0)') "analyse_us ", ANA_US
       WRITE(12,'(A,I0)') "factor_us ", FAC_US
       WRITE(12,'(A,I0)') "solve_us ", SOL_US
       WRITE(12,'(A,ES24.16E3)') "rel_res ", REL_RES
       WRITE(12,'(A,I0)') "info1 ", INFO(1)
       WRITE(12,'(A,I0)') "info24 ", INFO(24)
       WRITE(12,'(A,I0)') "info25 ", INFO(25)
+      WRITE(12,'(A,I0)') "scaling ", ISCALE
       WRITE(12,'(A)') "status ok"
       CLOSE(12)
       NDONE = NDONE + 1

--- a/scripts/harvest-pounce-kkt.py
+++ b/scripts/harvest-pounce-kkt.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Convert a pounce `--dump kkt:...` tree into corpus .mtx/.json pairs.
+
+Replaces the ripopt path in `harvest-mittelmann-kkt.sh`, which no
+longer works: ripopt commit 76d3575 (2026-04-28) deleted the dump
+implementation (`dump_kkt_matrix`, `write_kkt_mtx_file`, ...) while
+leaving `SolverOptions::kkt_dump_dir` and its CLI wiring in place, so
+`kkt_dump_dir=` is still accepted and silently writes nothing.
+
+pounce dumps the same systems in its own JSONL schema. Generate them
+with:
+
+    pounce <problem>.nl --dump kkt:all --dump-dir <dumpdir>
+
+which writes `<dumpdir>/iter_NNN/kkt_solve_NNN.jsonl`, one JSON object
+per line with `n`, `irn`, `jcn`, `vals`, `rhs` and the inertia fields.
+Then:
+
+    scripts/harvest-pounce-kkt.py --dump-dir <dumpdir> --name steering_12800
+
+writes `data/matrices/kkt-mittelmann/<name>/<name>_<iter:04>.{mtx,json}`
+in the layout the rest of the corpus tooling already reads.
+
+Only the first solve of each iteration is taken. Later `kkt_solve_NNN`
+records in the same iteration are inertia-correction retries of the
+same system with a different `delta_w`, so keeping them would weight
+hard iterations more heavily in any corpus statistic.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = ROOT / "data" / "matrices" / "kkt-mittelmann"
+
+
+def write_mtx(path: Path, n: int, irn, jcn, vals) -> int:
+    """Write the lower triangle in Matrix Market symmetric coordinate form.
+
+    pounce emits Fortran-style 1-based triplets for the whole symmetric
+    structure. Mirroring the entries into the lower triangle here means
+    a duplicated (i, j) would be written twice, so entries are summed
+    into a dict first -- Matrix Market has no defined semantics for a
+    repeated coordinate and readers disagree about it.
+    """
+    acc = {}
+    for i, j, v in zip(irn, jcn, vals):
+        if i < j:
+            i, j = j, i
+        acc[(i, j)] = acc.get((i, j), 0.0) + v
+    with path.open("w") as f:
+        f.write("%%MatrixMarket matrix coordinate real symmetric\n")
+        f.write(f"{n} {n} {len(acc)}\n")
+        for (i, j), v in sorted(acc.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+            f.write(f"{i} {j} {v:.17e}\n")
+    return len(acc)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dump-dir", required=True,
+                    help="pounce --dump-dir root containing iter_NNN/")
+    ap.add_argument("--name", required=True, help="problem name / file stem")
+    ap.add_argument("--out-dir", default=str(DEFAULT_OUT),
+                    help=f"corpus root (default: {DEFAULT_OUT})")
+    ap.add_argument("--max-iters", type=int, default=0,
+                    help="keep at most this many iterations (0 = all)")
+    args = ap.parse_args()
+
+    dump = Path(args.dump_dir)
+    iters = sorted(d for d in dump.glob("iter_*") if d.is_dir())
+    if not iters:
+        print(f"no iter_* directories under {dump}", file=sys.stderr)
+        return 1
+    if args.max_iters:
+        iters = iters[:args.max_iters]
+
+    out = Path(args.out_dir) / args.name
+    out.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for k, d in enumerate(iters):
+        solves = sorted(d.glob("kkt_solve_*.jsonl"))
+        if not solves:
+            continue
+        line = solves[0].read_text().splitlines()
+        if not line:
+            continue
+        rec = json.loads(line[0])
+        n = int(rec["n"])
+        stem = f"{args.name}_{k:04d}"
+        nnz = write_mtx(out / f"{stem}.mtx", n,
+                        rec["irn"], rec["jcn"], rec["vals"])
+        neg = int(rec.get("num_neg_evals_actual", -1))
+        (out / f"{stem}.json").write_text(json.dumps({
+            "problem_name": args.name,
+            "iteration": k,
+            "n": n,
+            "rhs": rec.get("rhs", []),
+            "inertia": {"negative": neg,
+                        "positive": n - neg if neg >= 0 else -1,
+                        "zero": 0},
+            "status": rec.get("status", "unknown"),
+            "source": "pounce --dump kkt",
+        }))
+        written += 1
+        print(f"  {stem}  n={n}  nnz={nnz}")
+
+    print(f"\n{written} iterations written to {out}")
+    return 0 if written else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scaling/hungarian.rs
+++ b/src/scaling/hungarian.rs
@@ -118,13 +118,34 @@ const RINF: f64 = f64::MAX / 2.0;
 /// parent/child arithmetic trivial (`parent = pos / 2`); externally
 /// the type exposes 0-based row indices.
 struct IndexHeap {
-    /// `heap[1..=len]` contains row indices. `heap[0]` is a dummy.
-    heap: Vec<usize>,
+    /// `heap[1..=len]` contains live entries. `heap[0]` is a dummy.
+    ///
+    /// Each entry carries its own key. SPRAL keeps only the row index
+    /// here and re-reads `d(idx)` at every sift level, which costs a
+    /// dependent random load per level -- the dominant cost on
+    /// trajectories whose searches outgrow cache (nql180 touches
+    /// ~53k rows per search at 13.2 ns/edge-scan, versus pinene's ~87
+    /// rows at 2.94 ns). Storing the key inline keeps sifting entirely
+    /// within this array, which parent/child arithmetic already walks
+    /// with locality. The comparisons performed are unchanged, so the
+    /// resulting matching is bit-identical.
+    heap: Vec<HeapEntry>,
     /// `pos[i]` = 1-based position of `i` in `heap`, or `0` if not
     /// present. The SPRAL `l(i)` array.
     pos: Vec<usize>,
     /// Number of live entries in the heap.
     len: usize,
+}
+
+/// A heap slot: the row index plus a cached copy of its key `d[idx]`.
+///
+/// The cached key is kept current by construction -- `d[i]` is only
+/// ever lowered immediately before `insert`/`update`, both of which
+/// rewrite the entry -- so it never diverges from `d`.
+#[derive(Clone, Copy)]
+struct HeapEntry {
+    key: f64,
+    idx: usize,
 }
 
 impl IndexHeap {
@@ -134,7 +155,7 @@ impl IndexHeap {
         // `heap_init_slots` growth regardless of where `new` is called.
         stats.heap_init_slots += m as u64;
         IndexHeap {
-            heap: vec![0; m + 1],
+            heap: vec![HeapEntry { key: RINF, idx: 0 }; m + 1],
             pos: vec![0; m],
             len: 0,
         }
@@ -161,7 +182,13 @@ impl IndexHeap {
     }
 
     fn peek(&self) -> usize {
-        self.heap[1]
+        self.heap[1].idx
+    }
+
+    /// Key of the minimum entry. Lets the caller test the shortest-path
+    /// termination bound without a random read into `d`.
+    fn peek_key(&self) -> f64 {
+        self.heap[1].key
     }
 
     fn contains(&self, i: usize) -> bool {
@@ -170,66 +197,64 @@ impl IndexHeap {
 
     /// Called when `d[i]` has just been decreased (or `i` was just
     /// inserted with `pos[i] == len`). Sifts `i` upward in the heap.
-    fn update(&mut self, i: usize, d: &[f64]) {
+    fn update(&mut self, i: usize, key: f64) {
         let mut p = self.pos[i];
         if p <= 1 {
-            self.heap[p] = i;
+            self.heap[p] = HeapEntry { key, idx: i };
             return;
         }
-        let v = d[i];
         while p > 1 {
             let parent_pos = p / 2;
-            let parent_idx = self.heap[parent_pos];
-            if v >= d[parent_idx] {
+            let parent = self.heap[parent_pos];
+            if key >= parent.key {
                 break;
             }
-            self.heap[p] = parent_idx;
-            self.pos[parent_idx] = p;
+            self.heap[p] = parent;
+            self.pos[parent.idx] = p;
             p = parent_pos;
         }
-        self.heap[p] = i;
+        self.heap[p] = HeapEntry { key, idx: i };
         self.pos[i] = p;
     }
 
     /// Insert row `i` (assumes `!contains(i)` and `d[i]` is set).
-    fn insert(&mut self, i: usize, d: &[f64]) {
+    fn insert(&mut self, i: usize, key: f64) {
         self.len += 1;
         self.pos[i] = self.len;
-        self.update(i, d);
+        self.update(i, key);
     }
 
     /// Delete the entry at 1-based heap position `pos0`. Mirrors
     /// SPRAL's `heap_delete`.
-    fn delete(&mut self, pos0: usize, d: &[f64]) {
-        let removed = self.heap[pos0];
-        self.pos[removed] = 0;
+    fn delete(&mut self, pos0: usize) {
+        self.pos[self.heap[pos0].idx] = 0;
         if self.len == pos0 {
             self.len -= 1;
             return;
         }
-        let idx = self.heap[self.len];
-        let v = d[idx];
+        let moved = self.heap[self.len];
+        let v = moved.key;
         self.len -= 1;
         let mut p = pos0;
 
         // Sift up.
         if p > 1 {
             loop {
-                let parent = p / 2;
-                let pk = self.heap[parent];
-                if v >= d[pk] {
+                let parent_pos = p / 2;
+                let parent = self.heap[parent_pos];
+                if v >= parent.key {
                     break;
                 }
-                self.heap[p] = pk;
-                self.pos[pk] = p;
-                p = parent;
+                self.heap[p] = parent;
+                self.pos[parent.idx] = p;
+                p = parent_pos;
                 if p <= 1 {
                     break;
                 }
             }
         }
-        self.heap[p] = idx;
-        self.pos[idx] = p;
+        self.heap[p] = moved;
+        self.pos[moved.idx] = p;
         if p != pos0 {
             return;
         }
@@ -240,9 +265,9 @@ impl IndexHeap {
             if child > self.len {
                 break;
             }
-            let mut dk = d[self.heap[child]];
+            let mut dk = self.heap[child].key;
             if child < self.len {
-                let dr = d[self.heap[child + 1]];
+                let dr = self.heap[child + 1].key;
                 if dk > dr {
                     child += 1;
                     dk = dr;
@@ -251,19 +276,19 @@ impl IndexHeap {
             if v <= dk {
                 break;
             }
-            let qk = self.heap[child];
-            self.heap[p] = qk;
-            self.pos[qk] = p;
+            let promoted = self.heap[child];
+            self.heap[p] = promoted;
+            self.pos[promoted.idx] = p;
             p = child;
         }
-        self.heap[p] = idx;
-        self.pos[idx] = p;
+        self.heap[p] = moved;
+        self.pos[moved.idx] = p;
     }
 
     /// Pop and return the minimum-key row. Mirrors SPRAL's `heap_pop`.
-    fn pop(&mut self, d: &[f64]) -> usize {
-        let top = self.heap[1];
-        self.delete(1, d);
+    fn pop(&mut self) -> usize {
+        let top = self.heap[1].idx;
+        self.delete(1);
         top
     }
 }
@@ -554,9 +579,9 @@ pub(crate) fn hungarian_match_instrumented(cost: &CostGraph) -> (Matching, Hunga
                 out_idx[jj] = k;
                 pr[jj] = j;
                 if heap.contains(i) {
-                    heap.update(i, &d);
+                    heap.update(i, dnew);
                 } else {
-                    heap.insert(i, &d);
+                    heap.insert(i, dnew);
                 }
             }
         }
@@ -566,11 +591,10 @@ pub(crate) fn hungarian_match_instrumented(cost: &CostGraph) -> (Matching, Hunga
             if heap.is_empty() {
                 break;
             }
-            let top = heap.peek();
-            if d[top] >= csp {
+            if heap.peek_key() >= csp {
                 break;
             }
-            let q0 = heap.pop(&d);
+            let q0 = heap.pop();
             visited[q0] = true;
             visited_rows.push(q0);
             let dq0 = d[q0];
@@ -606,9 +630,9 @@ pub(crate) fn hungarian_match_instrumented(cost: &CostGraph) -> (Matching, Hunga
                     }
                     d[i] = dnew;
                     if heap.contains(i) {
-                        heap.update(i, &d);
+                        heap.update(i, dnew);
                     } else {
-                        heap.insert(i, &d);
+                        heap.insert(i, dnew);
                     }
                     let jj = iperm[i];
                     out_idx[jj] = k;

--- a/src/scaling/value_bound.rs
+++ b/src/scaling/value_bound.rs
@@ -40,6 +40,12 @@ const GROWTH_COUNT: f64 = 1.5;
 /// of the baseline mean scaled diagonal.
 const EPS_DIAG: f64 = 1e-12;
 
+/// Factor by which the minimum scaled diagonal may shrink from its
+/// baseline before the collapse check rejects. `1.0 / GROWTH_FACTOR`:
+/// the minimum diagonal is allowed to fall by the same factor the
+/// worst dominance ratio is allowed to rise.
+const DIAG_SHRINK: f64 = 1.0 / GROWTH_FACTOR;
+
 /// Diagonal-dominance summary of `D · A · D`, aggregated over the
 /// qualifying rows only. Produced by [`scaled_dominance_stats`].
 #[derive(Debug, Clone, Copy)]
@@ -76,6 +82,9 @@ pub(crate) struct Mc64CacheValidity {
     /// Baseline mean `|scaled diagonal|` — a fixed reference for the
     /// collapse check (does not drift with the current matrix).
     mean_diag_0: f64,
+    /// Baseline minimum `|scaled diagonal|` over qualifying rows — the
+    /// drift reference for the collapse check.
+    min_diag_0: f64,
 }
 
 /// One O(nnz) sweep of `D · A · D` producing the [`DominanceStats`]
@@ -186,9 +195,9 @@ pub(crate) fn precompute_mc64_validity(matrix: &CscMatrix, scaling: &[f64]) -> M
         // tests that *same* length mismatch first — its length gate
         // returns `false` before any condition is evaluated. The
         // fingerprint values do NOT by themselves force a reject: with
-        // `mean_diag_0 = 0` the diagonal-collapse threshold
-        // `EPS_DIAG * mean_diag_0` is `0`, so condition 3 becomes
-        // vacuous (it passes for any non-negative scaled diagonal), and
+        // `mean_diag_0 = 0` and `min_diag_0 = 0` both condition-3
+        // thresholds are `0`, so condition 3 becomes vacuous (it passes
+        // for any non-negative scaled diagonal), and
         // `r0 = 1` does not force condition 1 to fail either. Rejection
         // on a length mismatch comes from the length gate, not from
         // these values.
@@ -204,6 +213,7 @@ pub(crate) fn precompute_mc64_validity(matrix: &CscMatrix, scaling: &[f64]) -> M
         r0: stats.max_ratio.max(1.0),
         n_off_dominant_0: stats.n_off_dominant,
         mean_diag_0: stats.mean_diag,
+        min_diag_0: stats.min_diag,
     }
 }
 
@@ -215,8 +225,9 @@ pub(crate) fn precompute_mc64_validity(matrix: &CscMatrix, scaling: &[f64]) -> M
 /// Rejects (returns `false`) if any of:
 /// 1. the worst dominance ratio grew past `GROWTH_FACTOR · r0`;
 /// 2. the off-dominant row count grew past `GROWTH_COUNT · count₀`;
-/// 3. a qualifying scaled diagonal collapsed below
-///    `EPS_DIAG · mean_diag₀`.
+/// 3. a qualifying scaled diagonal collapsed — below *both* the
+///    absolute floor `EPS_DIAG · mean_diag₀` and the drift bound
+///    `DIAG_SHRINK · min_diag₀`.
 ///
 /// A length mismatch (`scaling` or the stored mask not `matrix.n`)
 /// also returns `false` — recompute fresh, never index out of
@@ -234,7 +245,16 @@ pub(crate) fn mc64_value_bound_passes(
     let cond_ratio = stats.max_ratio <= GROWTH_FACTOR * validity.r0;
     let cond_count =
         (stats.n_off_dominant as f64) <= GROWTH_COUNT * (validity.n_off_dominant_0 as f64);
-    let cond_diag = stats.min_diag >= EPS_DIAG * validity.mean_diag_0;
+    // Disjunction, not a single test: the first clause is an absolute
+    // floor on the scaled diagonal, the second a drift bound against
+    // the baseline. The floor alone compares the current *minimum*
+    // against the baseline *mean* — different statistics, so it can
+    // reject a matrix against its own fingerprint whenever the scaled
+    // diagonal spans more than `1/EPS_DIAG`. The drift clause is
+    // zero-drift-safe by construction: re-checking the baseline gives
+    // `min_diag == min_diag_0` exactly.
+    let cond_diag = stats.min_diag >= EPS_DIAG * validity.mean_diag_0
+        || stats.min_diag >= DIAG_SHRINK * validity.min_diag_0;
     cond_ratio && cond_count && cond_diag
 }
 
@@ -382,6 +402,7 @@ mod tests {
             r0: 2.0,
             n_off_dominant_0: 10,
             mean_diag_0: 1.0,
+            min_diag_0: 1.0,
         };
         assert!(
             !mc64_value_bound_passes(&m, &s, &v),
@@ -409,6 +430,7 @@ mod tests {
             r0: 2.0,
             n_off_dominant_0: 1,
             mean_diag_0: 1.0,
+            min_diag_0: 1.0,
         };
         assert!(
             !mc64_value_bound_passes(&m, &s, &v),
@@ -430,10 +452,84 @@ mod tests {
             r0: 1.0,
             n_off_dominant_0: 0,
             mean_diag_0: 1.0,
+            min_diag_0: 1.0,
         };
         assert!(
             !mc64_value_bound_passes(&m, &s, &v),
             "collapsed scaled diagonal 1e-20 < 1e-12 must reject"
+        );
+    }
+
+    /// Regression: the gate must accept a matrix against its own
+    /// fingerprint. `diag(1e-14, 1.0)` under identity scaling has no
+    /// off-diagonals, so by hand `max_ratio = 0`, `n_off_dominant = 0`,
+    /// `min_diag = 1e-14` and `mean_diag = (1e-14 + 1)/2 = 0.5`.
+    /// Conditions 1 and 2 pass by construction (zero drift). The
+    /// absolute floor `1e-14 >= EPS_DIAG · 0.5 = 5e-13` is **false** —
+    /// so before the drift clause existed this rejected a matrix that
+    /// had not moved at all. The drift clause
+    /// `1e-14 >= DIAG_SHRINK · 1e-14 = 5e-15` is true.
+    ///
+    /// Observed on `robot_1600` in the corpus: zero drift on conditions
+    /// 1 and 2, condition 3 rejecting anyway. See
+    /// `dev/research/mc64-value-bound-diag-drift-2026-08-09.md`.
+    #[test]
+    fn value_bound_passes_on_identical_matrix_with_wide_diagonal_range() {
+        let m = CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[1e-14, 1.0]).expect("valid CSC");
+        let s = [1.0, 1.0];
+        let v = precompute_mc64_validity(&m, &s);
+        assert_eq!(v.min_diag_0, 1e-14, "baseline min diagonal");
+        assert!(
+            mc64_value_bound_passes(&m, &s, &v),
+            "a matrix must pass the value bound against its own fingerprint"
+        );
+    }
+
+    /// The `arki0003` control: a genuine collapse whose baseline
+    /// minimum was already small must still reject, so the drift
+    /// clause is not a blanket loosening.
+    ///
+    /// Numbers from the instrumented corpus run, not from the code:
+    /// `min_diag_0 = 9.372359e-6`, `mean_diag_0 = 9.925188e-1`, and a
+    /// current `min_diag` of `1.984196e-13` — eight orders down.
+    /// Absolute floor: `1.984196e-13 >= 1e-12 · 9.925188e-1 =
+    /// 9.925188e-13` is false. Drift: `1.984196e-13 >= 0.5 ·
+    /// 9.372359e-6 = 4.686e-6` is false. Both fail → reject.
+    /// A_N is diagonal so conditions 1 and 2 stay satisfied.
+    #[test]
+    fn value_bound_rejects_collapse_from_tiny_baseline() {
+        let m =
+            CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[1.984196e-13, 1.0]).expect("valid CSC");
+        let s = [1.0, 1.0];
+        let v = Mc64CacheValidity {
+            qualifying: vec![true, true],
+            r0: 1.0,
+            n_off_dominant_0: 0,
+            mean_diag_0: 9.925188e-1,
+            min_diag_0: 9.372359e-6,
+        };
+        assert!(
+            !mc64_value_bound_passes(&m, &s, &v),
+            "an eight-order collapse must reject even from a small baseline"
+        );
+    }
+
+    /// With no qualifying rows both baselines are `0.0`, so condition 3
+    /// is `min_diag >= 0` on both clauses — vacuous, exactly as it is
+    /// today with `mean_diag_0` alone. Locks the edge case against the
+    /// added field.
+    #[test]
+    fn value_bound_vacuous_when_no_qualifying_rows() {
+        // Off-diagonal only: neither row has a stored diagonal, so
+        // `qualifying` is all-false and the stats sweep counts nothing.
+        let m = CscMatrix::from_triplets(2, &[1], &[0], &[3.0]).expect("valid CSC");
+        let s = [1.0, 1.0];
+        let v = precompute_mc64_validity(&m, &s);
+        assert_eq!(v.min_diag_0, 0.0, "no qualifying rows → zero baseline");
+        assert_eq!(v.mean_diag_0, 0.0, "no qualifying rows → zero baseline");
+        assert!(
+            mc64_value_bound_passes(&m, &s, &v),
+            "condition 3 is vacuous when no row qualifies"
         );
     }
 
@@ -449,6 +545,7 @@ mod tests {
             r0: 3.0,
             n_off_dominant_0: 10,
             mean_diag_0: 1.0,
+            min_diag_0: 1.0,
         };
         assert!(
             mc64_value_bound_passes(&m, &s, &v),


### PR DESCRIPTION
Fourteen commits across four sessions. The branch started as the 0.15.0 docs
push plus a chain-KKT measurement against MA57; that measurement turned out to
be wrong and retracting it is what pointed at MC64, which is where most of the
work ended up. The original write-up is kept verbatim at the bottom — it is the
record of the retraction, not stale text.

## What's in it

**Code — MC64 scaling cache gate (`bd1bc26`).** The value-bound gate deciding
whether a cached MC64 scaling may be reused had three conditions; two measured
drift from the matrix the scaling was computed on, the third did not — it
compared the current **minimum** scaled diagonal against the baseline **mean**.
Different statistics, so it behaved as an absolute property of the matrix and
rejected reuse even when the matrix had not moved. Condition 3 is now the
disjunction of the original absolute floor and a drift bound against the
baseline minimum: a strict widening, so nothing accepted today can start being
rejected. Across 53 gate evaluations on the seven corpus families that route to
MC64, exactly two decisions change — both on `robot_1600`, cutting that
trajectory's factorization time 14.3% and its scaling time 39.8%. Inertia is
unchanged on every iterate of every family, and a genuine diagonal collapse
(`arki0003`, eight orders down) is still rejected.

**Code — inline-key Hungarian heap (`509f0ce`).** The matching's binary min-heap
stored only row indices and looked the key up through a random access into the
distance array on every comparison; it now stores the key inline. Comparisons
and tie-breaking are unchanged, so the matching is unchanged.
**Verified bit-identical on 51 matrices across 39 families** by hashing the raw
bits of the scaling vector each factorization produces. Median of 3:
`nql180_0000` 1.040x, `nql180_0002` 1.057x. `pinene_3200` and `marine_1600` are
flat, as the regime table predicts — the win is in the sift-down path, which
only matters once the heap outgrows cache.

**Negative result worth the review time.** The Hungarian *search bound*, which a
prior note of mine recommended as "same-output-less-work, needs no gate and no
residual argument", does not exist as a lever. The classic
shortest-augmenting-path bound (`csp`) is already implemented
(`src/scaling/hungarian.rs:541`, `:570`, `:591`), and any further truncation
ends a search before its shortest path is proven — suboptimal matching,
different scaling vector, a numerics change needing a corpus study and human
approval. `dev/tried-and-rejected.md:2313` separately *proves* no per-column
reduced-cost bound can ever prune the inner scan and already forbids retrying
it. The correction is recorded in the new research note rather than by editing
the old one.

**Benchmark harness (`782cf65`, `197c7be`).** The MA57 oracle was timing MC64
scaling inside `MA57BD`; retracted below. Both solvers now factorize
pre-scaled matrices offline so they see identical numbers.

**Diagnostics (`16b423c`, `8f8aa8c`).** Trajectory-level scaling profile, a
scaling-reuse safety check, and issue #125 step 2 sized before building it —
the sizing said not to build it.

## Verification

- Remote CI green on `5cc64a8`: `check` x2, `stress-smoke` x2, wheels
  3.10/3.12/3.13.
- `cargo test --release`: 807 passed, 0 failed.
- Scaling-vector bit fingerprint: 51/51 matrices match baseline, re-confirmed
  after the `origin/main` merge.

## Known caveat, not attributed

The `factor/MUMPS` tail is slightly worse than the last full-corpus bench
(`2026-08-09-09`): geomean 0.43 -> 0.44, p90 1.54 -> 1.57, p99 3.30 -> 3.45,
max 8.70 -> 12.40. All Phase 2.8.1 exit partitions still PASS. It is **not** the
MC64 change — that is bit-identical, and the heap does not run on the n=225-458
CUTEst matrices (`KIRBY2`, `GROUPING`) that set those tails. Main's
`Supernode.nrow` fix, flagged in its own checkpoint as a parallel-dispatch
behavior change, is the one plausible candidate in the diff but is unverified.
A single-matrix `max` swing is also within this harness's run-to-run noise.
Recorded in `dev/sessions/2026-08-10-02.md`; next session re-benches
`origin/main` alone to separate the two.

---

# Original PR description (the MA57 retraction)

> **CORRECTION (supersedes the MA57 table below).** The "no gap" result
> was produced with a misconfigured oracle and is wrong. `ma57_bench.F`
> sets `ICNTL(15) = 1`, which makes MA57 compute MC64 scaling *inside*
> `MA57BD` — the region the oracle times. feral computes its MC64 in
> **analysis**, which `factor_us` excludes. The comparison charged MA57
> per-factorization for work feral had already amortized and was not
> being billed for.
>
> Re-run with `ICNTL(15) = 0`, 15 pairs, `min factor_us`:
>
> | matrix | feral | ma57 | MA57 faster by | wins | p |
> |---|---|---|---|---|---|
> | dtoc1nd | 14,050 | 2,539 | 5.53x | 0/15 | 0.0001 |
> | clnlbeam | 21,979 | 5,384 | 4.08x | 1/15 | 0.0010 |
> | rocket_12800 | 22,266 | 5,955 | 3.74x | 0/15 | 0.0001 |
> | marine_1600 | 33,131 | 10,973 | 3.02x | 0/15 | 0.0001 |
> | steering_12800 | 34,517 | 17,097 | 2.02x | 0/15 | 0.0001 |
> | dtoc2 | 81,725 | 51,309 | 1.59x | 0/15 | 0.0001 |
>
> MA57 is faster on **all six**. Three independent checks say this is
> the real number:
>
> - #153 measured the same six through pounce and got 1.29x-3.77x in
>   MA57's favor. Its MA57 times (clnlbeam 7.27 ms, rocket 8.79,
>   steering 18.96) match `ICNTL(15)=0` (5.38, 5.96, 17.1), not the
>   oracle's (201, 554, 292).
> - The proxy conclusion this PR claimed to supersede — 1.4x-2.4x
>   slower — was right in direction and close in magnitude. A correct
>   finding was overturned by a worse measurement.
> - The steering accuracy caveat was the same artifact. With scaling
>   off MA57 gets `1.59e-14`, not `4.53e-08`.
>
> Results 2 and 3 are unaffected: they compare feral builds to each
> other and never touch the oracle. The #150 attribution, the dtoc1nd
> regression, and the refuted E-core hypothesis all stand.
>
> What the checking missed: `factor_us` was verified to cover `MA57BD`
> only, and that was treated as sufficient. The boundary of the timed
> region was checked; the contents were not.
>
> **Confirmed by a clean experiment** ([comment](https://github.com/jkitchin/feral/pull/157#issuecomment-5234058841)).
> The table above still had feral doing MC64 in analysis and MA57 doing
> none. Pre-scaling both arms offline (`prescale_mtx` writes `D A D`;
> feral `Identity`, MA57 `ICNTL(15) = 0`) so they factorize identical
> numbers gives the same answer: MA57 faster by 4.72x / 3.56x / 2.92x /
> 2.64x / 1.46x, all 0/15 at p = 0.0001. `steering_12800` is excluded
> there — MA57's residual is `2.12e-05` against feral's `1.62e-14` on
> the same pre-scaled input, so it cannot carry a timing.

---

Supersedes #152. Docs, research notes and benchmark harness. **No solver source changed.**

## What changed since the first version of this PR

The original PR shipped a proxy measurement and asked for three
follow-ups on a machine with `data/matrices/`. Those have now been run
on an M4 Pro (`Mac16,11`, 10P+4E), and **both of the proxy's headline
conclusions are contradicted.** The proxy note is kept, marked
superseded, with the contradiction stated at the top — it is a useful
record of geometry-matched stand-ins giving the wrong answer.

New: `dev/research/chain-kkt-corpus-2026-08-09.md`.

## Result 1 — feral is not behind MA57 on chain KKTs

Six real KKTs from `data/matrices/kkt-mittelmann`, paired alternating
A/B, `min factor_us` over 15 pairs, exact sign test. Ratio > 1 means
feral is faster.

| matrix | n | main | ma57 | ratio | wins | p |
|---|---|---|---|---|---|---|
| rocket_12800 | 89,601 | 22,893 | 535,659 | **23.40** | 15/15 | 0.0001 |
| clnlbeam | 99,999 | 21,739 | 210,481 | **9.68** | 15/15 | 0.0001 |
| steering_12800 | 115,201 | 33,923 | 273,494 | **8.06** | 15/15 | 0.0001 |
| marine_1600 | 76,807 | 33,373 | 42,471 | 1.27 | 15/15 | 0.0001 |
| dtoc2 | 103,920 | 81,163 | 61,245 | 0.76 | 0/15 | 0.0001 |
| dtoc1nd | 9,685 | 14,297 | 4,561 | 0.32 | 0/15 | 0.0001 |

The proxies said "slower than MA57 on all five, 1.4x to 2.4x, worst on
the largest and most chain-like." On the real matrices the largest and
most chain-like are where feral wins hardest.

**Caveat that belongs with the 8.06x:** on `steering_12800` MA57's
residual is `4.53e-08` against feral's `3.52e-14`, same matrix and RHS.
feral reports `refined yes`, so part of that is iterative refinement
the MA57 oracle does not do. `factor_us` is factorization only so the
timing stands, but feral is faster there *and* more accurate, against a
looser MA57 solve. The correctness gate in the new runner is what
surfaced this; a timing-only table would have hidden it.

## Result 2 — the regression is real, and it is on the smallest matrix

Ratios vs `v0.14.0`. All large-matrix gains and the `dtoc1nd` loss are
15/15 at p = 0.0001.

| matrix | #149 SIMD | #150 parallel | v0.15.0 | main |
|---|---|---|---|---|
| clnlbeam | 0.966 | 2.048 | 2.054 | 2.048 |
| steering_12800 | 0.986 | 1.646 | 1.644 | 1.669 |
| dtoc2 | 0.999 | 1.401 | 1.438 | 1.434 |
| rocket_12800 | 0.979 | 1.200 | 1.255 | 1.214 |
| marine_1600 | 0.953 | 0.956 | 0.953 | 0.943 |
| **dtoc1nd** | 0.960 | **0.764** | **0.762** | **0.750** |

#150 (`fad5670`) is the mover and it is a large win on the four
largest. The one regression is `dtoc1nd`, n = 9,685 — 25%, introduced
by #150, carried unchanged into v0.15.0 and main. The proxies got the
existence of a regression right and its location exactly backwards.

v0.15.0 and main are indistinguishable, so the tag-vs-post-tag question
this PR flagged as open is closed: neither #155 nor #156 moves anything
here.

#149's SIMD kernel is below 1.0 on all six, significantly on `clnlbeam`
(0.966, 0/15, p = 0.0001). It helped on the proxies. That deserves its
own bisect.

## Result 3 — thread count does nothing; the E-core hypothesis is refuted

`RAYON_NUM_THREADS` = 1/2/4/8/10 vs default: every ratio within 6% of
1.0, one significant and in the wrong direction. On a 10P+4E machine,
where the predicted effect should be larger than on the 4P+4E M2 that
generated the hypothesis. Recorded in `tried-and-rejected.md`.

The knob was verified live first — feral reads the global rayon pool
(`rayon::current_num_threads()`), and the same variable moved the
proxies by up to 65%.

**Consequence:** single-threaded main matches all-threads main on every
matrix, so **#150's gains are not parallelism gains.** Any follow-up
that tries to extend #150 by parallelizing harder starts from a false
premise.

## steering_12800 was missing; the harvest path is dead

The corpus shipped only a zero-byte `.solver.log` for it. Cause: ripopt
commit `76d3575` deleted the KKT dump implementation while leaving
`SolverOptions::kkt_dump_dir` and its CLI wiring in place, so
`kkt_dump_dir=` still parses and silently writes nothing — the harvest
reports "OK ... 0 mtx" and exits 0.

Regenerated with pounce (`--dump kkt:1-3`) plus a new
`scripts/harvest-pounce-kkt.py`. Validated against an external oracle
rather than itself: pounce reports `num_neg_evals_actual = 51201`, and
feral and MA57 independently agree (`inertia_neg = 51201`,
`inertia_zero = 0`). This also unblocks the 41 Mittelmann families that
were never harvested.

`dtoc2_0001`/`_0002` are excluded: singular by both solvers
(`inertia_zero` 4 and 103, both `rel_res = NaN`). `dtoc2_0000` is used
instead.

## Harness

- `arm_run.py` — `ab_run.py` generalized to N arms with per-arm env
  overrides, reusing its protocol functions so the statistics are the
  same code. This is the `probe_bisect.py` the original note recorded
  as written-but-never-run. Prints a correctness gate before any timing
  table.
- `real_corpus_mtx.py` — builds the matrix set from
  `data/matrices/kkt-mittelmann`, selection rules in the docstring.
- `scripts/harvest-pounce-kkt.py` — pounce JSONL dump to corpus
  `.mtx`/`.json`.

## Limits

One iterate per family, six families, one machine, aarch64 only.
`factor_us` is numeric factorization only, and analysis dominates wall
clock on these matrices (`clnlbeam` analyse 4.59 s vs factor 38 ms), so
this still does not directly answer pounce#552's end-to-end numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


