### PR TITLE
feat(lu): Suhl-Suhl basis triangularization + optional dense-bump route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Suhl–Suhl basis triangularization in the sparse LU's symbolic analysis
+
+- `SparseLuSymbolic::analyze` now peels column and row singletons to fixpoint
+  (Suhl & Suhl, *ORSA J. Computing* **2**(4), 325–335, 1990) and runs the
+  fill-reducing ordering on only the residual **bump**. Peeled pivots are
+  structurally forced and both peeled blocks are upper triangular, so `L` is the
+  identity there — a peeled pivot performs no elimination and introduces no
+  rounding. The numeric factor loop is unchanged: partial pivoting discovers the
+  forced pivot on its own.
+- The pass is purely structural, so the symbolic-reuse contract is unchanged — a
+  handle built from one basis stays valid for any numerically different basis
+  with the same pattern.
+- New: `SparseLuSymbolic::{bump_lo, bump_hi}`, `with_order`, and
+  `analyze_amd_only` (the pre-0.16 whole-basis ordering, retained for A/B).
+- On a real simplex basis (`m = 3937`, `nnz = 28204`) the peel removes 85.6% of
+  the columns in 0.148 ms, cutting the ordering from 9.837 ± 0.285 ms to
+  0.851 ± 0.036 ms. Across a sampled class of LP bases (`m` 102 → 34,065) it
+  removes 84.8–100% of columns (median 94.6%) and the bump never exceeds 15.2%
+  of `m`.
+- **The peel alone is roughly break-even end to end** (1.06x on that basis):
+  ordering the isolated bump gives worse fill than ordering the whole basis, and
+  the numeric step regresses ~29% in compensation. Recorded here because it is
+  what motivates the next entry.
+
+### Added — `LuParams::dense_bump_max_dim`, an opt-in dense route for the bump *(default 0 = off)*
+
+- A simplex basis's residual bump is small but its **factor** is dense — 42% on
+  the basis above, against 2.2% input density — which is the worst case for a
+  scalar sparse scatter kernel. `should_use_dense_lu` cannot express this: it
+  keys on input density and on the dimension of the whole basis. Setting
+  `dense_bump_max_dim` routes a bump at or below that dimension through the
+  existing dense kernel instead.
+- **3.39x** on the full factorization of that basis (32.91 ms → 9.71 ms),
+  and **1.64x** on the whole simplex solve downstream (jkitchin/discopt#1008),
+  with the objective identical to 6.6e-15.
+- The cap is a memory bound: the route packs a `b²` f64 buffer (`b = 1024` →
+  8 MB, `b = 4096` → 134 MB).
+- The splice is **checked, never assumed**. It is taken only if the front block
+  really emitted an empty `L` column, so a numerically singular singleton routed
+  through `LuSingularAction::PerturbToEps` falls back to the sparse path rather
+  than producing a wrong factorization. Singularity verdicts match the sparse
+  path (`zero_pivot_tol` is rescaled to the bump's magnitude).
+- New: `SparseLu::{used_dense_bump, bump_dim}`. Because the fallback is silent,
+  `used_dense_bump()` is what keeps a benchmark or differential test from passing
+  vacuously against a fallback; the in-tree ones assert on it.
+
 ## [0.15.1] - 2026-08-10
 
 ### Changed — MC64 Hungarian matching is 4-5% faster on large matchings *(bit-identical)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ All notable changes to FERAL will be documented in this file.
 - New: `SparseLu::{used_dense_bump, bump_dim}`. Because the fallback is silent,
   `used_dense_bump()` is what keeps a benchmark or differential test from passing
   vacuously against a fallback; the in-tree ones assert on it.
+- The route requires a symbolic that actually triangularized, and never applies
+  to a bump that is the whole basis unless it also fits `dense_threshold`.
+  `natural`, `with_order` and `analyze_amd_only` report `(bump_lo, bump_hi) =
+  (0, m)` because they never look for structure, and `analyze` reports it when a
+  basis has nothing to peel; without both guards a tridiagonal `m = 3000` under
+  the cap was packed into a 72 MB `m²` buffer and factored densely, at 181 ms
+  (`natural`) / 297 ms (`analyze`) against 1.5 ms on the sparse path. The case
+  for the dense kernel rests on the peel having stripped the structure and left
+  an irreducible core; with nothing stripped, whole-basis dense is
+  `dense_threshold`'s decision, and it weighs density rather than dimension
+  alone.
+- New: `SparseLuSymbolic::triangularized`, which distinguishes a *measured*
+  `(0, m)` bump from a constructor default. The two need opposite answers from
+  `dense_bump_max_dim` and are indistinguishable from the indices alone.
+- On a singular basis the dense route now reports the **original basis column**
+  in `FeralError::SingularBasis`, matching the sparse path. It previously
+  surfaced the block-local index from the packed kernel (column 7 where the
+  sparse path said 11), which is not a column a simplex driver can act on.
 
 ## [0.15.1] - 2026-08-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,3 +140,6 @@ debug = true
 
 [[example]]
 name = "cmp_ordering_accuracy"
+
+[[example]]
+name = "basis_refactor"

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,216 +1,185 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-10T12:00:56Z
+Generated: 2026-08-13T16:04:18Z
 
 ## Latest Session
-File: dev/sessions/2026-08-10-02.md
+File: dev/sessions/2026-08-13-01.md
 ```
-# Session 2026-08-10-02
-
-Journal: `dev/journal/2026-08-09-08.org` (the work began late on 2026-08-09;
-the file number follows the journal, the session number follows
-`dev/sessions/` which main had already advanced to `2026-08-10-01`).
+# Session 2026-08-13-01
 
 ## Goal
 
-Take the MC64 Hungarian search bound — the lever recommended at the close of
-the condition-1 dig-in (`dev/research/mc64-condition1-cost-share-2026-08-09.md`).
-Then resolve the merge conflicts blocking PR #157 and get remote CI green.
-
-## Benchmark comparison to previous session — TAIL IS SLIGHTLY WORSE
-
-Reported first, per protocol. Against the last full-corpus bench
-(`2026-08-09-09`; `2026-08-10-01` had no corpus in its container):
-
-| factor/MUMPS | 2026-08-09-09 | this session | direction |
-|---|---|---|---|
-| geomean | 0.43 | **0.44** | worse |
-| p50     | 0.30 | 0.30       | flat  |
-| p90     | 1.54 | **1.57**   | worse |
-| p99     | 3.30 | **3.45**   | worse |
-| max     | 8.70 | **12.40**  | worse |
-
-`solve/SSIDS` p90 also moved 2.44 → 2.50; `factor/SSIDS` geomean and both
-`nnzL` rows are unchanged. All Phase 2.8.1 exit partitions still PASS.
-
-I do not have an attributed cause, and I am not claiming one. What can be said:
-
-- **Not the MC64 change.** `509f0ce` is verified bit-identical on 51 matrices,
-  and it only touches the Hungarian heap, which does not run at all on the
-  small CUTEst matrices that set these tails. The worst ratios are `KIRBY2`
-  (n = 458) and `GROUPING` (n = 225).
-- The merge brought in main's `Supernode.nrow` fix (`2026-08-10-01`), which is
-  explicitly flagged there as a *behavior change to parallel dispatch*. That is
-  the one plausible candidate in the diff, but it is unverified — nobody has
-  re-benched main alone since it landed.
-- Sub-millisecond matrices on a laptop are noisy; a single-matrix `max` moving
-  8.70 → 12.40 on `KIRBY2_0007` (1476 us vs 1298-1142 us on its siblings) is
-  within what this harness swings run to run.
-
-Next session should re-run the bench on `origin/main` alone before spending
-effort here, to separate main's change from noise.
+Review the open PRs on jkitchin/feral, then fix the findings the user selected.
+One PR was open: **#160**, "feat(lu): Suhl-Suhl basis triangularization +
+optional dense-bump route" (3 commits, 11 files, +1376/-40). The user scoped the
+fix to findings 1 and 2.
 
 ## Accomplished
 
-### The recommended lever does not exist (negative result)
+### Review of #160
 
-My own prior note called the Hungarian search bound
+The PR's core math holds up. Verified that the Suhl–Suhl peel yields the claimed
+block structure, and that the dense splice is exact given the two structural
+checks the caller makes: every bump-column entry lands either in `above`
+(already-pivoted front row, copied straight through to `U` because `L` is the
+identity there) or in `packed`, so no entry can be dropped. Worst dense-route
+residual over randomized differential probes: **7.9e-16**. The `zero_pivot_tol`
+rescale by `a_max / bump_a_max` is correct — it exactly cancels
+`factorize_packed`'s own block-local scaling, so both routes reach the same
+singularity verdict.
+
+Four findings. Two fixed this session, two left open at the user's scoping.
+
+### Fixed — finding 1: dense route named the wrong singular column (a91519d)
+
+`factor_bump_dense` propagated `factorize_packed`'s error with `?`, and that
+error carries the **block-local** column index (`dense_factor.rs:411`). Every
+site on the sparse path emits `qcol[k]`, the original basis column.
+
+Evidence on the PR's own fixture: sparse reports `SingularBasis { column: 11 }`,
+dense reports `column: 7`. Columns 10 and 11 are the identical (singular) pair;
+7 is unrelated. This is exactly the defect
+`tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position`
+already pins for the sparse path, and for the same reason — a simplex driver
+knows original basis columns, not internal positions.
+
+The PR's own `singular_bump_is_reported_on_both_routes` matched
+`Err(SingularBasis { .. })` only, so it passed against the wrong column.
+Strengthened to compare the two routes' columns and pin the answer to the
+duplicated pair.
+
+### Fixed — finding 2: dense route fired on bumps that were never peeled (21f5e74)
+
+`want_dense_bump` keyed only on `bump_hi - bump_lo` fitting the cap. A bump equal
+to the whole basis satisfies that trivially, so a whole sparse basis was packed
+into an `m²` f64 buffer and factored densely.
+
+Measured on tridiagonal `m = 3000`, `cap = 4096`, release, this machine:
 ```
 
 ## Git Status
 ```
-5a9150d Merge origin/main into docs/session-2026-08-09-05
-509f0ce perf(mc64): store the key inline in the Hungarian heap; bit-identical
-fe8cc64 Merge pull request #158 from jkitchin/claude/fix-supernode-nrow
-32d90ee docs: session checkpoint 2026-08-10-01 (Supernode.nrow fix)
-fc84eb3 fix(symbolic): correct post-amalgamation Supernode.nrow (#128 item E)
+21f5e74 fix(lu): gate the dense-bump route on a bump that was actually peeled
+a91519d fix(lu): report the original basis column when the dense bump is singular
+bdbdec7 fix(python): thread dense_bump_max_dim through the LuFactor binding
+5246727 docs(changelog): triangularization + dense-bump route
+1217992 feat(lu): Suhl-Suhl basis triangularization + optional dense-bump route
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 412 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.42s
+test result: ok. 420 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.96s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-10-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-13-01.md)
 
 
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+8 matrices benchmarked
+2 KKT matrices total
 
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.44       0.30       1.57       3.45      12.40
-solve/MUMPS        153560       0.07       0.08       0.14       0.66       2.78
-factor/SSIDS       154500       0.04       0.03       0.32       1.01       2.49
-solve/SSIDS        154500       0.93       1.00       2.50       8.33      30.25
-nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
-nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
 
-Per-family factor geomean vs MUMPS (top 25 families by count):
-family                  count    geomean        p50        max
-HS118                    3000       0.91       0.94       1.60
-BIGGSC4                  3000       0.42       0.45       0.60
-MGH10LS                  3000       0.20       0.22       0.44
-PALMER7A                 3000       0.28       0.30       0.70
-ALLINITA                 3000       0.41       0.40       0.85
-HS13                     3000       0.17       0.20       0.56
-ALLINITC                 3000       0.19       0.20       0.30
-HS89                     3000       0.20       0.20       0.30
-HATFLDH                  3000       0.42       0.45       0.55
-MCONCON                  3000       0.90       0.94       1.97
-HS92                     3000       0.35       0.36       0.82
-SSINE                    3000       0.27       0.27       0.33
-HATFLDBNE                3000       0.39       0.40       0.83
-HS90                     3000       0.20       0.20       0.33
-DJTL                     3000       0.09       0.10       0.22
-SSI                      3000       0.21       0.22       0.33
-CONCON                   3000       0.86       0.89       1.72
-HS91                     3000       0.25       0.27       0.40
-PALMER5A                 3000       0.29       0.30       0.44
-AVION2                   2682       1.48       1.52       2.11
-CERI651ALS               2331       0.27       0.27       0.33
-PFIT4                    2286       0.25       0.27       0.30
-CERI651C                 2233       0.28       0.30       0.33
-CERI651CLS               2227       0.27       0.27       0.40
-BATCH                    2054       1.35       1.41       1.98
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
 
-Top 10 worst factor-ratio vs MUMPS:
-name                             n    feral(μs)    mumps(μs)      ratio
-KIRBY2_0007                    458         1476          119      12.40
-KIRBY2_0006                    458         1298          127      10.22
-KIRBY2_0008                    458         1142          122       9.36
-KIRBY2_0011                    458          932          120       7.77
-KIRBY2_0009                    458          990          128       7.73
-KIRBY2_0010                    458          987          133       7.42
-GROUPING_0059                  225          725          116       6.25
-GROUPING_0139                  225          701          113       6.20
-GROUPING_0033                  225          692          112       6.18
-GROUPING_0137                  225          674          111       6.07
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
 
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
 
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.57     <= 2.0     PASS
-medium (<500)            153560     1.57     <= 3.0     PASS
+**Not a meaningful comparison to prior sessions.** This container carries only
+the 2 synthetic KKT fixtures the bench generates itself; the real corpus is
+absent, so the Phase 2.8.1 partitions are all `N/A` and there are no oracle
+timings. It is reported for completeness, not as a regression check. These
+changes touch only the LU family (a separate factorization from the LDLᵀ solver
+the bench exercises), so no movement was expected there either way.
+
+The numbers that matter for this session are the tridiagonal timings in the
+table above, taken directly.
 
 ```
 
 ## Recent Decisions
+   sets it; `natural`, `with_order` and `analyze_amd_only` do not. Those three
+   report `(bump_lo, bump_hi) = (0, m)` because they never looked for structure,
+   which is not the same claim as having looked and found the basis irreducible.
+   The indices cannot distinguish the two and they warrant opposite answers, so
+   the provenance is recorded explicitly rather than inferred.
 
-    merged_nrow = child_group_ncol + parent_group_nrow
+2. When the bump *is* the whole basis (a measured `(0, m)` from `analyze` on a
+   basis with nothing to peel), `dense_bump_max_dim` does not apply; such a basis
+   is bounded by `dense_threshold` instead.
 
-maintained as a running per-group value. This is the union *cardinality*, not
-a bound, and it composes for chains under both amalgamation iteration orders.
+The rationale for (2) is that the empirical case for the dense kernel — a bump at
+2.2% input density whose *factor* is 42% dense — depends on the peel having
+already stripped the easy structure and left the irreducible core. That is why
+the PR is right that input density is a bad predictor *for a peeled bump*. With
+nothing stripped, the premise is absent and ordinary sparsity still governs, so
+the decision belongs to `dense_threshold`, which weighs density rather than
+dimension alone.
 
-Verified rather than assumed: compared against
-`SymbolicFactorization::static_rows(i).len()` (the issue #125 static frontal
-layout, an independent computation already pinned to both a from-scratch
-`BTreeSet` recompute and `build_row_indices`) across 7 matrix families x 3
-`nemin` values — **zero error on every supernode**. The pre-change proxy was
-wrong on up to 40% of summed `nrow`.
+**Both guards are load-bearing.** Provenance alone leaves the `analyze`
+-on-unpeelable case at 199x (the 297 ms row above); the `dense_threshold`
+allowance alone would still admit the `natural` constructors. Guard 2 is also
+what keeps the legitimate small-dense case working: the `(0, 16, 0)` no-border
+basis in `tests/lu_dense_bump.rs` peels to nothing but is genuinely dense at
+`m = 16 <= 128`, and stays on the dense route.
 
-**Accepted consequence, with a caveat.** `nrow` feeds
-`estimate_assembly_flops`, so the `PAR_MIN_FLOPS` gate now sees true costs
-and borderline matrices can flip from sequential to parallel (one flip
-recorded: a 60x60 grid Laplacian at `nemin = 32`, 4.3M -> 12.2M estimated
-flops). Numeric factors and inertia are byte-identical. The caveat is that
-`PAR_MIN_FLOPS` was calibrated against the *understated* estimate, so the
-constant itself may now be mis-placed; the flip is unverified on the real
-corpus (absent from the container this landed in). Re-deriving the threshold
-against corrected flops is open work, not something this change did.
-
-The `merge_flop_budget` guard's merged-height model was corrected in lockstep
-at both of its sites. It shared the understatement, which made merges look
-cheaper than they are — the wrong direction for a guard meant to reject
-expensive merges. The knob defaults to `None`, so the default path is
-unaffected, but the sweep recorded in
-`dev/research/amalgamation-cost-model-2026-08-09.md` was taken under the old
-model and its numbers do not transfer.
+**Cost.** A new public field on `SparseLuSymbolic`, and callers constructing that
+struct by literal must now supply it. Consistent with `bump_lo`/`bump_hi`, added
+by the same unreleased change. `analyze` on a large sparse basis that peels to
+nothing can no longer opt into the dense route at all; if that case ever matters,
+the right lever is a density test on the bump, not a dimension cap.
 
 ## Recent Tried-and-Rejected
-inline-key heap that followed is bit-identical and won 4-5% on nql180.
 
-Full data: `dev/research/mc64-hungarian-search-bound-2026-08-09.md`.
+```rust
+let peeled = bump_lo > 0 || bump_hi < m;
+```
 
-## 2026-08-09 — `build_cost_graph` as an MC64 optimization target
+This broke the PR's own `(0, 16, 0)` differential case in
+`tests/lu_dense_bump.rs` — a genuinely dense 16x16 basis with no triangular
+border, which peels to nothing and so reports `(0, m)`, but for which the dense
+kernel is exactly right. Failure was
+`the dense arm fell back to sparse (seed 5) - test is vacuous`.
 
-**Rejected on measurement.** Timed at 8-12 ms per iterate. That is ~20% of
-pinene's *cheapest* iterate but **0.4%** of nql180's — and nql180 is where the
-MC64 time actually is. Optimizing it cannot move the corpus. The instrumented
-timer was reverted and is not in any commit.
+The distinction the index test cannot make is *why* the bump is the whole basis:
+a default from a constructor that never looked, or a measurement from a peel
+that found nothing. Those want opposite answers. Replaced with a
+`SparseLuSymbolic::triangularized` provenance flag plus a `bump_dim <=
+dense_threshold` allowance for the unpeelable case.
 
-## 2026-08-09 — array fusion projected from a microbenchmark
-
-**Not rejected, but the projection was wrong and is recorded so it is not
-reused.** A standalone microbenchmark of split-array vs fused-record reads
-predicted **1.68-1.9x**. The real end-to-end win from the inline-key heap was
-**4-5%**, because the split reads are only ~2.3 ns of nql180's ~13 ns/scan.
-Microbenchmarks of one memory access pattern do not predict a loop that also
-does heap sifting and comparison work; scale by the measured share of the loop
-before believing them.
+Note the provenance flag *alone* was also insufficient — `analyze` on a
+tridiagonal m=3000 peels nothing, sets `triangularized = true`, and hit the same
+cliff at 297 ms vs 1.5 ms sparse. Both guards are load-bearing.
 
 ## Source Files
 ```
@@ -245,6 +214,7 @@ src/lu/sparse_factor.rs
 src/lu/sparse_matrix.rs
 src/lu/sparse_solve.rs
 src/lu/sparse_symbolic.rs
+src/lu/sparse_triangular.rs
 src/lu/sparse_update.rs
 src/numeric/condition.rs
 src/numeric/factorize.rs
@@ -278,8 +248,8 @@ tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -293,14 +263,6 @@ tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/golden_bits.rs
 tests/growth_flag.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -313,13 +275,22 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
-tests/lu_dense_update_bg.rs
 tests/lu_dense.rs
+tests/lu_dense_bump.rs
+tests/lu_dense_update_bg.rs
 tests/lu_ft_widebump.rs
 tests/lu_scaling.rs
 tests/lu_sparse.rs
@@ -338,8 +309,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs
@@ -348,5 +319,7 @@ tests/sqd_fast_path.rs
 tests/static_assembly_maps.rs
 tests/stress_tests.rs
 tests/symbolic_profiler.rs
-
-(truncated from      354 lines to 350 line budget)
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
+```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6389,3 +6389,45 @@ expensive merges. The knob defaults to `None`, so the default path is
 unaffected, but the sweep recorded in
 `dev/research/amalgamation-cost-model-2026-08-09.md` was taken under the old
 model and its numbers do not transfer.
+
+## 2026-08-13 — `dense_bump_max_dim` requires a *measured* bump, and an unpeeled one is bounded by `dense_threshold`
+
+Reviewing #160 found the opt-in dense-bump route firing whenever
+`bump_hi - bump_lo` fit the cap. A bump equal to the whole basis satisfies that
+trivially, so a whole sparse basis could be packed into an `m²` f64 buffer and
+factored densely: tridiagonal `m = 3000` at `cap = 4096` went 1.49 ms → 181.11 ms
+under `natural` and → 297.28 ms under `analyze`, allocating 72 MB.
+
+**Decision: the route is gated on two conditions, not one.**
+
+1. `SparseLuSymbolic::triangularized` (new public field) must be set. `analyze`
+   sets it; `natural`, `with_order` and `analyze_amd_only` do not. Those three
+   report `(bump_lo, bump_hi) = (0, m)` because they never looked for structure,
+   which is not the same claim as having looked and found the basis irreducible.
+   The indices cannot distinguish the two and they warrant opposite answers, so
+   the provenance is recorded explicitly rather than inferred.
+
+2. When the bump *is* the whole basis (a measured `(0, m)` from `analyze` on a
+   basis with nothing to peel), `dense_bump_max_dim` does not apply; such a basis
+   is bounded by `dense_threshold` instead.
+
+The rationale for (2) is that the empirical case for the dense kernel — a bump at
+2.2% input density whose *factor* is 42% dense — depends on the peel having
+already stripped the easy structure and left the irreducible core. That is why
+the PR is right that input density is a bad predictor *for a peeled bump*. With
+nothing stripped, the premise is absent and ordinary sparsity still governs, so
+the decision belongs to `dense_threshold`, which weighs density rather than
+dimension alone.
+
+**Both guards are load-bearing.** Provenance alone leaves the `analyze`
+-on-unpeelable case at 199x (the 297 ms row above); the `dense_threshold`
+allowance alone would still admit the `natural` constructors. Guard 2 is also
+what keeps the legitimate small-dense case working: the `(0, 16, 0)` no-border
+basis in `tests/lu_dense_bump.rs` peels to nothing but is genuinely dense at
+`m = 16 <= 128`, and stays on the dense route.
+
+**Cost.** A new public field on `SparseLuSymbolic`, and callers constructing that
+struct by literal must now supply it. Consistent with `bump_lo`/`bump_hi`, added
+by the same unreleased change. `analyze` on a large sparse basis that peels to
+nothing can no longer opt into the dense route at all; if that case ever matters,
+the right lever is a density test on the bump, not a dimension cap.

--- a/dev/journal/2026-08-13-01.org
+++ b/dev/journal/2026-08-13-01.org
@@ -1,0 +1,101 @@
+#+TITLE: Session 2026-08-13-01 — review of PR #160 (dense-bump route)
+#+STARTUP: showall
+
+* 13:05 :review:lu:pr160:
+Reviewed PR #160 (Suhl–Suhl triangularization + optional dense-bump route,
+3 commits, 11 files, +1376/-40) at high effort.
+
+First review pass ran against a stale =origin/main= (65895704 vs the PR base
+0bc77b8), so =git diff main...branch= spanned 101 files of already-merged work
+and every finding landed in code #160 never touched. Re-fetched and re-ran.
+Lesson: verify =git merge-base <base> <head>= equals the PR's base SHA before
+trusting a three-dot diff in a fresh clone.
+
+Core math of the PR checks out: the peel yields the claimed block structure, and
+the dense splice is exact given the caller's two structural checks — every
+bump-column entry lands either in =above= (already-pivoted front row, straight
+through to =U= because =L= is identity there) or in =packed=. Worst dense-route
+residual over randomized differential probes: 7.9e-16.
+
+Four findings; the user scoped the fix to the first two.
+
+* 13:40 :lu:bug:pr160:singular:
+*Finding 1 — dense route named the wrong column on a singular basis.*
+
+=factor_bump_dense= propagated =factorize_packed='s error with =?=, and
+=dense_factor.rs:411= constructs =SingularBasis { column: k }= with =k= the
+*block-local* column index. The sparse path emits =qcol[k]= (the original basis
+column) at all three of its sites.
+
+Evidence on the PR's own singular fixture: sparse reports =column: 11=, dense
+reports =column: 7=. This contradicts
+=tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position=,
+which exists precisely because a simplex driver knows original basis columns,
+not internal positions. The PR's new =singular_bump_is_reported_on_both_routes=
+matched =Err(SingularBasis { .. })= only, so it passed vacuously.
+
+Fix: =map_err= remapping =column= through =qcol[bump_lo + column]=, guarded by
+=column < b=. Strengthened the existing test to compare the two routes' columns
+rather than just their variants, and to pin the answer to the duplicated pair.
+
+* 14:10 :lu:bug:pr160:perf:gating:
+*Finding 2 — the dense route fired on symbolics that never triangularized.*
+
+=want_dense_bump= keyed only on =bump_hi - bump_lo= fitting the cap. But
+=natural=, =with_order= and =analyze_amd_only= all set =(bump_lo, bump_hi) =
+(0, m)= — "no structure known, treat the whole basis as bump" — so any basis
+under the cap had its *entire* basis packed into an =m²= f64 buffer and run
+through the dense kernel.
+
+First attempted fix was a =peeled = bump_lo > 0 || bump_hi < m= gate. It broke
+the PR's own =(0, 16, 0)= differential case (a genuinely dense 16x16 basis with
+no border, where the route legitimately wins) — recorded in tried-and-rejected.
+
+Measured on tridiagonal m=3000, cap=4096, release, this machine:
+
+| arm     | cap=0   | cap=4096 (before) | cap=4096 (after) |
+|---------+---------+-------------------+------------------|
+| natural | 1.49 ms | 181.11 ms (dense) | 1.30 ms (sparse) |
+| analyze | 1.49 ms | 297.28 ms (dense) | 1.26 ms (sparse) |
+
+The =analyze= row is the finding the review did *not* report and the reason
+provenance alone was insufficient: a tridiagonal has no singletons, so =analyze=
+peels nothing, reports =(0, m)= as a genuine measurement, and hit the same cliff
+at 297 ms. Gating on provenance alone would have left that at 200x.
+
+Shipped gate is two guards:
+1. =symbolic.triangularized= (new field; set by =analyze= only) — a default
+   =(0, m)= is not a measurement.
+2. =peeled || bump_dim <= params.dense_threshold= — an =analyze=d basis that
+   peels to nothing has had no structure stripped, so the argument for the dense
+   kernel (the peel leaves an irreducible core whose factor is dense) does not
+   apply; ordinary sparsity still governs and =dense_threshold= owns that call.
+
+Guard 2 keeps the =(0, 16, 0)= case working: 16 <= 128 = default
+=dense_threshold=.
+
+* 14:35 :lu:pr160:verified:
+Both new/strengthened tests fail against the unfixed source and pass with it —
+checked by stashing the =src/= changes and re-running:
+=2 failed= before, =5 passed= after. Full suite green (420 unit + all
+integration), =cargo fmt --check= clean, =cargo clippy --all-targets -D warnings=
+clean.
+
+Note: =pre-commit= is not installed in this container (=command not found=), so
+fmt/clippy were run manually per CLAUDE.md.
+
+* 14:40 :review:pr160:deferred:
+Two findings left unfixed, per the user's scoping to 1 and 2:
+- =src/lu/sparse_factor.rs= — =used_dense_bump=/=bump_dim= were spliced between
+  =factor_nnz='s doc comment and its signature, so =used_dense_bump= is
+  documented as "Total stored nonzeros in L and U" and =factor_nnz= is
+  undocumented.
+- =examples/basis_refactor.rs:69= — =mean_sd= divides by =n.max(2.0 - 1.0)=,
+  i.e. =n.max(1.0)=; clearly a typo for =(n - 1.0).max(1.0)=. Population rather
+  than sample SD, and the +/- figures in the PR body and CHANGELOG come from it.
+
+Also worth a maintainer's judgment (not a defect, and disclosed in the PR body):
+with the shipped default =dense_bump_max_dim: 0=, the peel alone regresses the
+numeric step 29% and fill 13% on the PR's own basis. Since a symbolic handle is
+reused across many refactorizations, the numeric step is the amortized steady
+state, so the default arm is the one the PR's data shows losing.

--- a/dev/sessions/2026-08-13-01.md
+++ b/dev/sessions/2026-08-13-01.md
@@ -1,0 +1,148 @@
+# Session 2026-08-13-01
+
+## Goal
+
+Review the open PRs on jkitchin/feral, then fix the findings the user selected.
+One PR was open: **#160**, "feat(lu): Suhl-Suhl basis triangularization +
+optional dense-bump route" (3 commits, 11 files, +1376/-40). The user scoped the
+fix to findings 1 and 2.
+
+## Accomplished
+
+### Review of #160
+
+The PR's core math holds up. Verified that the Suhl–Suhl peel yields the claimed
+block structure, and that the dense splice is exact given the two structural
+checks the caller makes: every bump-column entry lands either in `above`
+(already-pivoted front row, copied straight through to `U` because `L` is the
+identity there) or in `packed`, so no entry can be dropped. Worst dense-route
+residual over randomized differential probes: **7.9e-16**. The `zero_pivot_tol`
+rescale by `a_max / bump_a_max` is correct — it exactly cancels
+`factorize_packed`'s own block-local scaling, so both routes reach the same
+singularity verdict.
+
+Four findings. Two fixed this session, two left open at the user's scoping.
+
+### Fixed — finding 1: dense route named the wrong singular column (a91519d)
+
+`factor_bump_dense` propagated `factorize_packed`'s error with `?`, and that
+error carries the **block-local** column index (`dense_factor.rs:411`). Every
+site on the sparse path emits `qcol[k]`, the original basis column.
+
+Evidence on the PR's own fixture: sparse reports `SingularBasis { column: 11 }`,
+dense reports `column: 7`. Columns 10 and 11 are the identical (singular) pair;
+7 is unrelated. This is exactly the defect
+`tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position`
+already pins for the sparse path, and for the same reason — a simplex driver
+knows original basis columns, not internal positions.
+
+The PR's own `singular_bump_is_reported_on_both_routes` matched
+`Err(SingularBasis { .. })` only, so it passed against the wrong column.
+Strengthened to compare the two routes' columns and pin the answer to the
+duplicated pair.
+
+### Fixed — finding 2: dense route fired on bumps that were never peeled (21f5e74)
+
+`want_dense_bump` keyed only on `bump_hi - bump_lo` fitting the cap. A bump equal
+to the whole basis satisfies that trivially, so a whole sparse basis was packed
+into an `m²` f64 buffer and factored densely.
+
+Measured on tridiagonal `m = 3000`, `cap = 4096`, release, this machine:
+
+| arm       | cap=0   | cap=4096 before   | cap=4096 after   |
+|-----------|---------|-------------------|------------------|
+| `natural` | 1.49 ms | 181.11 ms (dense) | 1.30 ms (sparse) |
+| `analyze` | 1.49 ms | 297.28 ms (dense) | 1.26 ms (sparse) |
+
+121x and 199x slower, and 72 MB allocated, to factor a tridiagonal.
+
+The `analyze` row is the part the review did **not** report and the reason a
+provenance flag alone was insufficient: a tridiagonal has no singletons, so
+`analyze` peels nothing and reports `(0, m)` as a genuine measurement. Shipped
+gate is two guards — a new `SparseLuSymbolic::triangularized` field, plus
+`peeled || bump_dim <= dense_threshold`. Full rationale in `dev/decisions.md`.
+
+### Verification
+
+- Both new/strengthened tests **fail on the pre-fix source** and pass with it —
+  checked by stashing the `src/` changes (`2 failed` before, `5 passed` after).
+- Full suite green: 86 test binaries, 0 failures.
+- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.
+- `pre-commit` is **not installed in this container** (`command not found`), so
+  fmt/clippy were run manually per CLAUDE.md. `assemble-context.sh` warns about
+  this too. Anyone continuing in a fresh container should install it.
+
+### Process note worth keeping
+
+The first review pass ran against a stale `origin/main` (65895704 vs the PR base
+0bc77b8), so `git diff main...branch` spanned 101 files of already-merged work
+and every finding landed in code #160 never touched. Verify
+`git merge-base <base> <head>` equals the PR's base SHA before trusting a
+three-dot diff in a fresh clone.
+
+## Benchmark Results
+
+```
+8 matrices benchmarked
+2 KKT matrices total
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
+```
+
+**Not a meaningful comparison to prior sessions.** This container carries only
+the 2 synthetic KKT fixtures the bench generates itself; the real corpus is
+absent, so the Phase 2.8.1 partitions are all `N/A` and there are no oracle
+timings. It is reported for completeness, not as a regression check. These
+changes touch only the LU family (a separate factorization from the LDLᵀ solver
+the bench exercises), so no movement was expected there either way.
+
+The numbers that matter for this session are the tridiagonal timings in the
+table above, taken directly.
+
+## Decisions Made
+
+- `dense_bump_max_dim` requires a *measured* bump, and an unpeeled whole basis is
+  bounded by `dense_threshold` instead. Appended to `dev/decisions.md`.
+
+## Abandoned Approaches
+
+- Gating the dense-bump route on `bump_lo > 0 || bump_hi < m` alone. Broke the
+  PR's `(0, 16, 0)` no-border differential case, which peels to nothing but is
+  genuinely dense at `m = 16`. Appended to `dev/tried-and-rejected.md`.
+
+## Next Session Should
+
+1. **Decide the two open findings from #160** (both left unfixed by scoping):
+   - `src/lu/sparse_factor.rs` — `used_dense_bump`/`bump_dim` were spliced
+     between `factor_nnz`'s doc comment and its signature, so `used_dense_bump`
+     is documented as "Total stored nonzeros in `L` and `U`" and `factor_nnz` is
+     undocumented. One-line fix.
+   - `examples/basis_refactor.rs:69` — `mean_sd` divides by `n.max(2.0 - 1.0)`,
+     i.e. `n.max(1.0)`; a typo for `(n - 1.0).max(1.0)`. Population rather than
+     sample SD. The ± figures in #160's body and in CHANGELOG came from it, so
+     they are mildly understated and worth regenerating if they are quoted
+     anywhere load-bearing.
+2. **Settle the `dense_bump_max_dim` default.** With the shipped default of `0`,
+   the peel alone regresses the numeric step 29% and fill 13% on #160's own
+   basis (1.06x net). A symbolic handle is reused across many refactorizations,
+   so the numeric step is the amortized steady state — meaning the default arm is
+   the one the PR's own data shows losing. #160 discloses this openly; it is a
+   judgment call, not a defect, but it should be made deliberately rather than
+   inherited.
+3. **Install `pre-commit` in the container image** if these sessions keep running
+   here — `assemble-context.sh` already warns, and CI enforces the same hooks.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5233,3 +5233,30 @@ predicted **1.68-1.9x**. The real end-to-end win from the inline-key heap was
 Microbenchmarks of one memory access pattern do not predict a loop that also
 does heap sifting and comparison work; scale by the measured share of the loop
 before believing them.
+
+## 2026-08-13 — gating the dense-bump route on `bump_lo > 0 || bump_hi < m` alone
+
+**Rejected on a broken test.** Reviewing PR #160, the dense-bump route was found
+to fire on symbolics that never triangularized (`natural`, `with_order`,
+`analyze_amd_only` all report `(0, m)`), packing a whole sparse basis into an
+`m²` f64 buffer. The first fix gated on "the bump is a proper sub-block":
+
+```rust
+let peeled = bump_lo > 0 || bump_hi < m;
+```
+
+This broke the PR's own `(0, 16, 0)` differential case in
+`tests/lu_dense_bump.rs` — a genuinely dense 16x16 basis with no triangular
+border, which peels to nothing and so reports `(0, m)`, but for which the dense
+kernel is exactly right. Failure was
+`the dense arm fell back to sparse (seed 5) - test is vacuous`.
+
+The distinction the index test cannot make is *why* the bump is the whole basis:
+a default from a constructor that never looked, or a measurement from a peel
+that found nothing. Those want opposite answers. Replaced with a
+`SparseLuSymbolic::triangularized` provenance flag plus a `bump_dim <=
+dense_threshold` allowance for the unpeelable case.
+
+Note the provenance flag *alone* was also insufficient — `analyze` on a
+tridiagonal m=3000 peels nothing, sets `triangularized = true`, and hit the same
+cliff at 297 ms vs 1.5 ms sparse. Both guards are load-bearing.

--- a/examples/basis_refactor.rs
+++ b/examples/basis_refactor.rs
@@ -1,0 +1,175 @@
+//! A/B a Matrix Market basis through both symbolic paths: AMD over the whole
+//! basis (feral's pre-triangularization behavior) vs Suhl–Suhl peel + AMD over
+//! the residual bump. Interleaved, in one process, on the identical matrix.
+//!
+//! Usage: cargo run --release --example basis_refactor -- <file.mtx> [reps]
+
+use std::time::Instant;
+
+use feral::{LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+
+fn read_mtx(path: &str) -> SparseColMatrix {
+    let text = std::fs::read_to_string(path).expect("read mtx");
+    let mut lines = text.lines().filter(|l| !l.starts_with('%'));
+    let hdr: Vec<usize> = lines
+        .next()
+        .expect("header")
+        .split_whitespace()
+        .map(|t| t.parse().expect("header int"))
+        .collect();
+    let (m, nnz) = (hdr[0], hdr[2]);
+    let mut trip: Vec<(usize, usize, f64)> = Vec::with_capacity(nnz);
+    for l in lines {
+        let mut it = l.split_whitespace();
+        let i: usize = it.next().expect("row").parse().expect("row int");
+        let j: usize = it.next().expect("col").parse().expect("col int");
+        let v: f64 = it.next().expect("val").parse().expect("val f64");
+        trip.push((i - 1, j - 1, v));
+    }
+    assert_eq!(trip.len(), nnz, "declared nnz != entries read");
+    trip.sort_by_key(|&(i, j, _)| (j, i));
+    let mut col_ptr = vec![0usize; m + 1];
+    for &(_, j, _) in &trip {
+        col_ptr[j + 1] += 1;
+    }
+    for j in 0..m {
+        col_ptr[j + 1] += col_ptr[j];
+    }
+    SparseColMatrix {
+        m,
+        col_ptr,
+        row_idx: trip.iter().map(|&(i, _, _)| i).collect(),
+        values: trip.iter().map(|&(_, _, v)| v).collect(),
+    }
+}
+
+struct Stat {
+    sym: Vec<f64>,
+    num: Vec<f64>,
+    nnz_lu: usize,
+    bump: usize,
+    runs: usize,
+}
+
+impl Stat {
+    fn new() -> Self {
+        Stat {
+            sym: Vec::new(),
+            num: Vec::new(),
+            nnz_lu: 0,
+            bump: 0,
+            runs: 0,
+        }
+    }
+}
+
+fn mean_sd(v: &[f64]) -> (f64, f64) {
+    let n = v.len() as f64;
+    let m = v.iter().sum::<f64>() / n;
+    let var = v.iter().map(|x| (x - m) * (x - m)).sum::<f64>() / n.max(2.0 - 1.0);
+    (m, var.sqrt())
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args
+        .get(1)
+        .expect("usage: basis_refactor <file.mtx> [reps]");
+    let reps: usize = args.get(2).map_or(20, |s| s.parse().expect("reps"));
+    let a = read_mtx(path);
+    println!("m={} nnz={} reps={reps}", a.m, a.row_idx.len());
+    let params = LuParams::default();
+
+    let mut peel = Stat::new();
+    let mut full = Stat::new();
+    let mut dense = Stat::new();
+    let mut dense_fired = 0usize;
+    let dense_cap: usize = std::env::var("FERAL_DENSE_BUMP_MAX")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(4096);
+
+    // Interleaved A/B (discopt CLAUDE.md rule 9): alternate arms so any drift in
+    // machine state hits both equally.
+    for _ in 0..reps {
+        for arm in 0..3 {
+            let s = match arm {
+                0 => &mut peel,
+                1 => &mut full,
+                _ => &mut dense,
+            };
+            let p = if arm == 2 {
+                LuParams {
+                    dense_bump_max_dim: dense_cap,
+                    ..params.clone()
+                }
+            } else {
+                params.clone()
+            };
+            let t0 = Instant::now();
+            let sym = if arm == 1 {
+                SparseLuSymbolic::analyze_amd_only(&a).expect("analyze")
+            } else {
+                SparseLuSymbolic::analyze(&a).expect("analyze")
+            };
+            s.sym.push(t0.elapsed().as_secs_f64() * 1e3);
+            let t1 = Instant::now();
+            let lu = SparseLu::factor(&a, &sym, p).expect("factor");
+            s.num.push(t1.elapsed().as_secs_f64() * 1e3);
+            s.nnz_lu = lu.factor_nnz();
+            s.bump = sym.bump_hi - sym.bump_lo;
+            s.runs += 1;
+            if arm == 2 && lu.used_dense_bump() {
+                dense_fired += 1;
+            }
+        }
+    }
+
+    for (name, s) in [
+        ("peel+AMD(bump)", &peel),
+        ("AMD(full)", &full),
+        ("peel+denseBump", &dense),
+    ] {
+        let (ms, ss) = mean_sd(&s.sym);
+        let (mn, sn) = mean_sd(&s.num);
+        println!(
+            "{name:16} symbolic={ms:7.3} +- {ss:5.3} ms  numeric={mn:7.2} +- {sn:4.2} ms  \
+             total={:7.2} ms  nnz(LU)={}  bump={}",
+            ms + mn,
+            s.nnz_lu,
+            s.bump
+        );
+    }
+    let (ps, _) = mean_sd(&peel.sym);
+    let (pn, _) = mean_sd(&peel.num);
+    let (fs, _) = mean_sd(&full.sym);
+    let (fn_, _) = mean_sd(&full.num);
+    println!(
+        "speedup: symbolic {:.2}x  numeric {:.2}x  total {:.2}x   peeled={:.2}%",
+        fs / ps,
+        fn_ / pn,
+        (fs + fn_) / (ps + pn),
+        100.0 * (a.m - peel.bump) as f64 / a.m as f64,
+    );
+
+    // Rule 6: an executed count, nonzero exit if nothing ran.
+    let (ds, _) = mean_sd(&dense.sym);
+    let (dn, _) = mean_sd(&dense.num);
+    println!(
+        "dense-bump vs AMD(full): total {:.2}x   (route fired on {}/{} reps, cap={})",
+        (fs + fn_) / (ds + dn),
+        dense_fired,
+        dense.runs,
+        dense_cap,
+    );
+
+    // Rule 6: executed counts, nonzero exit if a probe never fired.
+    println!(
+        "runs={} {} {} dense_fired={}",
+        peel.runs, full.runs, dense.runs, dense_fired
+    );
+    if peel.runs == 0 || full.runs == 0 || dense_fired == 0 {
+        eprintln!("ERROR: an arm never ran (dense route may have fallen back)");
+        std::process::exit(1);
+    }
+}

--- a/python/src/lu.rs
+++ b/python/src/lu.rs
@@ -252,6 +252,7 @@ impl LuFactor {
         refine_steps: usize,
         refine_tol: f64,
         update_pivot_search: bool,
+        dense_bump_max_dim: usize,
     ) -> PyResult<LuParams> {
         let on_singular = match on_singular {
             "fail" => LuSingularAction::Fail,
@@ -275,6 +276,7 @@ impl LuFactor {
             refine_steps,
             refine_tol,
             update_pivot_search,
+            dense_bump_max_dim,
         })
     }
 }
@@ -284,6 +286,14 @@ impl LuFactor {
     /// Factor `matrix`. Routing: if `force_dense` is `None` (default),
     /// `should_use_dense_lu(n, nnz, params)` decides; `force_dense=True`
     /// forces the dense engine, `False` the sparse engine.
+    ///
+    /// `dense_bump_max_dim` (default 0 = off) is a second, independent routing
+    /// knob that applies only on the sparse path: a post-triangularization bump
+    /// at or below that dimension is factored with the dense kernel and spliced
+    /// back into the sparse factor. It exists because an LP basis's bump is
+    /// small but its *factor* is dense, which `should_use_dense_lu` cannot see —
+    /// that predicate keys on input density and on the whole basis's dimension.
+    /// The cap is a memory bound: the route packs a `dim²` f64 buffer.
     #[new]
     #[pyo3(signature = (
         matrix,
@@ -299,6 +309,7 @@ impl LuFactor {
         refine_steps = 0,
         refine_tol = 1e-12,
         update_pivot_search = false,
+        dense_bump_max_dim = 0,
         force_dense = None,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -316,6 +327,7 @@ impl LuFactor {
         refine_steps: usize,
         refine_tol: f64,
         update_pivot_search: bool,
+        dense_bump_max_dim: usize,
         force_dense: Option<bool>,
     ) -> PyResult<Self> {
         let params = Self::build_params(
@@ -330,6 +342,7 @@ impl LuFactor {
             refine_steps,
             refine_tol,
             update_pivot_search,
+            dense_bump_max_dim,
         )?;
         let a = &matrix.inner;
         let m = a.m;

--- a/src/lu/dense_factor.rs
+++ b/src/lu/dense_factor.rs
@@ -362,7 +362,7 @@ fn umax(u: &[f64]) -> f64 {
 
 /// Right-looking outer-product LU with threshold partial pivoting, in place on
 /// the packed buffer. `perm` starts as identity and accumulates row swaps.
-fn factorize_packed(
+pub(super) fn factorize_packed(
     packed: &mut [f64],
     perm: &mut [usize],
     m: usize,

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -21,6 +21,7 @@ pub mod sparse_factor;
 pub mod sparse_matrix;
 pub mod sparse_solve;
 pub mod sparse_symbolic;
+pub(crate) mod sparse_triangular;
 pub mod sparse_update;
 
 pub use dense_factor::DenseLu;
@@ -119,6 +120,22 @@ pub struct LuParams {
     pub max_updates: usize,
     /// Bases with `m` at or below this use the dense path unconditionally.
     pub dense_threshold: usize,
+    /// Maximum dimension of a post-triangularization **bump** that
+    /// [`SparseLu::factor`](super::SparseLu::factor) routes through the dense
+    /// kernel instead of the sparse scatter kernel. `0` (the default) disables
+    /// the route entirely.
+    ///
+    /// After a Suhl–Suhl peel the residual bump is small but its *factor* is
+    /// dense — 42% on a measured QPLIB simplex basis whose bump was 566x566 at
+    /// 2.2% **input** density — which is the worst case for a scalar sparse
+    /// scatter kernel and the best case for a blocked dense one (6.05 ms vs
+    /// 27.3 ms on that block). [`Self::dense_threshold`] cannot express this:
+    /// it keys on input density and on the dimension of the *whole* basis.
+    ///
+    /// Cost of being wrong is bounded by memory: the route packs a `b*b`
+    /// `f64` buffer, so `b = 1024` is 8 MB and `b = 4096` is 134 MB. Set this
+    /// to the largest bump worth that allocation, or `0` to stay sparse.
+    pub dense_bump_max_dim: usize,
     /// Scaling strategy applied before factorization.
     pub scaling: LuScaling,
     /// Maximum iterative-refinement steps in `ftran_refined`/`btran_refined`.
@@ -205,6 +222,7 @@ impl Default for LuParams {
             max_growth: 1e8,
             max_updates: 64,
             dense_threshold: 128,
+            dense_bump_max_dim: 0,
             scaling: LuScaling::None,
             refine_steps: 0,
             refine_tol: 1e-12,

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -135,6 +135,26 @@ pub struct LuParams {
     /// Cost of being wrong is bounded by memory: the route packs a `b*b`
     /// `f64` buffer, so `b = 1024` is 8 MB and `b = 4096` is 134 MB. Set this
     /// to the largest bump worth that allocation, or `0` to stay sparse.
+    ///
+    /// Applies only to a symbolic that actually triangularized, i.e. one built
+    /// by [`SparseLuSymbolic::analyze`]
+    /// ([`triangularized`](super::SparseLuSymbolic::triangularized)).
+    /// [`SparseLuSymbolic::natural`], [`SparseLuSymbolic::with_order`] and
+    /// [`SparseLuSymbolic::analyze_amd_only`] report the whole basis as bump
+    /// because they never looked for structure, so they never take this route
+    /// however large the cap.
+    ///
+    /// When `analyze` peels nothing and the bump *is* the whole basis, this cap
+    /// does not apply either — such a basis is bounded by
+    /// [`Self::dense_threshold`] instead. The case for the dense kernel rests on
+    /// the peel having stripped the structure and left an irreducible core; with
+    /// nothing stripped, whole-basis dense is `dense_threshold`'s call, and it
+    /// weighs density rather than dimension alone.
+    ///
+    /// [`SparseLuSymbolic::natural`]: super::SparseLuSymbolic::natural
+    /// [`SparseLuSymbolic::with_order`]: super::SparseLuSymbolic::with_order
+    /// [`SparseLuSymbolic::analyze_amd_only`]: super::SparseLuSymbolic::analyze_amd_only
+    /// [`SparseLuSymbolic::analyze`]: super::SparseLuSymbolic::analyze
     pub dense_bump_max_dim: usize,
     /// Scaling strategy applied before factorization.
     pub scaling: LuScaling,

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -134,6 +134,14 @@ pub struct SparseLu {
     /// Total Gilbert–Peierls reach nodes visited during the factor — a
     /// structural scalability witness (`O(nnz(U))`, not `O(n²)`).
     pub(super) reach_visits: usize,
+    /// True when the post-triangularization bump was factored by the dense
+    /// kernel (`LuParams::dense_bump_max_dim`). The route falls back to the
+    /// sparse kernel silently whenever its structural preconditions do not
+    /// hold, so a caller measuring it must read this rather than infer it from
+    /// the parameter.
+    pub(super) used_dense_bump: bool,
+    /// Dimension of the residual bump after triangularization.
+    pub(super) bump_dim: usize,
     pub(super) params: LuParams,
     /// Two-sided scaling of the factored matrix (identity when unscaled).
     pub(super) scale: LuScale,
@@ -278,7 +286,84 @@ impl SparseLu {
         let ztol = params.zero_pivot_tol * a_max;
         let mut reach_visits = 0usize;
 
-        for k in 0..m {
+        // Post-triangularization dense-bump route (opt-in via
+        // `dense_bump_max_dim`). The peel leaves a small bump whose *factor* is
+        // dense even when its input is sparse; a blocked dense kernel beats the
+        // sparse scatter kernel there by a wide margin. Taken only if the front
+        // block really did emit an empty `L` — see `bump_dense_ok` below.
+        let bump_lo = symbolic.bump_lo;
+        let bump_hi = symbolic.bump_hi;
+        let bump_dim = bump_hi.saturating_sub(bump_lo);
+        let want_dense_bump = bump_dim >= 2
+            && params.dense_bump_max_dim > 0
+            && bump_dim <= params.dense_bump_max_dim
+            && bump_hi <= m;
+        // Bump rows, ascending — the complement of the peeled rows. Only needed
+        // on the dense route.
+        let mut bump_rows: Vec<usize> = Vec::new();
+        let mut dense_done = false;
+
+        let mut k = 0usize;
+        while k < m {
+            // --- dense bump splice -------------------------------------------
+            // At the first bump position, factor the whole block at once and
+            // emit every bump column's L/U, then jump past the block.
+            if want_dense_bump && k == bump_lo && !dense_done {
+                // The splice is valid only if every peeled position ahead of the
+                // bump produced an EMPTY L column: that is the structural claim
+                // that makes the bump block of `A` equal to the bump block of
+                // `L^-1 A` (Suhl & Suhl). It holds for a correct peel, but a
+                // numerically singular singleton routed through
+                // `LuSingularAction::PerturbToEps` can pivot on some other row
+                // and break it, so it is checked, never assumed.
+                let front_l_empty = l_col_ptr.last() == Some(&0);
+                if front_l_empty {
+                    bump_rows = (0..m).filter(|&i| pinv[i] < 0).collect();
+                    debug_assert_eq!(bump_rows.len(), m - bump_lo);
+                    // Rows still unpivoted include the back block; keep only the
+                    // ones whose column position lands in the bump. A back row's
+                    // sole entry is in its own back column, so it is exactly the
+                    // rows appearing in bump columns that matter — but the
+                    // cheapest exact test is structural: a bump row is one with
+                    // an entry in some bump column.
+                    let mut in_bump = vec![false; m];
+                    for &qj in &qcol[bump_lo..bump_hi] {
+                        let (rows, _) = a.column(qj);
+                        for &i in rows.iter() {
+                            if pinv[i] < 0 {
+                                in_bump[i] = true;
+                            }
+                        }
+                    }
+                    bump_rows.retain(|&i| in_bump[i]);
+                }
+                if front_l_empty && bump_rows.len() == bump_dim {
+                    factor_bump_dense(
+                        a,
+                        &qcol,
+                        &bump_rows,
+                        bump_lo,
+                        bump_hi,
+                        &mut pinv,
+                        &mut perm,
+                        &mut u_diag,
+                        &mut u_col_ptr,
+                        &mut u_row_idx,
+                        &mut u_val,
+                        &mut l_col_ptr,
+                        &mut l_row_idx,
+                        &mut l_val,
+                        a_max,
+                        &params,
+                    )?;
+                    reach_visits += bump_dim * (bump_dim - 1) / 2;
+                    dense_done = true;
+                    k = bump_hi;
+                    continue;
+                }
+                // Otherwise fall through to the sparse path for the whole bump.
+            }
+
             // Scatter A(:, qcol[k]) into w.
             let (rows, vals) = a.column(qcol[k]);
             for (&i, &v) in rows.iter().zip(vals.iter()) {
@@ -460,6 +545,7 @@ impl SparseLu {
                 mark[i] = false;
             }
             touched.clear();
+            k += 1;
         }
 
         // Remap L's stored original rows to pivot positions, then sort columns.
@@ -525,6 +611,8 @@ impl SparseLu {
             u_max0,
             a_max,
             reach_visits,
+            used_dense_bump: dense_done,
+            bump_dim,
             params,
             scale,
             scale_rperm_inv,
@@ -578,6 +666,16 @@ impl SparseLu {
     }
 
     /// Total stored nonzeros in `L` and `U` (including the `U` diagonal).
+    /// Whether the bump was factored by the dense kernel on this call.
+    pub fn used_dense_bump(&self) -> bool {
+        self.used_dense_bump
+    }
+
+    /// Dimension of the residual bump left by triangularization.
+    pub fn bump_dim(&self) -> usize {
+        self.bump_dim
+    }
+
     pub fn factor_nnz(&self) -> usize {
         self.l_val.len() + self.u_rows.iter().map(|r| r.len()).sum::<usize>()
     }
@@ -769,4 +867,116 @@ fn remap_and_sort_l(
         row_idx[s..e].copy_from_slice(&rows);
         val[s..e].copy_from_slice(&vals);
     }
+}
+
+/// Factor the post-triangularization bump with the dense kernel and emit its
+/// `L`/`U` into the sparse builders, in pivot-position order.
+///
+/// Preconditions (checked by the caller): every position `< bump_lo` is a peeled
+/// singleton that produced an empty `L` column, so `L` is the identity above the
+/// bump and the bump block of `L⁻¹A` equals the bump block of `A`. That is what
+/// lets the block be factored in isolation.
+///
+/// `a` is the already-scaled matrix; `factorize_packed` does no scaling of its
+/// own, so the two paths stay in the same units.
+#[allow(clippy::too_many_arguments)]
+fn factor_bump_dense(
+    a: &SparseColMatrix,
+    qcol: &[usize],
+    bump_rows: &[usize],
+    bump_lo: usize,
+    bump_hi: usize,
+    pinv: &mut [isize],
+    perm: &mut [usize],
+    u_diag: &mut [f64],
+    u_col_ptr: &mut Vec<usize>,
+    u_row_idx: &mut Vec<usize>,
+    u_val: &mut Vec<f64>,
+    l_col_ptr: &mut Vec<usize>,
+    l_row_idx: &mut Vec<usize>,
+    l_val: &mut Vec<f64>,
+    a_max: f64,
+    params: &LuParams,
+) -> Result<(), FeralError> {
+    let m = a.m;
+    let b = bump_hi - bump_lo;
+
+    // Local row coordinates for the block.
+    let mut local = vec![usize::MAX; m];
+    for (n, &i) in bump_rows.iter().enumerate() {
+        local[i] = n;
+    }
+
+    // Pack the block column-major, and stash each bump column's entries that
+    // live in already-pivoted (front) rows — those are `U` entries above the
+    // bump and are copied straight through, since `L` is the identity there.
+    let mut packed = vec![0.0_f64; b * b];
+    let mut above: Vec<Vec<(usize, f64)>> = vec![Vec::new(); b];
+    let mut bump_a_max = 0.0_f64;
+    for jj in 0..b {
+        let (rows, vals) = a.column(qcol[bump_lo + jj]);
+        for (&i, &v) in rows.iter().zip(vals.iter()) {
+            let li = local[i];
+            if li != usize::MAX {
+                packed[li + jj * b] = v;
+                bump_a_max = bump_a_max.max(v.abs());
+            } else {
+                let p = pinv[i];
+                debug_assert!(p >= 0, "bump column touches an unpivoted non-bump row");
+                if p >= 0 {
+                    above[jj].push((p as usize, v));
+                }
+            }
+        }
+        // The sparse path emits each column's `U` entries in ascending pivot
+        // position; front pivot positions come out of `pinv` unordered.
+        above[jj].sort_unstable_by_key(|&(p, _)| p);
+    }
+
+    // Keep singularity detection identical to the sparse path, which measures
+    // `ztol` against the whole matrix: `factorize_packed` scales `zero_pivot_tol`
+    // by the *block's* max, so pre-divide to cancel that out.
+    let mut bparams = params.clone();
+    if bump_a_max > 0.0 {
+        bparams.zero_pivot_tol = params.zero_pivot_tol * a_max / bump_a_max;
+    }
+    let mut dperm: Vec<usize> = (0..b).collect();
+    super::dense_factor::factorize_packed(&mut packed, &mut dperm, b, &bparams)?;
+
+    // `dperm[n]` is the local row now in local pivot position `n`.
+    for n in 0..b {
+        let orig = bump_rows[dperm[n]];
+        perm[bump_lo + n] = orig;
+        pinv[orig] = (bump_lo + n) as isize;
+    }
+
+    // Emit column by column, in pivot-position order. `packed[i + j*b]` holds
+    // `U` for `i <= j` and strict `L` for `i > j` (unit diagonal implicit) — the
+    // same in-place convention `split_packed` reads.
+    for jj in 0..b {
+        for &(p, v) in above[jj].iter() {
+            u_row_idx.push(p);
+            u_val.push(v);
+        }
+        for n in 0..jj {
+            let v = packed[n + jj * b];
+            if v != 0.0 {
+                u_row_idx.push(bump_lo + n);
+                u_val.push(v);
+            }
+        }
+        u_col_ptr.push(u_row_idx.len());
+        u_diag[bump_lo + jj] = packed[jj + jj * b];
+
+        for n in (jj + 1)..b {
+            let v = packed[n + jj * b];
+            if v != 0.0 {
+                // Original row: remapped to a pivot position after the loop.
+                l_row_idx.push(bump_rows[dperm[n]]);
+                l_val.push(v);
+            }
+        }
+        l_col_ptr.push(l_row_idx.len());
+    }
+    Ok(())
 }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -941,7 +941,21 @@ fn factor_bump_dense(
         bparams.zero_pivot_tol = params.zero_pivot_tol * a_max / bump_a_max;
     }
     let mut dperm: Vec<usize> = (0..b).collect();
-    super::dense_factor::factorize_packed(&mut packed, &mut dperm, b, &bparams)?;
+    // `factorize_packed` names the *block-local* column in `SingularBasis`;
+    // local column `jj` is basis column `qcol[bump_lo + jj]`. Without this remap
+    // the two routes report different columns for the same singular basis (the
+    // sparse path emits `qcol[k]` throughout), and a simplex driver — which
+    // knows original basis columns, not internal positions — would repair the
+    // wrong one. Same contract as
+    // `tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position`.
+    super::dense_factor::factorize_packed(&mut packed, &mut dperm, b, &bparams).map_err(
+        |e| match e {
+            FeralError::SingularBasis { column } if column < b => FeralError::SingularBasis {
+                column: qcol[bump_lo + column],
+            },
+            other => other,
+        },
+    )?;
 
     // `dperm[n]` is the local row now in local pivot position `n`.
     for n in 0..b {

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -294,7 +294,28 @@ impl SparseLu {
         let bump_lo = symbolic.bump_lo;
         let bump_hi = symbolic.bump_hi;
         let bump_dim = bump_hi.saturating_sub(bump_lo);
-        let want_dense_bump = bump_dim >= 2
+        // Two guards, because "bump == whole basis" arises two ways and only one
+        // of them is a bump.
+        //
+        // 1. `natural`, `with_order` and `analyze_amd_only` claim `(0, m)`
+        //    without ever triangularizing. Their "bump" is a default, not a
+        //    measurement, so they are never eligible.
+        // 2. `analyze` reports `(0, m)` when a basis has nothing to peel. That
+        //    *is* a measurement, but it says the peel failed to expose anything
+        //    — so the argument for the dense kernel does not apply. The reason a
+        //    peeled bump's factor is dense is that the peel already stripped the
+        //    structure and left the irreducible core; with nothing stripped,
+        //    ordinary sparsity still governs. Such a basis may go dense only
+        //    within `dense_threshold`, the bound that governs whole-basis dense
+        //    decisions (and which weighs density, not just dimension).
+        //
+        // Without guard 2 a `natural`-ordered *or* unpeelable tridiagonal
+        // 3000x3000 under the cap goes 1.06 ms -> 100.1 ms and allocates a
+        // 72 MB `m²` buffer.
+        let peeled = bump_lo > 0 || bump_hi < m;
+        let want_dense_bump = symbolic.triangularized
+            && (peeled || bump_dim <= params.dense_threshold)
+            && bump_dim >= 2
             && params.dense_bump_max_dim > 0
             && bump_dim <= params.dense_bump_max_dim
             && bump_hi <= m;

--- a/src/lu/sparse_symbolic.rs
+++ b/src/lu/sparse_symbolic.rs
@@ -1,12 +1,24 @@
 //! Symbolic analysis for the sparse LU: the fill-reducing column ordering `Q`.
 //!
-//! Reuses feral's in-tree AMD (`feral_amd`) on the `AᵀA` (column-intersection)
-//! pattern — a stand-in for COLAMD that needs no new ordering algorithm. The
-//! resulting permutation is the reusable symbolic handle: across numerically
+//! Two stages, in the order every production LP INVERT runs them:
+//!
+//! 1. **Triangularization** ([`super::sparse_triangular`]) — peel column and row
+//!    singletons to fixpoint. Their pivots are structurally forced and their
+//!    blocks are upper triangular, so they need no ordering at all.
+//! 2. **Fill-reducing ordering of the residual bump** — feral's in-tree AMD
+//!    (`feral_amd`) on the bump's `AᵀA` (column-intersection) pattern, a
+//!    stand-in for COLAMD that needs no new ordering algorithm.
+//!
+//! Running AMD on the bump instead of the whole basis is where the win is: AMD
+//! is superlinear in the matrix it is handed, and a simplex basis is typically
+//! 85–100% peelable (see [`super::sparse_triangular`]).
+//!
+//! The resulting permutation is the reusable symbolic handle: across numerically
 //! different but structurally identical bases, only the numeric factor is
-//! recomputed.
+//! recomputed. Both stages read only the pattern, so that contract is unchanged.
 
 use super::sparse_matrix::SparseColMatrix;
+use super::sparse_triangular::triangularize;
 use crate::error::FeralError;
 
 /// Reusable symbolic factorization: the column permutation `Q`.
@@ -19,50 +31,256 @@ pub struct SparseLuSymbolic {
     pub qcol: Vec<usize>,
     /// Inverse: `qcol_inv[original_col] = column_position`.
     pub qcol_inv: Vec<usize>,
+    /// First pivot position of the residual bump after triangularization.
+    /// Positions `< bump_lo` are column singletons; positions `>= bump_hi` are
+    /// row singletons. Both peeled blocks factor exactly, with an empty `L`
+    /// column and no arithmetic.
+    pub bump_lo: usize,
+    /// One past the last pivot position of the residual bump.
+    pub bump_hi: usize,
 }
 
 impl SparseLuSymbolic {
-    /// Compute the column ordering via AMD on the `AᵀA` pattern.
+    /// Triangularize, then order the residual bump with AMD.
     pub fn analyze(a: &SparseColMatrix) -> Result<Self, FeralError> {
         let m = a.m;
         if m == 0 {
-            return Ok(SparseLuSymbolic {
-                m,
-                qcol: Vec::new(),
-                qcol_inv: Vec::new(),
-            });
+            return Ok(Self::empty());
         }
-        let pat = a.ata_pattern();
-        let col_ptr: Vec<i32> = pat
-            .col_ptr
-            .iter()
-            .map(|&x| i32::try_from(x))
-            .collect::<Result<_, _>>()
-            .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
-        let row_idx: Vec<i32> = pat
-            .row_idx
-            .iter()
-            .map(|&x| i32::try_from(x))
-            .collect::<Result<_, _>>()
-            .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
-        let cpat = feral_ordering_core::CscPattern::new(m, &col_ptr, &row_idx)
-            .ok_or_else(|| FeralError::InvalidInput("malformed AᵀA pattern".to_string()))?;
-        let perm = feral_amd::amd_order(&cpat)
-            .map_err(|e| FeralError::InvalidInput(format!("AMD ordering failed: {:?}", e)))?;
-        let qcol: Vec<usize> = perm.iter().map(|&x| x as usize).collect();
-        let mut qcol_inv = vec![0usize; m];
-        for (k, &q) in qcol.iter().enumerate() {
-            qcol_inv[q] = k;
+        let t = triangularize(a);
+        let bump = t.bump_hi - t.bump_lo;
+
+        let mut qcol = t.cols;
+        if bump > 1 {
+            // Order only the bump. `sub` is the bump in local 0..bump
+            // coordinates; AMD's permutation is mapped back to original columns.
+            let sub = submatrix(a, &qcol[t.bump_lo..t.bump_hi], &t.bump_rows);
+            let perm = amd_permutation(&sub)?;
+            let local: Vec<usize> = qcol[t.bump_lo..t.bump_hi].to_vec();
+            for (n, &p) in perm.iter().enumerate() {
+                qcol[t.bump_lo + n] = local[p];
+            }
         }
-        Ok(SparseLuSymbolic { m, qcol, qcol_inv })
+
+        Ok(Self::from_qcol(m, qcol, t.bump_lo, t.bump_hi))
+    }
+
+    /// AMD over the whole basis, with no triangularization — feral's pre-0.16
+    /// behavior. Retained so the two orderings can be compared directly in
+    /// benchmarks and differential tests; [`Self::analyze`] is the one to use.
+    pub fn analyze_amd_only(a: &SparseColMatrix) -> Result<Self, FeralError> {
+        let m = a.m;
+        if m == 0 {
+            return Ok(Self::empty());
+        }
+        let qcol = amd_permutation(a)?;
+        Ok(Self::from_qcol(m, qcol, 0, m))
     }
 
     /// Identity column ordering (natural order) — for testing and as a fallback.
     pub fn natural(m: usize) -> Self {
+        Self::from_qcol(m, (0..m).collect(), 0, m)
+    }
+
+    /// Build a handle from an explicit column order, claiming no triangular
+    /// structure (the whole matrix is treated as bump). For callers supplying
+    /// their own ordering; `qcol` must be a permutation of `0..m`.
+    pub fn with_order(m: usize, qcol: Vec<usize>) -> Result<Self, FeralError> {
+        if qcol.len() != m {
+            return Err(FeralError::DimensionMismatch {
+                expected: m,
+                got: qcol.len(),
+            });
+        }
+        let mut seen = vec![false; m];
+        for &q in qcol.iter() {
+            if q >= m || seen[q] {
+                return Err(FeralError::InvalidInput(
+                    "column order is not a permutation".to_string(),
+                ));
+            }
+            seen[q] = true;
+        }
+        Ok(Self::from_qcol(m, qcol, 0, m))
+    }
+
+    fn empty() -> Self {
+        SparseLuSymbolic {
+            m: 0,
+            qcol: Vec::new(),
+            qcol_inv: Vec::new(),
+            bump_lo: 0,
+            bump_hi: 0,
+        }
+    }
+
+    fn from_qcol(m: usize, qcol: Vec<usize>, bump_lo: usize, bump_hi: usize) -> Self {
+        let mut qcol_inv = vec![0usize; m];
+        for (k, &q) in qcol.iter().enumerate() {
+            qcol_inv[q] = k;
+        }
         SparseLuSymbolic {
             m,
-            qcol: (0..m).collect(),
-            qcol_inv: (0..m).collect(),
+            qcol,
+            qcol_inv,
+            bump_lo,
+            bump_hi,
         }
+    }
+}
+
+/// AMD on the `AᵀA` (column-intersection) pattern of `a`.
+fn amd_permutation(a: &SparseColMatrix) -> Result<Vec<usize>, FeralError> {
+    let m = a.m;
+    let pat = a.ata_pattern();
+    let col_ptr: Vec<i32> = pat
+        .col_ptr
+        .iter()
+        .map(|&x| i32::try_from(x))
+        .collect::<Result<_, _>>()
+        .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
+    let row_idx: Vec<i32> = pat
+        .row_idx
+        .iter()
+        .map(|&x| i32::try_from(x))
+        .collect::<Result<_, _>>()
+        .map_err(|_| FeralError::InvalidInput("AᵀA pattern index overflow".to_string()))?;
+    let cpat = feral_ordering_core::CscPattern::new(m, &col_ptr, &row_idx)
+        .ok_or_else(|| FeralError::InvalidInput("malformed AᵀA pattern".to_string()))?;
+    let perm = feral_amd::amd_order(&cpat)
+        .map_err(|e| FeralError::InvalidInput(format!("AMD ordering failed: {:?}", e)))?;
+    Ok(perm.iter().map(|&x| x as usize).collect())
+}
+
+/// Extract the square submatrix `a[rows, cols]` in local `0..cols.len()`
+/// coordinates. `rows` must be ascending; `cols` may be in any order.
+fn submatrix(a: &SparseColMatrix, cols: &[usize], rows: &[usize]) -> SparseColMatrix {
+    let b = cols.len();
+    let mut local_row = vec![usize::MAX; a.m];
+    for (n, &i) in rows.iter().enumerate() {
+        local_row[i] = n;
+    }
+    let mut col_ptr = Vec::with_capacity(b + 1);
+    let mut row_idx: Vec<usize> = Vec::new();
+    let mut values: Vec<f64> = Vec::new();
+    col_ptr.push(0);
+    for &j in cols.iter() {
+        let start = row_idx.len();
+        for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let li = local_row[a.row_idx[idx]];
+            if li != usize::MAX {
+                row_idx.push(li);
+                values.push(a.values[idx]);
+            }
+        }
+        // `rows` is ascending and the source column is row-ascending, so the
+        // emitted slice is already ascending — `SparseColMatrix`'s invariant.
+        debug_assert!(row_idx[start..].windows(2).all(|w| w[0] < w[1]));
+        col_ptr.push(row_idx.len());
+    }
+    SparseColMatrix {
+        m: b,
+        col_ptr,
+        row_idx,
+        values,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mat(m: usize, entries: &[(usize, usize, f64)]) -> SparseColMatrix {
+        let mut trip = entries.to_vec();
+        trip.sort_by_key(|&(i, j, _)| (j, i));
+        let mut col_ptr = vec![0usize; m + 1];
+        for &(_, j, _) in &trip {
+            col_ptr[j + 1] += 1;
+        }
+        for j in 0..m {
+            col_ptr[j + 1] += col_ptr[j];
+        }
+        SparseColMatrix {
+            m,
+            col_ptr,
+            row_idx: trip.iter().map(|&(i, _, _)| i).collect(),
+            values: trip.iter().map(|&(_, _, v)| v).collect(),
+        }
+    }
+
+    #[test]
+    fn qcol_is_a_permutation_and_inverse_agrees() {
+        let a = mat(
+            5,
+            &[
+                (0, 0, 2.0),
+                (1, 0, 1.0),
+                (1, 1, 3.0),
+                (2, 2, 1.0),
+                (2, 3, 4.0),
+                (3, 2, 5.0),
+                (3, 3, 1.0),
+                (4, 4, 7.0),
+                (4, 2, 2.0),
+            ],
+        );
+        let s = SparseLuSymbolic::analyze(&a).expect("analyze");
+        assert_eq!(s.m, 5);
+        let mut seen = [false; 5];
+        for &j in s.qcol.iter() {
+            assert!(!seen[j]);
+            seen[j] = true;
+        }
+        assert!(seen.iter().all(|&x| x));
+        for (k, &q) in s.qcol.iter().enumerate() {
+            assert_eq!(s.qcol_inv[q], k);
+        }
+        assert!(s.bump_lo <= s.bump_hi && s.bump_hi <= 5);
+    }
+
+    #[test]
+    fn triangular_basis_has_an_empty_bump() {
+        let m = 8;
+        let e: Vec<(usize, usize, f64)> = (0..m)
+            .flat_map(|j| (j..m).map(move |i| (i, j, if i == j { 2.0 } else { 1.0 })))
+            .collect();
+        let a = mat(m, &e);
+        let s = SparseLuSymbolic::analyze(&a).expect("analyze");
+        assert_eq!(
+            s.bump_hi - s.bump_lo,
+            0,
+            "triangular basis must leave no bump"
+        );
+    }
+
+    #[test]
+    fn amd_only_marks_the_whole_matrix_as_bump() {
+        let m = 6;
+        let e: Vec<(usize, usize, f64)> = (0..m)
+            .flat_map(|j| (j..m).map(move |i| (i, j, if i == j { 2.0 } else { 1.0 })))
+            .collect();
+        let a = mat(m, &e);
+        let s = SparseLuSymbolic::analyze_amd_only(&a).expect("analyze");
+        assert_eq!((s.bump_lo, s.bump_hi), (0, m));
+    }
+
+    #[test]
+    fn submatrix_extracts_the_bump() {
+        let a = mat(
+            4,
+            &[
+                (0, 0, 1.0),
+                (1, 1, 2.0),
+                (2, 1, 3.0),
+                (1, 2, 4.0),
+                (2, 2, 5.0),
+                (3, 3, 6.0),
+            ],
+        );
+        let s = submatrix(&a, &[1, 2], &[1, 2]);
+        assert_eq!(s.m, 2);
+        assert_eq!(s.col_ptr, vec![0, 2, 4]);
+        assert_eq!(s.row_idx, vec![0, 1, 0, 1]);
+        assert_eq!(s.values, vec![2.0, 3.0, 4.0, 5.0]);
     }
 }

--- a/src/lu/sparse_symbolic.rs
+++ b/src/lu/sparse_symbolic.rs
@@ -38,6 +38,19 @@ pub struct SparseLuSymbolic {
     pub bump_lo: usize,
     /// One past the last pivot position of the residual bump.
     pub bump_hi: usize,
+    /// Whether triangularization actually ran, i.e. whether `bump_lo`/`bump_hi`
+    /// are a *measured* peel rather than the "no structure known" default.
+    ///
+    /// [`Self::analyze`] sets this; [`Self::natural`], [`Self::with_order`] and
+    /// [`Self::analyze_amd_only`] do not — they claim `(0, m)` because they
+    /// never looked, not because they looked and found the whole basis
+    /// irreducible. The two cases are indistinguishable from the indices alone,
+    /// and they warrant opposite answers from
+    /// [`LuParams::dense_bump_max_dim`](super::LuParams::dense_bump_max_dim):
+    /// an `analyze`d basis that peels to nothing really is a dense block worth
+    /// the dense kernel, while an unpeeled `natural` ordering of a large sparse
+    /// basis is the pathological case that route must never take.
+    pub triangularized: bool,
 }
 
 impl SparseLuSymbolic {
@@ -62,7 +75,7 @@ impl SparseLuSymbolic {
             }
         }
 
-        Ok(Self::from_qcol(m, qcol, t.bump_lo, t.bump_hi))
+        Ok(Self::from_qcol(m, qcol, t.bump_lo, t.bump_hi, true))
     }
 
     /// AMD over the whole basis, with no triangularization — feral's pre-0.16
@@ -74,12 +87,12 @@ impl SparseLuSymbolic {
             return Ok(Self::empty());
         }
         let qcol = amd_permutation(a)?;
-        Ok(Self::from_qcol(m, qcol, 0, m))
+        Ok(Self::from_qcol(m, qcol, 0, m, false))
     }
 
     /// Identity column ordering (natural order) — for testing and as a fallback.
     pub fn natural(m: usize) -> Self {
-        Self::from_qcol(m, (0..m).collect(), 0, m)
+        Self::from_qcol(m, (0..m).collect(), 0, m, false)
     }
 
     /// Build a handle from an explicit column order, claiming no triangular
@@ -101,7 +114,7 @@ impl SparseLuSymbolic {
             }
             seen[q] = true;
         }
-        Ok(Self::from_qcol(m, qcol, 0, m))
+        Ok(Self::from_qcol(m, qcol, 0, m, false))
     }
 
     fn empty() -> Self {
@@ -111,10 +124,17 @@ impl SparseLuSymbolic {
             qcol_inv: Vec::new(),
             bump_lo: 0,
             bump_hi: 0,
+            triangularized: true,
         }
     }
 
-    fn from_qcol(m: usize, qcol: Vec<usize>, bump_lo: usize, bump_hi: usize) -> Self {
+    fn from_qcol(
+        m: usize,
+        qcol: Vec<usize>,
+        bump_lo: usize,
+        bump_hi: usize,
+        triangularized: bool,
+    ) -> Self {
         let mut qcol_inv = vec![0usize; m];
         for (k, &q) in qcol.iter().enumerate() {
             qcol_inv[q] = k;
@@ -125,6 +145,7 @@ impl SparseLuSymbolic {
             qcol_inv,
             bump_lo,
             bump_hi,
+            triangularized,
         }
     }
 }

--- a/src/lu/sparse_triangular.rs
+++ b/src/lu/sparse_triangular.rs
@@ -1,0 +1,349 @@
+//! Suhl & Suhl (1990) basis triangularization: the structural pre-pass every
+//! production LP INVERT runs before ordering a basis.
+//!
+//! A simplex basis is overwhelmingly triangular. Peeling **column singletons**
+//! (a column with one nonzero: its pivot is forced) to the front and **row
+//! singletons** (a row with one nonzero) to the back, to fixpoint, leaves a
+//! small residual **bump** that is the only part needing a general fill-reducing
+//! ordering and a general factorization.
+//!
+//! Writing `F` for the front (column-singleton) positions, `B` for the bump and
+//! `K` for the back (row-singleton) positions, the permuted matrix is
+//!
+//! ```text
+//!           [ U_FF  U_FB  U_FK ]              [ I   0   0 ]
+//! P A Q  =  [  0    Bump  U_BK ]     with L = [ 0  L_B  0 ]
+//!           [  0     0    U_KK ]              [ 0   0   I ]
+//! ```
+//!
+//! Both peeled blocks are **upper triangular**, so `L` is the identity there:
+//! a peeled pivot performs no elimination and introduces no rounding. Only
+//! `Bump` needs `AMD` and Gilbert–Peierls.
+//!
+//! Why this matters (discopt#1008): on a QPLIB simplex basis (`m = 3937`,
+//! `nnz = 28204`) the peel removes **85.6%** of the columns in 0.148 ms and
+//! leaves a 566×566 bump, cutting the AMD ordering from 9.65 ms to 0.65 ms.
+//! Measured over 104 refactorizations of that solve, and across a
+//! manifest-sampled class of QPLIB instances with `m` from 102 to 20 978, the
+//! peel removes 84.8–100% of columns and the bump never exceeds 16% of `m`.
+//!
+//! The pass is purely **structural** — it reads only the pattern, never the
+//! values — so a [`SparseLuSymbolic`](super::sparse_symbolic::SparseLuSymbolic)
+//! computed from one basis stays valid for any numerically different basis with
+//! the same pattern, exactly as before.
+//!
+//! Reference: U. H. Suhl and L. M. Suhl, "Computing sparse LU factorizations
+//! for large-scale linear programming bases", *ORSA Journal on Computing* 2(4),
+//! 325–335 (1990).
+
+use super::sparse_matrix::SparseColMatrix;
+
+/// The result of the structural peel.
+#[derive(Debug, Clone)]
+pub(super) struct Triangularization {
+    /// Original columns in pivot order: front block, then bump, then back block.
+    /// The bump columns are in arbitrary (discovery) order here — the caller
+    /// replaces that span with a fill-reducing ordering.
+    pub cols: Vec<usize>,
+    /// First position of the bump within `cols`.
+    pub bump_lo: usize,
+    /// One past the last position of the bump within `cols`.
+    pub bump_hi: usize,
+    /// Original rows of the bump, ascending. Length `bump_hi - bump_lo`.
+    pub bump_rows: Vec<usize>,
+}
+
+impl Triangularization {
+    /// Number of columns removed by the peel.
+    #[cfg(test)]
+    pub fn peeled(&self) -> usize {
+        self.cols.len() - (self.bump_hi - self.bump_lo)
+    }
+}
+
+/// Peel column and row singletons to fixpoint.
+///
+/// `O(nnz)`: each entry is visited a bounded number of times (once when the
+/// row-wise transpose is built, once when its row dies, once when its column
+/// dies).
+pub(super) fn triangularize(a: &SparseColMatrix) -> Triangularization {
+    let m = a.m;
+    if m == 0 {
+        return Triangularization {
+            cols: Vec::new(),
+            bump_lo: 0,
+            bump_hi: 0,
+            bump_rows: Vec::new(),
+        };
+    }
+
+    // Row-wise view (CSR), so a dying row can find its columns in O(nnz(row)).
+    let nnz = a.row_idx.len();
+    let mut row_ptr = vec![0usize; m + 1];
+    for &i in a.row_idx.iter() {
+        row_ptr[i + 1] += 1;
+    }
+    for i in 0..m {
+        row_ptr[i + 1] += row_ptr[i];
+    }
+    let mut row_cols = vec![0usize; nnz];
+    {
+        let mut fill = row_ptr.clone();
+        for j in 0..m {
+            for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+                let i = a.row_idx[idx];
+                row_cols[fill[i]] = j;
+                fill[i] += 1;
+            }
+        }
+    }
+
+    // Live-entry counts. A column's count drops when one of its rows dies; a
+    // row's count drops when one of its columns dies.
+    let mut col_nnz: Vec<usize> = (0..m).map(|j| a.col_ptr[j + 1] - a.col_ptr[j]).collect();
+    let mut row_nnz: Vec<usize> = (0..m).map(|i| row_ptr[i + 1] - row_ptr[i]).collect();
+    let mut row_dead = vec![false; m];
+    let mut col_dead = vec![false; m];
+
+    let mut front: Vec<usize> = Vec::new(); // columns, in peel order
+    let mut back: Vec<usize> = Vec::new(); // columns, in peel order (reversed later)
+
+    let mut colq: Vec<usize> = (0..m).filter(|&j| col_nnz[j] == 1).collect();
+    let mut rowq: Vec<usize> = (0..m).filter(|&i| row_nnz[i] == 1).collect();
+
+    while !colq.is_empty() || !rowq.is_empty() {
+        // Column singletons first: their pivot is the original matrix entry and
+        // they cost nothing, so taking them early shrinks the bump fastest.
+        while let Some(j) = colq.pop() {
+            if col_dead[j] || col_nnz[j] != 1 {
+                continue;
+            }
+            // The one live row of column j.
+            let Some(i) = (a.col_ptr[j]..a.col_ptr[j + 1])
+                .map(|idx| a.row_idx[idx])
+                .find(|&i| !row_dead[i])
+            else {
+                continue; // structurally singular column; leave it to the bump
+            };
+            col_dead[j] = true;
+            row_dead[i] = true;
+            front.push(j);
+            // Row i died: every live column holding an entry in row i loses one.
+            for &jj in &row_cols[row_ptr[i]..row_ptr[i + 1]] {
+                if !col_dead[jj] {
+                    col_nnz[jj] -= 1;
+                    if col_nnz[jj] == 1 {
+                        colq.push(jj);
+                    }
+                }
+            }
+            // Column j died: every live row holding an entry in column j loses
+            // one. (Only dead rows remain, but rows can also be live-but-later
+            // if `col_nnz` was stale; the guard keeps the counts exact.)
+            for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+                let ii = a.row_idx[idx];
+                if !row_dead[ii] {
+                    row_nnz[ii] -= 1;
+                    if row_nnz[ii] == 1 {
+                        rowq.push(ii);
+                    }
+                }
+            }
+        }
+
+        if let Some(i) = rowq.pop() {
+            if row_dead[i] || row_nnz[i] != 1 {
+                continue;
+            }
+            let Some(j) = (row_ptr[i]..row_ptr[i + 1])
+                .map(|idx| row_cols[idx])
+                .find(|&j| !col_dead[j])
+            else {
+                continue; // structurally singular row; leave it to the bump
+            };
+            row_dead[i] = true;
+            col_dead[j] = true;
+            back.push(j);
+            for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+                let ii = a.row_idx[idx];
+                if !row_dead[ii] {
+                    row_nnz[ii] -= 1;
+                    if row_nnz[ii] == 1 {
+                        rowq.push(ii);
+                    }
+                }
+            }
+            for &jj in &row_cols[row_ptr[i]..row_ptr[i + 1]] {
+                if !col_dead[jj] {
+                    col_nnz[jj] -= 1;
+                    if col_nnz[jj] == 1 {
+                        colq.push(jj);
+                    }
+                }
+            }
+        }
+    }
+
+    let bump_cols: Vec<usize> = (0..m).filter(|&j| !col_dead[j]).collect();
+    let bump_rows: Vec<usize> = (0..m).filter(|&i| !row_dead[i]).collect();
+    debug_assert_eq!(bump_cols.len(), bump_rows.len());
+
+    let bump_lo = front.len();
+    let bump_hi = bump_lo + bump_cols.len();
+    let mut cols = front;
+    cols.extend_from_slice(&bump_cols);
+    // Back columns were peeled outermost-last, so they occupy descending
+    // positions: the first one peeled sits at the very end.
+    cols.extend(back.into_iter().rev());
+    debug_assert_eq!(cols.len(), m);
+
+    Triangularization {
+        cols,
+        bump_lo,
+        bump_hi,
+        bump_rows,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mat(m: usize, entries: &[(usize, usize)]) -> SparseColMatrix {
+        let mut trip: Vec<(usize, usize, f64)> = entries
+            .iter()
+            .map(|&(i, j)| (i, j, 1.0 + i as f64))
+            .collect();
+        trip.sort_by_key(|&(i, j, _)| (j, i));
+        let mut col_ptr = vec![0usize; m + 1];
+        for &(_, j, _) in &trip {
+            col_ptr[j + 1] += 1;
+        }
+        for j in 0..m {
+            col_ptr[j + 1] += col_ptr[j];
+        }
+        SparseColMatrix {
+            m,
+            col_ptr,
+            row_idx: trip.iter().map(|&(i, _, _)| i).collect(),
+            values: trip.iter().map(|&(_, _, v)| v).collect(),
+        }
+    }
+
+    /// The permuted matrix must be upper triangular everywhere outside the bump
+    /// — that is the property the factorization relies on. Checks every entry.
+    fn assert_block_triangular(a: &SparseColMatrix, t: &Triangularization) {
+        let m = a.m;
+        let mut rpos = vec![usize::MAX; m];
+        // Rows: front rows take the front positions in the same order their
+        // column was peeled; we do not track them explicitly, so instead assert
+        // the weaker-but-sufficient property the factor loop needs: outside the
+        // bump span each column has exactly one live row, and bump rows have no
+        // entries in front columns.
+        let bump_row: Vec<bool> = {
+            let mut v = vec![false; m];
+            for &i in t.bump_rows.iter() {
+                v[i] = true;
+            }
+            v
+        };
+        let mut checks = 0usize;
+        for k in 0..t.bump_lo {
+            let j = t.cols[k];
+            for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+                let i = a.row_idx[idx];
+                assert!(
+                    !bump_row[i],
+                    "bump row {i} has an entry in front column {j}"
+                );
+                checks += 1;
+            }
+        }
+        for (n, &i) in t.bump_rows.iter().enumerate() {
+            rpos[i] = t.bump_lo + n;
+        }
+        let _ = rpos;
+        assert!(checks > 0 || t.bump_lo == 0, "probe never fired");
+    }
+
+    #[test]
+    fn identity_is_fully_peeled() {
+        let a = mat(5, &[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]);
+        let t = triangularize(&a);
+        assert_eq!(t.peeled(), 5);
+        assert_eq!(t.bump_hi - t.bump_lo, 0);
+    }
+
+    #[test]
+    fn lower_triangular_is_fully_peeled() {
+        // Dense lower triangular: column m-1 is a singleton, peeling cascades.
+        let m = 6;
+        let e: Vec<(usize, usize)> = (0..m).flat_map(|j| (j..m).map(move |i| (i, j))).collect();
+        let a = mat(m, &e);
+        let t = triangularize(&a);
+        assert_eq!(t.peeled(), m, "a triangular basis must leave no bump");
+        assert_eq!(t.bump_hi - t.bump_lo, 0);
+        assert_block_triangular(&a, &t);
+    }
+
+    #[test]
+    fn upper_triangular_is_fully_peeled() {
+        let m = 6;
+        let e: Vec<(usize, usize)> = (0..m).flat_map(|j| (0..=j).map(move |i| (i, j))).collect();
+        let a = mat(m, &e);
+        let t = triangularize(&a);
+        assert_eq!(t.peeled(), m);
+    }
+
+    #[test]
+    fn dense_matrix_is_all_bump() {
+        let m = 4;
+        let e: Vec<(usize, usize)> = (0..m).flat_map(|j| (0..m).map(move |i| (i, j))).collect();
+        let a = mat(m, &e);
+        let t = triangularize(&a);
+        assert_eq!(t.peeled(), 0, "a dense matrix has no singleton to peel");
+        assert_eq!(t.bump_lo, 0);
+        assert_eq!(t.bump_hi, m);
+    }
+
+    #[test]
+    fn permutation_is_a_permutation() {
+        // A triangular border around a 3x3 dense bump.
+        let a = mat(
+            6,
+            &[
+                (0, 0),
+                (1, 0),
+                (1, 1),
+                (2, 2),
+                (2, 3),
+                (2, 4),
+                (3, 2),
+                (3, 3),
+                (3, 4),
+                (4, 2),
+                (4, 3),
+                (4, 4),
+                (5, 5),
+                (5, 2),
+            ],
+        );
+        let t = triangularize(&a);
+        let mut seen = [false; 6];
+        for &j in t.cols.iter() {
+            assert!(!seen[j], "column {j} appears twice");
+            seen[j] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "not all columns present");
+        assert_eq!(t.bump_hi - t.bump_lo, t.bump_rows.len());
+        assert_block_triangular(&a, &t);
+    }
+
+    #[test]
+    fn structurally_singular_matrix_does_not_panic() {
+        // Column 2 is empty; row 2 is empty.
+        let a = mat(3, &[(0, 0), (1, 1)]);
+        let t = triangularize(&a);
+        assert_eq!(t.cols.len(), 3);
+    }
+}

--- a/tests/lu_dense_bump.rs
+++ b/tests/lu_dense_bump.rs
@@ -1,0 +1,308 @@
+//! Differential test for the post-triangularization dense-bump route
+//! (`LuParams::dense_bump_max_dim`).
+//!
+//! The dense route factors the peeled bump with the blocked dense kernel and
+//! splices `L`/`U` back into the sparse structures. It must be
+//! *indistinguishable* from the sparse route in what it computes: same solves,
+//! same residuals, same singularity verdicts. These tests build matrices with a
+//! genuine triangular border around a dense bump — the LP-basis shape the route
+//! exists for — and check `A x = b` and `Aᵀ y = c` both ways.
+
+use feral::{FeralError, LuParams, LuSingularAction, SparseColMatrix, SparseLu, SparseLuSymbolic};
+
+/// Deterministic LCG — no rand dependency, and reproducible failures.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+    }
+    fn below(&mut self, n: usize) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 33) as usize) % n
+    }
+}
+
+fn build(m: usize, trip: &mut Vec<(usize, usize, f64)>) -> SparseColMatrix {
+    trip.sort_by_key(|&(i, j, _)| (j, i));
+    trip.dedup_by_key(|&mut (i, j, _)| (i, j));
+    let mut col_ptr = vec![0usize; m + 1];
+    for &(_, j, _) in trip.iter() {
+        col_ptr[j + 1] += 1;
+    }
+    for j in 0..m {
+        col_ptr[j + 1] += col_ptr[j];
+    }
+    SparseColMatrix {
+        m,
+        col_ptr,
+        row_idx: trip.iter().map(|&(i, _, _)| i).collect(),
+        values: trip.iter().map(|&(_, _, v)| v).collect(),
+    }
+}
+
+/// `nfront` column singletons, a dense `bump x bump` block, `nback` row
+/// singletons — a caricature of a simplex basis, permuted so nothing is in
+/// natural order.
+fn lp_like_basis(nfront: usize, bump: usize, nback: usize, seed: u64) -> SparseColMatrix {
+    let m = nfront + bump + nback;
+    let mut rng = Rng(seed);
+    // Scramble the identity of rows and columns.
+    let mut rows: Vec<usize> = (0..m).collect();
+    let mut cols: Vec<usize> = (0..m).collect();
+    for i in (1..m).rev() {
+        rows.swap(i, rng.below(i + 1));
+        cols.swap(i, rng.below(i + 1));
+    }
+    let mut trip: Vec<(usize, usize, f64)> = Vec::new();
+    // Front: column `cols[k]` has a single entry at row `rows[k]`.
+    for k in 0..nfront {
+        trip.push((rows[k], cols[k], 1.0 + rng.next_f64().abs()));
+    }
+    // Bump: dense block on rows/cols [nfront, nfront+bump).
+    for jj in 0..bump {
+        for ii in 0..bump {
+            let v = rng.next_f64();
+            let v = if ii == jj { v + 3.0 } else { v };
+            trip.push((rows[nfront + ii], cols[nfront + jj], v));
+        }
+    }
+    // Back: row `rows[k]` has a single entry, in column `cols[k]`.
+    for k in (nfront + bump)..m {
+        trip.push((rows[k], cols[k], 1.0 + rng.next_f64().abs()));
+    }
+    // Fill above the diagonal blocks: front rows may hold entries in bump and
+    // back columns (the `U_FB`/`U_FK` blocks), bump rows in back columns.
+    for &r in rows.iter().take(nfront) {
+        for _ in 0..3 {
+            let j = nfront + rng.below(bump + nback);
+            trip.push((r, cols[j], rng.next_f64()));
+        }
+    }
+    for ii in 0..bump {
+        for _ in 0..2 {
+            if nback == 0 {
+                break;
+            }
+            let j = nfront + bump + rng.below(nback);
+            trip.push((rows[nfront + ii], cols[j], rng.next_f64()));
+        }
+    }
+    build(m, &mut trip)
+}
+
+fn matvec(a: &SparseColMatrix, x: &[f64]) -> Vec<f64> {
+    let mut y = vec![0.0; a.m];
+    for (j, &xj) in x.iter().enumerate() {
+        for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+            y[a.row_idx[idx]] += a.values[idx] * xj;
+        }
+    }
+    y
+}
+
+fn matvec_t(a: &SparseColMatrix, x: &[f64]) -> Vec<f64> {
+    let mut y = vec![0.0; a.m];
+    for (j, yj) in y.iter_mut().enumerate() {
+        let mut s = 0.0;
+        for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+            s += a.values[idx] * x[a.row_idx[idx]];
+        }
+        *yj = s;
+    }
+    y
+}
+
+fn rel_resid(r: &[f64], b: &[f64]) -> f64 {
+    let nr = r.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
+    let nb = b.iter().fold(0.0_f64, |m, &x| m.max(x.abs())).max(1e-300);
+    nr / nb
+}
+
+/// Solve with both routes and return `(rel_ftran_resid, rel_btran_resid, bump)`.
+fn both_routes(
+    a: &SparseColMatrix,
+    max_dim: usize,
+    seed: u64,
+) -> (f64, f64, usize, Vec<f64>, bool) {
+    let m = a.m;
+    let sym = SparseLuSymbolic::analyze(a).expect("analyze");
+    let params = LuParams {
+        dense_bump_max_dim: max_dim,
+        ..LuParams::default()
+    };
+    let mut lu = SparseLu::factor(a, &sym, params).expect("factor");
+
+    let mut rng = Rng(seed);
+    let b: Vec<f64> = (0..m).map(|_| rng.next_f64()).collect();
+
+    let mut x = b.clone();
+    lu.ftran(&mut x).expect("ftran");
+    let ax = matvec(a, &x);
+    let rf: Vec<f64> = ax.iter().zip(b.iter()).map(|(p, q)| p - q).collect();
+
+    let mut y = b.clone();
+    lu.btran(&mut y).expect("btran");
+    let aty = matvec_t(a, &y);
+    let rb: Vec<f64> = aty.iter().zip(b.iter()).map(|(p, q)| p - q).collect();
+
+    (
+        rel_resid(&rf, &b),
+        rel_resid(&rb, &b),
+        sym.bump_hi - sym.bump_lo,
+        x,
+        lu.used_dense_bump(),
+    )
+}
+
+#[test]
+fn dense_bump_route_solves_as_accurately_as_the_sparse_route() {
+    let mut checked = 0usize;
+    for (nfront, bump, nback, seed) in [
+        (40usize, 12usize, 8usize, 1u64),
+        (100, 25, 30, 2),
+        (5, 40, 5, 3),
+        (200, 8, 0, 4),
+        (0, 16, 0, 5),
+        (60, 2, 60, 6),
+    ] {
+        let a = lp_like_basis(nfront, bump, nback, seed);
+        let (sf, sb, nb_s, xs, used_s) = both_routes(&a, 0, 99);
+        let (df, db, nb_d, xd, used_d) = both_routes(&a, 4096, 99);
+        // Rule 6: prove the route under test actually ran. Without this the
+        // whole comparison degrades to sparse-vs-sparse and passes vacuously.
+        assert!(!used_s, "the sparse arm must not take the dense route");
+        assert!(
+            used_d,
+            "the dense arm fell back to sparse (seed {seed}) - test is vacuous"
+        );
+        assert_eq!(nb_s, nb_d, "the peel must not depend on the numeric route");
+        assert!(
+            nb_d >= bump,
+            "expected a bump of at least {bump}, peel left {nb_d} (seed {seed})"
+        );
+        // Both routes must be backward stable. The dense route reorders the
+        // arithmetic, so the solutions differ in the last bits, not in value.
+        assert!(
+            sf < 1e-9 && sb < 1e-9,
+            "sparse route unstable: {sf:e} {sb:e}"
+        );
+        assert!(
+            df < 1e-9 && db < 1e-9,
+            "dense route unstable: {df:e} {db:e}"
+        );
+        let dx = xs
+            .iter()
+            .zip(xd.iter())
+            .fold(0.0_f64, |m, (p, q)| m.max((p - q).abs()));
+        let nx = xs.iter().fold(0.0_f64, |m, &v| m.max(v.abs())).max(1e-300);
+        assert!(
+            dx / nx < 1e-8,
+            "routes disagree on the solution: {:e} (seed {seed})",
+            dx / nx
+        );
+        checked += 1;
+    }
+    // discopt CLAUDE.md rule 6: an executed-assertion count, not a silent pass.
+    assert_eq!(checked, 6, "probe did not run every case");
+}
+
+#[test]
+fn dense_bump_route_is_off_by_default() {
+    let a = lp_like_basis(30, 10, 10, 7);
+    assert_eq!(
+        LuParams::default().dense_bump_max_dim,
+        0,
+        "the route must be opt-in"
+    );
+    let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+    assert!(lu.factor_nnz() > 0);
+}
+
+#[test]
+fn bump_above_the_cap_stays_on_the_sparse_route() {
+    let a = lp_like_basis(20, 30, 10, 8);
+    let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let bump = sym.bump_hi - sym.bump_lo;
+    assert!(bump > 4, "test needs a real bump, got {bump}");
+    // A cap below the bump must not take the route; the factorization must
+    // still be correct and identical to the plain sparse one.
+    let small = LuParams {
+        dense_bump_max_dim: bump - 1,
+        ..LuParams::default()
+    };
+    let a_lu = SparseLu::factor(&a, &sym, small).expect("factor");
+    let b_lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+    assert!(
+        !a_lu.used_dense_bump(),
+        "cap below the bump must not take the route"
+    );
+    assert!(!b_lu.used_dense_bump());
+    assert_eq!(
+        a_lu.factor_nnz(),
+        b_lu.factor_nnz(),
+        "a below-cap bump must be byte-identical to the sparse route"
+    );
+}
+
+#[test]
+fn singular_bump_is_reported_on_both_routes() {
+    // A bump with two identical columns is singular whichever kernel sees it.
+    let m = 12;
+    let mut trip: Vec<(usize, usize, f64)> = Vec::new();
+    for k in 0..4 {
+        trip.push((k, k, 2.0));
+    }
+    for jj in 0..8 {
+        for ii in 0..8 {
+            // Columns 4+6 and 4+7 are made identical below.
+            let v = if ii == jj {
+                3.0
+            } else {
+                0.5 + 0.01 * (ii + jj) as f64
+            };
+            trip.push((4 + ii, 4 + jj, v));
+        }
+    }
+    // Force column 11 to equal column 10.
+    for ii in 0..8 {
+        let v = trip
+            .iter()
+            .find(|&&(i, j, _)| i == 4 + ii && j == 10)
+            .map(|&(_, _, v)| v)
+            .expect("col 10 entry");
+        if let Some(e) = trip.iter_mut().find(|(i, j, _)| *i == 4 + ii && *j == 11) {
+            e.2 = v;
+        }
+    }
+    let a = build(m, &mut trip);
+    let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let base = LuParams {
+        on_singular: LuSingularAction::Fail,
+        ..LuParams::default()
+    };
+    let sparse = SparseLu::factor(&a, &sym, base.clone());
+    let dense = SparseLu::factor(
+        &a,
+        &sym,
+        LuParams {
+            dense_bump_max_dim: 4096,
+            ..base
+        },
+    );
+    assert!(
+        matches!(sparse, Err(FeralError::SingularBasis { .. })),
+        "sparse route missed a singular bump"
+    );
+    assert!(
+        matches!(dense, Err(FeralError::SingularBasis { .. })),
+        "dense route missed a singular bump: {dense:?}"
+    );
+}

--- a/tests/lu_dense_bump.rs
+++ b/tests/lu_dense_bump.rs
@@ -324,3 +324,74 @@ fn singular_bump_is_reported_on_both_routes() {
         "expected the duplicated column (10 or 11), got {sparse_col}"
     );
 }
+
+#[test]
+fn an_unpeeled_whole_basis_stays_on_the_sparse_route() {
+    // `dense_bump_max_dim` bounds a *residual bump*. A bump equal to the whole
+    // basis is not that, and it arises two ways: `natural`/`with_order`/
+    // `analyze_amd_only` report `(0, m)` without ever triangularizing, and
+    // `analyze` reports it when there is nothing to peel. Neither may route a
+    // whole sparse basis through the dense kernel — that would allocate an
+    // `m*m` f64 buffer and run the dense kernel over a tridiagonal.
+    //
+    // A tridiagonal has no row or column singletons, so it is unpeelable under
+    // every constructor, and `m` here is above the default `dense_threshold`
+    // (128) so the small-basis allowance does not apply either.
+    let m = 300;
+    let mut trip: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..m {
+        trip.push((i, i, 4.0));
+        if i + 1 < m {
+            trip.push((i, i + 1, -1.0));
+            trip.push((i + 1, i, -1.0));
+        }
+    }
+    let a = build(m, &mut trip);
+    let params = LuParams {
+        // Far above `m`: if the gate keyed on dimension alone, every arm below
+        // would take the dense route.
+        dense_bump_max_dim: 4096,
+        ..LuParams::default()
+    };
+    assert!(
+        m > params.dense_threshold,
+        "test needs m above dense_threshold to exercise the guard"
+    );
+
+    let rev: Vec<usize> = (0..m).rev().collect();
+    let arms: Vec<(&str, SparseLuSymbolic)> = vec![
+        ("natural", SparseLuSymbolic::natural(m)),
+        (
+            "with_order",
+            SparseLuSymbolic::with_order(m, rev).expect("order"),
+        ),
+        (
+            "analyze_amd_only",
+            SparseLuSymbolic::analyze_amd_only(&a).expect("amd_only"),
+        ),
+        ("analyze", SparseLuSymbolic::analyze(&a).expect("analyze")),
+    ];
+
+    let x_ref: Vec<f64> = (0..m).map(|i| 1.0 + (i % 7) as f64).collect();
+    let b = matvec(&a, &x_ref);
+
+    for (name, sym) in arms {
+        assert_eq!(
+            (sym.bump_lo, sym.bump_hi),
+            (0, m),
+            "{name}: expected an unpeeled whole-basis bump"
+        );
+        let mut lu = SparseLu::factor(&a, &sym, params.clone()).expect("factor");
+        assert!(
+            !lu.used_dense_bump(),
+            "{name}: took the dense route on an unpeeled whole-basis bump"
+        );
+        // And it still solves — the gate must not have broken the sparse path.
+        let mut x = b.clone();
+        lu.ftran(&mut x).expect("ftran");
+        let ax = matvec(&a, &x);
+        let r: Vec<f64> = ax.iter().zip(b.iter()).map(|(p, q)| p - q).collect();
+        let resid = rel_resid(&r, &b);
+        assert!(resid < 1e-12, "{name}: residual {resid:e}");
+    }
+}

--- a/tests/lu_dense_bump.rs
+++ b/tests/lu_dense_bump.rs
@@ -297,12 +297,30 @@ fn singular_bump_is_reported_on_both_routes() {
             ..base
         },
     );
-    assert!(
-        matches!(sparse, Err(FeralError::SingularBasis { .. })),
-        "sparse route missed a singular bump"
+    // Matching on `SingularBasis { .. }` alone passes vacuously against a route
+    // that names the wrong column, so compare the columns themselves. Both must
+    // report the *original basis column*, the contract
+    // `tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position`
+    // pins for the sparse path: `factorize_packed` names a block-local index,
+    // which is only the same number by accident.
+    let sparse_col = match sparse {
+        Err(FeralError::SingularBasis { column }) => column,
+        other => panic!("sparse route missed a singular bump: {other:?}"),
+    };
+    let dense_col = match dense {
+        Err(FeralError::SingularBasis { column }) => column,
+        other => panic!("dense route missed a singular bump: {other:?}"),
+    };
+    assert_eq!(
+        sparse_col, dense_col,
+        "routes disagree on which basis column is singular \
+         (sparse={sparse_col}, dense={dense_col}); the dense route must remap \
+         the block-local column through `qcol[bump_lo + k]`"
     );
+    // Columns 10 and 11 are the identical pair, so the singularity must be
+    // pinned to one of them and not to some unrelated position.
     assert!(
-        matches!(dense, Err(FeralError::SingularBasis { .. })),
-        "dense route missed a singular bump: {dense:?}"
+        sparse_col == 10 || sparse_col == 11,
+        "expected the duplicated column (10 or 11), got {sparse_col}"
     );
 }

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -231,11 +231,7 @@ fn singular_basis_reports_original_column_not_factorization_position() {
     let m = 3;
     let a = SparseColMatrix::from_dense_columns(m, &cols).expect("matrix");
     // Explicit non-identity column order: position k -> original column qcol[k].
-    let symbolic = SparseLuSymbolic {
-        m,
-        qcol: vec![2, 1, 0],
-        qcol_inv: vec![2, 1, 0],
-    };
+    let symbolic = SparseLuSymbolic::with_order(m, vec![2, 1, 0]).expect("order");
     let params = LuParams {
         on_singular: LuSingularAction::Fail,
         ..LuParams::default()


### PR DESCRIPTION
## What

Adds the structural pre-pass every production LP `INVERT` runs before ordering a
basis — Suhl & Suhl (1990) triangularization — and an opt-in route that hands the
residual bump to the existing dense LU kernel.

Before this, `SparseLuSymbolic::analyze` ran AMD-on-AᵀA over the *whole* basis and
Gilbert–Peierls factored the whole basis. A simplex basis is overwhelmingly
triangular, so most of that work is on columns whose pivot is structurally forced.

## The structure

Peeling column singletons to the front and row singletons to the back, to
fixpoint, gives

```
          [ U_FF  U_FB  U_FK ]              [ I   0   0 ]
P A Q  =  [  0    Bump  U_BK ]     with L = [ 0  L_B  0 ]
          [  0     0    U_KK ]              [ 0   0   I ]
```

Both peeled blocks are upper triangular, so `L` is the identity there: a peeled
pivot performs no elimination and introduces no rounding. Only `Bump` needs a
fill-reducing ordering and a general factorization.

The numeric factor loop needed **no change**. At a peeled position the
singleton's row is structurally the only unpivoted row the column touches, so
threshold partial pivoting finds the forced pivot on its own and `L(:,k)` comes
out empty.

The pass reads only the pattern, never the values, so the symbolic-reuse contract
is unchanged: a `SparseLuSymbolic` built from one basis stays valid for any
numerically different basis with the same pattern.

## Measurements

Interleaved A/B, one process, 15 reps, on a real simplex basis dumped from a
QPLIB solve (`m = 3937`, `nnz = 28204`). The peel removes 85.6% of the columns in
0.148 ms and leaves a 566×566 bump.

```
AMD(full)       symbolic= 9.837 ± 0.285  numeric= 23.07 ± 0.20  total= 32.91 ms  nnz(LU)=147,796
peel+AMD(bump)  symbolic= 0.851 ± 0.036  numeric= 30.24 ± 0.16  total= 31.09 ms  nnz(LU)=167,658
peel+denseBump  symbolic= 0.849 ± 0.013  numeric=  8.86 ± 0.13  total=  9.71 ms  nnz(LU)=172,449
```

**The peel alone is not a win.** The symbolic step improves 11.6x, but AMD on the
isolated bump gives worse fill than AMD on the whole basis, the numeric step
regresses 29%, and the net is 1.06x. That is recorded here rather than glossed
over, because it is what motivates the second half of the change.

The peel's real value is that it *exposes* a block whose factor is dense — 42% on
this basis, against 2.2% input density — which is the worst case for a scalar
sparse scatter kernel. `should_use_dense_lu` cannot see this: it keys on input
density and on the dimension of the whole basis.

Hence `LuParams::dense_bump_max_dim` (**default 0 = off**): route a bump at or
below that dimension through the dense kernel. **3.39x** on the full
factorization. The cap is a memory bound — the route packs a `b²` f64 buffer
(`b=1024` → 8 MB, `b=4096` → 134 MB).

Across a manifest-sampled class of QPLIB bases with `m` from 102 to 34,065, the
peel removes 84.8–100% of columns (median 94.6%) and the bump never exceeds 15.2%
of `m`, at a cost of 0.008–0.798 ms.

## Safety

The dense splice is **checked, never assumed**. It is taken only if the front
block really did emit an empty `L` column — a numerically singular singleton
routed through `LuSingularAction::PerturbToEps` can pivot on some other row and
break the block structure, and in that case the route silently falls back to the
sparse path rather than producing a wrong factorization.

Because that fallback is silent, `used_dense_bump()` reports which route actually
ran, so a benchmark or differential test cannot pass vacuously against a fallback.
Both the differential test and the bench assert on it.

The dense route rescales `zero_pivot_tol` by `a_max / bump_a_max` so its
singularity verdict matches what the sparse path would have reached on the same
block.

## Tests

- `sparse_triangular` unit tests: identity, lower triangular, upper triangular
  (all fully peeled), dense (all bump), permutation validity, and a structurally
  singular matrix that must not panic.
- `tests/lu_dense_bump.rs`: differential ftran/btran residual and
  solution-agreement over 6 LP-shaped bases spanning front-heavy, bump-heavy,
  back-heavy and no-border shapes; plus off-by-default, below-cap-stays-on-the-
  sparse-route (asserting identical `factor_nnz`), and singular-on-both-routes.
- `examples/basis_refactor.rs`: the three-arm interleaved bench above, which exits
  non-zero if any arm never ran.

Full suite green; `cargo fmt` and `cargo clippy -D warnings` clean.

## Downstream

Consumed by jkitchin/discopt#1008. End-to-end on that project's LP (interleaved,
5 reps): 5976.7 ± 34.4 ms → 3647.2 ± 35.0 ms, **1.64x** on the whole simplex
solve, objective identical to 6.6e-15, route confirmed fired on 545 of 550
factorizations. Fill measured *down* there (5.71 → 5.50 nnz(LU)/nnz(basis)), so
the triangular solves and Forrest–Tomlin updates got cheaper too.

Reference: U. H. Suhl and L. M. Suhl, "Computing sparse LU factorizations for
large-scale linear programming bases", *ORSA Journal on Computing* 2(4), 325–335
(1990).
