### PR TITLE
release: feral v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
 ### Changed — `SparseLu::factor` now defaults to threshold-Markowitz pivoting (issue #171)
 
 - New `LuParams::pivoting: LuPivoting`, defaulting to `LuPivoting::Markowitz`.
@@ -330,7 +332,7 @@ All notable changes to FERAL will be documented in this file.
   solves turn out to be ~1% of that solve, not the 93% issue #161 originally
   attributed to the LU layer (a figure since retracted by its author). Three
   other QPLIB instances gain 4–13%. The cost that *does* move that LP is numeric
-  factorization, via `dense_bump_max_dim` — a different knob, added in 0.15.2.
+  factorization, via `dense_bump_max_dim` — a different knob, added below.
 
 ### Added — reach-limited ("hyper-sparse") sparse-LU triangular solves *(issue #161B)*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.15.1"
+version = "0.16.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lu/mod.rs
+++ b/src/lu/mod.rs
@@ -180,6 +180,15 @@ pub struct LuParams {
     /// because they never looked for structure, so setting this cap alongside
     /// any of them is a no-op however large it is.
     ///
+    /// **And since 0.16.0 it requires [`Self::pivoting`] pinned to
+    /// [`LuPivoting::GilbertPeierls`].** The default
+    /// [`LuPivoting::Markowitz`] chooses its own column order and never reads
+    /// the symbolic, so there is no peeled bump for this route to pack — under
+    /// the shipped defaults the cap is inert twice over. Reaching it takes all
+    /// three: `GilbertPeierls`, `analyze_triangularized`, and a non-zero cap
+    /// (issue #171). [`used_dense_bump`](super::SparseLu::used_dense_bump)
+    /// reports whether it fired.
+    ///
     /// Opting into the peel is worth having on its own — it is 4.2–9.8x on the
     /// symbolic step, which a simplex pays on every refactorization — but it
     /// also changes the rounding trajectory, and that is not free: see

--- a/src/lu/sparse_symbolic.rs
+++ b/src/lu/sparse_symbolic.rs
@@ -1,8 +1,17 @@
 //! Symbolic analysis for the sparse LU: the fill-reducing column ordering `Q`.
 //!
+//! **Since 0.16.0 nothing in this module is on the default factorization path.**
+//! [`super::LuParams::pivoting`] defaults to [`super::LuPivoting::Markowitz`],
+//! which chooses its column order *during* the numeric factorization and reads
+//! the symbolic it is handed only to check its dimension. Everything below —
+//! both orderings and the tradeoff between them — applies to
+//! [`super::SparseLu::factor`] only under
+//! `LuParams { pivoting: LuPivoting::GilbertPeierls, ..Default::default() }`
+//! (issue #171). [`super::SparseLu::used_markowitz`] reports which rule ran.
+//!
 //! Two orderings, and the caller picks:
 //!
-//! - [`SparseLuSymbolic::analyze`] — the **default**: feral's in-tree AMD
+//! - [`SparseLuSymbolic::analyze`] — the **default of the two**: feral's in-tree AMD
 //!   (`feral_amd`) on the whole basis's `AᵀA` (column-intersection) pattern, a
 //!   stand-in for COLAMD that needs no new ordering algorithm.
 //! - [`SparseLuSymbolic::analyze_triangularized`] — **opt-in**: first peel
@@ -93,8 +102,29 @@ pub struct SparseLuSymbolic {
 }
 
 impl SparseLuSymbolic {
-    /// AMD over the whole basis. The default ordering, and the one to use
-    /// unless you are opting into the dense-bump route.
+    /// AMD over the whole basis. The default ordering of the two this module
+    /// offers, and the one to use unless you are opting into the dense-bump
+    /// route.
+    ///
+    /// # Since 0.16.0 this is not what `SparseLu::factor` does by default
+    ///
+    /// [`super::LuParams::pivoting`] defaults to
+    /// [`super::LuPivoting::Markowitz`], which picks each pivot column during
+    /// the factorization and never consults the ordering computed here. Under
+    /// the shipped defaults, calling `analyze` and passing the result to
+    /// [`super::SparseLu::factor`] costs the AMD run and changes nothing about
+    /// the factor produced. To get this ordering, ask for it:
+    /// `LuParams { pivoting: LuPivoting::GilbertPeierls, ..Default::default() }`.
+    /// [`super::SparseLu::used_markowitz`] reports which rule actually ran, so a
+    /// caller need not infer it.
+    ///
+    /// The rest of this comment weighs whole-basis AMD against the peel. That
+    /// comparison is unchanged and still decides
+    /// [`Self::analyze`]-vs-[`Self::analyze_triangularized`] — but it is a
+    /// comparison *within* the Gilbert-Peierls route, not a description of what
+    /// feral does out of the box. On the 16-basis LP corpus Markowitz beat
+    /// whole-basis AMD on fill by 2.77x -> 1.06x geomean, which is why the
+    /// default moved (issue #171, `CHANGELOG.md` 0.16.0).
     ///
     /// # Why this does not triangularize
     ///
@@ -169,6 +199,11 @@ impl SparseLuSymbolic {
     /// for callers that want the ordering to be a setting they can flip and
     /// measure rather than a constructor they have to choose at the call site.
     /// Both of those are thin wrappers over this.
+    ///
+    /// Since 0.16.0 this setting is only observable under
+    /// `LuParams { pivoting: LuPivoting::GilbertPeierls, .. }`; the default
+    /// [`super::LuPivoting::Markowitz`] orders columns itself. See
+    /// [`Self::analyze`].
     pub fn analyze_with(a: &SparseColMatrix, params: LuOrderingParams) -> Result<Self, FeralError> {
         if params.triangularize {
             Self::analyze_triangularized(a)
@@ -200,6 +235,12 @@ impl SparseLuSymbolic {
     /// qualify your own instances against it; that is a real prerequisite, not
     /// boilerplate.
     ///
+    /// Since 0.16.0 this ordering reaches the factor only under
+    /// `LuParams { pivoting: LuPivoting::GilbertPeierls, .. }` — the default
+    /// [`super::LuPivoting::Markowitz`] ignores the symbolic, which also makes
+    /// [`super::LuParams::dense_bump_max_dim`] unreachable without that pin.
+    /// See [`Self::analyze`].
+    ///
     /// Equivalent to [`Self::analyze_with`] at
     /// `LuOrderingParams { triangularize: true }`.
     pub fn analyze_triangularized(a: &SparseColMatrix) -> Result<Self, FeralError> {
@@ -227,7 +268,10 @@ impl SparseLuSymbolic {
 
     /// AMD over the whole basis, with no triangularization. Identical to
     /// [`Self::analyze`]; retained as an explicit name for benchmark arms that
-    /// compare the two orderings side by side.
+    /// compare the two orderings side by side. Such an arm must pin
+    /// `LuParams { pivoting: LuPivoting::GilbertPeierls, .. }` since 0.16.0, or
+    /// both arms factor the same Markowitz ordering and the comparison is
+    /// vacuous — see [`Self::analyze`].
     pub fn analyze_amd_only(a: &SparseColMatrix) -> Result<Self, FeralError> {
         let m = a.m;
         if m == 0 {


### PR DESCRIPTION
Cuts 0.16.0. Bumps the six version strings the release checklist tracks, cuts
`CHANGELOG.md` `[Unreleased]` to `[0.16.0] - 2026-08-14`, and fixes the doc
comments that #171 made stale.

## Why 0.16.0 and not 0.15.2

`SparseLu::factor` changed its default pivoting rule to threshold-Markowitz
(#171). Markowitz chooses its column order during the factorization and ignores
the `symbolic` argument, so any caller that passes a chosen ordering now factors
something different unless it pins `LuPivoting::GilbertPeierls`. That is a
breaking behaviour change, and the minor bump is what a 0.x crate has to say it
with.

## Doc fixes carried in this PR

The `SparseLuSymbolic` module and its four constructors document at length which
ordering to prefer and what it costs. Every word of that was written when the
ordering computed there was the one `factor` used. Under the 0.16.0 default it
is not read at all, so the comments now open by saying so and point at
`used_markowitz()`. `LuParams::dense_bump_max_dim` gains the matching note: it
was already gated on a triangularized symbolic, and it is now gated on
`GilbertPeierls` as well, which makes it inert twice over under the shipped
defaults.

Also corrected: the `[Unreleased]` changelog referred to `dense_bump_max_dim` as
"added in 0.15.2". No such version exists — it ships here.

## Evidence

- `scripts/release-checklist.sh check` clean: all six version strings agree on
  0.16.0, no ordering crate is stale (none changed since v0.15.1, all still
  v0.2.1), CHANGELOG has a `[0.16.0]` section, tag does not exist yet.
- `cargo metadata --locked` passes on both workspaces, root and `python/`.
- A `0.15.1` grep over the six version-bearing sites comes back empty.
- `cargo doc --no-deps -p feral` produces exactly the same three warnings in the
  touched files as `main` does (same warnings, shifted line numbers) — no new
  broken intra-doc links.
- Full test results in a comment below.

No functional change: the only non-version, non-changelog edits are doc
comments.
