### PR TITLE
release: feral v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-08-10
+
 ### Changed — MC64 Hungarian matching is 4-5% faster on large matchings *(bit-identical)*
 
 - The Hungarian matching's binary min-heap stored only row indices and looked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.15.0"
+version = "0.15.1"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release. Cuts `[Unreleased]` to `[0.15.1] - 2026-08-10` and bumps all six
version strings.

## What's in it

- **MC64 scaling cache accepted its own matrices again.** The value-bound gate's
  condition 3 compared the current *minimum* scaled diagonal against the
  baseline *mean* — different statistics, so it behaved as an absolute property
  of the matrix rather than a drift measure and rejected reuse even when the
  matrix had not moved. Now the disjunction of the original absolute floor and a
  drift bound against the baseline minimum: a strict widening, so nothing
  accepted before can start being rejected. Two of 53 gate decisions change
  across the seven corpus families that route to MC64, both on `robot_1600`,
  cutting that trajectory's factorization time 14.3% and its scaling time 39.8%.
  Inertia unchanged on every iterate of every family; `arki0003`'s genuine
  eight-order diagonal collapse is still rejected.
- **Post-amalgamation `Supernode.nrow` underestimate.** Exact for a fundamental
  supernode, wrong after a size-based merge; measured undercounts reached 40% of
  summed `nrow`. Numeric factors and inertia were never affected —
  `build_row_indices` always recomputed the true row set — but everything that
  *estimates* from it was skewed, including parallel dispatch.
- **`Solver` derives `use_parallel` from the platform (#154).** `Solver::new()`
  and `with_params()` now use `available_parallelism()` instead of hardcoding
  `true`. **Watch for this on single-CPU hosts:** a container or CI runner pinned
  to one CPU now defaults to the sequential driver. That is intended, but it is a
  change in native behavior, not only a wasm one. `with_parallel(true)` restores
  the previous unconditional default.
- **A failed thread pool falls back to the sequential driver (#154)**, instead of
  silently running on rayon's *global* pool and defeating the isolation the
  per-`Solver` pool exists to provide. Bit-exact.
- **MC64 Hungarian matching is 4-5% faster on large matchings**, verified
  bit-identical on 51 matrices across 39 families by hashing the raw bits of the
  scaling vector. `nql180_0000` 1.040x, `nql180_0002` 1.057x.

## Release gates

- `cargo test --release`: 84 test binaries, **807 passed, 0 failed**.
- `tests/golden_bits.rs` **3/3** — the checklist's load-bearing gate. It asserts
  hardcoded `to_bits` digests of L/D recorded on x86_64; passing on aarch64 is
  what demonstrates cross-arch bit-identity.
- `cargo metadata --locked` clean in the root **and** in `python/`.
- A `0.15.0` grep over the six version sites comes back empty.

## Known caveat, not attributed

The `factor/MUMPS` bench tail is slightly worse than the last full-corpus
baseline (`2026-08-09-09`): geomean 0.43 -> 0.44, p90 1.54 -> 1.57, p99 3.30 ->
3.45, max 8.70 -> 12.40. All Phase 2.8.1 exit partitions still PASS. It is **not**
the MC64 heap change — bit-identical, and the heap does not run on the n=225-458
CUTEst matrices (`KIRBY2`, `GROUPING`) that set those tails. The `Supernode.nrow`
fix's dispatch change is the one plausible candidate in the diff but is
unverified, and a single-matrix `max` swing is within this harness's noise.
Recorded in `dev/sessions/2026-08-10-02.md`.
