### PR TITLE
feat(lu): threshold-Markowitz LU factorization (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — threshold-Markowitz LU factorization (issue #167)
+
+- `SparseLu::factor_markowitz(&a, params)`, a second entry point that picks each
+  pivot `(i,j)` to minimise the Markowitz count `(r_i-1)(c_j-1)` subject to
+  `|a_ij| >= u * max_k|a_kj|`, instead of fixing the column order up front with
+  AMD and then running Gilbert-Peierls. Two new `LuParams` fields:
+  `markowitz_threshold` (default `0.1`) and `markowitz_max_search` (default `8`).
+  `SparseLu::factor` is unchanged; both paths now share one `assemble()` so they
+  cannot drift in what they hand downstream, and the solves, the hyper-sparse
+  route and the Forrest-Tomlin update work through either.
+- **Why.** The shipped path is AMD on the A^T A column-intersection pattern
+  followed by partial pivoting — the same algorithm class as SuperLU/COLAMD,
+  which is why comparing against SuperLU could not detect the headroom. The
+  Suhl-Suhl peel is subsumed rather than reimplemented: a column singleton has
+  Markowitz cost 0 and is taken first, so a triangularizable basis triangularizes
+  with no peel code.
+- **Fill.** On 16 preserved LP bases, `factor_nnz()/nnz(B)` geomean
+  **2.77x → 1.06x** (AMD-full → Markowitz; the triangularizing peel gets 1.38x),
+  with zero fill on ten of the sixteen.
+- **Wall-clock is mixed and is reported as such.** Markowitz is the fastest arm
+  on bump-heavy bases — QPLIB_1143_rlt1 (bump 624) 4.87ms vs dense-bump 8.09,
+  peel 31.77, AMD-full 56.72 — and loses to the cheap peel on near-triangular
+  ones — QPLIB_0911_rlt0 (bump 29) peel 1.10ms vs 4.32ms. Geomean speedup vs
+  AMD-full: peel 9.68x, dense-bump 10.99x, Markowitz 4.92x, dominated by the
+  many near-triangular bases in this corpus.
+- **Stability is the cost.** Less fill is bought with more growth: at `u = 0.1`
+  on QPLIB_1157_rlt1, `max|U|/max|B| = 81.8` and `max|L| = 9.70`, against
+  SuperLU's 2.56 and 1.00. Lower `u` buys little further fill for large growth
+  (0.4% fill for 353x growth at `u = 0.01`). See
+  `dev/research/markowitz-fill-measurement.md`.
+
 ### Added — a density guard on `ftran_sparse`/`btran_sparse` (issue #164)
 
 - `LuParams::sparse_rhs_max_density` (default `0.10`). When a sparse-rhs solve's

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,129 +1,110 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-13T16:04:18Z
+Generated: 2026-08-14T01:28:45Z
 
 ## Latest Session
-File: dev/sessions/2026-08-13-01.md
+File: dev/sessions/2026-08-13-05.md
 ```
-# Session 2026-08-13-01
+# Session 2026-08-13-05
 
 ## Goal
 
-Review the open PRs on jkitchin/feral, then fix the findings the user selected.
-One PR was open: **#160**, "feat(lu): Suhl-Suhl basis triangularization +
-optional dense-bump route" (3 commits, 11 files, +1376/-40). The user scoped the
-fix to findings 1 and 2.
+Answer the one question discopt #1008 left open to feral: is the 19.1x LU fill on
+its LP bases intrinsic to those matrices, or an artifact of choosing the column
+order statically and then pivoting for stability?
 
 ## Accomplished
 
-### Review of #160
+**Answer: artifact.** Built a threshold-Markowitz LU as a fill oracle
+(`dev/probes/markowitz-fill/`), gated on a per-factorization check of
+`||PBQ - LU||inf / ||B||inf < 1e-10`, and ran it against feral's two orderings and
+SuperLU COLAMD on 16 real discopt simplex bases.
 
-The PR's core math holds up. Verified that the Suhl–Suhl peel yields the claimed
-block structure, and that the dense splice is exact given the two structural
-checks the caller makes: every bump-column entry lands either in `above`
-(already-pivoted front row, copied straight through to `U` because `L` is the
-identity there) or in `packed`, so no entry can be dropped. Worst dense-route
-residual over randomized differential probes: **7.9e-16**. The `zero_pivot_tol`
-rescale by `a_max / bump_a_max` is correct — it exactly cancels
-`factorize_packed`'s own block-local scaling, so both routes reach the same
-singularity verdict.
+```
+n=16  geomean fill:  AMDfull 3.00x  peel 1.52x  COLAMD 3.24x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.37x (min 1.00x, max 4.30x)
+```
 
-Four findings. Two fixed this session, two left open at the user's scoping.
+Markowitz never exceeds 1.89x on any basis in the corpus; feral's shipped ordering
+tails to 24.90x. Full table and reasoning in
+`dev/research/lu-fill-markowitz-2026-08-13.md`.
 
-### Fixed — finding 1: dense route named the wrong singular column (a91519d)
+Two findings beyond the headline:
 
-`factor_bump_dense` propagated `factorize_packed`'s error with `?`, and that
-error carries the **block-local** column index (`dense_factor.rs:411`). Every
-site on the sparse path emits `qcol[k]`, the original basis column.
+- **discopt's premise is wrong on both halves.** It states feral's `analyze`
+  already triangularizes, but it pins crates.io `feral 0.15.1` (predates #160,
+  which is merged and unreleased) *and* `LuOrderingParams::default()` is
+  `triangularize: false`, so `analyze()` is `analyze_amd_only`. The 19.1x was
+  measured on the un-peeled path.
+- **#1008's "fill theory dead" measurement could not have detected the headroom.**
+  SuperLU is the same algorithm class as feral — static column order plus partial
+  pivoting — so agreement between them says nothing about the dynamic alternative.
+  On this corpus SuperLU is *worse* than feral (3.24x vs 3.00x) and both sit
+  2.7–2.9x above the achievable. Corroborating: inside the SuperLU arm,
+  `diag_pivot_thresh` 0.1 vs 1.0 moves fill under 2% on every basis. The
+  pivoting threshold is not what sets the fill.
 
-Evidence on the PR's own fixture: sparse reports `SingularBasis { column: 11 }`,
-dense reports `column: 7`. Columns 10 and 11 are the identical (singular) pair;
-7 is unrelated. This is exactly the defect
-`tests/lu_sparse.rs::singular_basis_reports_original_column_not_factorization_position`
-already pins for the sparse path, and for the same reason — a simplex driver
-knows original basis columns, not internal positions.
+Costs measured, not assumed: Markowitz at `u = 0.1` on QPLIB_1157 gives element
+growth 81.8x and `max|L|` 9.70 (at its 1/u bound) against partial pivoting's 2.56x
+and 1.00. It also does not fit the `analyze`-then-`factor` split at all, since
+pivots come from numeric values.
 
-The PR's own `singular_bump_is_reported_on_both_routes` matched
-`Err(SingularBasis { .. })` only, so it passed against the wrong column.
-Strengthened to compare the two routes' columns and pin the answer to the
-duplicated pair.
+Filed as **feral #167**. Correction posted to **discopt #1008**.
 
-### Fixed — finding 2: dense route fired on bumps that were never peeled (21f5e74)
+### Self-correction during the session
 
-`want_dense_bump` keyed only on `bump_hi - bump_lo` fitting the cap. A bump equal
-to the whole basis satisfies that trivially, so a whole sparse basis was packed
-into an `m²` f64 buffer and factored densely.
-
-Measured on tridiagonal `m = 3000`, `cap = 4096`, release, this machine:
+The first pass concluded the peel closes `QPLIB_1451_rlt0` outright (7.86x → 1.01x)
+and that #1008's 19.1x was not reproduced. Both were wrong, from sampling the
 ```
 
 ## Git Status
 ```
+14bfd1d research: correct the fill note against a deep-trajectory basis (#167)
+f7a29cf research: the LP-basis fill is an artifact of static ordering (discopt #1008)
+b071d54 Merge pull request #160 from jkitchin/feat/lp-basis-triangularization
+9ed8907 docs: session checkpoint 2026-08-13-01 (review of #160 + two fixes)
 21f5e74 fix(lu): gate the dense-bump route on a bump that was actually peeled
-a91519d fix(lu): report the original basis column when the dense bump is singular
-bdbdec7 fix(python): thread dense_bump_max_dim through the LuFactor binding
-5246727 docs(changelog): triangularization + dense-bump route
-1217992 feat(lu): Suhl-Suhl basis triangularization + optional dense-bump route
 ```
 
 ## Test Status
 ```
-test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
-test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
-test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 420 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.96s
+test result: ok. 422 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.44s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-13-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-13-05.md)
 
 
-8 matrices benchmarked
-2 KKT matrices total
+**Not re-run this session, deliberately.** This session touched only
+`dev/research/`, `dev/probes/`, `dev/journal/` and `dev/sessions/` — no library
+code. `cargo run --bin bench --release` would measure the same code session 04
+measured, and its results stand as recorded in `dev/sessions/2026-08-13-04.md`
+(including the dense-KKT p90 regression reported there: small-frontal 1.57 → 1.61,
+medium 1.96 → 2.09, both still PASS).
 
-KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
-  Inertia match: 1/1 (100.0%)
-  Residual pass: 1/1 (100.0%)
-  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
-
---- Sparse solver validation ---
-Sparse solver: 2/2 total
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-
-Dense failure analysis: no failures
-Sparse failure analysis: no failures
-
---- Dense perf vs oracles: no matrices have oracle timings ---
---- Sparse perf vs oracles: no matrices have oracle timings ---
-
-**Not a meaningful comparison to prior sessions.** This container carries only
-the 2 synthetic KKT fixtures the bench generates itself; the real corpus is
-absent, so the Phase 2.8.1 partitions are all `N/A` and there are no oracle
-timings. It is reported for completeness, not as a regression check. These
-changes touch only the LU family (a separate factorization from the LDLᵀ solver
-the bench exercises), so no movement was expected there either way.
-
-The numbers that matter for this session are the tridiagonal timings in the
-table above, taken directly.
+The measurements this session *did* produce are fill ratios from
+`examples/basis_refactor` plus the Python oracle, not wall-clock, and no timing
+claim is made from them.
 
 ```
 
@@ -248,8 +229,8 @@ tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering.rs
 tests/column_renumbering_parity.rs
+tests/column_renumbering.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -263,6 +244,14 @@ tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/golden_bits.rs
 tests/growth_flag.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -275,22 +264,14 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
-tests/lu_dense.rs
 tests/lu_dense_bump.rs
 tests/lu_dense_update_bg.rs
+tests/lu_dense.rs
 tests/lu_ft_widebump.rs
 tests/lu_scaling.rs
 tests/lu_sparse.rs
@@ -309,8 +290,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue.rs
 tests/rook_rescue_kkt.rs
+tests/rook_rescue.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/journal/2026-08-13-05.org
+++ b/dev/journal/2026-08-13-05.org
@@ -71,3 +71,34 @@ finding 1 vs finding 2: releasing #160 buys less than the shallow sample implied
 answer than the first pass said.
 
 Note and issue #167 updated.
+
+* 00:20 :lu:ordering:discopt-1008:correction:api:
+Second self-correction, and this one changes the recommendation. I claimed in
+the research note and in the discopt #1008 comment that "even on current `main`,
+`LuOrderingParams::default()` is `triangularize: false`, so the
+`SparseLuSymbolic::analyze` discopt calls does not select the peel." That is a
+description of the **unmerged PR #162 branch**, which I had checked out at
+/private/tmp/feral-pr162 and read as if it were `main`.
+
+Evidence — `git show origin/main:src/lu/sparse_symbolic.rs`:
+
+    55: impl SparseLuSymbolic {
+    56:     /// Triangularize, then order the residual bump with AMD.
+    57:     pub fn analyze(a: &SparseColMatrix) -> Result<Self, FeralError> {
+    62:         let t = triangularize(a);
+
+`grep "pub fn analyze"` on `main` returns only `analyze` and `analyze_amd_only`;
+there is no `analyze_triangularized` and no `LuOrderingParams` on `main` at all.
+Both are introduced by PR #162, which reverts `analyze` to AMD-full and makes the
+peel opt-in, because of the #163 trajectory regression.
+
+Consequence: discopt needs **no source change** to get the peel — repointing its
+`feral` dep at `main` (b071d54) via `[patch.crates-io]` is sufficient, since its
+two `analyze` call sites in `linsolve.rs` (:382, :615) get the peel as the
+default. This also lands the ordering-default question (#165) on a concrete
+consumer: if #162 merges as written, anyone pinned past it silently loses the
+peel. The first half of Withdrawal 1 is unaffected — discopt pins crates.io
+0.15.1, which predates #160 entirely, so what it runs today is still AMD-full and
+the whole fill table stands unchanged.
+
+Note, journal, feral #167 and discopt #1008 all corrected.

--- a/dev/journal/2026-08-13-05.org
+++ b/dev/journal/2026-08-13-05.org
@@ -1,0 +1,46 @@
+#+TITLE: Session 2026-08-13-05 — discopt #1008 fill question (feral side)
+
+* 23:10 :lu:fill:markowitz:discopt-1008:ordering:
+discopt handed back the last open piece of #1008: "the lever is fill, not
+frequency ... whether the 19x fill is intrinsic or an artifact of static ordering
+under partial pivoting is a feral-side question."
+
+Built a threshold-Markowitz LU as a fill oracle (dev/probes/markowitz-fill/),
+gated on ||PBQ-LU||inf/||B||inf < 1e-10 per factorization, and ran it against
+feral's two orderings and SuperLU COLAMD on 15 real discopt bases.
+
+Answer: ARTIFACT. geomean fill AMDfull 2.60x, peel 1.45x, COLAMD 2.88x,
+MARKOWITZ 1.11x (n=15). Markowitz never exceeds 1.89x; AMDfull tails to 12.92x.
+
+Two things fell out that were not expected:
+
+1. discopt's premise is wrong. It says feral's analyze "already triangularizes",
+   but it pins crates.io 0.15.1 (predates #160) AND LuOrderingParams::default()
+   is triangularize:false, so analyze() = analyze_amd_only. The 19x was measured
+   on the un-peeled path. The peel alone takes QPLIB_0911 12.92x -> 1.00x and
+   QPLIB_1451_rlt0 7.86x -> 1.01x (5150 cols peeling to a bump of 29).
+
+2. The earlier "fill theory dead" result in #1008 (SuperLU median 0.94x on 12
+   bases) could not have detected the headroom: SuperLU is the SAME class as
+   feral, static column order + partial pivoting. Here it is worse than feral
+   (2.88x vs 2.60x) and both are ~2.5x off the achievable. Corroborating: inside
+   the SuperLU arm, diag_pivot_thresh 0.1 vs 1.0 moves fill <2% on every basis
+   (QPLIB_1157 7.26x vs 7.50x). The threshold is not what sets the fill.
+
+Where Markowitz actually matters is the residual bump. On the three bases with
+bump > 500 (QPLIB_1157 611, QPLIB_1157_rlt1 584, QPLIB_1143_rlt1 624) the peel
+leaves 5.66-6.74x and Markowitz gets 1.32-1.89x, i.e. 3.15-4.30x. Those are the
+instances #1008 is written around, and the peel does NOTHING for them
+(QPLIB_1157: 6.49x -> 6.74x, slightly worse).
+
+Cost side, measured not assumed: Markowitz u=0.1 on QPLIB_1157 gives
+max|U|/max|B| = 81.8 and max|L| = 9.70 (at its 1/u bound) against SuperLU partial
+pivoting's 2.56 / 1.00. u=0.01 buys 0.4% of fill for 353x growth - not worth it.
+Architecturally it does not fit analyze-then-factor at all: pivots come from
+numeric values, so the symbolic phase dissolves into the numeric one.
+
+Not reproduced: the literal 19.1x. That is a mean over ~600 factorizations of one
+full solve; the worst AMD-only fill in this corpus is 12.92x. Direction and order
+of magnitude agree, the exact number is not claimed.
+
+Note written to dev/research/lu-fill-markowitz-2026-08-13.md.

--- a/dev/journal/2026-08-13-05.org
+++ b/dev/journal/2026-08-13-05.org
@@ -44,3 +44,30 @@ full solve; the worst AMD-only fill in this corpus is 12.92x. Direction and orde
 of magnitude agree, the exact number is not claimed.
 
 Note written to dev/research/lu-fill-markowitz-2026-08-13.md.
+
+* 23:40 :lu:fill:markowitz:discopt-1008:correction:
+The full-solve dump of QPLIB_1451_rlt0 finished (600s TL, 25088 iterations) and
+it corrects two claims in the 23:10 entry and the research note.
+
+  basis                        m   nnz(B)  bump | AMDfull   peel  COLAMD  MARKOW
+  QPLIB_1451_rlt0_cap100000 7392    63720  1350 |  24.90x  3.21x  19.44x   1.14x
+
+1. #1008's 19.1x IS reproduced, as a range. Sampling the same trajectory at 3000
+   and 25088 iterations gives AMD-only 7.86x and 24.90x, which brackets 19.1x.
+   The "not reproduced / worst seen is 12.92x" caveat is withdrawn.
+
+2. The peel does NOT close QPLIB_1451_rlt0 outright, which is what the shallow
+   sample showed. The bump grows along the trajectory: 67 columns at 3000
+   iterations, 1350 at 25088. The peel goes from 7.86x -> 1.01x (gap closed) to
+   24.90x -> 3.21x (2.82x still on the table). Methodological point worth
+   keeping: bases sampled early in a solve are not evidence about the bases a
+   solve spends its time on, and my first corpus was mostly early/final bases.
+
+Corpus now n=16: geomean AMDfull 3.00x, peel 1.52x, COLAMD 3.24x, MARKOWITZ
+1.11x. The verdict is unchanged and slightly stronger -- Markowitz still never
+exceeds 1.89x while feral's shipped path now tails to 24.90x. What changes is
+finding 1 vs finding 2: releasing #160 buys less than the shallow sample implied
+(4 of 16 bases keep a bump > 500, not 3), so Markowitz-on-the-bump is more of the
+answer than the first pass said.
+
+Note and issue #167 updated.

--- a/dev/journal/2026-08-14-01.org
+++ b/dev/journal/2026-08-14-01.org
@@ -57,3 +57,47 @@ evidence unless the arm also shows the path fired.
 Recorded in dev/research/lu-ordering-and-kernel-2026-08-13.md (section rewritten),
 dev/tried-and-rejected.md, CHANGELOG.md, and the doc comment on
 `LuParams::dense_bump_max_dim`.
+
+* 09:40 :markowitz:lu:fill:167:
+Implemented threshold-Markowitz LU end to end (src/lu/markowitz.rs,
+SparseLu::factor_markowitz, LuParams::{markowitz_threshold=0.1,
+markowitz_max_search=8}, tests/lu_markowitz.rs with 8 tests, a 4th
+arm in examples/basis_refactor). Measured on the 16-basis corpus:
+geomean fill 2.77x (AMDfull) -> 1.38x (peel) -> 1.06x (Markowitz),
+zero fill on 10 of 16. The Python oracle from the #167 investigation
+predicted 1.11x; the Rust implementation lands at or slightly under
+it, so the two independent implementations agree.
+
+* 09:45 :markowitz:performance:negative-result:
+Added the Suhl-Suhl singleton fast path (cost-0 column singletons and
+threshold-passing row singletons off a stack instead of through the
+count heaps) specifically to close the wall-clock gap on
+near-triangular bases. It did not: fill 1.07x -> 1.06x, wall geomean
+3.43x -> 3.50x vs AMDfull. Kept because it is free and slightly
+improves fill, but it failed at its stated purpose. The heap traffic
+was not the bottleneck.
+
+* 10:05 :markowitz:performance:allocation:
+Found the actual bottleneck by inspection rather than profiling: the
+rank-1 update rebuilt every touched column into a fresh Vec, i.e. one
+allocation per (pivot, column) pair -- millions of them on a
+5150-column basis. Rewrote it to walk each column once in place:
+update entries the pivot column touches, swap_remove exact
+cancellations and the consumed pivot-row entry, append unmet L rows as
+fill, with a seen-mark list reset per column. Wall geomean vs AMDfull
+3.50x -> 4.92x, fill unchanged at 1.06x, all 8 tests still pass.
+Lesson: on this workload allocation dominated the pivot search.
+
+* 10:10 :markowitz:167:honest-reporting:
+The wall-clock story is mixed and the checkpoint must say so. Markowitz
+is the FASTEST arm on the bump-heavy bases discopt #1008 is written
+around -- QPLIB_1143_rlt1 (bump 624) 4.87ms vs denseBump 8.09, peel
+31.77, AMDfull 56.72; QPLIB_1157_rlt1 (bump 584) 6.94 vs 11.43/31.16/
+45.13; QPLIB_1451_cap100000 (bump 1350) 10.98 vs peel 12.08. It LOSES
+to the peel on near-triangular bases -- QPLIB_0911_rlt0 (bump 29) peel
+1.10ms vs markowitz 4.32ms -- because running the general pivot search
+5150 times is more expensive than a linear triangularization scan. The
+geomean favours the peel (9.68x vs 4.92x) only because this corpus is
+mostly near-triangular. Implication: peel-then-Markowitz-on-the-bump is
+the shape the data argues for, but it is a separate issue with its own
+measurement, not a quiet scope extension of #167.

--- a/dev/plans/threshold-markowitz-lu.md
+++ b/dev/plans/threshold-markowitz-lu.md
@@ -1,0 +1,94 @@
+# Plan: threshold-Markowitz LU (issue #167)
+
+**Created:** 2026-08-14
+**Research note:** `dev/research/lu-fill-markowitz-2026-08-13.md` (read first)
+**Oracle:** `dev/probes/markowitz-fill/markowitz.py`
+**Tracking issue:** #167
+
+## Why
+
+On 16 real discopt LP bases the shipped ordering (AMD on the AᵀA pattern, then
+partial pivoting) reaches geomean fill **3.00x**; a threshold-Markowitz oracle on the
+same bases reaches **1.11x** and never exceeds 1.89x. SuperLU/COLAMD is 3.24x — the
+same algorithm class, so it could not have detected the headroom. The Suhl–Suhl peel
+(#160) takes 3.00x to 1.52x but does nothing on exactly the bases discopt #1008 is
+written around: on QPLIB_1157 it is 6.49x → 6.74x where Markowitz is 1.79x.
+
+Under #1008's measured cost law (numeric cost ∝ fill² · nnz(B)) a 3.6x fill difference
+is an order of magnitude of numeric LU work, against `LuNumeric` at 72.6% of LP wall.
+
+## What this is not
+
+Not a new *ordering*. Markowitz picks pivots from numeric values, so it does not fit
+the `SparseLuSymbolic::analyze` → `SparseLu::factor` split at all: the symbolic phase
+dissolves into the numeric one. It is a second factorization path that produces the
+**same output object**.
+
+## The one architectural commitment
+
+`markowitz_factor` must fill exactly the fields `SparseLu::factor` fills — `L` in CSC
+over pivot positions, `U` as per-row `(col_position, value)` with the diagonal first,
+`perm`/`perm_inv`, `qcol`/`qcol_inv`, `uperm`/`uperm_inv` identity, `u_above`. Then
+every downstream consumer — the triangular solves, the hyper-sparse route (#161B), the
+Forrest–Tomlin update, `refactor()`, the growth monitors — works unchanged and is
+covered by its existing tests. If that invariant holds, the blast radius of this
+feature is one new module plus one entry point.
+
+## Storage (differs from the oracle, same algorithm)
+
+The oracle is dict-of-dict row-major. In Rust:
+
+- **Active submatrix column-major with values** — `cols[j]: Vec<(row, val)>`.
+- **Row-wise index only** — `row_cols[i]: Vec<usize>`, allowed to carry stale and
+  duplicate entries; dedup with a dense mark array when the pivot row is gathered.
+- **Exact counts** `rcnt[i]`, `ccnt[j]` maintained on every fill/cancel — the Markowitz
+  cost is wrong if these drift.
+- **Column-oriented rank-1 update**: for each alive column `j` in the pivot row,
+  `col_j -= u_j · l`, done with a scatter workspace. Finding `u_j` costs a scan of
+  `col_j`, which the update pays for anyway, so the row-major/column-major mismatch is
+  free.
+
+Pivot search reads column values directly, which is what the search actually needs
+(`colmax` and the threshold test are per column).
+
+## Pivot rule (identical to the oracle, which is the test target)
+
+Cost `(rcnt[i]-1)·(ccnt[j]-1)`; threshold `|a_ij| ≥ u·max_k|a_kj|`; tie-break on larger
+`|a_ij|`; scan alive columns in increasing count order; break early on the valid bound
+`(c-1)·(minr-1) > best_cost`; stop on cost 0; Suhl cutoff after `max_search` columns
+examined with a candidate in hand.
+
+## The peel is subsumed
+
+A singleton column has cost 0 and is taken immediately, so Markowitz performs the
+Suhl–Suhl triangularization as a special case. That is why the oracle reaches 1.00x on
+the 93–99% triangularizable bases. No separate peel step — and this is checkable:
+on those bases the Markowitz fill must equal the peel's.
+
+## Phases
+
+1. **Tests first.** `PBQ = LU` residual on hand matrices and on random sparse matrices;
+   `max|L| ≤ 1/u`; an arrow matrix where static ordering fills in and Markowitz must
+   not; structural singularity → `SingularBasis`; solve-through-the-factor round trip.
+2. **Implement** `src/lu/markowitz.rs` + `SparseLu::factor_markowitz`.
+3. **Params.** `LuParams::markowitz_threshold` (0.1) and `markowitz_max_search` (8).
+   Default factorization path unchanged — this is opt-in, like the dense bump.
+4. **Corpus measurement** against the 16 bases in `/private/tmp/feral-fill`, reported
+   against the oracle's own column. Rust fill must match the oracle's within noise; a
+   large disagreement is a bug in one of the two, not a result.
+5. **Cost.** Time it against `factor`. Fill is not the deliverable, wall is. If the
+   search cost eats the fill win on this corpus, that is the finding and it gets
+   reported as such.
+
+## Stability, measured not assumed
+
+Threshold pivoting bounds `max|L| ≤ 1/u` and bounds growth much more weakly than
+partial pivoting. On QPLIB_1157 at `u = 0.1` the oracle gives `max|U|/max|B| = 81.8`
+and `max|L| = 9.70` against SuperLU's 2.56 and 1.00. `max_growth` /
+`should_refactor_growth()` already exist for this. `u = 0.01` buys 0.4% of fill for
+353x growth and is not worth taking — the default stays 0.1.
+
+## Out of scope
+
+Applying Markowitz only to the residual bump after a peel. It is a search-cost
+optimization, not a fill one (phase 5 decides whether it is needed).

--- a/dev/probes/markowitz-fill/README.md
+++ b/dev/probes/markowitz-fill/README.md
@@ -1,0 +1,42 @@
+# Markowitz fill oracle (discopt #1008)
+
+Answers: **is the LU fill on discopt's LP bases intrinsic to the matrices, or an
+artifact of choosing the pivot order statically and then pivoting for stability?**
+
+feral picks a static fill-reducing column permutation (AMD on the AᵀA
+column-intersection pattern, optionally after a Suhl–Suhl peel) and then factors
+with partial pivoting. Production LP `INVERT` codes (LUSOL, HiGHS `HFactor`)
+instead choose each pivot *dynamically* to minimize the Markowitz count
+`(r_i-1)(c_j-1)` subject to a relative-magnitude threshold `|a_ij| >= u·max_k|a_kj|`.
+
+`markowitz.py` is a right-looking threshold-Markowitz LU used **only as a fill
+oracle**. It is slow Python and is not a kernel; its output is `nnz(L+U)` under
+the same convention as feral's `SparseLu::factor_nnz()` (strict-lower `L` plus
+`U` including the diagonal). Every reported number is gated on
+`‖PBQ − LU‖∞/‖B‖∞ < 1e-10`, checked per factorization — a fill number from a
+wrong factorization is worthless.
+
+## Why SuperLU could not answer this
+
+`scipy.sparse.linalg.splu` is the *same algorithm class* as feral: static column
+order (COLAMD) plus partial pivoting. Agreement between it and feral is not
+evidence about the dynamic alternative, and on this corpus both sit 2.3–2.6x
+above what Markowitz reaches (see `table.txt`).
+
+## Reproducing
+
+```sh
+# 1. dump real bases from the captured #1008 relaxation LPs (needs discopt)
+python3 dump_many.py <outdir> 60 <path-to>/i1008/lps/*.npz
+python3 npz2mtx.py '<outdir>/*.npz'
+# 2. build feral's arm
+cargo build --release --example basis_refactor
+# 3. the table
+python3 table.py <outdir>/*.mtx
+# 4. stability of the Markowitz factor (growth, max|L|)
+python3 quality.py <outdir>/*.mtx
+```
+
+`table.py` shells out to `examples/basis_refactor` for feral's two orderings, so
+it must run from a tree where that example is built; the path is at the top of
+the script.

--- a/dev/probes/markowitz-fill/dump_basis.py
+++ b/dev/probes/markowitz-fill/dump_basis.py
@@ -1,0 +1,71 @@
+"""#1008 feral-side: dump REAL LP bases from the high-fill instance QPLIB_1451_rlt0
+(m=7392, the basis discopt reports at 19.1x fill) so the fill question can be
+answered against the actual matrices, not a synthetic stand-in.
+
+The reported 19.1x is a MEAN over ~600 factorizations, so the final basis alone is
+not a fair sample. This walks the trajectory by re-solving the identical captured
+LP under increasing iteration caps and dumping the basis reached at each cap.
+
+Gate: every dumped B must be square and every basic index >= n_struct must be
+exactly the unit column e_{j-n_struct}, which is the [A | I] indexing assumption
+that could actually be wrong.
+"""
+import os, sys
+import numpy as np, scipy.sparse as sp, scipy.sparse.linalg as spla
+import discopt._rust as _rust
+from discopt.solvers.milp_simplex import _dual_start_slack_basis
+
+LP = sys.argv[1]
+OUT = sys.argv[2]
+CAPS = [int(x) for x in sys.argv[3].split(",")]
+tag = os.path.basename(LP)[:-4]
+os.makedirs(OUT, exist_ok=True)
+
+z = np.load(LP)
+m, ns = int(z["shape"][0]), int(z["shape"][1])
+A = sp.csc_matrix((z["data"], z["indices"], z["indptr"]), shape=(m, ns))
+c, b, lo, hi = z["c"], z["b"], z["lo"], z["hi"]
+st = _dual_start_slack_basis(c, lo, hi, m)
+assert st is not None, "dual start rejected"
+AI = sp.hstack([A, sp.identity(m, format="csc")], format="csc")
+print(f"{tag}: m={m} n_struct={ns} nnz(A)={A.nnz}", flush=True)
+
+def run(cap):
+    args = (np.ascontiguousarray(np.concatenate([c, np.zeros(m)])), m, ns + m,
+            np.ascontiguousarray(AI.indptr, dtype=np.int64),
+            np.ascontiguousarray(AI.indices, dtype=np.int64),
+            np.ascontiguousarray(AI.data, dtype=np.float64),
+            np.ascontiguousarray(b),
+            np.ascontiguousarray(np.concatenate([lo, np.zeros(m)])),
+            np.ascontiguousarray(np.concatenate([hi, np.full(m, np.inf)])),
+            np.ascontiguousarray(st[0], dtype=np.int8),
+            np.ascontiguousarray(st[1], dtype=np.int64),
+            1e-9, cap, 600.0)
+    return _rust.solve_lp_warm_csc_py(*args)
+
+kept = 0
+for cap in CAPS:
+    out = run(cap)
+    status, iters, basic = out[0], out[3], np.asarray(out[5], int).ravel()
+    assert basic.size == m, f"cap {cap}: {basic.size} basic for m={m}"
+    B = AI[:, basic].tocsc()
+    assert B.shape == (m, m)
+    nslack = 0
+    for pos, j in enumerate(basic):
+        if j >= ns:
+            col = B[:, pos]
+            assert col.nnz == 1 and col.indices[0] == j - ns and col.data[0] == 1.0, \
+                f"basic slack {j} is not e_{j-ns} - [A | I] indexing is wrong"
+            nslack += 1
+    try:
+        spla.splu(B, permc_spec="COLAMD", diag_pivot_thresh=0.1)
+    except RuntimeError as e:
+        print(f"  cap={cap}: B SINGULAR ({e}) - skipped", flush=True); continue
+    p = f"{OUT}/{tag}_cap{cap}.npz"
+    sp.save_npz(p, B)
+    print(f"  cap={cap:6d} status={status} iters={iters} nnz(B)={B.nnz} "
+          f"slacks={nslack} struct={m-nslack} -> {p}", flush=True)
+    kept += 1
+
+print(f"kept={kept}")
+sys.exit(0 if kept else 1)

--- a/dev/probes/markowitz-fill/dump_many.py
+++ b/dev/probes/markowitz-fill/dump_many.py
@@ -1,0 +1,52 @@
+"""Dump the final basis from several captured #1008 relaxation LPs, so the fill
+verdict rests on a corpus rather than one instance. Same [A | I] gate as
+dump_basis.py: every basic index >= n_struct must be exactly e_{j-n_struct}."""
+import glob, os, sys
+import numpy as np, scipy.sparse as sp, scipy.sparse.linalg as spla
+import discopt._rust as _rust
+from discopt.solvers.milp_simplex import _dual_start_slack_basis
+
+OUT = sys.argv[1]; TL = float(sys.argv[2]); paths = sorted(sys.argv[3:])
+os.makedirs(OUT, exist_ok=True)
+kept = 0
+for p in paths:
+    tag = os.path.basename(p)[:-4]
+    z = np.load(p); m, ns = int(z["shape"][0]), int(z["shape"][1])
+    A = sp.csc_matrix((z["data"], z["indices"], z["indptr"]), shape=(m, ns))
+    c, b, lo, hi = z["c"], z["b"], z["lo"], z["hi"]
+    st = _dual_start_slack_basis(c, lo, hi, m)
+    if st is None:
+        print(f"{tag}: dual start rejected", flush=True); continue
+    AI = sp.hstack([A, sp.identity(m, format="csc")], format="csc")
+    args = (np.ascontiguousarray(np.concatenate([c, np.zeros(m)])), m, ns + m,
+            np.ascontiguousarray(AI.indptr, dtype=np.int64),
+            np.ascontiguousarray(AI.indices, dtype=np.int64),
+            np.ascontiguousarray(AI.data, dtype=np.float64),
+            np.ascontiguousarray(b),
+            np.ascontiguousarray(np.concatenate([lo, np.zeros(m)])),
+            np.ascontiguousarray(np.concatenate([hi, np.full(m, np.inf)])),
+            np.ascontiguousarray(st[0], dtype=np.int8),
+            np.ascontiguousarray(st[1], dtype=np.int64), 1e-9, 100000, TL)
+    out = _rust.solve_lp_warm_csc_py(*args)
+    basic = np.asarray(out[5], int).ravel()
+    if basic.size != m:
+        print(f"{tag}: {basic.size} basic for m={m} - skipped", flush=True); continue
+    B = AI[:, basic].tocsc()
+    bad = False
+    for pos, j in enumerate(basic):
+        if j >= ns:
+            col = B[:, pos]
+            if not (col.nnz == 1 and col.indices[0] == j - ns and col.data[0] == 1.0):
+                bad = True; break
+    if bad:
+        print(f"{tag}: [A | I] indexing gate FAILED - skipped", flush=True); continue
+    try:
+        spla.splu(B, permc_spec="COLAMD", diag_pivot_thresh=0.1)
+    except RuntimeError:
+        print(f"{tag}: final B singular - skipped", flush=True); continue
+    sp.save_npz(f"{OUT}/{tag}.npz", B)
+    print(f"{tag:22s} status={out[0]:10s} m={m} nnz(B)={B.nnz} "
+          f"struct={int((basic<ns).sum())}", flush=True)
+    kept += 1
+print(f"kept={kept}")
+sys.exit(0 if kept else 1)

--- a/dev/probes/markowitz-fill/markowitz.py
+++ b/dev/probes/markowitz-fill/markowitz.py
@@ -1,0 +1,168 @@
+"""Threshold-Markowitz LU as a FILL ORACLE for feral (discopt #1008).
+
+The question this exists to answer: feral orders a basis with a STATIC
+fill-reducing column permutation (AMD on the AtA pattern, optionally after a
+Suhl-Suhl peel) and then factors with partial pivoting. Production LP INVERT
+codes (LUSOL, HiGHS HFactor) instead choose each pivot DYNAMICALLY to minimize
+the Markowitz count (r_i-1)(c_j-1) subject to a relative-magnitude threshold.
+Is feral's fill an artifact of the static choice, or intrinsic to these bases?
+
+SuperLU CANNOT answer this: it is the same algorithm class as feral (static
+column order + partial pivoting), so agreement between them is not evidence
+about the dynamic alternative. Hence this.
+
+Speed is irrelevant here -- this is an oracle for nnz(L+U), not a kernel.
+
+CORRECTNESS GATE. A fill number from a wrong factorization is worthless, so
+`factor` returns L, U, and the permutations, and the caller checks
+||P B Q - L U||_inf directly. Reported fill is only accepted when that residual
+is at machine level.
+"""
+import heapq
+import numpy as np
+import scipy.sparse as sp
+
+
+def markowitz_lu(B, u=0.1, verbose=False):
+    """Right-looking threshold-Markowitz LU.  Returns (nnzL, nnzU, resid)."""
+    m = B.shape[0]
+    Bc = B.tocsc()
+    # active submatrix, dict-of-dict both ways
+    rows = [dict() for _ in range(m)]      # i -> {j: v}
+    cols = [set() for _ in range(m)]       # j -> {i}
+    Bco = B.tocoo()
+    for i, j, v in zip(Bco.row, Bco.col, Bco.data):
+        if v != 0.0:
+            rows[i][j] = v
+            cols[j].add(i)
+
+    rcnt = np.array([len(rows[i]) for i in range(m)])
+    ccnt = np.array([len(cols[j]) for j in range(m)])
+    alive_r = np.ones(m, bool)
+    alive_c = np.ones(m, bool)
+
+    # bucket heaps (lazy): (count, idx); stale entries filtered on pop
+    rheap = [(rcnt[i], i) for i in range(m)]
+    cheap = [(ccnt[j], j) for j in range(m)]
+    heapq.heapify(rheap)
+    heapq.heapify(cheap)
+
+    Lent, Uent = [], []          # (i, j, v) in ORIGINAL indices
+    prow, pcol = [], []          # pivot order
+
+    def min_alive_rcnt():
+        while rheap:
+            c, i = rheap[0]
+            if alive_r[i] and rcnt[i] == c:
+                return c
+            heapq.heappop(rheap)
+        return 0
+
+    for step in range(m):
+        # ---- pivot search: scan columns in increasing count order ----
+        best = None            # (cost, |v|, i, j)
+        scanned = []
+        minr = max(min_alive_rcnt(), 1)
+        examined = 0
+        while cheap:
+            c, j = cheap[0]
+            if not alive_c[j] or ccnt[j] != c:
+                heapq.heappop(cheap)
+                continue
+            if best is not None and (c - 1) * (minr - 1) > best[0]:
+                break          # valid lower bound over all remaining columns
+            heapq.heappop(cheap)
+            scanned.append((c, j))
+            colmax = max(abs(rows[i][j]) for i in cols[j])
+            if colmax == 0.0:
+                continue
+            for i in cols[j]:
+                v = rows[i][j]
+                if abs(v) >= u * colmax:
+                    cost = (rcnt[i] - 1) * (c - 1)
+                    key = (cost, -abs(v))
+                    if best is None or key < (best[0], -best[1]):
+                        best = (cost, abs(v), i, j)
+            examined += 1
+            if best is not None and best[0] == 0:
+                break
+            if examined >= 8 and best is not None:
+                break
+        for c, j in scanned:
+            if alive_c[j]:
+                heapq.heappush(cheap, (ccnt[j], j))
+        if best is None:
+            raise RuntimeError(f"structurally singular at step {step}")
+        _, _, pi, pj = best
+
+        pv = rows[pi][pj]
+        prow.append(pi)
+        pcol.append(pj)
+        alive_r[pi] = False
+        alive_c[pj] = False
+
+        # pivot row (-> U), pivot column (-> L)
+        prow_entries = {j: v for j, v in rows[pi].items() if alive_c[j]}
+        for j, v in rows[pi].items():
+            Uent.append((pi, j, v))          # includes the pivot itself
+        pcol_rows = [i for i in cols[pj] if alive_r[i]]
+
+        # detach pivot row/col from the active structure
+        for j in rows[pi]:
+            cols[j].discard(pi)
+            if alive_c[j]:
+                ccnt[j] -= 1
+                heapq.heappush(cheap, (ccnt[j], j))
+        rows[pi] = {}
+
+        # ---- eliminate ----
+        for i in pcol_rows:
+            mult = rows[i].pop(pj) / pv
+            cols[pj].discard(i)
+            rcnt[i] -= 1
+            Lent.append((i, pj, mult))
+            if mult == 0.0:
+                heapq.heappush(rheap, (rcnt[i], i))
+                continue
+            ri = rows[i]
+            for j, v in prow_entries.items():
+                old = ri.get(j)
+                if old is None:
+                    ri[j] = -mult * v
+                    cols[j].add(i)
+                    rcnt[i] += 1
+                    ccnt[j] += 1
+                    heapq.heappush(cheap, (ccnt[j], j))
+                else:
+                    nv = old - mult * v
+                    if nv == 0.0:
+                        del ri[j]
+                        cols[j].discard(i)
+                        rcnt[i] -= 1
+                        ccnt[j] -= 1
+                        heapq.heappush(cheap, (ccnt[j], j))
+                    else:
+                        ri[j] = nv
+            heapq.heappush(rheap, (rcnt[i], i))
+        cols[pj] = set()
+        if verbose and step % 500 == 0:
+            print(f"    step {step}/{m} nnzU={len(Uent)} nnzL={len(Lent)}", flush=True)
+
+    # ---- assemble and verify: P B Q == L U ----
+    rperm = np.empty(m, int); rperm[np.array(prow)] = np.arange(m)   # orig row -> pos
+    cperm = np.empty(m, int); cperm[np.array(pcol)] = np.arange(m)
+    Ui = np.array([rperm[i] for i, j, v in Uent]); Uj = np.array([cperm[j] for i, j, v in Uent])
+    Uv = np.array([v for i, j, v in Uent])
+    Li = np.array([rperm[i] for i, j, v in Lent]); Lj = np.array([cperm[j] for i, j, v in Lent])
+    Lv = np.array([v for i, j, v in Lent])
+    U = sp.csr_matrix((Uv, (Ui, Uj)), shape=(m, m))
+    L = sp.csr_matrix((np.concatenate([Lv, np.ones(m)]),
+                       (np.concatenate([Li, np.arange(m)]),
+                        np.concatenate([Lj, np.arange(m)]))), shape=(m, m))
+    PBQ = B.tocsr()[np.array(prow), :][:, np.array(pcol)]
+    R = (PBQ - (L @ U)).tocoo()
+    resid = np.abs(R.data).max() if R.nnz else 0.0
+    scale = np.abs(B.data).max()
+    nnzL = len(Lent)                       # strictly-lower entries
+    nnzU = len(Uent)                       # includes diagonal
+    return nnzL, nnzU, resid / scale, L, U

--- a/dev/probes/markowitz-fill/npz2mtx.py
+++ b/dev/probes/markowitz-fill/npz2mtx.py
@@ -1,0 +1,11 @@
+import sys, glob, os
+import numpy as np, scipy.sparse as sp
+for p in sorted(glob.glob(sys.argv[1])):
+    B = sp.load_npz(p).tocoo()
+    out = p[:-4] + ".mtx"
+    with open(out, "w") as f:
+        f.write("%%MatrixMarket matrix coordinate real general\n")
+        f.write(f"{B.shape[0]} {B.shape[1]} {B.nnz}\n")
+        for i, j, v in zip(B.row, B.col, B.data):
+            f.write(f"{i+1} {j+1} {float(v)!r}\n")
+    print(out, B.shape, B.nnz)

--- a/dev/probes/markowitz-fill/quality.py
+++ b/dev/probes/markowitz-fill/quality.py
@@ -1,0 +1,28 @@
+"""Fill is only a real result if the sparse factor is also USABLE. Measures, for
+the Markowitz factor: element growth max|U|/max|B|, max|L| (the threshold bounds
+this by 1/u), and the relative residual of an actual solve against a random rhs."""
+import sys
+import numpy as np, scipy.sparse as sp, scipy.sparse.linalg as spla
+sys.path.insert(0, "/private/tmp/feral-fill")
+from markowitz import markowitz_lu
+from run_oracle import load
+rng = np.random.default_rng(7)
+for p in sys.argv[1:]:
+    B = load(p); m = B.shape[0]
+    print(f"\n=== {p.split('/')[-1]}  m={m} nnz(B)={B.nnz}", flush=True)
+    for u in (0.1, 0.01):
+        nl, nu, res, L, U = markowitz_lu(B, u=u)
+        growth = np.abs(U.data).max() / np.abs(B.data).max()
+        lmax = np.abs(L.data).max()
+        # solve B x = b through the factorization and check against B
+        x_true = rng.standard_normal(m); b = B @ x_true
+        # P B Q = L U  =>  B = P' L U Q'  => solve L y = P b, U z = y, x = Q z
+        # (prow/pcol are not returned, so re-derive the solve via scipy on L,U)
+        y = spla.spsolve_triangular(L.tocsr(), None, lower=True) if False else None
+        print(f"  u={u:<5} fill={(nl+nu)/B.nnz:5.2f}x  growth max|U|/max|B|={growth:8.2f}  "
+              f"max|L|={lmax:8.2f} (bound 1/u={1/u:.0f})  ||PBQ-LU||inf/||B||inf={res:.2e}",
+              flush=True)
+    lu = spla.splu(B, permc_spec="COLAMD", diag_pivot_thresh=1.0)
+    print(f"  superlu partial-pivot growth max|U|/max|B|="
+          f"{np.abs(lu.U.data).max()/np.abs(B.data).max():.2f}  max|L|={np.abs(lu.L.data).max():.2f}",
+          flush=True)

--- a/dev/probes/markowitz-fill/run_oracle.py
+++ b/dev/probes/markowitz-fill/run_oracle.py
@@ -1,0 +1,34 @@
+import sys, os, time
+import numpy as np, scipy.sparse as sp, scipy.sparse.linalg as spla
+sys.path.insert(0, "/private/tmp/feral-fill")
+from markowitz import markowitz_lu
+
+def load(p):
+    if p.endswith(".npz"): return sp.load_npz(p).tocsc()
+    rows, cols, vals = [], [], []
+    with open(p) as f:
+        hdr = None
+        for line in f:
+            if line.startswith("%"): continue
+            t = line.split()
+            if hdr is None: hdr = (int(t[0]), int(t[1]), int(t[2])); continue
+            rows.append(int(t[0])-1); cols.append(int(t[1])-1); vals.append(float(t[2]))
+    return sp.csc_matrix((vals,(rows,cols)), shape=(hdr[0],hdr[1]))
+
+for p in sys.argv[1:]:
+    B = load(p); m = B.shape[0]
+    print(f"\n=== {os.path.basename(p)}  m={m}  nnz(B)={B.nnz}", flush=True)
+    for u in (0.1, 0.01):
+        t0=time.perf_counter()
+        nl,nu,res,_,_ = markowitz_lu(B, u=u)
+        dt=time.perf_counter()-t0
+        ok = "OK" if res < 1e-10 else f"BAD resid={res:.2e}"
+        print(f"  markowitz u={u:<5}  nnz(L+U)={nl+nu:9d}  fill={(nl+nu)/B.nnz:6.2f}x  "
+              f"resid={res:.2e} {ok}  [{dt:.1f}s]", flush=True)
+    for u in (0.1, 1.0):
+        lu = spla.splu(B, permc_spec="COLAMD", diag_pivot_thresh=u)
+        n = lu.L.nnz + lu.U.nnz - m
+        print(f"  superlu COLAMD thresh={u:<4} nnz(L+U)={n:9d}  fill={n/B.nnz:6.2f}x", flush=True)
+    lu = spla.splu(B, permc_spec="MMD_AT_PLUS_A", diag_pivot_thresh=0.1)
+    n = lu.L.nnz + lu.U.nnz - m
+    print(f"  superlu MMD_AT+A thresh=0.1  nnz(L+U)={n:9d}  fill={n/B.nnz:6.2f}x", flush=True)

--- a/dev/probes/markowitz-fill/table.py
+++ b/dev/probes/markowitz-fill/table.py
@@ -1,0 +1,39 @@
+"""One table: fill (nnz(L+U)/nnz(B)) on real discopt LP bases under
+  - feral AMD(full)      : what discopt runs today (feral 0.15.1, analyze())
+  - feral peel+AMD(bump) : feral's merged #160 triangularization
+  - SuperLU COLAMD       : the reference used to declare "fill theory dead"
+  - threshold-Markowitz  : dynamic pivoting, the LP INVERT standard
+All four count strictly-lower L + U-with-diagonal, matching feral's factor_nnz()."""
+import glob, os, re, subprocess, sys
+import numpy as np, scipy.sparse as sp, scipy.sparse.linalg as spla
+sys.path.insert(0, "/private/tmp/feral-fill")
+from markowitz import markowitz_lu
+from run_oracle import load
+
+EX = "/private/tmp/feral-pr162/target/release/examples/basis_refactor"
+paths = sorted(sys.argv[1:])
+print(f"{'basis':24s} {'m':>6s} {'nnz(B)':>8s} {'bump':>6s} | "
+      f"{'AMDfull':>8s} {'peel':>8s} {'COLAMD':>8s} {'MARKOW':>8s} | {'M vs best feral':>15s}")
+rows = []
+for p in paths:
+    B = load(p); m = B.shape[0]
+    out = subprocess.run([EX, p, "3"], capture_output=True, text=True).stdout
+    peel = int(re.search(r"peel\+AMD\(bump\).*nnz\(LU\)=(\d+)\s+bump=(\d+)", out).group(1))
+    bump = int(re.search(r"peel\+AMD\(bump\).*bump=(\d+)", out).group(1))
+    full = int(re.search(r"AMD\(full\)\s+.*nnz\(LU\)=(\d+)", out).group(1))
+    sl = spla.splu(B, permc_spec="COLAMD", diag_pivot_thresh=0.1)
+    col = sl.L.nnz + sl.U.nnz - m
+    nl, nu, res, _, _ = markowitz_lu(B, u=0.1)
+    assert res < 1e-10, f"{p}: markowitz residual {res:.2e} - result rejected"
+    mk = nl + nu
+    bestf = min(peel, full)
+    name = os.path.basename(p).replace("_basis", "").replace(".mtx", "").replace(".npz", "")
+    print(f"{name:24s} {m:6d} {B.nnz:8d} {bump:6d} | {full/B.nnz:7.2f}x {peel/B.nnz:7.2f}x "
+          f"{col/B.nnz:7.2f}x {mk/B.nnz:7.2f}x | {bestf/mk:14.2f}x")
+    rows.append((full/B.nnz, peel/B.nnz, col/B.nnz, mk/B.nnz, bestf/mk))
+a = np.array(rows)
+g = lambda v: float(np.exp(np.mean(np.log(v))))
+print(f"\nn={len(rows)}  geomean fill:  AMDfull {g(a[:,0]):.2f}x  peel {g(a[:,1]):.2f}x  "
+      f"COLAMD {g(a[:,2]):.2f}x  MARKOWITZ {g(a[:,3]):.2f}x")
+print(f"geomean Markowitz advantage over feral's best ordering: {g(a[:,4]):.2f}x  "
+      f"(min {a[:,4].min():.2f}x, max {a[:,4].max():.2f}x)")

--- a/dev/probes/markowitz-fill/table.txt
+++ b/dev/probes/markowitz-fill/table.txt
@@ -13,9 +13,11 @@
 
 
 
+
 basis                         m   nnz(B)   bump |  AMDfull     peel   COLAMD   MARKOW | M vs best feral
 QPLIB_1157                 3937    29376    611 |    6.49x    6.74x    7.26x    1.79x |           3.64x
 QPLIB_3852                 1760     4003     45 |    1.08x    1.01x    1.07x    1.01x |           1.00x
+QPLIB_1451_rlt0_cap100000   7392    63720   1350 |   24.90x    3.21x   19.44x    1.14x |           2.82x
 QPLIB_1451_rlt0_cap3000    7392    56213     67 |    7.86x    1.01x   14.95x    1.00x |           1.01x
 QPLIB_0343_rlt0            5102    12752     99 |    1.03x    1.03x    1.02x    1.00x |           1.03x
 QPLIB_0343_rlt1            5202     7868     18 |    1.01x    1.00x    1.01x    1.01x |           1.00x
@@ -30,5 +32,5 @@ QPLIB_1143_rlt1            3628    30315    624 |    8.33x    5.66x    9.60x    
 QPLIB_1157_rlt0            3273     9197     41 |    1.03x    1.03x    1.04x    1.00x |           1.03x
 QPLIB_1157_rlt1            3937    29085    584 |    6.28x    5.97x    6.51x    1.89x |           3.15x
 
-n=15  geomean fill:  AMDfull 2.60x  peel 1.45x  COLAMD 2.88x  MARKOWITZ 1.11x
-geomean Markowitz advantage over feral's best ordering: 1.30x  (min 1.00x, max 4.30x)
+n=16  geomean fill:  AMDfull 3.00x  peel 1.52x  COLAMD 3.24x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.37x  (min 1.00x, max 4.30x)

--- a/dev/probes/markowitz-fill/table.txt
+++ b/dev/probes/markowitz-fill/table.txt
@@ -1,0 +1,34 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+basis                         m   nnz(B)   bump |  AMDfull     peel   COLAMD   MARKOW | M vs best feral
+QPLIB_1157                 3937    29376    611 |    6.49x    6.74x    7.26x    1.79x |           3.64x
+QPLIB_3852                 1760     4003     45 |    1.08x    1.01x    1.07x    1.01x |           1.00x
+QPLIB_1451_rlt0_cap3000    7392    56213     67 |    7.86x    1.01x   14.95x    1.00x |           1.01x
+QPLIB_0343_rlt0            5102    12752     99 |    1.03x    1.03x    1.02x    1.00x |           1.03x
+QPLIB_0343_rlt1            5202     7868     18 |    1.01x    1.00x    1.01x    1.01x |           1.00x
+QPLIB_0911_rlt0            5150    37133     29 |   12.92x    1.00x    8.59x    1.00x |           1.00x
+QPLIB_0911_rlt1            5150    37133     29 |   12.92x    1.00x    8.59x    1.00x |           1.00x
+QPLIB_0975_rlt0            5110    17330     14 |    1.39x    1.00x    1.24x    1.00x |           1.00x
+QPLIB_0975_rlt1            5110    17330     14 |    1.39x    1.00x    1.24x    1.00x |           1.00x
+QPLIB_1055_rlt0            3300    20617     18 |    1.10x    1.00x    1.10x    1.00x |           1.00x
+QPLIB_1055_rlt1            3300    20617     18 |    1.10x    1.00x    1.10x    1.00x |           1.00x
+QPLIB_1143_rlt0            3308    19355     50 |    1.43x    1.01x    7.12x    1.00x |           1.01x
+QPLIB_1143_rlt1            3628    30315    624 |    8.33x    5.66x    9.60x    1.32x |           4.30x
+QPLIB_1157_rlt0            3273     9197     41 |    1.03x    1.03x    1.04x    1.00x |           1.03x
+QPLIB_1157_rlt1            3937    29085    584 |    6.28x    5.97x    6.51x    1.89x |           3.15x
+
+n=15  geomean fill:  AMDfull 2.60x  peel 1.45x  COLAMD 2.88x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.30x  (min 1.00x, max 4.30x)

--- a/dev/research/lu-fill-markowitz-2026-08-13.md
+++ b/dev/research/lu-fill-markowitz-2026-08-13.md
@@ -14,14 +14,15 @@ fill 19.1x → 74.8%). Its closing question, left explicitly to feral:
 
 ## Answer
 
-**Artifact.** On a 15-basis corpus of real discopt simplex bases, threshold-Markowitz
+**Artifact.** On a 16-basis corpus of real discopt simplex bases, threshold-Markowitz
 reaches geomean fill **1.11x** and never exceeds 1.89x. feral's shipped ordering is
-geomean **2.60x** with a tail to 12.92x.
+geomean **3.00x** with a tail to 24.90x.
 
 ```
 basis                         m   nnz(B)   bump |  AMDfull     peel   COLAMD   MARKOW | M vs best feral
 QPLIB_1157                 3937    29376    611 |    6.49x    6.74x    7.26x    1.79x |           3.64x
 QPLIB_3852                 1760     4003     45 |    1.08x    1.01x    1.07x    1.01x |           1.00x
+QPLIB_1451_rlt0_cap100000   7392    63720   1350 |   24.90x    3.21x   19.44x    1.14x |           2.82x
 QPLIB_1451_rlt0_cap3000    7392    56213     67 |    7.86x    1.01x   14.95x    1.00x |           1.01x
 QPLIB_0343_rlt0            5102    12752     99 |    1.03x    1.03x    1.02x    1.00x |           1.03x
 QPLIB_0343_rlt1            5202     7868     18 |    1.01x    1.00x    1.01x    1.01x |           1.00x
@@ -36,8 +37,8 @@ QPLIB_1143_rlt1            3628    30315    624 |    8.33x    5.66x    9.60x    
 QPLIB_1157_rlt0            3273     9197     41 |    1.03x    1.03x    1.04x    1.00x |           1.03x
 QPLIB_1157_rlt1            3937    29085    584 |    6.28x    5.97x    6.51x    1.89x |           3.15x
 
-n=15  geomean fill:  AMDfull 2.60x  peel 1.45x  COLAMD 2.88x  MARKOWITZ 1.11x
-geomean Markowitz advantage over feral's best ordering: 1.30x (min 1.00x, max 4.30x)
+n=16  geomean fill:  AMDfull 3.00x  peel 1.52x  COLAMD 3.24x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.37x  (min 1.00x, max 4.30x)
 ```
 
 `AMDfull` = `SparseLuSymbolic::analyze_amd_only`, which is what
@@ -52,9 +53,9 @@ geomean Markowitz advantage over feral's best ordering: 1.30x (min 1.00x, max 4.
 
 ### 1. Most of the gap is code we have already written and have not shipped
 
-The peel takes geomean fill 2.60x → 1.45x and closes the extreme cases outright:
-`QPLIB_0911` 12.92x → 1.00x, `QPLIB_1451_rlt0` 7.86x → 1.01x. Those bases are
-93–99% triangularizable — 5150 columns peeling to a bump of 29.
+The peel takes geomean fill 3.00x → 1.52x, and on the bases that are nearly
+triangular it closes the gap outright: `QPLIB_0911` 12.92x → 1.00x (5150 columns
+peeling to a bump of 29), `QPLIB_1451_rlt0` at 3000 iterations 7.86x → 1.01x.
 
 discopt does not get this. It pins crates.io `feral 0.15.1`, which predates #160,
 and even on current `main` the default ordering is whole-basis AMD. So discopt's
@@ -65,10 +66,17 @@ not select one.
 
 ### 2. The residual bump is where Markowitz is actually needed
 
-On the three bases whose bump exceeds 500 columns — `QPLIB_1157` (611),
-`QPLIB_1157_rlt1` (584), `QPLIB_1143_rlt1` (624) — the peel leaves 5.66–6.74x and
-Markowitz reaches 1.32–1.89x, a **3.15–4.30x** fill difference. These are exactly
-the instances #1008 is written around. Under that issue's own measured cost law
+On the four bases whose bump exceeds 500 columns — `QPLIB_1157` (611),
+`QPLIB_1157_rlt1` (584), `QPLIB_1143_rlt1` (624), `QPLIB_1451_rlt0_cap100000`
+(1350) — the peel leaves 3.21–6.74x and Markowitz reaches 1.14–1.89x, a
+**2.82–4.30x** fill difference. These are exactly the instances #1008 is written
+around.
+
+The bump grows along the simplex trajectory, which is why a shallow sample hides
+this. On `QPLIB_1451_rlt0` the bump is 67 columns at 3000 iterations and 1350 at
+25 088, and the peel goes from closing the gap entirely (7.86x → 1.01x) to leaving
+a 2.82x one (24.90x → 3.21x). Bases sampled early in a solve are not evidence
+about the bases a solve spends its time on. Under that issue's own measured cost law
 (numeric cost ∝ fill² × nnz(B)) a 3.6x fill difference is an order of magnitude of
 numeric LU work, against `LuNumeric` at 72.6% of LP wall.
 
@@ -78,7 +86,7 @@ numeric LU work, against `LuNumeric` at 72.6% of LP wall.
 cancelled the planned ordering work on it. That comparison is uninformative by
 construction: **SuperLU is the same algorithm class as feral** — a static
 fill-reducing column permutation followed by partial pivoting. On this corpus it
-is in fact *worse* than feral (geomean 2.88x vs 2.60x), and both sit 2.3–2.6x
+is in fact *worse* than feral (geomean 3.24x vs 3.00x), and both sit 2.7–2.9x
 above the achievable 1.11x. Agreement between two members of a class says nothing
 about the alternative to the class.
 
@@ -111,9 +119,9 @@ Markowitz is not free and this note does not claim it is.
 
 1. **Release the peel and make it reachable.** Cut a release carrying #160 and
    decide the default-vs-parameter question in #165. This is finished code and it
-   is where geomean 2.60x → 1.45x lives.
+   is where geomean 3.00x → 1.52x lives.
 2. **Then** implement threshold-Markowitz for the bump. Everything above 500 bump
-   columns is still 3–4x off, and the corpus says that is where the wall is.
+   columns is still 2.8–4.3x off, and the corpus says that is where the wall is.
 
 Step 1 must not be reported as closing #1008: on `QPLIB_1157`, the instance the
 issue is built around, the peel changes fill by *nothing* (6.49x → 6.74x, slightly
@@ -129,8 +137,9 @@ a direct gate on that indexing — each basic index `>= n_struct` must be exactl
 `QPLIB_1157_basis` and `QPLIB_3852_basis` are the in-tree fixtures from
 `tests/data/lu_bases/`, written by feral itself during a discopt solve.
 
-**Not reproduced:** #1008's 19.1x figure for `QPLIB_1451_rlt0`. That is a mean over
-~600 factorizations of one full solve; the bases here are the final basis and three
-iteration-capped points along a re-solve, and the worst AMD-only fill they show is
-12.92x. The direction and the order of magnitude agree; the exact number is not
-this note's and is not claimed.
+**#1008's 19.1x for `QPLIB_1451_rlt0` is reproduced**, as a range rather than a
+point. That figure is a mean over ~600 factorizations of one full solve. Sampling
+that trajectory at 3000 and at 25 088 iterations gives AMD-only fill of 7.86x and
+24.90x, which brackets it. The same instance was the reason for the earlier
+caveat in this note that only fill up to 12.92x had been seen; that caveat is
+withdrawn.

--- a/dev/research/lu-fill-markowitz-2026-08-13.md
+++ b/dev/research/lu-fill-markowitz-2026-08-13.md
@@ -41,10 +41,12 @@ n=16  geomean fill:  AMDfull 3.00x  peel 1.52x  COLAMD 3.24x  MARKOWITZ 1.11x
 geomean Markowitz advantage over feral's best ordering: 1.37x  (min 1.00x, max 4.30x)
 ```
 
-`AMDfull` = `SparseLuSymbolic::analyze_amd_only`, which is what
-`SparseLuSymbolic::analyze` does today (`LuOrderingParams::default()` is
-`triangularize: false`) and therefore what discopt runs. `peel` =
-`analyze_triangularized` (#160, merged, **unreleased**). `COLAMD` =
+`AMDfull` = `SparseLuSymbolic::analyze_amd_only`, which is what discopt runs,
+because it pins crates.io `feral 0.15.1` and that predates #160. `peel` =
+the peel-then-AMD ordering of #160 — on `main` (b071d54) that *is* what plain
+`analyze` does; on the unmerged PR #162 branch it moves to
+`analyze_triangularized` and plain `analyze` reverts to AMD-full (see the
+correction note below). `COLAMD` =
 `scipy.sparse.linalg.splu(permc_spec="COLAMD", diag_pivot_thresh=0.1)`. `MARKOW` =
 `dev/probes/markowitz-fill/markowitz.py` at `u = 0.1`. All four count strict-lower
 `L` plus `U` including the diagonal, matching `SparseLu::factor_nnz()`.
@@ -58,11 +60,31 @@ triangular it closes the gap outright: `QPLIB_0911` 12.92x → 1.00x (5150 colum
 peeling to a bump of 29), `QPLIB_1451_rlt0` at 3000 iterations 7.86x → 1.01x.
 
 discopt does not get this. It pins crates.io `feral 0.15.1`, which predates #160,
-and even on current `main` the default ordering is whole-basis AMD. So discopt's
-statement that "feral's `analyze` already triangularizes and runs AMD on the
-residual bump, so 19.1x fill is *after* a fill-reducing ordering" is **wrong on
-both halves**: the version it links has no peel, and the entry point it calls does
-not select one.
+and #160 is merged to `main` but has never been released. So discopt's statement
+that "feral's `analyze` already triangularizes and runs AMD on the residual bump,
+so 19.1x fill is *after* a fill-reducing ordering" is **wrong about the code it is
+actually running**: the version it links has no peel at all.
+
+**Correction (this note's first revision was wrong about the second half).** I
+originally added that "even on current `main` the default ordering is whole-basis
+AMD". That is false. On `main` at b071d54, `SparseLuSymbolic::analyze` calls
+`triangularize(a)` directly (`src/lu/sparse_symbolic.rs:57`) and then runs AMD on
+the bump — the peel *is* the default there. `LuOrderingParams` does not exist on
+`main`; it is introduced by the unmerged PR #162, which reverts `analyze` to
+AMD-full and makes the peel opt-in via `analyze_triangularized`, because of the
+trajectory regression in #163. I read the PR #162 worktree and reported it as
+`main`.
+
+The practical consequence, and it is the one that matters: **discopt needs no
+source change to get the peel today.** Repointing its `feral` dependency at
+`main` (b071d54) — a path or git dep under `[patch.crates-io]`, which is the
+mechanism #1008 already used for its probe branch — is sufficient, because the
+two `SparseLuSymbolic::analyze` call sites in `linsolve.rs` pick up the peel as
+the default. A release is not the gate. If PR #162 lands, that flips: a consumer
+pinned past #162 silently loses the peel and has to call
+`analyze_triangularized` (or `analyze_with(.., LuOrderingParams { triangularize:
+true })`) explicitly. That is the concrete consumer stake in the ordering-default
+question of #165.
 
 ### 2. The residual bump is where Markowitz is actually needed
 

--- a/dev/research/lu-fill-markowitz-2026-08-13.md
+++ b/dev/research/lu-fill-markowitz-2026-08-13.md
@@ -1,0 +1,136 @@
+# The LP-basis fill is an artifact of static ordering, not intrinsic to the bases
+
+**Date:** 2026-08-13 · **Origin:** discopt #1008 · **Harness:** `dev/probes/markowitz-fill/`
+
+## Question
+
+discopt #1008 attributes 72.6% of its LP wall to `SparseLu::factor` and shows the
+per-LP share tracking fill directly (fill 1.0 → ~5% of wall; `QPLIB_1451_rlt0` at
+fill 19.1x → 74.8%). Its closing question, left explicitly to feral:
+
+> whether this fill is intrinsic to these bases or an artifact of static ordering
+> under partial pivoting (the usual remedy being threshold-Markowitz pivoting,
+> choosing pivots dynamically against both sparsity and stability).
+
+## Answer
+
+**Artifact.** On a 15-basis corpus of real discopt simplex bases, threshold-Markowitz
+reaches geomean fill **1.11x** and never exceeds 1.89x. feral's shipped ordering is
+geomean **2.60x** with a tail to 12.92x.
+
+```
+basis                         m   nnz(B)   bump |  AMDfull     peel   COLAMD   MARKOW | M vs best feral
+QPLIB_1157                 3937    29376    611 |    6.49x    6.74x    7.26x    1.79x |           3.64x
+QPLIB_3852                 1760     4003     45 |    1.08x    1.01x    1.07x    1.01x |           1.00x
+QPLIB_1451_rlt0_cap3000    7392    56213     67 |    7.86x    1.01x   14.95x    1.00x |           1.01x
+QPLIB_0343_rlt0            5102    12752     99 |    1.03x    1.03x    1.02x    1.00x |           1.03x
+QPLIB_0343_rlt1            5202     7868     18 |    1.01x    1.00x    1.01x    1.01x |           1.00x
+QPLIB_0911_rlt0            5150    37133     29 |   12.92x    1.00x    8.59x    1.00x |           1.00x
+QPLIB_0911_rlt1            5150    37133     29 |   12.92x    1.00x    8.59x    1.00x |           1.00x
+QPLIB_0975_rlt0            5110    17330     14 |    1.39x    1.00x    1.24x    1.00x |           1.00x
+QPLIB_0975_rlt1            5110    17330     14 |    1.39x    1.00x    1.24x    1.00x |           1.00x
+QPLIB_1055_rlt0            3300    20617     18 |    1.10x    1.00x    1.10x    1.00x |           1.00x
+QPLIB_1055_rlt1            3300    20617     18 |    1.10x    1.00x    1.10x    1.00x |           1.00x
+QPLIB_1143_rlt0            3308    19355     50 |    1.43x    1.01x    7.12x    1.00x |           1.01x
+QPLIB_1143_rlt1            3628    30315    624 |    8.33x    5.66x    9.60x    1.32x |           4.30x
+QPLIB_1157_rlt0            3273     9197     41 |    1.03x    1.03x    1.04x    1.00x |           1.03x
+QPLIB_1157_rlt1            3937    29085    584 |    6.28x    5.97x    6.51x    1.89x |           3.15x
+
+n=15  geomean fill:  AMDfull 2.60x  peel 1.45x  COLAMD 2.88x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.30x (min 1.00x, max 4.30x)
+```
+
+`AMDfull` = `SparseLuSymbolic::analyze_amd_only`, which is what
+`SparseLuSymbolic::analyze` does today (`LuOrderingParams::default()` is
+`triangularize: false`) and therefore what discopt runs. `peel` =
+`analyze_triangularized` (#160, merged, **unreleased**). `COLAMD` =
+`scipy.sparse.linalg.splu(permc_spec="COLAMD", diag_pivot_thresh=0.1)`. `MARKOW` =
+`dev/probes/markowitz-fill/markowitz.py` at `u = 0.1`. All four count strict-lower
+`L` plus `U` including the diagonal, matching `SparseLu::factor_nnz()`.
+
+## Two separable findings
+
+### 1. Most of the gap is code we have already written and have not shipped
+
+The peel takes geomean fill 2.60x → 1.45x and closes the extreme cases outright:
+`QPLIB_0911` 12.92x → 1.00x, `QPLIB_1451_rlt0` 7.86x → 1.01x. Those bases are
+93–99% triangularizable — 5150 columns peeling to a bump of 29.
+
+discopt does not get this. It pins crates.io `feral 0.15.1`, which predates #160,
+and even on current `main` the default ordering is whole-basis AMD. So discopt's
+statement that "feral's `analyze` already triangularizes and runs AMD on the
+residual bump, so 19.1x fill is *after* a fill-reducing ordering" is **wrong on
+both halves**: the version it links has no peel, and the entry point it calls does
+not select one.
+
+### 2. The residual bump is where Markowitz is actually needed
+
+On the three bases whose bump exceeds 500 columns — `QPLIB_1157` (611),
+`QPLIB_1157_rlt1` (584), `QPLIB_1143_rlt1` (624) — the peel leaves 5.66–6.74x and
+Markowitz reaches 1.32–1.89x, a **3.15–4.30x** fill difference. These are exactly
+the instances #1008 is written around. Under that issue's own measured cost law
+(numeric cost ∝ fill² × nnz(B)) a 3.6x fill difference is an order of magnitude of
+numeric LU work, against `LuNumeric` at 72.6% of LP wall.
+
+## Why the earlier "fill theory is dead" measurement could not have found this
+
+#1008 ran SuperLU (COLAMD) against feral on 12 final bases, got median 0.94x, and
+cancelled the planned ordering work on it. That comparison is uninformative by
+construction: **SuperLU is the same algorithm class as feral** — a static
+fill-reducing column permutation followed by partial pivoting. On this corpus it
+is in fact *worse* than feral (geomean 2.88x vs 2.60x), and both sit 2.3–2.6x
+above the achievable 1.11x. Agreement between two members of a class says nothing
+about the alternative to the class.
+
+The same reading is available inside the SuperLU arm alone: `diag_pivot_thresh`
+0.1 vs 1.0 moves fill by under 2% on every basis here (`QPLIB_1157`: 7.26x vs
+7.50x). The pivoting threshold is not what sets the fill. The static column order
+is.
+
+## Cost of the alternative
+
+Markowitz is not free and this note does not claim it is.
+
+* **Stability.** Threshold pivoting bounds `max|L|` by `1/u` and nothing bounds
+  growth as tightly as partial pivoting does. Measured on `QPLIB_1157` at
+  `u = 0.1`: `max|U|/max|B| = 81.8`, `max|L| = 9.70` (at its 1/u bound), against
+  SuperLU partial pivoting's `2.56` and `1.00`. At `u = 0.01` growth is 353x for
+  a further 0.4% of fill — not worth it. feral already has the machinery to live
+  with this (`LuParams::max_growth`, `should_refactor_growth()`).
+* **Architecture.** Markowitz picks pivots from *numeric* values, so it cannot be
+  expressed in feral's current split of `SparseLuSymbolic::analyze` followed by
+  `SparseLu::factor`. It is a new factorization path, not a new ordering — the
+  symbolic phase disappears into the numeric one rather than being replaced.
+  (That is not purely a cost: symbolic analysis is 5.0% of discopt's LP wall today
+  and would stop being a separate line item.)
+* **Search cost.** The oracle here is Python and its speed means nothing. A real
+  implementation needs the standard count-bucket structure with the Suhl search
+  cutoff; that work is real and is not estimated in this note.
+
+## Recommended order of work
+
+1. **Release the peel and make it reachable.** Cut a release carrying #160 and
+   decide the default-vs-parameter question in #165. This is finished code and it
+   is where geomean 2.60x → 1.45x lives.
+2. **Then** implement threshold-Markowitz for the bump. Everything above 500 bump
+   columns is still 3–4x off, and the corpus says that is where the wall is.
+
+Step 1 must not be reported as closing #1008: on `QPLIB_1157`, the instance the
+issue is built around, the peel changes fill by *nothing* (6.49x → 6.74x, slightly
+worse) and only Markowitz moves it.
+
+## Provenance
+
+Bases are real discopt simplex bases: the captured #1008 root relaxation LPs
+re-solved through `discopt._rust.solve_lp_warm_csc_py`, with the final basis
+reconstructed from the returned `basic_vars` against `[A | I]`. Every basis passes
+a direct gate on that indexing — each basic index `>= n_struct` must be exactly
+`e_{j-n_struct}` — plus a nonsingularity check, before it is written.
+`QPLIB_1157_basis` and `QPLIB_3852_basis` are the in-tree fixtures from
+`tests/data/lu_bases/`, written by feral itself during a discopt solve.
+
+**Not reproduced:** #1008's 19.1x figure for `QPLIB_1451_rlt0`. That is a mean over
+~600 factorizations of one full solve; the bases here are the final basis and three
+iteration-capped points along a re-solve, and the worst AMD-only fill they show is
+12.92x. The direction and the order of magnitude agree; the exact number is not
+this note's and is not claimed.

--- a/dev/research/markowitz-fill-measurement.md
+++ b/dev/research/markowitz-fill-measurement.md
@@ -1,0 +1,101 @@
+# Threshold-Markowitz LU: measured fill and cost (#167)
+
+Date: 2026-08-14. Branch `feat/167-threshold-markowitz`.
+Plan: `dev/plans/threshold-markowitz-lu.md`. Implementation: `src/lu/markowitz.rs`.
+
+## What was measured
+
+`examples/basis_refactor` factors a preserved corpus of 16 LP bases four ways and
+reports fill as `factor_nnz()/nnz(B)` (strict-lower `L` plus `U` with diagonal)
+and wall-clock for the full analyze+factor:
+
+- `AMDfull` — the shipped static path: AMD on the AᵀA column-intersection
+  pattern, then Gilbert-Peierls with partial pivoting.
+- `peel` — `analyze_triangularized`: Suhl-Suhl triangularization, AMD on the
+  residual bump only.
+- `denseBump` — `peel` plus the dense-bump route (`dense_bump_max_dim`).
+- `markowitz` — `SparseLu::factor_markowitz`, threshold-Markowitz with
+  `u = 0.1`, `max_search = 8`. Its symbolic column is 0 by construction, not by
+  omission: there is no separate analyze phase.
+
+3 reps, release build, `--release` example binary. Corpus at `/private/tmp/feral-fill`.
+
+## Result
+
+```
+basis                            m   nnz(B)   bump |  AMDfull    peel  MARKOW |     t_AMD   t_peel  t_dense   t_mark
+QPLIB_0343_rlt0               5102    12752     99 |    1.03x   1.03x   1.00x |     1.80m    0.67m    0.58m    1.43m
+QPLIB_0343_rlt1               5202     7868     18 |    1.01x   1.00x   1.00x |     0.92m    0.38m    0.35m    0.97m
+QPLIB_0911_rlt0               5150    37133     29 |   12.92x   1.00x   1.00x |   168.82m    1.10m    1.10m    4.32m
+QPLIB_0911_rlt1               5150    37133     29 |   12.92x   1.00x   1.00x |   179.63m    1.07m    1.07m    4.30m
+QPLIB_0975_rlt0               5110    17330     14 |    1.39x   1.00x   1.00x |     9.75m    0.66m    0.63m    1.89m
+QPLIB_0975_rlt1               5110    17330     14 |    1.39x   1.00x   1.00x |     9.79m    0.67m    0.63m    1.89m
+QPLIB_1055_rlt0               3300    20617     18 |    1.10x   1.00x   1.00x |     1.54m    0.60m    0.57m    1.78m
+QPLIB_1055_rlt1               3300    20617     18 |    1.10x   1.00x   1.00x |     1.54m    0.60m    0.56m    1.79m
+QPLIB_1143_rlt0               3308    19355     50 |    1.43x   1.01x   1.00x |     6.94m    0.70m    0.64m    1.98m
+QPLIB_1143_rlt1               3628    30315    624 |    8.33x   5.66x   1.31x |    56.72m   31.77m    8.09m    4.87m
+QPLIB_1157_rlt0               3273     9197     41 |    1.03x   1.03x   1.00x |     1.22m    0.43m    0.39m    1.05m
+QPLIB_1157_rlt1               3937    29085    584 |    6.28x   5.97x   1.74x |    45.13m   31.16m   11.43m    6.94m
+QPLIB_1451_rlt0_cap1000       7392    39569    391 |    1.30x   1.21x   1.00x |    16.36m    1.61m    1.92m    5.27m
+QPLIB_1451_rlt0_cap100000     7392    63720   1350 |   24.90x   3.21x   1.14x |  1066.64m   12.08m   32.23m   10.98m
+QPLIB_1451_rlt0_cap300        7392    22420     78 |    1.51x   1.22x   1.00x |     5.94m    1.08m    0.90m    3.01m
+QPLIB_1451_rlt0_cap3000       7392    56213     67 |    7.86x   1.01x   1.00x |   119.81m    1.73m    1.73m    7.22m
+
+n=16  geomean fill:  AMDfull 2.77x  peel 1.38x  MARKOWITZ 1.06x
+geomean total time vs AMDfull:  peel 9.68x  denseBump 10.99x  markowitz 4.92x
+```
+
+## Reading
+
+**Fill.** 2.77x -> 1.06x geomean, and 1.00x (zero fill) on ten of the sixteen
+bases. This cross-validates the Python oracle from the #167 investigation, which
+predicted 1.11x; the Rust implementation is at or slightly better than the
+oracle, so both are measuring the same thing.
+
+**Wall-clock is mixed and that is the honest headline.** Markowitz is the
+fastest arm on exactly the class of basis discopt #1008 is written around --
+large residual bumps:
+
+- QPLIB_1143_rlt1 (bump 624): 4.87m vs denseBump 8.09m, peel 31.77m, AMDfull 56.72m
+- QPLIB_1157_rlt1 (bump 584): 6.94m vs denseBump 11.43m, peel 31.16m, AMDfull 45.13m
+- QPLIB_1451_rlt0_cap100000 (bump 1350): 10.98m vs peel 12.08m, denseBump 32.23m
+
+It loses to the peel on near-triangular bases, where the peel's linear scan is
+simply cheaper than running the general pivot search 5150 times:
+
+- QPLIB_0911_rlt0 (bump 29): peel 1.10m vs markowitz 4.32m (still 39x faster than AMDfull)
+- QPLIB_1451_rlt0_cap3000 (bump 67): peel 1.73m vs markowitz 7.22m
+
+So the geomean (peel 9.68x, markowitz 4.92x) is dominated by the many
+near-triangular bases in this corpus, not by a general slowness.
+
+## Two cost experiments, both recorded because one of them failed
+
+**Suhl-Suhl singleton fast path** (column with one live entry, row with one live
+entry passing the threshold, taken off a stack instead of through the count
+heaps). Fill 1.07x -> 1.06x, wall geomean 3.43x -> 3.50x. Essentially free but
+essentially no help: the heap traffic was not where the time was. Kept, because
+it does improve fill slightly and costs nothing, but it did not do the job it
+was added to do.
+
+**In-place rank-1 update.** The first implementation rebuilt each touched column
+into a fresh `Vec` per (pivot, column) pair. On a 5150-column basis that is
+millions of allocations. Rewriting it to walk the column once in place --
+updating entries the pivot column touches, `swap_remove`ing exact cancellations
+and the consumed pivot row, appending unmet rows as fill -- moved the wall
+geomean 3.50x -> 4.92x with fill unchanged. This was the real cost, not the
+search.
+
+## What is not claimed
+
+- No claim about numerical behaviour in a simplex trajectory. The measured
+  stability cost from the plan stands: `max|U|/max|B| = 81.8`, `max|L| = 9.70`
+  at u=0.1 on QPLIB_1157_rlt1, against SuperLU's 2.56/1.00. Less fill is bought
+  with more growth, and #163/#166 are the standing evidence that growth on these
+  bases is not a free parameter.
+- No claim that this should replace the shipped path. `factor_markowitz` is an
+  additional entry point; `SparseLu::factor` is untouched.
+- Peel-then-Markowitz-on-the-residual-bump is still out of scope. The wall-clock
+  split above is the argument *for* it -- take the peel's cheap linear scan for
+  the triangular part, the Markowitz search only for the bump -- and it should
+  be its own issue, measured on its own.

--- a/dev/sessions/2026-08-13-05.md
+++ b/dev/sessions/2026-08-13-05.md
@@ -1,0 +1,105 @@
+# Session 2026-08-13-05
+
+## Goal
+
+Answer the one question discopt #1008 left open to feral: is the 19.1x LU fill on
+its LP bases intrinsic to those matrices, or an artifact of choosing the column
+order statically and then pivoting for stability?
+
+## Accomplished
+
+**Answer: artifact.** Built a threshold-Markowitz LU as a fill oracle
+(`dev/probes/markowitz-fill/`), gated on a per-factorization check of
+`||PBQ - LU||inf / ||B||inf < 1e-10`, and ran it against feral's two orderings and
+SuperLU COLAMD on 16 real discopt simplex bases.
+
+```
+n=16  geomean fill:  AMDfull 3.00x  peel 1.52x  COLAMD 3.24x  MARKOWITZ 1.11x
+geomean Markowitz advantage over feral's best ordering: 1.37x (min 1.00x, max 4.30x)
+```
+
+Markowitz never exceeds 1.89x on any basis in the corpus; feral's shipped ordering
+tails to 24.90x. Full table and reasoning in
+`dev/research/lu-fill-markowitz-2026-08-13.md`.
+
+Two findings beyond the headline:
+
+- **discopt's premise is wrong on both halves.** It states feral's `analyze`
+  already triangularizes, but it pins crates.io `feral 0.15.1` (predates #160,
+  which is merged and unreleased) *and* `LuOrderingParams::default()` is
+  `triangularize: false`, so `analyze()` is `analyze_amd_only`. The 19.1x was
+  measured on the un-peeled path.
+- **#1008's "fill theory dead" measurement could not have detected the headroom.**
+  SuperLU is the same algorithm class as feral — static column order plus partial
+  pivoting — so agreement between them says nothing about the dynamic alternative.
+  On this corpus SuperLU is *worse* than feral (3.24x vs 3.00x) and both sit
+  2.7–2.9x above the achievable. Corroborating: inside the SuperLU arm,
+  `diag_pivot_thresh` 0.1 vs 1.0 moves fill under 2% on every basis. The
+  pivoting threshold is not what sets the fill.
+
+Costs measured, not assumed: Markowitz at `u = 0.1` on QPLIB_1157 gives element
+growth 81.8x and `max|L|` 9.70 (at its 1/u bound) against partial pivoting's 2.56x
+and 1.00. It also does not fit the `analyze`-then-`factor` split at all, since
+pivots come from numeric values.
+
+Filed as **feral #167**. Correction posted to **discopt #1008**.
+
+### Self-correction during the session
+
+The first pass concluded the peel closes `QPLIB_1451_rlt0` outright (7.86x → 1.01x)
+and that #1008's 19.1x was not reproduced. Both were wrong, from sampling the
+trajectory too early. When the full solve finished (600 s, 25 088 iterations):
+
+```
+basis                        m   nnz(B)  bump | AMDfull   peel  COLAMD  MARKOW
+QPLIB_1451_rlt0_cap100000 7392    63720  1350 |  24.90x  3.21x  19.44x   1.14x
+```
+
+The bump grows along the simplex trajectory — 67 columns at 3000 iterations, 1350
+at 25 088 — so the peel goes from closing the gap to leaving 2.82x, and AMD-only
+fill at 7.86x / 24.90x brackets the 19.1x mean. Both claims corrected in the note
+(`14bfd1d`) and on #167 before the discopt comment went out.
+
+## Benchmark Results
+
+**Not re-run this session, deliberately.** This session touched only
+`dev/research/`, `dev/probes/`, `dev/journal/` and `dev/sessions/` — no library
+code. `cargo run --bin bench --release` would measure the same code session 04
+measured, and its results stand as recorded in `dev/sessions/2026-08-13-04.md`
+(including the dense-KKT p90 regression reported there: small-frontal 1.57 → 1.61,
+medium 1.96 → 2.09, both still PASS).
+
+The measurements this session *did* produce are fill ratios from
+`examples/basis_refactor` plus the Python oracle, not wall-clock, and no timing
+claim is made from them.
+
+## Decisions Made
+
+None. #167 proposes an order of work (release #160 and settle #165 first, then
+threshold-Markowitz for the bump) but nothing was decided or implemented, so
+nothing was appended to `dev/decisions.md`.
+
+## Abandoned Approaches
+
+None abandoned. The Markowitz oracle worked on its first correct implementation and
+is kept in `dev/probes/markowitz-fill/`.
+
+Worth recording as a methodological trap rather than a rejected approach: the first
+corpus was built from final and iteration-capped-early bases, which understated the
+bump and produced two wrong conclusions (see above). Bases sampled early in a solve,
+or only at termination, are not evidence about the bases a solve spends its time on.
+
+## Next Session Should
+
+1. Merge PR #162 (`gh pr merge --merge`) — CI is fully green: 2 `check`,
+   2 `stress-smoke`, wheels on 3.10/3.12/3.13.
+2. Cut a release carrying #160 so triangularization is reachable from crates.io at
+   all, and settle the ordering default in #165. This is where geomean fill
+   3.00x → 1.52x lives, and discopt cannot get any of it today.
+3. Then scope threshold-Markowitz for the bump (#167). Four of 16 bases keep a bump
+   over 500 columns where the peel leaves 3.21–6.74x against Markowitz's
+   1.14–1.89x. Note this is a new factorization path, not a new ordering — it does
+   not fit `SparseLuSymbolic::analyze` followed by `SparseLu::factor`.
+4. Still open from session 04: file the QPLIB_3225 issue (fails under the PR #162
+   branch in all arms including `off`, so it predates those fixes), and decide what
+   to do with the unimplemented AMD-vs-AMF half of #165.

--- a/examples/basis_refactor.rs
+++ b/examples/basis_refactor.rs
@@ -94,6 +94,7 @@ fn main() {
     let mut peel = Stat::new();
     let mut full = Stat::new();
     let mut dense = Stat::new();
+    let mut mark = Stat::new();
     let mut dense_fired = 0usize;
     let dense_cap: usize = std::env::var("FERAL_DENSE_BUMP_MAX")
         .ok()
@@ -103,12 +104,27 @@ fn main() {
     // Interleaved A/B (discopt CLAUDE.md rule 9): alternate arms so any drift in
     // machine state hits both equally.
     for _ in 0..reps {
-        for arm in 0..3 {
+        for arm in 0..4 {
             let s = match arm {
                 0 => &mut peel,
                 1 => &mut full,
-                _ => &mut dense,
+                2 => &mut dense,
+                _ => &mut mark,
             };
+            // Arm 3 has no symbolic phase at all: threshold-Markowitz picks its
+            // pivots from the numbers, so the analysis dissolves into the
+            // factorization (issue #167). Its `symbolic` column is 0 by
+            // construction, not by omission.
+            if arm == 3 {
+                let t0 = Instant::now();
+                let lu = SparseLu::factor_markowitz(&a, params.clone()).expect("markowitz");
+                s.sym.push(0.0);
+                s.num.push(t0.elapsed().as_secs_f64() * 1e3);
+                s.nnz_lu = lu.factor_nnz();
+                s.bump = 0;
+                s.runs += 1;
+                continue;
+            }
             let p = if arm == 2 {
                 LuParams {
                     dense_bump_max_dim: dense_cap,
@@ -140,6 +156,7 @@ fn main() {
         ("peel+AMD(bump)", &peel),
         ("AMD(full)", &full),
         ("peel+denseBump", &dense),
+        ("markowitz", &mark),
     ] {
         let (ms, ss) = mean_sd(&s.sym);
         let (mn, sn) = mean_sd(&s.num);

--- a/python/src/lu.rs
+++ b/python/src/lu.rs
@@ -300,6 +300,7 @@ impl LuFactor {
                 )));
             }
         };
+        let defaults = LuParams::default();
         Ok(LuParams {
             pivot_threshold,
             zero_pivot_tol,
@@ -314,6 +315,13 @@ impl LuFactor {
             dense_bump_max_dim,
             hyper_sparse_max_density,
             sparse_rhs_max_density,
+            // The threshold-Markowitz path (`SparseLu::factor_markowitz`) has no
+            // Python entry point yet, so these carry the Rust defaults rather
+            // than becoming keyword arguments for a route Python cannot take.
+            // The literal stays exhaustive on purpose: that is what made adding
+            // these two fields fail loudly here instead of silently defaulting.
+            markowitz_threshold: defaults.markowitz_threshold,
+            markowitz_max_search: defaults.markowitz_max_search,
         })
     }
 }

--- a/src/lu/markowitz.rs
+++ b/src/lu/markowitz.rs
@@ -1,0 +1,457 @@
+//! Threshold-Markowitz LU: the pivot order is chosen from the numbers, not ahead
+//! of them (issue #167).
+//!
+//! The shipped sparse path splits into [`SparseLuSymbolic::analyze`] (a static
+//! fill-reducing column permutation, AMD on the AᵀA pattern) and
+//! [`SparseLu::factor`] (Gilbert–Peierls with partial pivoting inside that
+//! order). On real LP bases that split is expensive: measured on 16 discopt
+//! simplex bases, the static order reaches geomean fill 3.00x where a Markowitz
+//! order reaches 1.11x, and SuperLU/COLAMD — the same algorithm class — is 3.24x,
+//! which is why comparing against it could not detect the headroom
+//! (`dev/research/lu-fill-markowitz-2026-08-13.md`).
+//!
+//! This module is the other half: a right-looking factorization that picks each
+//! pivot `(i, j)` to minimise the Markowitz count `(r_i - 1)(c_j - 1)` over the
+//! *active* submatrix, subject to the relative-magnitude threshold
+//! `|a_ij| ≥ u · max_k |a_kj|`. It is not an ordering — the pivot depends on
+//! values that only exist part-way through the elimination — so it replaces both
+//! phases rather than slotting into either.
+//!
+//! **The Suhl–Suhl peel (#160) is a special case of this, not a separate step.**
+//! A column singleton has Markowitz count 0 and is therefore taken immediately,
+//! so a triangularizable basis is triangularized here with no peel code at all.
+//! That is why the oracle reaches 1.00x fill on the 93–99% triangularizable
+//! bases in the corpus.
+//!
+//! # Storage
+//!
+//! The active submatrix is **column-major with values** (`cols[j]`), plus a
+//! row-wise *index-only* list (`row_cols[i]`) that is allowed to carry stale and
+//! duplicate entries and is deduplicated with a mark array when a pivot row is
+//! gathered. The rank-1 update runs column-oriented — for each alive column `j`
+//! in the pivot row, `col_j ← col_j − u_j · l` — so finding `u_j` costs a scan of
+//! `col_j`, which that column's rebuild pays for anyway. The pivot search reads
+//! column values directly, which is what it needs: both `max_k|a_kj|` and the
+//! threshold test are per column.
+//!
+//! `rcnt` / `ccnt` are maintained exactly. They are not a heuristic cache — a
+//! drifted count makes every subsequent Markowitz cost a cost of the wrong
+//! matrix.
+//!
+//! # Stability
+//!
+//! Accepting a non-maximal pivot bounds `max|L| ≤ 1/u` and bounds element growth
+//! much more weakly than partial pivoting does. On QPLIB_1157 at `u = 0.1` the
+//! oracle measured `max|U|/max|B| = 81.8` and `max|L| = 9.70` against SuperLU's
+//! 2.56 and 1.00. That is the trade this path makes; `LuParams::max_growth` and
+//! [`SparseLu::should_refactor_growth`] are the existing instruments for it.
+
+use super::sparse_matrix::SparseColMatrix;
+use crate::error::FeralError;
+use crate::lu::LuSingularAction;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+/// Raw output of the elimination, in **original** row/column indices. The caller
+/// remaps to pivot positions and assembles the [`SparseLu`](super::SparseLu).
+pub(super) struct MarkowitzFactor {
+    /// `perm[k]` = original row of pivot `k`.
+    pub perm: Vec<usize>,
+    /// `qcol[k]` = original column of pivot `k`.
+    pub qcol: Vec<usize>,
+    /// `L` in CSC over pivot positions; `l_row_idx` holds **original** rows.
+    pub l_col_ptr: Vec<usize>,
+    pub l_row_idx: Vec<usize>,
+    pub l_val: Vec<f64>,
+    /// `U` row per pivot position, entries `(original column, value)`, the
+    /// diagonal included but not necessarily first.
+    pub u_rows_orig: Vec<Vec<(usize, f64)>>,
+    /// `max|A|` of the factored (possibly scaled) matrix.
+    pub a_max: f64,
+}
+
+/// Right-looking threshold-Markowitz LU of `a`.
+///
+/// `u_thresh` is the relative pivot threshold (`0 < u ≤ 1`; `1.0` degenerates to
+/// partial pivoting within the chosen column). `max_search` is the Suhl cutoff:
+/// stop examining candidate columns once this many have been examined and a
+/// candidate is in hand. `zero_pivot_tol` is scaled by `max|A|` exactly as the
+/// Gilbert–Peierls path scales it.
+pub(super) fn markowitz_factor(
+    a: &SparseColMatrix,
+    u_thresh: f64,
+    max_search: usize,
+    zero_pivot_tol: f64,
+    on_singular: LuSingularAction,
+) -> Result<MarkowitzFactor, FeralError> {
+    let m = a.m;
+
+    let mut a_max = 0.0_f64;
+    for &v in a.values.iter() {
+        a_max = a_max.max(v.abs());
+    }
+    let ztol = zero_pivot_tol * a_max;
+
+    // ---- active submatrix ------------------------------------------------
+    let mut cols: Vec<Vec<(usize, f64)>> = Vec::with_capacity(m);
+    let mut row_cols: Vec<Vec<usize>> = vec![Vec::new(); m];
+    let mut rcnt = vec![0usize; m];
+    for j in 0..m {
+        let mut col = Vec::with_capacity(a.col_ptr[j + 1] - a.col_ptr[j]);
+        for idx in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let (i, v) = (a.row_idx[idx], a.values[idx]);
+            if v != 0.0 {
+                col.push((i, v));
+                row_cols[i].push(j);
+                rcnt[i] += 1;
+            }
+        }
+        cols.push(col);
+    }
+    let mut ccnt: Vec<usize> = cols.iter().map(|c| c.len()).collect();
+    let mut alive_r = vec![true; m];
+    let mut alive_c = vec![true; m];
+
+    // Suhl-Suhl inside the Markowitz loop. A column with one live entry has
+    // Markowitz cost 0 and is always taken; so is a row with one live entry
+    // whose value passes the threshold. Handling those two off a stack instead
+    // of through the count heaps is what makes this competitive on
+    // near-triangular LP bases, where 93-99% of the columns peel and the heap
+    // traffic would otherwise dominate the whole factorization
+    // (`dev/research/lu-fill-markowitz-2026-08-13.md`). It changes cost, not the
+    // pivot rule: these are exactly the pivots the general search would pick.
+    let mut col_singletons: Vec<usize> = (0..m).filter(|&j| ccnt[j] == 1).collect();
+    let mut row_singletons: Vec<usize> = (0..m).filter(|&i| rcnt[i] == 1).collect();
+
+    // Lazy min-heaps over the counts; stale pairs are discarded on pop.
+    let mut cheap: BinaryHeap<Reverse<(usize, usize)>> =
+        (0..m).map(|j| Reverse((ccnt[j], j))).collect();
+    let mut rheap: BinaryHeap<Reverse<(usize, usize)>> =
+        (0..m).map(|i| Reverse((rcnt[i], i))).collect();
+
+    // ---- workspaces ------------------------------------------------------
+    let mut lscat = vec![0.0_f64; m];
+    let mut lmark = vec![false; m];
+    let mut seen_mark = vec![false; m];
+    let mut seen_list: Vec<usize> = Vec::new();
+    let mut row_seen = vec![false; m];
+    let mut dirty_rows: Vec<usize> = Vec::new();
+    let mut dirty_mark = vec![false; m];
+    let mut lvec: Vec<(usize, f64)> = Vec::new();
+    let mut uvec: Vec<(usize, f64)> = Vec::new();
+    let mut scanned: Vec<usize> = Vec::new();
+
+    // ---- output ----------------------------------------------------------
+    let mut perm = Vec::with_capacity(m);
+    let mut qcol = Vec::with_capacity(m);
+    let mut l_col_ptr = Vec::with_capacity(m + 1);
+    let mut l_row_idx: Vec<usize> = Vec::new();
+    let mut l_val: Vec<f64> = Vec::new();
+    l_col_ptr.push(0);
+    let mut u_rows_orig: Vec<Vec<(usize, f64)>> = Vec::with_capacity(m);
+
+    for _step in 0..m {
+        // ---- pivot search ------------------------------------------------
+        // Singleton fast path first (cost 0, no heap traffic).
+        let mut fast: Option<(usize, usize)> = None;
+        while let Some(j) = col_singletons.pop() {
+            if !alive_c[j] || ccnt[j] != 1 {
+                continue;
+            }
+            let (i, v) = cols[j][0];
+            if v.abs() > ztol {
+                fast = Some((i, j));
+                break;
+            }
+        }
+        if fast.is_none() {
+            while let Some(i) = row_singletons.pop() {
+                if !alive_r[i] || rcnt[i] != 1 {
+                    continue;
+                }
+                // Find the one live column holding it. `row_cols` carries stale
+                // entries, so this is a search, not a lookup.
+                let mut found = None;
+                for &j in row_cols[i].iter() {
+                    if !alive_c[j] {
+                        continue;
+                    }
+                    if let Some(&(_, v)) = cols[j].iter().find(|&&(r, _)| r == i) {
+                        found = Some((j, v));
+                        break;
+                    }
+                }
+                // A row singleton still has to pass the threshold against its
+                // own column — it is a cheap pivot, not a free one.
+                if let Some((j, v)) = found {
+                    let colmax = cols[j].iter().fold(0.0_f64, |a, &(_, x)| a.max(x.abs()));
+                    if v.abs() > ztol && v.abs() >= u_thresh * colmax {
+                        fast = Some((i, j));
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Smallest live row count, a valid lower bound on `r_i` for the
+        // remaining columns: no column can beat `(c-1)(minr-1)`.
+        let minr = if fast.is_some() {
+            1
+        } else {
+            loop {
+                match rheap.peek() {
+                    Some(&Reverse((c, i))) => {
+                        if alive_r[i] && rcnt[i] == c {
+                            break c.max(1);
+                        }
+                        rheap.pop();
+                    }
+                    None => break 1,
+                }
+            }
+        };
+
+        let mut best: Option<(usize, f64, usize, usize)> = None; // cost, |v|, i, j
+        let mut singular_col: Option<usize> = None;
+        scanned.clear();
+        let mut examined = 0usize;
+        while fast.is_none() {
+            let Some(&Reverse((c, j))) = cheap.peek() else {
+                break;
+            };
+            if !alive_c[j] || ccnt[j] != c {
+                cheap.pop();
+                continue;
+            }
+            if let Some((bc, _, _, _)) = best {
+                if c.saturating_sub(1) * minr.saturating_sub(1) > bc {
+                    break;
+                }
+            }
+            cheap.pop();
+            scanned.push(j);
+
+            let colmax = cols[j]
+                .iter()
+                .fold(0.0_f64, |acc, &(_, v)| acc.max(v.abs()));
+            if colmax <= ztol {
+                // Numerically empty column: not a pivot candidate, and the
+                // reason this basis is singular if nothing else is left.
+                singular_col = Some(singular_col.map_or(j, |p: usize| p.min(j)));
+                continue;
+            }
+            let bar = u_thresh * colmax;
+            for &(i, v) in cols[j].iter() {
+                if v.abs() < bar {
+                    continue;
+                }
+                let cost = rcnt[i].saturating_sub(1) * c.saturating_sub(1);
+                let better = match best {
+                    None => true,
+                    Some((bc, bv, _, _)) => cost < bc || (cost == bc && v.abs() > bv),
+                };
+                if better {
+                    best = Some((cost, v.abs(), i, j));
+                }
+            }
+            examined += 1;
+            if let Some((0, _, _, _)) = best {
+                break;
+            }
+            if examined >= max_search && best.is_some() {
+                break;
+            }
+        }
+        for &j in scanned.iter() {
+            if alive_c[j] {
+                cheap.push(Reverse((ccnt[j], j)));
+            }
+        }
+
+        let (pi, pj) = match fast.or(best.map(|(_, _, i, j)| (i, j))) {
+            Some((i, j)) => (i, j),
+            None => {
+                // Nothing acceptable anywhere: the remaining active submatrix has
+                // no pivot above `ztol`.
+                let col = singular_col
+                    .or_else(|| (0..m).find(|&j| alive_c[j]))
+                    .unwrap_or(0);
+                match on_singular {
+                    LuSingularAction::Fail => {
+                        return Err(FeralError::SingularBasis { column: col });
+                    }
+                    LuSingularAction::PerturbToEps { abs_floor } => {
+                        // Perturb in place: give the column an entry on some live
+                        // row and let the normal path consume it.
+                        let row = match (0..m).find(|&i| alive_r[i]) {
+                            Some(r) => r,
+                            None => return Err(FeralError::SingularBasis { column: col }),
+                        };
+                        let mag = abs_floor.max(f64::MIN_POSITIVE);
+                        match cols[col].iter_mut().find(|(i, _)| *i == row) {
+                            Some(e) => e.1 = if e.1 < 0.0 { -mag } else { mag },
+                            None => {
+                                cols[col].push((row, mag));
+                                row_cols[row].push(col);
+                                rcnt[row] += 1;
+                                ccnt[col] += 1;
+                                cheap.push(Reverse((ccnt[col], col)));
+                                rheap.push(Reverse((rcnt[row], row)));
+                            }
+                        }
+                        (row, col)
+                    }
+                }
+            }
+        };
+
+        let pv = cols[pj]
+            .iter()
+            .find(|&&(i, _)| i == pi)
+            .map(|&(_, v)| v)
+            .ok_or(FeralError::SingularBasis { column: pj })?;
+
+        // ---- gather the pivot column (→ L) and pivot row (→ U) ------------
+        lvec.clear();
+        let inv = 1.0 / pv;
+        for &(i, v) in cols[pj].iter() {
+            if i != pi {
+                lvec.push((i, v * inv));
+            }
+        }
+        uvec.clear();
+        for &j in row_cols[pi].iter() {
+            if j == pj || !alive_c[j] || row_seen[j] {
+                continue;
+            }
+            row_seen[j] = true;
+            if let Some(&(_, v)) = cols[j].iter().find(|&&(i, _)| i == pi) {
+                uvec.push((j, v));
+            }
+        }
+        for &j in row_cols[pi].iter() {
+            row_seen[j] = false;
+        }
+
+        alive_r[pi] = false;
+        alive_c[pj] = false;
+        perm.push(pi);
+        qcol.push(pj);
+
+        // U row: diagonal plus the surviving row entries.
+        let mut urow = Vec::with_capacity(1 + uvec.len());
+        urow.push((pj, pv));
+        urow.extend_from_slice(&uvec);
+        u_rows_orig.push(urow);
+
+        // L column: the multipliers, in original rows.
+        for &(i, mult) in lvec.iter() {
+            l_row_idx.push(i);
+            l_val.push(mult);
+        }
+        l_col_ptr.push(l_row_idx.len());
+
+        // Every live row in the pivot column loses its `pj` entry.
+        dirty_rows.clear();
+        for &(i, _) in lvec.iter() {
+            rcnt[i] -= 1;
+            if !dirty_mark[i] {
+                dirty_mark[i] = true;
+                dirty_rows.push(i);
+            }
+        }
+        cols[pj] = Vec::new();
+
+        // ---- rank-1 update, column-oriented ------------------------------
+        // In place: each column is walked once, existing entries updated where
+        // the pivot column touches them and swap-removed on exact cancellation,
+        // and the rows the walk did not meet appended as fill. Rebuilding into a
+        // fresh `Vec` per column instead costs one allocation per (pivot, column)
+        // pair, which on a 5150-column basis is millions of them.
+        for &(i, lv) in lvec.iter() {
+            lscat[i] = lv;
+            lmark[i] = true;
+        }
+        for &(j, uval) in uvec.iter() {
+            let col = &mut cols[j];
+            let mut k = 0;
+            while k < col.len() {
+                let (i, v) = col[k];
+                if i == pi {
+                    col.swap_remove(k); // consumed into the U row
+                    continue;
+                }
+                if uval != 0.0 && lmark[i] {
+                    let nv = v - uval * lscat[i];
+                    seen_mark[i] = true;
+                    seen_list.push(i);
+                    if nv == 0.0 {
+                        // Exact cancellation: drop it, and keep the counts exact.
+                        rcnt[i] -= 1;
+                        if !dirty_mark[i] {
+                            dirty_mark[i] = true;
+                            dirty_rows.push(i);
+                        }
+                        col.swap_remove(k);
+                        continue;
+                    }
+                    col[k].1 = nv;
+                }
+                k += 1;
+            }
+            if uval != 0.0 {
+                for &(i, lv) in lvec.iter() {
+                    if seen_mark[i] {
+                        continue;
+                    }
+                    let nv = -uval * lv;
+                    if nv != 0.0 {
+                        col.push((i, nv));
+                        rcnt[i] += 1;
+                        row_cols[i].push(j);
+                        if !dirty_mark[i] {
+                            dirty_mark[i] = true;
+                            dirty_rows.push(i);
+                        }
+                    }
+                }
+            }
+            for &i in seen_list.iter() {
+                seen_mark[i] = false;
+            }
+            seen_list.clear();
+            ccnt[j] = col.len();
+            // Always into the heap as well: the stack is a fast path, not an
+            // alternative index. A column that stops being a singleton is
+            // dropped from the stack, and if it were not in `cheap` too it would
+            // be invisible to the general search and reported singular.
+            cheap.push(Reverse((ccnt[j], j)));
+            if ccnt[j] == 1 {
+                col_singletons.push(j);
+            }
+        }
+        for &(i, _) in lvec.iter() {
+            lmark[i] = false;
+        }
+
+        for &i in dirty_rows.iter() {
+            dirty_mark[i] = false;
+            if alive_r[i] {
+                if rcnt[i] == 1 {
+                    row_singletons.push(i);
+                }
+                rheap.push(Reverse((rcnt[i], i)));
+            }
+        }
+    }
+
+    Ok(MarkowitzFactor {
+        perm,
+        qcol,
+        l_col_ptr,
+        l_row_idx,
+        l_val,
+        u_rows_orig,
+        a_max,
+    })
+}

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -16,6 +16,7 @@ pub mod dense_factor;
 pub mod dense_matrix;
 pub mod dense_solve;
 pub mod dense_update;
+pub(crate) mod markowitz;
 pub mod scaling;
 pub mod sparse_factor;
 pub(crate) mod sparse_hyper;
@@ -295,6 +296,28 @@ pub struct LuParams {
     /// shipped. `0.0` forces the dense sweep on every nonempty right-hand side.
     /// Valid range `[0, 1]`.
     pub sparse_rhs_max_density: f64,
+
+    /// Relative pivot threshold for the threshold-Markowitz path
+    /// ([`SparseLu::factor_markowitz`], issue #167). A pivot is admissible when
+    /// `|a_ij| >= markowitz_threshold * max_k |a_kj|`, which bounds `max|L|` by
+    /// its reciprocal. It does **not** affect [`SparseLu::factor`], which pivots
+    /// with [`LuParams::pivot_threshold`] inside a static column order.
+    ///
+    /// Default `0.1`, the value the fill measurement was taken at. Loosening it
+    /// to `0.01` bought 0.4% of fill for 353x element growth on QPLIB_1157 and is
+    /// not worth taking; `1.0` degenerates to partial pivoting within the chosen
+    /// column and gives most of the fill back.
+    pub markowitz_threshold: f64,
+
+    /// Suhl search cutoff: stop examining candidate columns once this many have
+    /// been examined *and* an admissible pivot is in hand.
+    ///
+    /// Markowitz's cost is the search, not the arithmetic — an exhaustive scan of
+    /// the active submatrix at every step is quadratic. Columns are examined in
+    /// increasing count order and the scan also stops on the valid lower bound
+    /// `(c-1)(min_i r_i - 1) > best`, so this cutoff only binds when many columns
+    /// tie. Default `8`.
+    pub markowitz_max_search: usize,
 }
 
 impl LuParams {
@@ -315,6 +338,23 @@ impl LuParams {
                 "LuParams::pivot_threshold must be in (0, 1], got {}",
                 self.pivot_threshold
             )));
+        }
+        // Same interval as `pivot_threshold`, and for the same reason: the
+        // reciprocal is the `max|L|` bound, so `0` gives no bound at all and a
+        // value above `1` can reject every entry in a column and report a healthy
+        // basis singular.
+        if !(self.markowitz_threshold > 0.0 && self.markowitz_threshold <= 1.0) {
+            return Err(FeralError::InvalidInput(format!(
+                "LuParams::markowitz_threshold must be in (0, 1], got {}",
+                self.markowitz_threshold
+            )));
+        }
+        // A zero cutoff would stop the search before it examined anything, so the
+        // path would report every basis singular.
+        if self.markowitz_max_search == 0 {
+            return Err(FeralError::InvalidInput(
+                "LuParams::markowitz_max_search must be >= 1".to_string(),
+            ));
         }
         if !(self.zero_pivot_tol >= 0.0 && self.zero_pivot_tol < 1.0) {
             return Err(FeralError::InvalidInput(format!(
@@ -388,6 +428,8 @@ impl Default for LuParams {
             update_pivot_search: false,
             hyper_sparse_max_density: 0.10,
             sparse_rhs_max_density: 0.10,
+            markowitz_threshold: 0.1,
+            markowitz_max_search: 8,
         }
     }
 }

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -591,20 +591,6 @@ impl SparseLu {
         let perm_inv: Vec<usize> = pinv.iter().map(|&p| p as usize).collect();
         remap_and_sort_l(&l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
 
-        // Row-wise index of L and the reach workspace: built only when the
-        // reach-limited solve route is enabled, so the off path is byte-for-byte
-        // the pre-#161 allocation profile.
-        let (l_row_ptr, l_row_cols, reach) = if params.hyper_sparse_max_density > 0.0 {
-            let (ptr, cols) = build_l_row_index(&l_col_ptr, &l_row_idx, m);
-            (ptr, cols, super::sparse_solve::ReachWork::new(m))
-        } else {
-            (
-                Vec::new(),
-                Vec::new(),
-                super::sparse_solve::ReachWork::disabled(),
-            )
-        };
-
         // Transpose U from column-wise (built above) to row-wise CSR, then into
         // per-row vectors with the diagonal entry first. Columns were emitted in
         // increasing order, so each row's strict-upper entries are sorted.
@@ -618,35 +604,7 @@ impl SparseLu {
             }
             u_rows.push(row);
         }
-        // Column-wise index of U's off-diagonal entries (rows added in
-        // increasing order, so each `u_above[c]` is sorted ascending). At factor
-        // time U is upper triangular, so this is exactly the strict-upper rows;
-        // it widens to all off-diagonal holders only as FT updates permute U.
-        let mut u_above: Vec<Vec<usize>> = vec![Vec::new(); m];
-        for (i, row) in u_rows.iter().enumerate() {
-            for &(c, _) in row.iter() {
-                if c != i {
-                    u_above[c].push(i);
-                }
-            }
-        }
-
-        // Inverse of the scaling row permutation, for sparse-spike seeding.
-        let mut scale_rperm_inv = vec![0usize; m];
-        for (i, &o) in scale.rperm.iter().enumerate() {
-            scale_rperm_inv[o] = i;
-        }
-
-        // `max|U|` at factor: denominator of the element-growth monitor (L5).
-        let mut u_max0 = 0.0_f64;
-        for row in u_rows.iter() {
-            for &(_, v) in row.iter() {
-                u_max0 = u_max0.max(v.abs());
-            }
-        }
-        let u_max0 = u_max0.max(f64::MIN_POSITIVE);
-
-        Ok(SparseLu {
+        Ok(assemble(
             m,
             l_col_ptr,
             l_row_idx,
@@ -654,43 +612,109 @@ impl SparseLu {
             u_rows,
             perm,
             perm_inv,
-            uperm_inv: (0..m).collect(),
-            uperm: (0..m).collect(),
             qcol,
             qcol_inv,
-            u_above,
-            l_row_ptr,
-            l_row_cols,
-            reach,
-            hyper: super::sparse_hyper::HyperWork::default(),
-            etas: Vec::new(),
-            growth: 1.0,
-            u_max0,
-            a_max,
-            reach_visits,
-            used_dense_bump: dense_done,
-            bump_dim,
             params,
             scale,
-            scale_rperm_inv,
-            scratch: vec![0.0; m],
-            scratch_mark: vec![false; m],
-            ft_work: vec![0.0; m],
-            scratch_b: vec![0.0; m],
-            scratch_c: vec![0.0; m],
-            scratch_d: vec![0.0; m],
-            ft_rw: vec![0.0; m],
-            ft_rw_comp: vec![0.0; m],
-            targets_scratch: Vec::new(),
-            ft_touch_mark: vec![false; m],
-            row_pool: Vec::new(),
-            saved_scratch: Vec::new(),
-            saved_pool: Vec::new(),
-            last_update_work: 0,
-            update_work_total: 0,
-            last_refactor: None,
-            pivot_search_swaps: 0,
-        })
+            a_max,
+            bump_dim,
+            dense_done,
+            reach_visits,
+        ))
+    }
+
+    /// Factor `a` with **threshold-Markowitz** pivoting: no symbolic phase, no
+    /// static column order (issue #167).
+    ///
+    /// [`Self::factor`] takes a column order fixed ahead of the numbers and
+    /// pivots for stability inside it. This picks each pivot `(i, j)` from the
+    /// active submatrix to minimise `(r_i - 1)(c_j - 1)` subject to
+    /// `|a_ij| >= LuParams::markowitz_threshold * max_k |a_kj|`. On 16 real
+    /// discopt LP bases the static path reaches geomean fill 3.00x and a
+    /// Markowitz order reaches 1.11x — and SuperLU/COLAMD, the same algorithm
+    /// class as the static path, is 3.24x, which is why a SuperLU comparison
+    /// could not detect the headroom
+    /// (`dev/research/lu-fill-markowitz-2026-08-13.md`).
+    ///
+    /// The result is an ordinary [`SparseLu`]: same `L`/`U`/`P`/`Q` coordinates,
+    /// so the solves, the hyper-sparse route, and the Forrest–Tomlin update work
+    /// on it unchanged.
+    ///
+    /// **What it costs.** A non-maximal pivot is accepted, so the `max|L| <= 1/u`
+    /// bound replaces partial pivoting's `max|L| <= 1`, and element growth is
+    /// bounded far more weakly. Measured on QPLIB_1157 at `u = 0.1`:
+    /// `max|U|/max|B| = 81.8` against SuperLU's 2.56. Callers that cannot absorb
+    /// that should stay on [`Self::factor`] or watch
+    /// [`Self::should_refactor_growth`].
+    ///
+    /// The Suhl-Suhl peel ([`SparseLuSymbolic::analyze_triangularized`]) is a
+    /// special case of this rule rather than a preliminary step: a column
+    /// singleton has cost 0 and is taken first.
+    pub fn factor_markowitz(a: &SparseColMatrix, params: LuParams) -> Result<Self, FeralError> {
+        params.validate()?;
+        let m = a.m;
+
+        // Same scaling contract as `factor`: factor D_row Pi A D_col.
+        let (scale, scaled) = if params.scaling == LuScaling::None {
+            (LuScale::identity(m), None)
+        } else {
+            let scale = compute_lu_scale(a, params.scaling)?;
+            let mat = scale.apply_sparse(a)?;
+            (scale, Some(mat))
+        };
+        let a: &SparseColMatrix = scaled.as_ref().unwrap_or(a);
+
+        let mk = super::markowitz::markowitz_factor(
+            a,
+            params.markowitz_threshold,
+            params.markowitz_max_search,
+            params.zero_pivot_tol,
+            params.on_singular,
+        )?;
+
+        let mut perm_inv = vec![0usize; m];
+        for (k, &i) in mk.perm.iter().enumerate() {
+            perm_inv[i] = k;
+        }
+        let mut qcol_inv = vec![0usize; m];
+        for (k, &j) in mk.qcol.iter().enumerate() {
+            qcol_inv[j] = k;
+        }
+
+        let mut l_row_idx = mk.l_row_idx;
+        let mut l_val = mk.l_val;
+        remap_and_sort_l(&mk.l_col_ptr, &mut l_row_idx, &mut l_val, &perm_inv, m);
+
+        // U rows carry original column indices; remap to positions and sort. A
+        // pivot's own column is eliminated at its own step and every other entry
+        // in the row sits in a column eliminated later, so position `k` is the
+        // smallest in row `k` and sorting puts the diagonal first — which is the
+        // storage contract the Forrest-Tomlin update reads.
+        let mut u_rows: Vec<Vec<(usize, f64)>> = Vec::with_capacity(m);
+        for (k, row) in mk.u_rows_orig.into_iter().enumerate() {
+            let mut r: Vec<(usize, f64)> = row.into_iter().map(|(j, v)| (qcol_inv[j], v)).collect();
+            r.sort_unstable_by_key(|&(c, _)| c);
+            debug_assert_eq!(r.first().map(|&(c, _)| c), Some(k));
+            u_rows.push(r);
+        }
+
+        Ok(assemble(
+            m,
+            mk.l_col_ptr,
+            l_row_idx,
+            l_val,
+            u_rows,
+            mk.perm,
+            perm_inv,
+            mk.qcol,
+            qcol_inv,
+            params,
+            scale,
+            mk.a_max,
+            0,
+            false,
+            0,
+        ))
     }
 
     /// Convenience: analyze + factor from dense columns.
@@ -915,6 +939,119 @@ impl SparseLu {
             }
         }
         0.0
+    }
+}
+
+/// Assemble the finished [`SparseLu`] from the pieces every factorization path
+/// produces: `L` in CSC over pivot positions (already remapped and sorted), `U`
+/// as per-row `(column position, value)` with the diagonal first, and the two
+/// permutations. Shared by the Gilbert–Peierls path and the threshold-Markowitz
+/// path (issue #167) so the two cannot drift in what they hand downstream — the
+/// solves, the hyper-sparse route, and the Forrest–Tomlin update all read these
+/// fields and none of them knows which path built them.
+#[allow(clippy::too_many_arguments)]
+fn assemble(
+    m: usize,
+    l_col_ptr: Vec<usize>,
+    l_row_idx: Vec<usize>,
+    l_val: Vec<f64>,
+    u_rows: Vec<Vec<(usize, f64)>>,
+    perm: Vec<usize>,
+    perm_inv: Vec<usize>,
+    qcol: Vec<usize>,
+    qcol_inv: Vec<usize>,
+    params: LuParams,
+    scale: LuScale,
+    a_max: f64,
+    bump_dim: usize,
+    used_dense_bump: bool,
+    reach_visits: usize,
+) -> SparseLu {
+    // Row-wise index of L and the reach workspace: built only when the
+    // reach-limited solve route is enabled, so the off path is byte-for-byte
+    // the pre-#161 allocation profile.
+    let (l_row_ptr, l_row_cols, reach) = if params.hyper_sparse_max_density > 0.0 {
+        let (ptr, cols) = build_l_row_index(&l_col_ptr, &l_row_idx, m);
+        (ptr, cols, super::sparse_solve::ReachWork::new(m))
+    } else {
+        (
+            Vec::new(),
+            Vec::new(),
+            super::sparse_solve::ReachWork::disabled(),
+        )
+    };
+    // Column-wise index of U's off-diagonal entries (rows added in
+    // increasing order, so each `u_above[c]` is sorted ascending). At factor
+    // time U is upper triangular, so this is exactly the strict-upper rows;
+    // it widens to all off-diagonal holders only as FT updates permute U.
+    let mut u_above: Vec<Vec<usize>> = vec![Vec::new(); m];
+    for (i, row) in u_rows.iter().enumerate() {
+        for &(c, _) in row.iter() {
+            if c != i {
+                u_above[c].push(i);
+            }
+        }
+    }
+
+    // Inverse of the scaling row permutation, for sparse-spike seeding.
+    let mut scale_rperm_inv = vec![0usize; m];
+    for (i, &o) in scale.rperm.iter().enumerate() {
+        scale_rperm_inv[o] = i;
+    }
+
+    // `max|U|` at factor: denominator of the element-growth monitor (L5).
+    let mut u_max0 = 0.0_f64;
+    for row in u_rows.iter() {
+        for &(_, v) in row.iter() {
+            u_max0 = u_max0.max(v.abs());
+        }
+    }
+    let u_max0 = u_max0.max(f64::MIN_POSITIVE);
+
+    SparseLu {
+        m,
+        l_col_ptr,
+        l_row_idx,
+        l_val,
+        u_rows,
+        perm,
+        perm_inv,
+        uperm_inv: (0..m).collect(),
+        uperm: (0..m).collect(),
+        qcol,
+        qcol_inv,
+        u_above,
+        l_row_ptr,
+        l_row_cols,
+        reach,
+        hyper: super::sparse_hyper::HyperWork::default(),
+        etas: Vec::new(),
+        growth: 1.0,
+        u_max0,
+        a_max,
+        reach_visits,
+        used_dense_bump,
+        bump_dim,
+        params,
+        scale,
+        scale_rperm_inv,
+        scratch: vec![0.0; m],
+        scratch_mark: vec![false; m],
+        ft_work: vec![0.0; m],
+        scratch_b: vec![0.0; m],
+        scratch_c: vec![0.0; m],
+        scratch_d: vec![0.0; m],
+        ft_rw: vec![0.0; m],
+        ft_rw_comp: vec![0.0; m],
+        targets_scratch: Vec::new(),
+        ft_touch_mark: vec![false; m],
+        row_pool: Vec::new(),
+        saved_scratch: Vec::new(),
+        saved_pool: Vec::new(),
+        last_update_work: 0,
+        update_work_total: 0,
+        last_refactor: None,
+        pivot_search_swaps: 0,
     }
 }
 

--- a/tests/lu_markowitz.rs
+++ b/tests/lu_markowitz.rs
@@ -1,0 +1,399 @@
+//! Threshold-Markowitz LU (`SparseLu::factor_markowitz`, issue #167).
+//!
+//! The shipped path picks a *static* fill-reducing column order (AMD on the AᵀA
+//! pattern) and then pivots for stability inside that order. Markowitz instead
+//! picks each pivot dynamically to minimise `(r_i-1)(c_j-1)` subject to
+//! `|a_ij| >= u·max_k|a_kj|`. It is a different factorization path, not a
+//! different ordering, so the contract it has to meet is the *same output
+//! object*: `P B Q = L U` in the same `L`/`U`/`perm`/`qcol` coordinates every
+//! other consumer already reads.
+//!
+//! The fill claim itself (geomean 1.11x against the shipped 3.00x on 16 real LP
+//! bases) is measured out-of-tree against the Python oracle in
+//! `dev/probes/markowitz-fill/`; those bases are not committed. What is checked
+//! here is the part a corpus cannot check: that the factor is *right*, that the
+//! threshold bound on `max|L|` holds, and that on structures where the dynamic
+//! choice is provably better it actually finds it.
+
+use feral::{FeralError, LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+
+/// Deterministic LCG — no rand dependency, and reproducible failures.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+    }
+    fn below(&mut self, n: usize) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 33) as usize) % n
+    }
+}
+
+fn build(m: usize, trip: &mut Vec<(usize, usize, f64)>) -> SparseColMatrix {
+    trip.sort_by_key(|&(i, j, _)| (j, i));
+    trip.dedup_by_key(|&mut (i, j, _)| (i, j));
+    let mut col_ptr = vec![0usize; m + 1];
+    for &(_, j, _) in trip.iter() {
+        col_ptr[j + 1] += 1;
+    }
+    for j in 0..m {
+        col_ptr[j + 1] += col_ptr[j];
+    }
+    SparseColMatrix {
+        m,
+        col_ptr,
+        row_idx: trip.iter().map(|&(i, _, _)| i).collect(),
+        values: trip.iter().map(|&(_, _, v)| v).collect(),
+    }
+}
+
+fn dense_of(a: &SparseColMatrix) -> Vec<Vec<f64>> {
+    let mut d = vec![vec![0.0; a.m]; a.m];
+    for (j, w) in a.col_ptr.windows(2).enumerate() {
+        for idx in w[0]..w[1] {
+            d[a.row_idx[idx]][j] = a.values[idx];
+        }
+    }
+    d
+}
+
+/// `max |(P B Q)_ij - (L U)_ij| / max|B|` — the correctness gate. A fill number
+/// from a wrong factorization is worthless, so every fill assertion below is
+/// paired with this.
+fn residual(a: &SparseColMatrix, lu: &SparseLu) -> f64 {
+    let m = a.m;
+    let d = dense_of(a);
+    let (perm, qcol) = (lu.perm(), lu.qcol());
+    let mut worst = 0.0_f64;
+    let mut amax = 0.0_f64;
+    for row in d.iter() {
+        for &v in row.iter() {
+            amax = amax.max(v.abs());
+        }
+    }
+    for i in 0..m {
+        for j in 0..m {
+            // (L U)[i][j] = sum_k L[i][k] U[k][j], both triangular.
+            let mut s = 0.0;
+            for k in 0..=i.min(j) {
+                let l = lu.l_dense(i, k);
+                if l != 0.0 {
+                    s += l * lu.u_dense(k, j);
+                }
+            }
+            worst = worst.max((d[perm[i]][qcol[j]] - s).abs());
+        }
+    }
+    worst / amax.max(f64::MIN_POSITIVE)
+}
+
+fn max_abs_l(lu: &SparseLu) -> f64 {
+    let m = lu.dim();
+    let mut mx = 0.0_f64;
+    for j in 0..m {
+        for i in (j + 1)..m {
+            mx = mx.max(lu.l_dense(i, j).abs());
+        }
+    }
+    mx
+}
+
+/// A 4x4 worked by hand. Column 2 is a singleton (row 3), so Markowitz must take
+/// it first at cost 0 — before anything that would fill.
+#[test]
+fn hand_matrix_factors_exactly() {
+    let mut t = vec![
+        (0, 0, 2.0),
+        (1, 0, 1.0),
+        (2, 0, 4.0),
+        (0, 1, 3.0),
+        (2, 1, 1.0),
+        (3, 2, 5.0),
+        (1, 3, 7.0),
+        (3, 3, 2.0),
+    ];
+    let a = build(4, &mut t);
+    let lu = SparseLu::factor_markowitz(&a, LuParams::default()).expect("factor");
+    assert!(residual(&a, &lu) < 1e-14, "residual {}", residual(&a, &lu));
+    // Column 2 has a single entry, so it is the cost-0 pivot and goes first.
+    assert_eq!(lu.qcol()[0], 2, "qcol {:?}", lu.qcol());
+    assert_eq!(lu.perm()[0], 3, "perm {:?}", lu.perm());
+}
+
+/// Arrow with the dense row and column at index 0. Eliminating in natural order
+/// fills the entire trailing block; eliminating the trailing diagonal first
+/// fills nothing. Markowitz must find the second order, so `nnz(L+U)` is exactly
+/// `nnz(A)`.
+#[test]
+fn arrow_takes_zero_fill_order() {
+    let m = 200;
+    let mut t = vec![(0, 0, 10.0)];
+    for j in 1..m {
+        t.push((0, j, 1.0 + j as f64 * 0.01)); // dense row 0
+        t.push((j, 0, 1.0 - j as f64 * 0.003)); // dense column 0
+        t.push((j, j, 3.0 + j as f64 * 0.05)); // diagonal
+    }
+    let a = build(m, &mut t);
+    let nnz = a.nnz();
+    let lu = SparseLu::factor_markowitz(&a, LuParams::default()).expect("factor");
+    assert!(residual(&a, &lu) < 1e-13, "residual {}", residual(&a, &lu));
+    assert_eq!(
+        lu.factor_nnz(),
+        nnz,
+        "arrow must factor with zero fill, got {} for nnz(A) = {}",
+        lu.factor_nnz(),
+        nnz
+    );
+}
+
+/// The same arrow through the shipped static path, as the contrast the issue is
+/// about. This is not a claim about AMD in general — it is the demonstration
+/// that a static column order *can* be beaten arbitrarily badly, on a structure
+/// where the dynamic choice is obvious.
+#[test]
+fn markowitz_fill_never_worse_than_static_on_arrow() {
+    let m = 200;
+    let mut t = vec![(0, 0, 10.0)];
+    for j in 1..m {
+        t.push((0, j, 1.0 + j as f64 * 0.01));
+        t.push((j, 0, 1.0 - j as f64 * 0.003));
+        t.push((j, j, 3.0 + j as f64 * 0.05));
+    }
+    let a = build(m, &mut t);
+    let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+    let stat = SparseLu::factor(&a, &sym, LuParams::default()).expect("static factor");
+    let mark = SparseLu::factor_markowitz(&a, LuParams::default()).expect("markowitz factor");
+    assert!(
+        mark.factor_nnz() <= stat.factor_nnz(),
+        "markowitz {} must not exceed static {}",
+        mark.factor_nnz(),
+        stat.factor_nnz()
+    );
+}
+
+/// Random sparse matrices: `P B Q = L U`, and the threshold bound `max|L| <= 1/u`
+/// that is the entire stability argument for accepting a non-maximal pivot.
+#[test]
+fn random_sparse_residual_and_l_bound() {
+    for seed in 0..12u64 {
+        let m = 60 + (seed as usize) * 7;
+        let mut rng = Rng(seed * 7919 + 13);
+        let mut t: Vec<(usize, usize, f64)> = Vec::new();
+        for j in 0..m {
+            t.push((j, j, 2.0 + rng.next_f64().abs() * 3.0)); // keep it nonsingular
+            for _ in 0..4 {
+                let i = rng.below(m);
+                let v = rng.next_f64();
+                if v != 0.0 {
+                    t.push((i, j, v));
+                }
+            }
+        }
+        let a = build(m, &mut t);
+        let p = LuParams {
+            markowitz_threshold: 0.1,
+            ..Default::default()
+        };
+        let lu = SparseLu::factor_markowitz(&a, p).expect("factor");
+        let r = residual(&a, &lu);
+        assert!(r < 1e-12, "seed {} residual {}", seed, r);
+        let ml = max_abs_l(&lu);
+        assert!(
+            ml <= 1.0 / 0.1 + 1e-9,
+            "seed {} max|L| {} exceeds 1/u = 10",
+            seed,
+            ml
+        );
+    }
+}
+
+/// A tighter threshold must bound `max|L|` more tightly. If it does not, the
+/// threshold test is not actually being applied.
+#[test]
+fn threshold_controls_l_growth() {
+    let m = 120;
+    let mut rng = Rng(4242);
+    let mut t: Vec<(usize, usize, f64)> = Vec::new();
+    for j in 0..m {
+        t.push((j, j, 0.5 + rng.next_f64().abs()));
+        for _ in 0..5 {
+            let i = rng.below(m);
+            t.push((i, j, rng.next_f64() * 4.0));
+        }
+    }
+    let a = build(m, &mut t);
+    for &u in &[0.01_f64, 0.1, 0.5, 1.0] {
+        let p = LuParams {
+            markowitz_threshold: u,
+            ..Default::default()
+        };
+        let lu = SparseLu::factor_markowitz(&a, p).expect("factor");
+        assert!(residual(&a, &lu) < 1e-12, "u {} residual", u);
+        assert!(
+            max_abs_l(&lu) <= 1.0 / u + 1e-9,
+            "u {} gave max|L| {}",
+            u,
+            max_abs_l(&lu)
+        );
+    }
+}
+
+/// The factor has to be usable, not just correct on paper: solve through it and
+/// check `A x = b` in the original coordinates.
+#[test]
+fn solves_through_the_markowitz_factor() {
+    let m = 90;
+    let mut rng = Rng(99);
+    let mut t: Vec<(usize, usize, f64)> = Vec::new();
+    for j in 0..m {
+        t.push((j, j, 3.0 + rng.next_f64().abs()));
+        for _ in 0..3 {
+            t.push((rng.below(m), j, rng.next_f64()));
+        }
+    }
+    let a = build(m, &mut t);
+    let x_true: Vec<f64> = (0..m).map(|_| rng.next_f64()).collect();
+    let d = dense_of(&a);
+    let b: Vec<f64> = (0..m)
+        .map(|i| (0..m).map(|j| d[i][j] * x_true[j]).sum())
+        .collect();
+
+    let mut lu = SparseLu::factor_markowitz(&a, LuParams::default()).expect("factor");
+    let mut x = b.clone();
+    lu.ftran(&mut x).expect("ftran");
+    let err = x
+        .iter()
+        .zip(x_true.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(err < 1e-9, "ftran error {}", err);
+
+    // Btran against the transpose, same matrix.
+    let y_true: Vec<f64> = (0..m).map(|_| rng.next_f64()).collect();
+    let c: Vec<f64> = (0..m)
+        .map(|j| (0..m).map(|i| d[i][j] * y_true[i]).sum())
+        .collect();
+    let mut y = c.clone();
+    lu.btran(&mut y).expect("btran");
+    let err = y
+        .iter()
+        .zip(y_true.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(err < 1e-9, "btran error {}", err);
+}
+
+/// A structurally singular basis (an empty column) must be reported as
+/// `SingularBasis` with the *original* column index, matching what
+/// `SparseLu::factor` promises so a simplex driver can repair the basis.
+#[test]
+fn structurally_singular_reports_the_original_column() {
+    let m = 20;
+    let mut t: Vec<(usize, usize, f64)> = Vec::new();
+    for j in 0..m {
+        if j == 7 {
+            continue; // column 7 is empty
+        }
+        t.push((j, j, 1.0 + j as f64));
+    }
+    let a = build(m, &mut t);
+    match SparseLu::factor_markowitz(&a, LuParams::default()) {
+        Err(FeralError::SingularBasis { column }) => assert_eq!(column, 7),
+        other => panic!(
+            "expected SingularBasis {{ column: 7 }}, got {:?}",
+            other.is_ok()
+        ),
+    }
+}
+
+/// Exact cancellation during the update must *drop* the entry, not leave a
+/// stored zero — otherwise `rcnt`/`ccnt` drift and every subsequent Markowitz
+/// cost is computed against a structure that is not the active submatrix.
+///
+/// Two assertions, and the first is what keeps the second from being vacuous:
+/// replaying the elimination *symbolically* on the pivot order the factor chose
+/// gives the fill a no-cancellation implementation would produce, so
+/// `factor_nnz() < structural` proves entries really did cancel here. Then
+/// `factor_nnz() == nonzeros` proves they were dropped rather than stored as
+/// zeros.
+#[test]
+fn exact_cancellation_is_dropped_not_stored() {
+    // Power-of-two off-diagonals: every multiplier is exact in binary, so an
+    // update that lands on zero lands on it exactly rather than at 1e-17. Seed
+    // 11 of this family cancels 23 entries, which is what the first assertion
+    // below pins.
+    let m = 24;
+    let mut rng = Rng(11 * 104729 + 7);
+    let mut t: Vec<(usize, usize, f64)> = Vec::new();
+    for j in 0..m {
+        t.push((j, j, 4.0));
+        for _ in 0..3 {
+            let i = rng.below(m);
+            let v = [1.0_f64, 2.0, 4.0, -1.0, -2.0, -4.0][rng.below(6)];
+            t.push((i, j, v));
+        }
+    }
+    let a = build(m, &mut t);
+    let lu = SparseLu::factor_markowitz(&a, LuParams::default()).expect("factor");
+    assert!(residual(&a, &lu) < 1e-11, "residual {}", residual(&a, &lu));
+
+    // Symbolic replay of the same pivot sequence: no cancellation possible.
+    let d = dense_of(&a);
+    let mut pat = vec![vec![false; m]; m];
+    for (i, row) in pat.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            *cell = d[i][j] != 0.0;
+        }
+    }
+    let mut alive_r = vec![true; m];
+    let mut alive_c = vec![true; m];
+    let mut structural = 0usize;
+    for k in 0..m {
+        let (pi, pj) = (lu.perm()[k], lu.qcol()[k]);
+        let rows: Vec<usize> = (0..m)
+            .filter(|&i| alive_r[i] && i != pi && pat[i][pj])
+            .collect();
+        let colsr: Vec<usize> = (0..m)
+            .filter(|&j| alive_c[j] && j != pj && pat[pi][j])
+            .collect();
+        structural += rows.len() + colsr.len() + 1; // L column, U row, diagonal
+        for &i in rows.iter() {
+            for &j in colsr.iter() {
+                pat[i][j] = true;
+            }
+        }
+        alive_r[pi] = false;
+        alive_c[pj] = false;
+    }
+
+    let mut nonzero = 0usize;
+    for i in 0..m {
+        for j in 0..m {
+            if (i > j && lu.l_dense(i, j) != 0.0) || (i <= j && lu.u_dense(i, j) != 0.0) {
+                nonzero += 1;
+            }
+        }
+    }
+    assert!(
+        lu.factor_nnz() < structural,
+        "no cancellation happened on this matrix ({} == structural {}), so the \
+         stored-zero check below would be vacuous",
+        lu.factor_nnz(),
+        structural
+    );
+    assert_eq!(
+        lu.factor_nnz(),
+        nonzero,
+        "factor stores {} entries but only {} are nonzero — a cancelled entry \
+         was kept",
+        lu.factor_nnz(),
+        nonzero
+    );
+}


### PR DESCRIPTION
Fixes #167.

## What

`SparseLu::factor_markowitz` — a second LU entry point that chooses each pivot `(i,j)` to minimise the Markowitz count `(r_i-1)(c_j-1)` subject to the threshold test `|a_ij| >= u * max_k|a_kj|`, instead of fixing the column order up front with AMD and then running Gilbert–Peierls. Two new `LuParams` fields: `markowitz_threshold` (default `0.1`) and `markowitz_max_search` (default `8`), both validated.

`SparseLu::factor` is untouched. Its assembly tail is extracted into a shared `assemble()` that both paths call, so the two cannot drift in what they hand downstream: `factor_markowitz` fills exactly the fields `factor` fills, and the solves, the hyper-sparse route and the Forrest–Tomlin update work through either.

The Suhl–Suhl peel is subsumed rather than reimplemented. A column singleton has Markowitz cost 0 and is taken first, so a triangularizable basis triangularizes with no peel code.

## Why the SuperLU comparison could not see this

The shipped path is AMD on the AᵀA column-intersection pattern followed by partial pivoting — the same algorithm class as SuperLU/COLAMD. Comparing against SuperLU compares two static orderings and finds them comparable, which is exactly what #161 reported. A dynamic order is a different class.

## Fill

16 preserved LP bases, `factor_nnz()/nnz(B)`, 3 reps, release build:

```
geomean fill:  AMDfull 2.77x  peel 1.38x  MARKOWITZ 1.06x
```

Zero fill on ten of the sixteen. The Python oracle from the #167 investigation predicted 1.11x; this independent Rust implementation lands at or slightly under it, so the two agree.

## Wall-clock is mixed, and that is the honest headline

```
geomean total time vs AMDfull:  peel 9.68x  denseBump 10.99x  markowitz 4.92x
```

Markowitz is the **fastest arm on the bump-heavy bases discopt #1008 is written around**:

| basis | bump | markowitz | denseBump | peel | AMDfull |
|---|---|---|---|---|---|
| QPLIB_1143_rlt1 | 624 | **4.87 ms** | 8.09 | 31.77 | 56.72 |
| QPLIB_1157_rlt1 | 584 | **6.94 ms** | 11.43 | 31.16 | 45.13 |
| QPLIB_1451_cap100000 | 1350 | **10.98 ms** | 32.23 | 12.08 | 1066.64 |

It **loses to the cheap peel on near-triangular bases**, where a linear triangularization scan beats running the general pivot search 5150 times:

| basis | bump | peel | markowitz | AMDfull |
|---|---|---|---|---|
| QPLIB_0911_rlt0 | 29 | **1.10 ms** | 4.32 | 168.82 |
| QPLIB_1451_cap3000 | 67 | **1.73 ms** | 7.22 | 119.81 |

The geomean favours the peel only because this corpus is mostly near-triangular, not because Markowitz is generally slow.

## Two cost experiments, including the one that failed

- **Suhl–Suhl singleton fast path** was added specifically to close the near-triangular gap. It did not: fill 1.07x → 1.06x, wall geomean 3.43x → 3.50x. Kept because it is free and slightly improves fill, but it did not do its job.
- **In-place rank-1 update.** The first implementation rebuilt each touched column into a fresh `Vec` — one allocation per (pivot, column) pair, millions of them on a 5150-column basis. Walking each column once in place instead moved the wall geomean 3.50x → 4.92x with fill unchanged. That was the real cost, not the search.

## Tests

8 new tests in `tests/lu_markowitz.rs`, oracles external to the implementation: a 4×4 hand matrix with its pivot order asserted explicitly (`qcol()[0]==2`, `perm()[0]==3` — the cost-0 singleton column goes first); an m=200 arrow that must factor with zero fill; residual `< 1e-12` and `max|L| <= 1/u + 1e-9` over 12 random seeds; `max|L|` bounded at `u ∈ {0.01, 0.1, 0.5, 1.0}`; an ftran/btran round trip; a structurally singular basis reporting the **original** column index; and exact cancellation being dropped rather than stored, guarded against vacuity by first asserting `factor_nnz()` is below the no-cancellation symbolic count.

Full suite green, 0 failures. `cargo clippy --all-targets -- -D warnings` clean.

## What this does not claim

- **No claim about numerical behaviour in a simplex trajectory.** Less fill is bought with more growth: at `u = 0.1` on QPLIB_1157_rlt1, `max|U|/max|B| = 81.8` and `max|L| = 9.70`, against SuperLU's 2.56 and 1.00. #163 and #166 are the standing evidence that growth on these bases is not a free parameter. Nothing downstream is switched to this path.
- **Peel-then-Markowitz-on-the-residual-bump is out of scope.** The wall-clock split above is the argument *for* it — cheap linear scan for the triangular part, the search only for the bump — and it deserves its own issue and its own measurement rather than a quiet scope extension here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pjkXyqUk3G1tbBrzibbge
