### PR TITLE
feat(lu)!: default SparseLu::factor to threshold-Markowitz pivoting (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `SparseLu::factor` now defaults to threshold-Markowitz pivoting (issue #171)
+
+- New `LuParams::pivoting: LuPivoting`, defaulting to `LuPivoting::Markowitz`.
+  `LuPivoting::GilbertPeierls` selects the previous behaviour (factor in the
+  column order carried by the caller's `SparseLuSymbolic`).
+- **Breaking behaviour change for callers that pass a chosen ordering.**
+  `Markowitz` picks its column order during the factorization, so it *ignores*
+  `factor`'s `symbolic` argument. Code that compares orderings — or that relies
+  on AMD/METIS/AMF/`analyze_triangularized` being honoured — must now set
+  `pivoting: LuPivoting::GilbertPeierls` explicitly, or it will silently
+  factor something else. `SparseLu::used_markowitz()` reports which rule ran.
+- **Why.** On the 16-basis LP corpus, against the previous default:
+  `factor_nnz()/nnz(B)` geomean **2.77x → 1.06x**, never worse on any basis,
+  faster on 15 of 16. Worst case `QPLIB_0343_rlt1` 0.92 → 0.97 ms (+5% on the
+  second-cheapest basis); best case `QPLIB_1451_rlt0_cap100000` 1066.64 → 10.98
+  ms with fill 24.90x → 1.14x.
+- **Downstream evidence, not just corpus fill.** With `SparseLu::factor` routed
+  through Markowitz, discopt's `discopt-core` LP suite passes 112/112, and
+  `bchoco06_illcond_scaled_path_recovers_bound_649` passes with the route
+  firing 46 times — the test that fails under the triangularizing peel.
+- `dense_bump_max_dim` and `analyze`'s ordering are **unchanged** (both still
+  off): the peel loses bchoco06's dual bound (#168), and the dense-bump route is
+  gated on a peeled bump, so it cannot be enabled independently. Note the new
+  interaction: because the dense bump factors the residual bump left by a
+  *peeling symbolic*, and `Markowitz` has no symbolic at all, under the shipped
+  defaults `dense_bump_max_dim` is now inert twice over. Reaching that route
+  requires `pivoting: GilbertPeierls` **and** `analyze_triangularized` **and**
+  a non-zero cap.
+- Migration note for downstream test suites: seven in-repo test sites across
+  five files asserted Gilbert-Peierls-specific behaviour under
+  `LuParams::default()` and had to pin `GilbertPeierls`. If your tests assert
+  on `reach_visits()`, `used_dense_bump()`, a specific pivot row, or a supplied
+  ordering, expect the same. Note also that plain `cargo test` stops at the
+  first failing test *binary*: use `--no-fail-fast` when auditing, or you will
+  see one failure per run instead of all of them.
+
 ### Added — threshold-Markowitz LU factorization (issue #167)
 
 - `SparseLu::factor_markowitz(&a, params)`, a second entry point that picks each

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6628,3 +6628,66 @@ which exceeds `m` on the reach path too. Without a dedicated counter the tests
 could not tell an inert guard from a working one.
 
 Evidence: PR #162 review, findings 1 and 4; `dev/journal/2026-08-13-04.org`.
+
+
+## 2026-08-14 — LU defaults: Markowitz on, triangularization and the dense bump off (issue #171)
+
+`LuParams::pivoting` is added and defaults to `LuPivoting::Markowitz`.
+`triangularize` and `dense_bump_max_dim` stay off. AMF stays off. Each of the
+four levers was decided separately, on downstream evidence rather than on the
+corpus alone.
+
+**Markowitz becomes the default.** Against the previously shipped route
+(AMD on AᵀA + Gilbert–Peierls) on the 16-basis LP corpus: `factor_nnz()/nnz(B)`
+geomean 2.77x → 1.06x, never worse on any basis, and faster on 15 of 16. The one
+loss is `QPLIB_0343_rlt1`, 0.97 ms vs 0.92 ms — 5% on the second-cheapest basis
+in the corpus. On the expensive end it is not close: `QPLIB_1451_rlt0_cap100000`
+goes 1066.64 ms → 10.98 ms with fill 24.90x → 1.14x.
+
+Corpus fill was not treated as sufficient. The rule was also run downstream,
+through discopt's `[patch.crates-io]`, with `SparseLu::factor` routed to
+`factor_markowitz`: the full `discopt-core` LP suite passes **112/112**, and
+`bchoco06_illcond_scaled_path_recovers_bound_649` — the test that disqualifies
+the peel — passes with the probe firing **46** times, so the route demonstrably
+ran. That last point is the #168 rule applied: pass/fail on a silently
+substitutable route is not evidence unless the arm also shows the route fired.
+
+**Triangularization stays off.** The peel loses the dual bound on bchoco06
+(`Numerical` where `Optimal` is required) at `dense_bump_max_dim` 0 and 4096
+alike, with whole-basis AMD the only passing arm (#168). A controlled two-arm
+A/B on QPLIB_3225 through discopt (#166) found the peel *neutral* there — both
+arms reach the published optimum 511.52671247757985 — so the cost is
+instance-dependent, not universal. One instance where it is neutral does not
+outweigh one where it loses a bound.
+
+**The dense bump stays off, and could not have been turned on separately.** The
+route is gated on a bump that was actually peeled (21f5e74), so it is
+unreachable unless triangularization is on. It is one lever, not two.
+
+**AMF stays off** because no downstream measurement was taken this session. That
+is an absence of evidence, not a finding against it.
+
+**Known cost of this decision.** `Markowitz` ignores `factor`'s `symbolic`
+argument, because it does not use a precomputed column order. That is a silent
+semantic change for any caller that carefully chose an ordering and passed it in
+— exactly the silent-fallback shape #168 warned about. Three mitigations, and no
+claim that they eliminate it: the selector is an explicit enum rather than a
+bool, `SparseLu::used_markowitz()` makes the executed route observable so a
+measurement can assert instead of infer, and every in-repo ordering comparison
+(`examples/lu_fill_orderings.rs`, `src/bin/probe_lu_phases.rs`,
+`src/bin/probe_ft_eta.rs`) is pinned to `GilbertPeierls` in this change. An
+out-of-tree caller comparing orderings against `LuParams::default()` will
+silently compare nothing until it pins the rule. Seven in-repo test sites
+across five files failed on this change — `sparse_lu_honors_pivot_threshold`,
+`dense_bump_route_needs_the_peel_and_the_cap_together`, the whole
+`lu_dense_bump` suite, `reach_route_composes_with_the_dense_bump_route`,
+`perturb_chooses_largest_magnitude_row_matching_dense`,
+`factor_traversal_is_subquadratic`, and
+`sparse_solves_compose_with_the_dense_bump_route` — and every one was fixed by
+pinning `GilbertPeierls`, never by weakening an assertion. That seven
+independent tests failed is corroboration that the hazard is real, not
+hypothetical, and it is a fair estimate of what a downstream suite should
+expect to have to pin.
+
+Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
+`dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.

--- a/dev/journal/2026-08-14-01.org
+++ b/dev/journal/2026-08-14-01.org
@@ -101,3 +101,126 @@ geomean favours the peel (9.68x vs 4.92x) only because this corpus is
 mostly near-triangular. Implication: peel-then-Markowitz-on-the-bump is
 the shape the data argues for, but it is a separate issue with its own
 measurement, not a quiet scope extension of #167.
+
+* 11:20 :161:superlu:measurement:
+Re-measured #161's two claims on merged main (+#167). SuperLU reproduces
+its original numbers exactly on this machine (213,132 factor-nnz, 7.26x
+fill, 11.13 ms on QPLIB_1157), so old and new numbers are comparable.
+Part A: shipped defaults 44.89 ms = 4.03x SuperLU; peel+denseBump 10.91
+ms = parity; Markowitz 6.73 ms at fill 1.74x = 1.65x FASTER than SuperLU
+at 4.2x less fill. On QPLIB_3852: SuperLU 0.21, defaults 0.60,
+denseBump 0.21, markowitz 0.42 ms.
+Part B at the SHIPPED hyper_sparse_max_density=0.10: ftran p50 88.42us
+-> 7.92us (11.17x), btran 0.98x (neutral), ftran_sparse p50 0.04us.
+My first run used the example's own default 0.25 and showed btran 0.67x
+-- that is the known regression that drove the default down to 0.10
+(dev/sessions/2026-08-13-02.md), not a new finding. Re-ran at 0.10
+before reporting.
+
+* 11:25 :161:premise:superlu:
+The finding that matters: SuperLU is NOT work-proportional either. Same
+factor, same basis: unit rhs (solution nnz=1) 107.2us, dense rhs
+(solution nnz=3937) 106.0us. #161 measured feral against ITSELF on this
+axis and called it a defect. Against the reference it was never
+feral-specific -- and at 7.92us it is now a feral advantage.
+Also: #161's premise "the ordering is not the problem, our fill matches
+COLAMD" was a true observation with a false conclusion. AMD-on-A^T A and
+COLAMD are the same class; matching the reference inside a class cannot
+detect that the class is leaving 4x on the table. #167 measured it:
+6.49x -> 1.74x fill on that exact basis.
+Closed #161 with the full table; opened #171 for the defaults decision
+(all three levers -- dense bump, Markowitz, AMF -- are off by default,
+and the shipped config is 4.03x SuperLU).
+
+* 11:50 :166:scoping:correction:
+Two of my assumptions about the #166 A/B were wrong, found by checking
+rather than by reasoning.
+1. I planned to dump QPLIB_3225's LP from Python and replay it in Rust.
+   Dead: solver.py:1473 calls solve_spatial_tree_py, so the whole B&B
+   tree runs INSIDE Rust and node LPs never surface to Python. The
+   wrapper I installed on solve_milp_csc_py logged 0 calls, which is how
+   I found out.
+2. More important: main today does NOT peel. LuOrderingParams uses
+   #[derive(Default)] so triangularize=false, and released 0.15.1's
+   analyze is plain AMD on A^T A (grep: 0 occurrences of "triangularize"
+   in the tag). So main == 0.15.1 in ordering behaviour, and the
+   extension in the shared venv -- which links feral 0.15.1 from
+   crates.io -- IS the amd_only arm.
+That extension solved QPLIB_3225: objective 511.52671247757985 against
+the published reference 511.5267124, bound 508.875, 4480 nodes,
+status=time_limit at TL=120s. So the amd_only arm finds the optimum, and
+main is not in the failing configuration. The failing arm must be the
+peel.
+
+* 11:55 :166:harness:
+Building the decisive flip properly: two feral worktrees off today's
+main differing in exactly one line (analyze -> analyze_with(default)
+vs analyze -> analyze_triangularized), two discopt worktrees pinned at
+bce881ff with [patch.crates-io] feral = <arm path>, maturin build per
+arm into /private/tmp/i166/wheels-<arm>. Nothing is installed into the
+user's shared venv; the extension .so is loaded via PYTHONPATH. Both
+arms are built from the SAME feral source so the flip is the only
+difference -- the released-0.15.1 run above is a reference point, not
+one of the two arms.
+
+* 13:10 :166:result:ab:
+Both #166 arms finished. amd: objective 511.52671247757985, bound
+508.88462071047877, 4625 nodes, time_limit. peel: objective
+511.52671247757985, bound 508.88769205717875, 5357 nodes, time_limit.
+Arm identity verified two ways -- the two .so files have distinct md5s,
+and run_arm.py asserts the loaded module path starts with its own arm
+prefix before solving. Conclusion: QPLIB_3225 does NOT track the
+ordering flip; both arms reach the published optimum 511.5267124. #166
+closed as not reproducible, with the two scoping corrections recorded
+(main does not peel; Python-side LP extraction is impossible because the
+spatial tree runs in Rust). This does NOT clear the peel in general --
+#168's bchoco06 conviction stands. The two results are not in tension:
+the peel's cost is instance-dependent.
+
+* 13:35 :171:markowitz:downstream:decision:
+The lever #171 was missing was Markowitz measured DOWNSTREAM, so I took
+it. Patched a throwaway feral worktree so SparseLu::factor returns
+Self::factor_markowitz unconditionally, with eprintln!("PROBE_MARKOWITZ")
+so the route cannot be silently absent (#168's rule). Through discopt's
+[patch.crates-io]: the full discopt-core LP suite passes 112/112, and
+bchoco06_illcond_scaled_path_recovers_bound_649 -- the exact test the
+peel FAILS -- passes with 46 PROBE_MARKOWITZ firings. Combined with the
+corpus (fill geomean 2.77x -> 1.06x, never worse on any of 16 bases,
+faster on 15/16), that is enough to flip the default. Decision: Markowitz
+on, triangularize off (bchoco06), dense bump off (it is gated on a peeled
+bump since 21f5e74, so it is not a separate lever), AMF off (no
+downstream measurement taken -- absence of evidence, not evidence
+against).
+
+* 14:20 :171:implementation:silent-substitution:
+Implemented as an explicit enum LuPivoting {GilbertPeierls, Markowitz}
+on LuParams rather than a bool, defaulting to Markowitz, with
+SparseLu::used_markowitz() so any measurement can assert which rule ran.
+Known cost, stated not buried: Markowitz ignores factor's `symbolic`
+argument, so an out-of-tree caller that carefully chose an ordering and
+passed LuParams::default() silently gets Markowitz instead. Four in-repo
+tests caught exactly this hazard and all four were fixed by pinning
+GilbertPeierls, never by weakening an assertion:
+- lu::sparse_solve::tests::sparse_lu_honors_pivot_threshold (asserts the
+  GP threshold rule against a `natural` symbolic; Markowitz ignores both)
+- tests/lu_default_ordering.rs dense_bump_route_needs_the_peel_and_the_cap_together
+- tests/lu_dense_bump.rs (whole file, via a gp() helper)
+- tests/lu_hyper_sparse.rs reach_route_composes_with_the_dense_bump_route
+  ("the dense-bump route did not fire on both arms")
+Four independent tests failing is corroboration that the hazard is real.
+Self-inflicted bug worth recording: my file-wide sed on lu_dense_bump.rs
+rewrote the gp() helper's OWN body to ..gp(), making it infinitely
+recursive -- "has overflowed its stack", SIGABRT. Fixed by restoring
+..LuParams::default() inside the helper.
+
+* 14:55 :testing:process:fail-fast:
+Process error worth recording: I ran `cargo test` (no flags) four times
+in a row and each run reported exactly ONE failing test binary, so I
+"fixed the last failure" three times over. cargo test stops after the
+first failing test target -- run 5's log has zero occurrences of
+`lu_sparse_rhs`, meaning that binary never executed. Every "the suite is
+green except X" read was wrong by construction. Switched to
+`cargo test --no-fail-fast`, which surfaces all failing targets in one
+pass. Lesson: for a change that touches a default shared by every test,
+fail-fast turns one measurement into N sequential ones and hides the
+true blast radius.

--- a/examples/lu_fill_orderings.rs
+++ b/examples/lu_fill_orderings.rs
@@ -19,7 +19,7 @@
 
 use std::time::Instant;
 
-use feral::{LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 fn read_mtx(path: &str) -> SparseColMatrix {
     let text = std::fs::read_to_string(path).expect("read mtx");
@@ -107,7 +107,13 @@ fn main() {
         // never fires here (it requires a symbolic that triangularized). Every
         // arm therefore runs the same sparse scatter kernel and the comparison
         // is ordering against ordering, nothing else.
-        let p = LuParams::default();
+        // Pinned: `LuParams::pivoting` defaults to `Markowitz`, which ignores
+        // `sym` entirely -- leaving the default here would make every arm of an
+        // ordering comparison measure the same thing.
+        let p = LuParams {
+            pivoting: LuPivoting::GilbertPeierls,
+            ..LuParams::default()
+        };
         let mut times = Vec::with_capacity(reps);
         let mut fnnz = 0usize;
         for _ in 0..reps {
@@ -144,6 +150,7 @@ fn main() {
     for (label, cap) in [("peel+sparse", 0usize), ("peel+denseBump", 4096)] {
         let p = LuParams {
             dense_bump_max_dim: cap,
+            pivoting: LuPivoting::GilbertPeierls,
             ..LuParams::default()
         };
         let mut times = Vec::with_capacity(reps);

--- a/python/src/lu.rs
+++ b/python/src/lu.rs
@@ -315,11 +315,14 @@ impl LuFactor {
             dense_bump_max_dim,
             hyper_sparse_max_density,
             sparse_rhs_max_density,
-            // The threshold-Markowitz path (`SparseLu::factor_markowitz`) has no
-            // Python entry point yet, so these carry the Rust defaults rather
-            // than becoming keyword arguments for a route Python cannot take.
+            // Threshold-Markowitz tuning and the pivot-rule selector carry the
+            // Rust defaults rather than becoming keyword arguments. `pivoting`
+            // defaults to `Markowitz` (#171), so the Python path gets the same
+            // rule as the Rust path -- it is inherited here, not overridden.
             // The literal stays exhaustive on purpose: that is what made adding
-            // these two fields fail loudly here instead of silently defaulting.
+            // the Markowitz fields fail loudly here instead of silently
+            // defaulting.
+            pivoting: defaults.pivoting,
             markowitz_threshold: defaults.markowitz_threshold,
             markowitz_max_search: defaults.markowitz_max_search,
         })

--- a/src/bin/probe_ft_eta.rs
+++ b/src/bin/probe_ft_eta.rs
@@ -15,7 +15,7 @@
 
 use std::path::PathBuf;
 
-use feral::{LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 type SparseCol = Vec<(usize, f64)>;
 
@@ -124,6 +124,7 @@ fn run_cover(m: usize, per_col: usize, nupd: usize) {
         max_updates: 1_000_000,
         max_growth: 1e30,
         pivot_threshold: pivtol,
+        pivoting: LuPivoting::GilbertPeierls,
         ..LuParams::default()
     };
     let factor = |basis: &[SparseCol]| -> Option<SparseLu> {
@@ -241,6 +242,7 @@ fn main() {
         max_updates: 1_000_000,
         max_growth: 1e30,
         pivot_threshold: pivtol,
+        pivoting: LuPivoting::GilbertPeierls,
         ..LuParams::default()
     };
 

--- a/src/bin/probe_lu_phases.rs
+++ b/src/bin/probe_lu_phases.rs
@@ -9,7 +9,7 @@
 
 use std::time::Instant;
 
-use feral::{LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 // Deterministic LCG (no Instant/rand needed for reproducibility).
 struct Rng(u64);
@@ -50,7 +50,12 @@ fn main() {
     let cols = random_basis(m, density, 0xC0FFEE);
     let a = SparseColMatrix::from_sparse_columns(m, &cols).expect("valid basis");
     let nnz: usize = cols.iter().map(|c| c.len()).sum();
-    let params = LuParams::default();
+    // Pinned: this probe attributes time to the symbolic/numeric phases of the
+    // Gilbert-Peierls route, which the `Markowitz` default does not have.
+    let params = LuParams {
+        pivoting: LuPivoting::GilbertPeierls,
+        ..LuParams::default()
+    };
 
     // Warm + time each phase separately. Analyze and factor are the
     // per-refactorization costs; ftran/btran are the per-pivot solve costs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ pub use lu::dense_matrix::GeneralMatrix;
 pub use lu::sparse_factor::SparseLu;
 pub use lu::sparse_matrix::SparseColMatrix;
 pub use lu::sparse_symbolic::{LuOrderingParams, SparseLuSymbolic};
-pub use lu::{should_use_dense_lu, LuParams, LuScaling, LuSingularAction, RefactorCause};
+pub use lu::{
+    should_use_dense_lu, LuParams, LuPivoting, LuScaling, LuSingularAction, RefactorCause,
+};
 pub use numeric::condition::{
     estimate_condition_1norm, estimate_inverse_norm_1, hager_higham_inverse_norm_1, matrix_norm_1,
     HagerHighamOperator,

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -94,6 +94,32 @@ pub enum LuScaling {
     Mc64ThenInfNorm,
 }
 
+/// Which pivot rule [`SparseLu::factor`](super::SparseLu::factor) uses.
+///
+/// The two rules differ in *when* the column order is chosen, which is why
+/// they are a parameter rather than two unrelated entry points:
+///
+/// - [`GilbertPeierls`](LuPivoting::GilbertPeierls) fixes the column order up
+///   front from the caller's [`SparseLuSymbolic`](super::SparseLuSymbolic) and
+///   then pivots for stability within it. This is the same algorithm class as
+///   SuperLU/COLAMD.
+/// - [`Markowitz`](LuPivoting::Markowitz) chooses each pivot `(i, j)` during
+///   the factorization to minimise `(r_i - 1) * (c_j - 1)` subject to
+///   `|a_ij| >= markowitz_threshold * max_k |a_kj|`, so the ordering responds
+///   to the fill the factorization actually creates.
+///
+/// **`Markowitz` ignores the `symbolic` argument**, because it does not use a
+/// precomputed column order. Code that compares orderings must therefore pin
+/// `GilbertPeierls` explicitly, and [`SparseLu::used_markowitz`] reports which
+/// rule actually ran so a measurement can assert on it rather than infer it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LuPivoting {
+    /// Caller-supplied column order (AMD/METIS/AMF/...) + partial pivoting.
+    GilbertPeierls,
+    /// Threshold-Markowitz: the column order is chosen during factorization.
+    Markowitz,
+}
+
 /// Tuning parameters for the LU factorization and its updates.
 ///
 /// Mirrors the shape of [`crate::dense::factor::BunchKaufmanParams`].
@@ -122,6 +148,13 @@ pub struct LuParams {
     pub max_updates: usize,
     /// Bases with `m` at or below this use the dense path unconditionally.
     pub dense_threshold: usize,
+    /// Pivot rule for [`SparseLu::factor`](super::SparseLu::factor).
+    ///
+    /// Defaults to [`LuPivoting::Markowitz`] (issue #171). On the 16-basis LP
+    /// corpus that default gives `factor_nnz()/nnz(B)` geomean 1.06x against
+    /// 2.77x for `GilbertPeierls` on AMD, and is faster on 15 of the 16.
+    /// Set `GilbertPeierls` to factor in a caller-chosen column order.
+    pub pivoting: LuPivoting,
     /// Maximum dimension of a post-triangularization **bump** that
     /// [`SparseLu::factor`](super::SparseLu::factor) routes through the dense
     /// kernel instead of the sparse scatter kernel. `0` (the default) disables
@@ -421,6 +454,7 @@ impl Default for LuParams {
             max_growth: 1e8,
             max_updates: 64,
             dense_threshold: 128,
+            pivoting: LuPivoting::Markowitz,
             dense_bump_max_dim: 0,
             scaling: LuScaling::None,
             refine_steps: 0,

--- a/src/lu/sparse_factor.rs
+++ b/src/lu/sparse_factor.rs
@@ -14,7 +14,7 @@
 
 use super::scaling::{compute_lu_scale, LuScale};
 use super::sparse_symbolic::SparseLuSymbolic;
-use super::{LuParams, LuScaling, LuSingularAction, RefactorCause};
+use super::{LuParams, LuPivoting, LuScaling, LuSingularAction, RefactorCause};
 use crate::error::FeralError;
 use crate::lu::sparse_matrix::SparseColMatrix;
 
@@ -157,6 +157,11 @@ pub struct SparseLu {
     /// hold, so a caller measuring it must read this rather than infer it from
     /// the parameter.
     pub(super) used_dense_bump: bool,
+    /// True when the factorization used threshold-Markowitz pivoting rather
+    /// than the caller's column order. Like `used_dense_bump`, this exists so
+    /// a measurement can assert which route ran instead of inferring it from
+    /// the parameter.
+    pub(super) used_markowitz: bool,
     /// Dimension of the residual bump after triangularization.
     pub(super) bump_dim: usize,
     pub(super) params: LuParams,
@@ -251,11 +256,23 @@ impl SparseLu {
     ) -> Result<Self, FeralError> {
         params.validate()?;
         let m = a.m;
+        // Checked before the dispatch below, not after: `Markowitz` ignores
+        // `symbolic`, but a caller who hands us a symbolic for the wrong
+        // dimension has a bug either way and should hear about it on both
+        // routes rather than only on one.
         if symbolic.m != m {
             return Err(FeralError::DimensionMismatch {
                 expected: m,
                 got: symbolic.m,
             });
+        }
+        // `Markowitz` chooses its own column order, so `symbolic` carries no
+        // ordering information on that route and is deliberately unused beyond
+        // the dimension check. The default is `Markowitz` (#171); callers
+        // comparing orderings must pin `GilbertPeierls`. `used_markowitz()`
+        // reports which rule ran.
+        if params.pivoting == LuPivoting::Markowitz {
+            return Self::factor_markowitz(a, params);
         }
         // Scaling: factor Ã = D_row Π A D_col (pattern is invariant under row
         // permutation/scaling, so the column ordering `symbolic` still applies).
@@ -619,6 +636,7 @@ impl SparseLu {
             a_max,
             bump_dim,
             dense_done,
+            false,
             reach_visits,
         ))
     }
@@ -713,6 +731,7 @@ impl SparseLu {
             mk.a_max,
             0,
             false,
+            true,
             0,
         ))
     }
@@ -754,6 +773,16 @@ impl SparseLu {
     /// vacuously against the fallback.
     pub fn used_dense_bump(&self) -> bool {
         self.used_dense_bump
+    }
+
+    /// True when threshold-Markowitz pivoting produced this factorization.
+    ///
+    /// [`LuParams::pivoting`] defaults to [`LuPivoting::Markowitz`], and the
+    /// `GilbertPeierls` route is also reachable by explicit request, so a
+    /// measurement that cares which rule ran must read this rather than infer
+    /// it from the parameter it passed.
+    pub fn used_markowitz(&self) -> bool {
+        self.used_markowitz
     }
 
     /// Dimension of the residual bump left by triangularization.
@@ -965,6 +994,7 @@ fn assemble(
     a_max: f64,
     bump_dim: usize,
     used_dense_bump: bool,
+    used_markowitz: bool,
     reach_visits: usize,
 ) -> SparseLu {
     // Row-wise index of L and the reach workspace: built only when the
@@ -1031,6 +1061,7 @@ fn assemble(
         a_max,
         reach_visits,
         used_dense_bump,
+        used_markowitz,
         bump_dim,
         params,
         scale,

--- a/src/lu/sparse_solve.rs
+++ b/src/lu/sparse_solve.rs
@@ -741,12 +741,17 @@ mod tests {
         let a = SparseColMatrix::from_dense_columns(2, &cols).expect("matrix");
         let symbolic = SparseLuSymbolic::natural(2);
 
+        // Both arms pin `GilbertPeierls`: this test is about that route's
+        // `pivot_threshold` rule inside a caller-supplied (natural) column
+        // order, and the `Markowitz` default (#171) uses neither -- it picks its
+        // own order and reads `markowitz_threshold`.
         // Strict partial pivoting (u = 1.0): the max-magnitude row wins.
         let strict = SparseLu::factor(
             &a,
             &symbolic,
             LuParams {
                 pivot_threshold: 1.0,
+                pivoting: crate::lu::LuPivoting::GilbertPeierls,
                 ..LuParams::default()
             },
         )
@@ -760,6 +765,7 @@ mod tests {
             &symbolic,
             LuParams {
                 pivot_threshold: 0.5,
+                pivoting: crate::lu::LuPivoting::GilbertPeierls,
                 ..LuParams::default()
             },
         )

--- a/tests/lu_default_ordering.rs
+++ b/tests/lu_default_ordering.rs
@@ -23,7 +23,7 @@
 //!
 //! See `dev/research/lu-ordering-and-kernel-2026-08-13.md`.
 
-use feral::{LuOrderingParams, LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{LuOrderingParams, LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 /// An LP-shaped basis: a triangular border the peel can strip, wrapped around a
 /// bump it cannot. `nfront` column singletons, then a `bump`x`bump` dense block,
@@ -103,8 +103,14 @@ fn dense_bump_route_needs_the_peel_and_the_cap_together() {
     // The two are opted into as a pair (issue #163). Setting the cap without
     // the peeling constructor must be an inert no-op, not a partial opt-in.
     let a = lp_like_basis(40, 12, 25);
+    // `GilbertPeierls` is pinned because the dense-bump route lives on that
+    // route only: it factors the residual bump left by a peeling symbolic, and
+    // the `Markowitz` default (#171) has no symbolic and no peel. So under the
+    // shipped defaults `dense_bump_max_dim` is now inert twice over — this test
+    // is about the inner gate, and pinning is what keeps it testing that.
     let params = LuParams {
         dense_bump_max_dim: 4096,
+        pivoting: LuPivoting::GilbertPeierls,
         ..LuParams::default()
     };
 

--- a/tests/lu_dense_bump.rs
+++ b/tests/lu_dense_bump.rs
@@ -12,7 +12,23 @@
 //! Since issue #163 the peel is opt-in and `analyze` is whole-basis AMD, which
 //! reports no bump and so can never take this route.
 
-use feral::{FeralError, LuParams, LuSingularAction, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{
+    FeralError, LuParams, LuPivoting, LuSingularAction, SparseColMatrix, SparseLu, SparseLuSymbolic,
+};
+
+/// Defaults with the pivot rule pinned to `GilbertPeierls`.
+///
+/// Every test in this file is about the dense-bump route, which factors the
+/// residual bump left by a peeling symbolic. The shipped default is `Markowitz`
+/// (#171), which has no symbolic and no peel, so it cannot reach that route at
+/// all — leaving the default here would make the whole file pass vacuously
+/// against a factorization that never ran the code under test.
+fn gp() -> LuParams {
+    LuParams {
+        pivoting: LuPivoting::GilbertPeierls,
+        ..LuParams::default()
+    }
+}
 
 /// Deterministic LCG — no rand dependency, and reproducible failures.
 struct Rng(u64);
@@ -139,7 +155,7 @@ fn both_routes(
     let sym = SparseLuSymbolic::analyze_triangularized(a).expect("analyze");
     let params = LuParams {
         dense_bump_max_dim: max_dim,
-        ..LuParams::default()
+        ..gp()
     };
     let mut lu = SparseLu::factor(a, &sym, params).expect("factor");
 
@@ -226,7 +242,7 @@ fn dense_bump_route_is_off_by_default() {
         "the route must be opt-in"
     );
     let sym = SparseLuSymbolic::analyze_triangularized(&a).expect("analyze");
-    let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+    let lu = SparseLu::factor(&a, &sym, gp()).expect("factor");
     assert!(lu.factor_nnz() > 0);
 }
 
@@ -240,10 +256,10 @@ fn bump_above_the_cap_stays_on_the_sparse_route() {
     // still be correct and identical to the plain sparse one.
     let small = LuParams {
         dense_bump_max_dim: bump - 1,
-        ..LuParams::default()
+        ..gp()
     };
     let a_lu = SparseLu::factor(&a, &sym, small).expect("factor");
-    let b_lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+    let b_lu = SparseLu::factor(&a, &sym, gp()).expect("factor");
     assert!(
         !a_lu.used_dense_bump(),
         "cap below the bump must not take the route"
@@ -290,7 +306,7 @@ fn singular_bump_is_reported_on_both_routes() {
     let sym = SparseLuSymbolic::analyze_triangularized(&a).expect("analyze");
     let base = LuParams {
         on_singular: LuSingularAction::Fail,
-        ..LuParams::default()
+        ..gp()
     };
     let sparse = SparseLu::factor(&a, &sym, base.clone());
     let dense = SparseLu::factor(
@@ -356,7 +372,7 @@ fn an_unpeeled_whole_basis_stays_on_the_sparse_route() {
         // Far above `m`: if the gate keyed on dimension alone, every arm below
         // would take the dense route.
         dense_bump_max_dim: 4096,
-        ..LuParams::default()
+        ..gp()
     };
     assert!(
         m > params.dense_threshold,

--- a/tests/lu_hyper_sparse.rs
+++ b/tests/lu_hyper_sparse.rs
@@ -14,7 +14,7 @@
 //! `‖Bx − a‖∞` against the original basis is asserted too, so a bug that
 //! corrupts both routes identically cannot hide.
 
-use feral::{FeralError, LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{FeralError, LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 /// Deterministic LCG — same generator as `src/bin/probe_lu_phases.rs`, so a
 /// failing seed can be replayed there.
@@ -490,7 +490,12 @@ fn reach_route_composes_with_the_dense_bump_route() {
     // `analyze_triangularized`, not `analyze`: since issue #163 the peel is
     // opt-in, and `dense_bump_max_dim` only applies to a symbolic that peeled.
     let sym = SparseLuSymbolic::analyze_triangularized(&a).expect("analyze");
+    // The dense-bump route lives on the Gilbert-Peierls path: it splices into
+    // the factor built from `sym`'s peel, and threshold-Markowitz (the default
+    // since #171) chooses its own column order and never peels. Leaving the
+    // default here would make `used_dense_bump()` false and this test vacuous.
     let mk = |d: f64| LuParams {
+        pivoting: LuPivoting::GilbertPeierls,
         dense_bump_max_dim: 512,
         hyper_sparse_max_density: d,
         ..LuParams::default()

--- a/tests/lu_markowitz.rs
+++ b/tests/lu_markowitz.rs
@@ -15,7 +15,7 @@
 //! threshold bound on `max|L|` holds, and that on structures where the dynamic
 //! choice is provably better it actually finds it.
 
-use feral::{FeralError, LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{FeralError, LuParams, LuPivoting, SparseColMatrix, SparseLu, SparseLuSymbolic};
 
 /// Deterministic LCG — no rand dependency, and reproducible failures.
 struct Rng(u64);
@@ -396,4 +396,76 @@ fn exact_cancellation_is_dropped_not_stored() {
         lu.factor_nnz(),
         nonzero
     );
+}
+
+/// `LuParams::pivoting` defaults to `Markowitz` (issue #171), and the choice is
+/// observable rather than inferred.
+///
+/// Both routes are silent — `factor` returns the same type either way — so a
+/// test that only checked the answer would pass whichever rule ran. That is the
+/// failure mode #168 recorded, hence the `used_markowitz()` assertions and the
+/// arrow-matrix fill witness: the two rules must disagree on this matrix, or the
+/// routing assertions would be vacuous.
+#[test]
+fn default_params_route_through_markowitz_and_the_choice_is_observable() {
+    // Arrow with the dense row/column first: a static order that eliminates the
+    // tip first fills in completely, Markowitz takes it last and fills nothing.
+    let m = 40;
+    let mut t: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..m {
+        t.push((i, 0, if i == 0 { 4.0 } else { 1.0 }));
+    }
+    for j in 1..m {
+        t.push((0, j, 1.0));
+        t.push((j, j, 3.0));
+    }
+    let a = build(m, &mut t);
+    let sym = SparseLuSymbolic::analyze(&a).expect("analyze");
+
+    let dflt = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor default");
+    assert!(
+        dflt.used_markowitz(),
+        "LuParams::default() must route through Markowitz (#171)"
+    );
+
+    let gp = SparseLu::factor(
+        &a,
+        &sym,
+        LuParams {
+            pivoting: LuPivoting::GilbertPeierls,
+            ..Default::default()
+        },
+    )
+    .expect("factor gilbert-peierls");
+    assert!(
+        !gp.used_markowitz(),
+        "an explicit GilbertPeierls request must not silently take the Markowitz route"
+    );
+
+    // The witness: without a fill gap the two assertions above could hold on a
+    // factorization that ignored the rule entirely.
+    assert!(
+        dflt.factor_nnz() < gp.factor_nnz(),
+        "the two rules must produce different fill on this arrow matrix, else the \
+         routing assertions are vacuous (markowitz {} vs gilbert-peierls {})",
+        dflt.factor_nnz(),
+        gp.factor_nnz()
+    );
+
+    // Routing is not allowed to cost correctness: both must still solve.
+    let d = dense_of(&a);
+    let x_true: Vec<f64> = (0..m).map(|i| 1.0 + i as f64).collect();
+    let b: Vec<f64> = (0..m)
+        .map(|i| (0..m).map(|j| d[i][j] * x_true[j]).sum())
+        .collect();
+    for lu in [dflt, gp].iter_mut() {
+        let mut x = b.clone();
+        lu.ftran(&mut x).expect("ftran");
+        let err = x
+            .iter()
+            .zip(x_true.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(err < 1e-9, "solve error {err}");
+    }
 }

--- a/tests/lu_sparse.rs
+++ b/tests/lu_sparse.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use feral::lu::sparse_matrix::SparseColMatrix;
-use feral::lu::{DenseLu, LuParams, LuSingularAction, SparseLu, SparseLuSymbolic};
+use feral::lu::{DenseLu, LuParams, LuPivoting, LuSingularAction, SparseLu, SparseLuSymbolic};
 use feral::FeralError;
 
 fn cols_from_rows(rows: &[&[f64]]) -> (Vec<Vec<f64>>, usize) {
@@ -262,7 +262,12 @@ fn perturb_chooses_largest_magnitude_row_matching_dense() {
         vec![1.0, 0.0, 0.0],   // col 2: e_0
     ];
     let m = 3;
+    // L13 is a *Gilbert-Peierls* contract: it pins the sparse GP pivot choice
+    // to the dense path's. Threshold-Markowitz (the default since #171) picks
+    // its own row and column order, so under the default this test would
+    // compare two different factorizations and say nothing about L13.
     let params = LuParams {
+        pivoting: LuPivoting::GilbertPeierls,
         on_singular: LuSingularAction::PerturbToEps { abs_floor: 1e-10 },
         ..LuParams::default()
     };
@@ -555,7 +560,14 @@ fn factor_traversal_is_subquadratic() {
     let work = |n: usize| -> usize {
         let a = tridiagonal(n);
         let sym = SparseLuSymbolic::natural(n);
-        let lu = SparseLu::factor(&a, &sym, LuParams::default()).expect("factor");
+        // `reach_visits()` counts the Gilbert-Peierls symbolic reach, which the
+        // Markowitz route (the default since #171) does not run — under the
+        // default the counter is 0 and the comparison below is vacuous.
+        let params = LuParams {
+            pivoting: LuPivoting::GilbertPeierls,
+            ..LuParams::default()
+        };
+        let lu = SparseLu::factor(&a, &sym, params).expect("factor");
         // Sanity: tridiagonal has no fill.
         assert_eq!(lu.factor_nnz(), a.nnz());
         lu.reach_visits()

--- a/tests/lu_sparse_rhs.rs
+++ b/tests/lu_sparse_rhs.rs
@@ -18,7 +18,9 @@
 //!   wall-clock benchmark cannot pin an asymptote. `last_sparse_solve_work()`
 //!   is asserted to stay flat while `m` grows 8x.
 
-use feral::{FeralError, LuParams, LuScaling, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{
+    FeralError, LuParams, LuPivoting, LuScaling, SparseColMatrix, SparseLu, SparseLuSymbolic,
+};
 
 struct Rng(u64);
 impl Rng {
@@ -526,7 +528,12 @@ fn sparse_solves_compose_with_the_dense_bump_route() {
     let mut lu = SparseLu::factor(
         &a,
         &sym,
+        // The dense-bump route lives on the Gilbert-Peierls path: it splices
+        // into the factor built from `sym`'s peel, and threshold-Markowitz (the
+        // default since #171) chooses its own column order and never peels.
+        // Leaving the default here would make `used_dense_bump()` false.
         LuParams {
+            pivoting: LuPivoting::GilbertPeierls,
             dense_bump_max_dim: 512,
             ..LuParams::default()
         },


### PR DESCRIPTION
Closes #171.

## What

Adds `LuParams::pivoting: LuPivoting` and defaults it to `LuPivoting::Markowitz`.
`SparseLu::factor` now dispatches to `factor_markowitz` unless the caller pins
`LuPivoting::GilbertPeierls`. The other three levers #171 asked about stay off:
`triangularize`, `dense_bump_max_dim`, and AMF.

This is a **behaviour change for existing callers** — see "Known cost" below.

## Why — the evidence

**Corpus** (16 preserved LP bases, `factor_nnz()/nnz(B)`):

| | Gilbert-Peierls on AMD | Markowitz |
|---|---|---|
| fill geomean | 2.77x | **1.06x** |
| bases where it is worse | — | **none** |
| faster on | 1 of 16 | **15 of 16** |

Worst case for Markowitz is `QPLIB_0343_rlt1`, 0.92 -> 0.97 ms — 5% on the
second-cheapest basis in the corpus. Best case is
`QPLIB_1451_rlt0_cap100000`, 1066.64 -> 10.98 ms with fill 24.90x -> 1.14x.

**Downstream**, because corpus fill alone was not treated as sufficient. A
throwaway feral with `SparseLu::factor` routed unconditionally to
`factor_markowitz` plus a `PROBE_MARKOWITZ` eprintln, patched into discopt via
`[patch.crates-io]`:

- full `discopt-core` LP suite: **112/112 pass**
- `bchoco06_illcond_scaled_path_recovers_bound_649` — the exact test the
  triangularization peel **fails** (#168) — passes, with the probe firing **46**
  times, so the route demonstrably ran.

That last point is #168's rule applied: a pass on a silently substitutable route
is not evidence unless the arm also shows the route fired.

## Why the other three levers stay off

- **`triangularize`**: the peel loses the dual bound on bchoco06 (`Numerical`
  where `Optimal` is required) at `dense_bump_max_dim` 0 and 4096 alike (#168).
  A controlled two-arm A/B on QPLIB_3225 (#166) found it *neutral* there, so the
  cost is instance-dependent — but one neutral instance does not outweigh one
  lost bound.
- **`dense_bump_max_dim`**: since 21f5e74 the route is gated on a bump that was
  actually peeled, so it cannot be enabled without `triangularize`. It is one
  lever with the peel, not a second one.
- **AMF**: no downstream measurement was taken. That is an absence of evidence,
  not a finding against it.

## Known cost — stated, not buried

`Markowitz` **ignores `factor`'s `symbolic` argument** (beyond the dimension
check), because it does not use a precomputed column order. An out-of-tree
caller that carefully chose an ordering and passed `LuParams::default()` now
silently gets Markowitz instead — exactly the silent-substitution shape #168
warned about.

Three mitigations, with no claim that they eliminate it:

1. the selector is an explicit enum, not a bool;
2. `SparseLu::used_markowitz()` makes the executed route observable, so a
   measurement can assert which rule ran instead of inferring it;
3. every in-repo ordering comparison is pinned to `GilbertPeierls` in this
   change (`examples/lu_fill_orderings.rs`, `src/bin/probe_lu_phases.rs`,
   `src/bin/probe_ft_eta.rs`).

**Seven in-repo test sites across five files caught this hazard** and every one
was fixed by pinning `GilbertPeierls`, never by weakening an assertion:

- `lu::sparse_solve::tests::sparse_lu_honors_pivot_threshold`
- `tests/lu_default_ordering.rs::dense_bump_route_needs_the_peel_and_the_cap_together`
- `tests/lu_dense_bump.rs` (whole file, via a `gp()` helper)
- `tests/lu_hyper_sparse.rs::reach_route_composes_with_the_dense_bump_route`
- `tests/lu_sparse.rs::perturb_chooses_largest_magnitude_row_matching_dense`
- `tests/lu_sparse.rs::factor_traversal_is_subquadratic`
- `tests/lu_sparse_rhs.rs::sparse_solves_compose_with_the_dense_bump_route`

That seven independent tests failed is corroboration that the risk is real, not
hypothetical.

## Tests

`cargo test --no-fail-fast` green. Note for reviewers: plain `cargo test` stops
at the first failing test *binary*, which for a change to a shared default
reports one failure per run and hides the blast radius — use `--no-fail-fast`.

New test `default_params_route_through_markowitz_and_the_choice_is_observable`
asserts `dflt.used_markowitz()`, `!gp.used_markowitz()`, and a fill witness
`dflt.factor_nnz() < gp.factor_nnz()` so the routing assertions cannot be
vacuous, with both factorizations solving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pjkXyqUk3G1tbBrzibbge
