### PR TITLE
fix(scaling): make the router's head gate permutation-invariant (#134B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,14 @@ All notable changes to FERAL will be documented in this file.
   the Policy 4 fallback already covers it.
 - The 2026-05-17 threshold panel is preserved: clnlbeam's symmetric max degree
   is 5 and ACOPP30's is 29, both still under the `32` gate.
-- Cost: one `n`-length degree accumulator; the router is no longer
-  allocation-free.
+- Cost: none measurable. The gates are ordered so the symmetric pass stays
+  off the common path — the allocation-free pass decides every matrix that
+  fails the slack-mass gate or whose densest stored column already clears
+  `32` (sound because symmetric degree is never below stored degree), so only
+  the genuinely ambiguous remainder allocates an `n`-length accumulator. A
+  first cut that allocated unconditionally cost +5% on the dense
+  small-frontal p90 (1.58 → 1.66) and +6.5% on dense medium (2.00 → 2.13);
+  with the ordering both buckets beat the previous baseline (1.54 and 1.91).
 - **Not fixed:** the slack-mass gate is still order-dependent, leaving 114 of
   1004 families routing on index order. Every invariant reformulation measured
   strips `Mc64Symmetric` from 89 families including `marine_1600` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — scaling router no longer routes on index order (issue #134 item B)
+
+- `pick_scaling_strategy`'s dense-head gate now counts the **symmetric degree**
+  of each index rather than the length of its stored lower-triangle column.
+  `CscMatrix` stores one triangle, so a stored column length measures couplings
+  to one side of `j` only — a property of the index order, not of the matrix.
+- **The bug.** Under the pure relabeling `P(i) = n-1-i`, VESUVIO's arrow head
+  reports a stored max degree of 1026 one way and 11 the other, and the route
+  flips `Mc64Symmetric` → `InfNorm`, forfeiting the documented 6x–243x MC64 win.
+  The IPOPT variable convention puts the duals last, so this is the shape POUNCE
+  and discopt actually emit. Measured over the 1004-family KKT corpus, the old
+  router was permutation-invariant on 841; the new one on 890.
+- **Monotone, so nothing loses MC64.** Symmetric degree is never less than
+  stored degree, so the gate can only become easier to pass: 15 families change
+  route and all 15 gain `Mc64Symmetric` (MSS1, BIGBANK, BLOWEYA/B/C, C-RELOAD,
+  CHAIN, CLEUVEN2, CMPC1, LEUVEN1, LEUVEN2, SOSQP1, SOSQP2, arki0003, arki0009).
+  Inertia is identical under both routes on all 15; factor-time ratio median
+  0.98 (range 0.95–1.19); accuracy neutral or better on 14 (CHAIN 5.02e-6 →
+  1.42e-8, SOSQP1 8.49e-6 → 1.95e-6). MSS1 is the exception — 0.872 → 1.037 ms
+  and 1.43e-1 → 6.15e-1 forward error — but at 1e-1 neither route solves it, and
+  the Policy 4 fallback already covers it.
+- The 2026-05-17 threshold panel is preserved: clnlbeam's symmetric max degree
+  is 5 and ACOPP30's is 29, both still under the `32` gate.
+- Cost: one `n`-length degree accumulator; the router is no longer
+  allocation-free.
+- **Not fixed:** the slack-mass gate is still order-dependent, leaving 114 of
+  1004 families routing on index order. Every invariant reformulation measured
+  strips `Mc64Symmetric` from 89 families including `marine_1600` and
+  `rocket_12800`, so it needs IPM-outcome evidence rather than a routing-parity
+  argument. See `dev/research/router-permutation-invariance-2026-08-15.md`.
+
 ## [0.16.0] - 2026-08-14
 
 ### Changed — `SparseLu::factor` now defaults to threshold-Markowitz pivoting (issue #171)

--- a/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
+++ b/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
@@ -97,6 +97,47 @@ fn symmetric_gates(m: &CscMatrix) -> Gates {
     Gates { diag_only, max_deg }
 }
 
+/// The permutation-invariant candidate for #134B.
+///
+/// Both gates are computed on the *symmetric* degree — the degree of
+/// column `j` in the full matrix, not in the stored lower triangle —
+/// so a symmetric relabeling cannot change either one.
+///
+/// The head gate is the max symmetric degree. The slack-mass gate
+/// counts columns whose symmetric degree is at most `slack_max` and
+/// whose diagonal is present and nonzero: in an arrow KKT a slack
+/// column carries its diagonal plus its single coupling to the arrow
+/// head, so its symmetric degree is 2 regardless of whether the head
+/// leads or trails. That is the invariant the shipped `nnz_col == 1`
+/// test is a storage-dependent special case of.
+fn invariant_gates(m: &CscMatrix, slack_max: usize) -> Gates {
+    let mut deg = vec![0usize; m.n];
+    let mut has_diag = vec![false; m.n];
+    for j in 0..m.n {
+        for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+            if m.values[k] == 0.0 {
+                continue;
+            }
+            let i = m.row_idx[k];
+            deg[j] += 1;
+            if i == j {
+                has_diag[j] = true;
+            } else {
+                deg[i] += 1;
+            }
+        }
+    }
+    let mut diag_only = 0;
+    let mut max_deg = 0;
+    for j in 0..m.n {
+        max_deg = max_deg.max(deg[j]);
+        if deg[j] <= slack_max && has_diag[j] {
+            diag_only += 1;
+        }
+    }
+    Gates { diag_only, max_deg }
+}
+
 /// Symmetrically reverse the index order: `P(i) = n-1-i`. The matrix
 /// is the same up to a symmetric permutation, so every
 /// permutation-invariant property (including whether MC64 helps) is
@@ -390,6 +431,7 @@ fn issue_134b() {
         agree,
         flips.len()
     );
+    calibrate();
     if !flips.is_empty() {
         println!(
             "\n  {:<20} {:>8} {:>10} {:>8} {:>10} {:>8}",
@@ -457,42 +499,744 @@ fn cache_hits() {
     }
 }
 
-/// Part 5: KR is cap-bound, not tolerance-bound, on working iterates.
-/// So the question is not "does warm start converge sooner" but "how
-/// good a scaling does each budget buy". Sweep the cap, cold vs
-/// warm-started, and report the equilibration quality reached.
+/// Part 5: the one KR question `dev/research/scaling-warm-start-2026-08-09.md`
+/// did not measure.
+///
+/// That note falsified "warm-start reduces the sweep count" (it does
+/// not — KR is cap-bound) and separately rejected "lower the cap"
+/// (cold KR at cap 5 is ~26x worse equilibrated than at cap 10). What
+/// it did not try is the *combination*: carry `d` forward across the
+/// IPM sequence AND spend fewer sweeps per factorization, so the
+/// iteration becomes one long continued run rather than N truncated
+/// restarts.
+///
+/// The experiment is the shipping comparison, not a single pair:
+///   - cold chain  = today. Every iterate restarts from `d = 1`, 10 sweeps.
+///   - warm chain  = candidate. Iterate 0 pays 10 sweeps; every later
+///     iterate starts from the previous iterate's `d` and spends `k`.
+///
+/// Both are scored by the equilibration they actually deliver
+/// (`max_i |rowmax_i - 1|` of the matrix the factorization then sees).
+/// Only pairs with an unchanged pattern are compared, since a pattern
+/// change is where a real solver would drop the carried `d` anyway.
+fn kr_chain(label: &str, dir: &Path, limit: usize) {
+    let its = iterates(dir, limit);
+    if its.len() < 3 {
+        println!("{}: fewer than 3 usable iterates, skipping", label);
+        return;
+    }
+    // Restrict to the longest run of iterates sharing iterate 1's
+    // pattern (iterate 0 is routinely a different pattern).
+    let base_nnz = its[1].1.nnz();
+    let seq: Vec<&CscMatrix> = its
+        .iter()
+        .map(|(_, m)| m)
+        .filter(|m| m.nnz() == base_nnz)
+        .collect();
+    if seq.len() < 3 {
+        println!("{}: no stable-pattern run, skipping", label);
+        return;
+    }
+    println!(
+        "{}  n={} nnz={}  {} stable-pattern iterates",
+        label,
+        seq[0].n,
+        base_nnz,
+        seq.len()
+    );
+    println!(
+        "    {:>4}  {:>12}  {:>12}  {:>12}  {:>7}",
+        "k", "cold@10 geo", "warm@k geo", "warm@10 geo", "warm@k wins"
+    );
+    // Cold chain: independent of k.
+    let cold: Vec<f64> = seq
+        .iter()
+        .map(|m| kr_sweeps_capped(m, None, 10).final_dev)
+        .collect();
+    let geo = |v: &[f64]| -> f64 {
+        let s: f64 = v.iter().map(|x| x.max(1e-300).ln()).sum();
+        (s / v.len() as f64).exp()
+    };
+    for k in [2usize, 3, 5, 10] {
+        // Warm chain: iterate 0 pays the full 10, the rest pay k.
+        let mut d = kr_sweeps_capped(seq[0], None, 10).d;
+        let mut warm = Vec::with_capacity(seq.len());
+        warm.push(cold[0]);
+        for m in seq.iter().skip(1) {
+            let r = kr_sweeps_capped(m, Some(&d), k);
+            warm.push(r.final_dev);
+            d = r.d;
+        }
+        let wins = warm
+            .iter()
+            .zip(cold.iter())
+            .skip(1)
+            .filter(|(w, c)| w < c)
+            .count();
+        let warm10 = if k == 10 { geo(&warm) } else { f64::NAN };
+        println!(
+            "    {:>4}  {:>12.3e}  {:>12.3e}  {:>12}  {:>3}/{:<3}",
+            k,
+            geo(&cold),
+            geo(&warm),
+            if warm10.is_nan() {
+                "-".to_string()
+            } else {
+                format!("{:.3e}", warm10)
+            },
+            wins,
+            seq.len() - 1
+        );
+    }
+    println!();
+}
+
 fn kr_budget() {
-    println!("\n=== #153: KR quality per sweep budget (cold vs warm-started) ===\n");
-    let base = Path::new("data/matrices/kkt-mittelmann");
-    for prob in ["clnlbeam", "dtoc1nd", "marine_1600", "rocket_12800"] {
-        let its = iterates(&base.join(prob), 2);
-        if its.len() < 2 {
+    println!("\n=== #153: warm chain at budget k vs the shipped cold chain at 10 ===");
+    println!("    (geo = geometric mean of max_i |rowmax_i - 1| over the run;");
+    println!("     lower is better; 'wins' counts iterates where warm@k beat cold@10)\n");
+    let mm = Path::new("data/matrices/kkt-mittelmann");
+    let kkt = Path::new("data/matrices/kkt");
+    let exp = Path::new("data/matrices/kkt-expansion");
+    // The two matrices that actually run InfNorm at steady state.
+    kr_chain("clnlbeam       [InfNorm route]", &mm.join("clnlbeam"), 20);
+    kr_chain(
+        "steering_12800 [InfNorm route]",
+        &mm.join("steering_12800"),
+        20,
+    );
+    // The 2026-08-09 note's own hard fixtures, now with real IPM
+    // drift instead of the note's synthetic +/-5% perturbation.
+    kr_chain("HYDCAR20       [note fixture]", &kkt.join("HYDCAR20"), 40);
+    kr_chain("TWIRISM1       [note fixture]", &exp.join("TWIRISM1"), 40);
+    // MC64-routed, for contrast: KR is not on their path.
+    kr_chain("marine_1600    [MC64 route]", &mm.join("marine_1600"), 20);
+}
+
+/// Every corpus root the scaling router is validated against.
+/// `kkt-mittelmann` is where the "MC64 hurts clnlbeam" evidence lives
+/// (journal 2026-05-16), so a sweep that omits it does not cover the
+/// panel the shipped thresholds were calibrated on.
+const CORPUS_ROOTS: &[&str] = &[
+    "data/matrices/kkt",
+    "data/matrices/kkt-mittelmann",
+    "data/matrices/kkt-expansion",
+];
+
+/// #134B calibration: does the invariant gate reproduce the shipped
+/// route on the 2026-05-17 panel, and how many corpus families move?
+fn calibrate() {
+    println!("\n(c) invariant gate (symmetric degree, slack_max=2) vs the shipped router:\n");
+    let kkt = Path::new("data/matrices/kkt");
+    println!("  calibration panel (expected: VESUVIO-class YES, clnlbeam/ACOPP30 NO):");
+    println!(
+        "  {:<12} {:>7} {:>26} {:>30} {:>16}",
+        "matrix", "n", "shipped (stored)", "invariant (symmetric)", "reversed inv."
+    );
+    for fam in [
+        "VESUVIO", "VESUVIOU", "VESUVIA", "MUONSINE", "CRESC132", "ACOPP30", "ACOPR30", "AIRPORT",
+        "HAIFAM",
+    ] {
+        let its = iterates(&kkt.join(fam), 1);
+        let Some((_, m)) = its.first() else { continue };
+        let gs = stored_gates(m);
+        let gi = invariant_gates(m, 2);
+        let rev = reverse_permute(m).ok();
+        let gir = rev.as_ref().map(|r| invariant_gates(r, 2));
+        println!(
+            "  {:<12} {:>7} {:>26} {:>30} {:>16}",
+            fam,
+            m.n,
+            format!("d1={} md={} {:?}", gs.diag_only, gs.max_deg, gs.route(m.n)),
+            format!("s2={} md={} {:?}", gi.diag_only, gi.max_deg, gi.route(m.n)),
+            match &gir {
+                Some(g) => format!("{:?}", g.route(m.n)),
+                None => "-".into(),
+            },
+        );
+    }
+
+    // Corpus: how many families change route, and is the invariant
+    // gate actually invariant?
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for root in CORPUS_ROOTS {
+        if let Ok(rd) = std::fs::read_dir(Path::new(root)) {
+            dirs.extend(
+                rd.filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir()),
+            );
+        }
+    }
+    dirs.sort();
+    for slack_max in [1usize, 2, 3] {
+        let (mut total, mut changed, mut inv_ok, mut shipped_not_inv) = (0, 0, 0, 0);
+        let mut gained = Vec::new();
+        let mut lost = Vec::new();
+        for dir in &dirs {
+            let its = iterates(dir, 1);
+            let Some((_, m)) = its.first() else { continue };
+            total += 1;
+            let rs = stored_gates(m).route(m.n);
+            let gi = invariant_gates(m, slack_max);
+            let ri = gi.route(m.n);
+            let name = dir
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            if rs != ri {
+                changed += 1;
+                if ri == ScalingStrategy::Mc64Symmetric {
+                    gained.push(name.clone())
+                } else {
+                    lost.push(name.clone())
+                }
+            }
+            if let Ok(rev) = reverse_permute(m) {
+                // Is the candidate actually permutation-invariant?
+                if invariant_gates(&rev, slack_max).route(m.n) == ri {
+                    inv_ok += 1;
+                }
+                // Is the shipped router invariant? (control)
+                if stored_gates(&rev).route(m.n) != rs {
+                    shipped_not_inv += 1;
+                }
+            }
+        }
+        println!(
+            "\n  slack_max={}: {} families | route changes vs shipped: {} ({} gain MC64, {} lose it)",
+            slack_max, total, changed, gained.len(), lost.len()
+        );
+        println!(
+            "    invariant under reversal: candidate {}/{}   shipped router NOT invariant on {}",
+            inv_ok, total, shipped_not_inv
+        );
+        if !gained.is_empty() {
+            println!("    gain MC64: {}", gained.join(" "));
+        }
+        if !lost.is_empty() {
+            println!("    lose MC64: {}", lost.join(" "));
+        }
+    }
+}
+
+/// The 8 families whose route changes under the invariant gate
+/// (slack_max=2). This is the whole risk surface of #134B: every
+/// other family routes exactly where it does today.
+/// Discover the families whose route changes under the shippable
+/// variant: gate (a) unchanged (stored `nnz_col == 1 && diag`), gate
+/// (b) on symmetric max degree. Monotone -- every change is a gain.
+fn movers_gate_b() -> Vec<(String, PathBuf)> {
+    let mut out = Vec::new();
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for root in CORPUS_ROOTS {
+        if let Ok(rd) = std::fs::read_dir(Path::new(root)) {
+            dirs.extend(
+                rd.filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir()),
+            );
+        }
+    }
+    dirs.sort();
+    for d in dirs {
+        let Some((_, m)) = iterates(&d, 1).into_iter().next() else {
+            continue;
+        };
+        let st = stored_gates(&m);
+        let sy = invariant_gates(&m, 2);
+        let base = st.route(m.n);
+        let new = Gates {
+            diag_only: st.diag_only,
+            max_deg: sy.max_deg,
+        }
+        .route(m.n);
+        if base != new {
+            let name = d
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            out.push((name, d));
+        }
+    }
+    out
+}
+
+/// Factor every iterate of `m` under a forced strategy and report
+/// (median factor ms, max scaled residual, inertia signature, failures).
+fn run_route(mats: &[(String, CscMatrix)], strat: ScalingStrategy) -> (f64, f64, Vec<i64>, usize) {
+    let mut times = Vec::new();
+    let mut worst = 0.0f64;
+    let mut sig = Vec::new();
+    let mut fails = 0usize;
+    for (_, m) in mats {
+        let mut s = Solver::new().with_scaling(strat.clone());
+        // 3 repeats, take the min: factor time here is a few hundred
+        // microseconds, so timer noise dominates a single sample.
+        let mut best = f64::INFINITY;
+        let mut ok = false;
+        for _ in 0..3 {
+            s = Solver::new().with_scaling(strat.clone());
+            let t = Instant::now();
+            let st = s.factor(m, None);
+            let el = t.elapsed().as_secs_f64() * 1e3;
+            ok = matches!(st, feral::FactorStatus::Success);
+            best = best.min(el);
+        }
+        if !ok {
+            fails += 1;
+            sig.push(i64::MIN);
             continue;
         }
-        let d0 = kr_sweeps_capped(&its[0].1, None, 10).d;
+        times.push(best);
+        sig.push(match s.inertia() {
+            Some(i) => i.negative as i64,
+            None => -1,
+        });
+        // rhs = A * ones, so the exact solution is all ones.
+        let n = m.n;
+        let mut b = vec![0.0f64; n];
+        for j in 0..n {
+            for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                let i = m.row_idx[k];
+                let v = m.values[k];
+                b[i] += v;
+                if i != j {
+                    b[j] += v;
+                }
+            }
+        }
+        if let Ok(x) = s.solve(&b) {
+            let err = x.iter().map(|v| (v - 1.0).abs()).fold(0.0f64, f64::max);
+            if err.is_finite() {
+                worst = worst.max(err);
+            } else {
+                worst = f64::INFINITY;
+            }
+        }
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let med = if times.is_empty() {
+        f64::NAN
+    } else {
+        times[times.len() / 2]
+    };
+    (med, worst, sig, fails)
+}
+
+/// Price the route changes: does the new route cost time or accuracy
+/// on the 8 families that move?
+fn price_movers() {
+    println!("\n(d) pricing the 8 route changes (all iterates, min-of-3 factor, rhs = A*1):\n");
+    println!(
+        "  {:<11} {:>5} {:>4} {:>11} {:>11} {:>7} {:>11} {:>11} {:>9}",
+        "family",
+        "n",
+        "its",
+        "InfNorm ms",
+        "MC64 ms",
+        "t ratio",
+        "InfNorm err",
+        "MC64 err",
+        "inertia"
+    );
+    for (fam, dir) in movers_gate_b() {
+        let fam = fam.as_str();
+        let dir_note = &"gain MC64";
+        let mats = iterates(&dir, 40);
+        if mats.is_empty() {
+            println!("  {:<11} (no iterates)", fam);
+            continue;
+        }
+        let n = mats[0].1.n;
+        let (t_inf, e_inf, s_inf, f_inf) = run_route(&mats, ScalingStrategy::InfNorm);
+        let (t_m64, e_m64, s_m64, f_m64) = run_route(&mats, ScalingStrategy::Mc64Symmetric);
+        // Which of the two is the NEW route?
+        let new_is_mc64 = *dir_note == "gain MC64";
+        let (t_old, t_new) = if new_is_mc64 {
+            (t_inf, t_m64)
+        } else {
+            (t_m64, t_inf)
+        };
         println!(
-            "{}  (quality = max_i |rowmax_i - 1| after the budget)",
-            prob
+            "  {:<11} {:>5} {:>4} {:>11.3} {:>11.3} {:>7.2} {:>11.2e} {:>11.2e} {:>9} {} {}",
+            fam,
+            n,
+            mats.len(),
+            t_inf,
+            t_m64,
+            t_new / t_old,
+            e_inf,
+            e_m64,
+            if s_inf == s_m64 { "same" } else { "DIFFER" },
+            dir_note,
+            if f_inf + f_m64 > 0 {
+                format!("[fail inf={} mc64={}]", f_inf, f_m64)
+            } else {
+                String::new()
+            },
         );
+    }
+    println!(
+        "\n  't ratio' is new-route time / old-route time; <1 means the change is free or faster."
+    );
+}
+
+/// How marginal is each `slack_max` decision? Prints the slack-mass
+/// ratio at slack_max = 1,2,3 against the 0.30 gate for the panel and
+/// the movers, so the threshold is chosen on data rather than taste.
+fn marginality() {
+    println!("\n(e) slack-mass ratio vs the 0.30 gate, by slack_max:\n");
+    println!(
+        "  {:<11} {:>6} {:>6} {:>8} {:>8} {:>8}  gate b (md>32)",
+        "family", "n", "sym md", "s<=1/n", "s<=2/n", "s<=3/n"
+    );
+    let kkt = Path::new("data/matrices/kkt");
+    let fams = [
+        "clnlbeam",
+        "CLNLBEAM",
+        "steering",
+        "VESUVIO",
+        "VESUVIOU",
+        "VESUVIA",
+        "MUONSINE",
+        "CRESC132",
+        "ACOPP30",
+        "ACOPR14",
+        "CRESC100",
+        "DECONVBNE",
+        "AIRPORT",
+        "GOFFIN",
+        "HAIFAM",
+        "LHAIFAM",
+        "MAKELA4",
+        "ACOPR30",
+    ];
+    for fam in fams {
+        let dir = CORPUS_ROOTS
+            .iter()
+            .map(|r| Path::new(r).join(fam))
+            .find(|p| p.is_dir())
+            .unwrap_or_else(|| kkt.join(fam));
+        let its = iterates(&dir, 1);
+        let Some((_, m)) = its.first() else {
+            println!("  {:<11} (missing)", fam);
+            continue;
+        };
+        let g = |k| invariant_gates(m, k);
+        let md = g(1).max_deg;
         println!(
-            "    {:>6}  {:>12}  {:>12}",
-            "budget", "cold dev", "warm dev"
+            "  {:<11} {:>6} {:>6} {:>8.3} {:>8.3} {:>8.3}  {}",
+            fam,
+            m.n,
+            md,
+            g(1).diag_only as f64 / m.n as f64,
+            g(2).diag_only as f64 / m.n as f64,
+            g(3).diag_only as f64 / m.n as f64,
+            if md > 32 {
+                "pass"
+            } else {
+                "FAIL -> InfNorm regardless"
+            },
         );
-        for cap in [1usize, 2, 3, 5, 10] {
-            let c = kr_sweeps_capped(&its[1].1, None, cap);
-            let w = kr_sweeps_capped(&its[1].1, Some(&d0), cap);
+    }
+}
+
+/// For families the shipped router sends to MC64, what is the
+/// symmetric degree of the columns it counts as "slack"? If those
+/// degrees are small and tightly clustered a single `slack_max`
+/// works; if they spread, the slack-mass gate needs a different
+/// invariant formulation.
+fn slack_degree_spectrum() {
+    let fams = [
+        "VESUVIO",
+        "MUONSINE",
+        "CRESC132",
+        "ACOPR30",
+        "marine_1600",
+        "rocket_12800",
+        "ROCKET",
+        "STEERING",
+        "robot_1600",
+        "pinene_3200",
+        "gasoil_3200",
+        "TWIRISM1",
+        "MSQRTA",
+        "LEUVEN3",
+        "ACOPP118",
+        "MPC1",
+        "CMPC2",
+    ];
+    println!("\n(f) symmetric degree of the columns the SHIPPED gate counts as slack:\n");
+    println!(
+        "  {:<13} {:>7} {:>8} {:>7}  {:>5} {:>5} {:>5} {:>5}   cumulative frac of n with sym deg <= k",
+        "family", "n", "stored/n", "sym md", "min", "med", "p90", "max"
+    );
+    println!(
+        "  {:<13} {:>7} {:>8} {:>7}  {:>5} {:>5} {:>5} {:>5}   {:>6} {:>6} {:>6} {:>6} {:>6}",
+        "", "", "", "", "", "", "", "", "k=2", "k=3", "k=4", "k=6", "k=8"
+    );
+    for fam in fams {
+        let dir = CORPUS_ROOTS
+            .iter()
+            .map(|r| Path::new(r).join(fam))
+            .find(|p| p.is_dir());
+        let Some(dir) = dir else {
+            println!("  {:<13} (missing)", fam);
+            continue;
+        };
+        let its = iterates(&dir, 1);
+        let Some((_, m)) = its.first() else { continue };
+        let n = m.n;
+        // symmetric degrees
+        let mut deg = vec![0usize; n];
+        for j in 0..n {
+            for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                if m.values[k] == 0.0 {
+                    continue;
+                }
+                let i = m.row_idx[k];
+                deg[j] += 1;
+                if i != j {
+                    deg[i] += 1;
+                }
+            }
+        }
+        // degrees of the columns the shipped gate counts
+        let mut counted = Vec::new();
+        #[allow(clippy::needless_range_loop)]
+        for j in 0..n {
+            let mut nnz = 0;
+            let mut d = false;
+            for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                if m.values[k] == 0.0 {
+                    continue;
+                }
+                nnz += 1;
+                if m.row_idx[k] == j {
+                    d = true;
+                }
+            }
+            if nnz == 1 && d {
+                counted.push(deg[j]);
+            }
+        }
+        if counted.is_empty() {
             println!(
-                "    {:>6}  {:>12.3e}  {:>12.3e}",
-                cap, c.final_dev, w.final_dev
+                "  {:<13} {:>7} {:>8.3} {:>7}  (shipped gate counts none)",
+                fam,
+                n,
+                0.0,
+                deg.iter().max().copied().unwrap_or(0)
             );
+            continue;
+        }
+        counted.sort_unstable();
+        let pick = |q: f64| counted[((counted.len() as f64 - 1.0) * q) as usize];
+        let cum = |k: usize| deg.iter().filter(|&&d| d <= k).count() as f64 / n as f64;
+        println!(
+            "  {:<13} {:>7} {:>8.3} {:>7}  {:>5} {:>5} {:>5} {:>5}   {:>6.3} {:>6.3} {:>6.3} {:>6.3} {:>6.3}",
+            fam,
+            n,
+            counted.len() as f64 / n as f64,
+            deg.iter().max().copied().unwrap_or(0),
+            counted[0],
+            pick(0.5),
+            pick(0.9),
+            counted[counted.len() - 1],
+            cum(2),
+            cum(3),
+            cum(4),
+            cum(6),
+            cum(8),
+        );
+    }
+}
+
+/// The complete design space: gate (a) and gate (b) can each be
+/// computed on stored or symmetric degrees, independently. Which
+/// combinations are permutation-invariant, and what does each cost in
+/// route churn?
+fn decision_table() {
+    println!("\n(g) gate (a) x gate (b) design table over the full corpus:\n");
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for root in CORPUS_ROOTS {
+        if let Ok(rd) = std::fs::read_dir(Path::new(root)) {
+            dirs.extend(
+                rd.filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir()),
+            );
+        }
+    }
+    dirs.sort();
+    let mats: Vec<CscMatrix> = dirs
+        .iter()
+        .filter_map(|d| iterates(d, 1).into_iter().next().map(|(_, m)| m))
+        .collect();
+    let revs: Vec<Option<CscMatrix>> = mats.iter().map(|m| reverse_permute(m).ok()).collect();
+
+    // route(a_sym, b_sym): gate (a) counts slack as sym deg <= 2 when
+    // a_sym, else stored nnz == 1; gate (b) uses sym max deg when
+    // b_sym, else stored max nnz.
+    fn route(m: &CscMatrix, a_sym: bool, b_sym: bool) -> ScalingStrategy {
+        let st = stored_gates(m);
+        let sy = invariant_gates(m, 2);
+        let g = Gates {
+            diag_only: if a_sym { sy.diag_only } else { st.diag_only },
+            max_deg: if b_sym { sy.max_deg } else { st.max_deg },
+        };
+        g.route(m.n)
+    }
+
+    println!(
+        "  {:<22} {:>9} {:>9} {:>9}  {:>26}",
+        "variant", "changes", "gain", "lose", "invariant under reversal"
+    );
+    for (label, a_sym, b_sym) in [
+        ("shipped (stored,stored)", false, false),
+        ("(stored a, sym b)", false, true),
+        ("(sym a, stored b)", true, false),
+        ("(sym a, sym b)", true, true),
+    ] {
+        let (mut ch, mut gain, mut lose, mut inv) = (0, 0, 0, 0);
+        for (i, m) in mats.iter().enumerate() {
+            let base = route(m, false, false);
+            let r = route(m, a_sym, b_sym);
+            if r != base {
+                ch += 1;
+                if r == ScalingStrategy::Mc64Symmetric {
+                    gain += 1
+                } else {
+                    lose += 1
+                }
+            }
+            if let Some(rev) = &revs[i] {
+                if route(rev, a_sym, b_sym) == r {
+                    inv += 1;
+                }
+            }
+        }
+        println!(
+            "  {:<22} {:>9} {:>9} {:>9}  {:>19}/{}",
+            label,
+            ch,
+            gain,
+            lose,
+            inv,
+            mats.len()
+        );
+    }
+
+    // Does each variant hold the duals-last case (reversed VESUVIO)?
+    println!("\n  reversed-VESUVIO check (the pounce/discopt duals-last shape):");
+    let kkt = Path::new("data/matrices/kkt");
+    for fam in ["VESUVIO", "MUONSINE", "CRESC132"] {
+        let its = iterates(&kkt.join(fam), 1);
+        let Some((_, m)) = its.first() else { continue };
+        let Ok(rev) = reverse_permute(m) else {
+            continue;
+        };
+        print!("    {:<10}", fam);
+        for (label, a_sym, b_sym) in [
+            ("stored,stored", false, false),
+            ("stored,sym", false, true),
+            ("sym,stored", true, false),
+            ("sym,sym", true, true),
+        ] {
+            let ok = route(&rev, a_sym, b_sym) == ScalingStrategy::Mc64Symmetric;
+            print!("  {}={}", label, if ok { "MC64" } else { "InfNorm" });
         }
         println!();
     }
 }
 
+/// Post-fix verification: call the SHIPPED `pick_scaling_strategy`
+/// (not a local reimplementation) on every family and its symmetric
+/// reversal, and count invariance and route changes for real.
+fn verify_shipped() {
+    println!("\n(h) shipped pick_scaling_strategy, measured directly:\n");
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for root in CORPUS_ROOTS {
+        if let Ok(rd) = std::fs::read_dir(Path::new(root)) {
+            dirs.extend(
+                rd.filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir()),
+            );
+        }
+    }
+    dirs.sort();
+    let (mut total, mut inv, mut vs_old, mut gain, mut lose) = (0, 0, 0, 0, 0);
+    let mut noninv = Vec::new();
+    for d in &dirs {
+        let Some((_, m)) = iterates(d, 1).into_iter().next() else {
+            continue;
+        };
+        total += 1;
+        let r = pick_scaling_strategy(&m);
+        // the pre-fix router, reproduced locally
+        let old = stored_gates(&m).route(m.n);
+        if r != old {
+            vs_old += 1;
+            if r == ScalingStrategy::Mc64Symmetric {
+                gain += 1
+            } else {
+                lose += 1
+            }
+        }
+        if let Ok(rev) = reverse_permute(&m) {
+            if pick_scaling_strategy(&rev) == r {
+                inv += 1;
+            } else if noninv.len() < 12 {
+                noninv.push(
+                    d.file_name()
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_default(),
+                );
+            }
+        }
+    }
+    println!("  families:                     {}", total);
+    println!("  invariant under reversal:     {}/{}", inv, total);
+    println!(
+        "  route changes vs pre-fix:     {} ({} gain MC64, {} lose)",
+        vs_old, gain, lose
+    );
+    println!(
+        "  still order-dependent (gate a, sample): {}",
+        noninv.join(" ")
+    );
+}
+
 fn main() {
-    issue_153();
-    cache_hits();
-    kr_budget();
-    issue_134b();
+    let which: Vec<String> = std::env::args().skip(1).collect();
+    let want = |k: &str| which.is_empty() || which.iter().any(|a| a == k);
+    if want("153") {
+        issue_153();
+    }
+    if want("cache") {
+        cache_hits();
+    }
+    if want("kr") {
+        kr_budget();
+    }
+    if want("134b") {
+        issue_134b();
+    }
+    if want("price") {
+        price_movers();
+    }
+    if want("marg") {
+        marginality();
+    }
+    if want("spec") {
+        slack_degree_spectrum();
+    }
+    if want("table") {
+        decision_table();
+    }
+    if want("verify") {
+        verify_shipped();
+    }
 }

--- a/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
+++ b/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
@@ -1,0 +1,491 @@
+//! Diagnostic for the two open scaling levers: #153's warm-path scaling
+//! and #134 item B's lower-triangle-blind router gates.
+//!
+//! Read-only. Answers three questions with numbers rather than
+//! reasoning-from-the-source:
+//!
+//!   1. What does `pick_scaling_strategy` actually route the six #153
+//!      downstream KKTs to? (Decides whether the existing MC64 warm
+//!      cache is even applicable to them.)
+//!   2. How many Knight-Ruiz sweeps does `compute_infnorm` burn from
+//!      `d = 1`, and how many would it burn warm-started from the
+//!      previous iterate's `d`? (Bounds the #153 scaling win.)
+//!   3. Over the KKT corpus, how many matrices would the router send
+//!      somewhere else if its gates counted *symmetric* degrees
+//!      instead of stored lower-triangle degrees — and does the route
+//!      flip when an arrow KKT is symmetrically reversed? (Sizes #134
+//!      item B.)
+
+use feral::scaling::{pick_scaling_strategy, ScalingStrategy};
+use feral::{read_mtx, CscMatrix, Solver};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// The router's gate inputs, computed two ways.
+struct Gates {
+    diag_only: usize,
+    max_deg: usize,
+}
+
+impl Gates {
+    /// `>32` dense column AND `>=30%` degree-1 diagonal columns.
+    fn route(&self, n: usize) -> ScalingStrategy {
+        if n == 0 {
+            return ScalingStrategy::InfNorm;
+        }
+        if self.max_deg > 32 && self.diag_only as f64 / n as f64 >= 0.3 {
+            ScalingStrategy::Mc64Symmetric
+        } else {
+            ScalingStrategy::InfNorm
+        }
+    }
+}
+
+/// What `pick_scaling_strategy` counts today: stored lower-triangle
+/// entries per column, value-aware (issue #47).
+fn stored_gates(m: &CscMatrix) -> Gates {
+    let mut diag_only = 0;
+    let mut max_deg = 0;
+    for j in 0..m.n {
+        let mut nnz = 0;
+        let mut diag = false;
+        for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+            if m.values[k] == 0.0 {
+                continue;
+            }
+            nnz += 1;
+            if m.row_idx[k] == j {
+                diag = true;
+            }
+        }
+        max_deg = max_deg.max(nnz);
+        if nnz == 1 && diag {
+            diag_only += 1;
+        }
+    }
+    Gates { diag_only, max_deg }
+}
+
+/// What #134 item B proposes: the full symmetric degree of each
+/// column — stored entries plus the entries that symmetry puts in the
+/// unstored upper triangle. Same O(n + nnz), one extra n-vector.
+fn symmetric_gates(m: &CscMatrix) -> Gates {
+    let mut deg = vec![0usize; m.n];
+    let mut has_diag = vec![false; m.n];
+    for j in 0..m.n {
+        for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+            if m.values[k] == 0.0 {
+                continue;
+            }
+            let i = m.row_idx[k];
+            deg[j] += 1;
+            if i == j {
+                has_diag[j] = true;
+            } else {
+                deg[i] += 1;
+            }
+        }
+    }
+    let mut diag_only = 0;
+    let mut max_deg = 0;
+    for j in 0..m.n {
+        max_deg = max_deg.max(deg[j]);
+        if deg[j] == 1 && has_diag[j] {
+            diag_only += 1;
+        }
+    }
+    Gates { diag_only, max_deg }
+}
+
+/// Symmetrically reverse the index order: `P(i) = n-1-i`. The matrix
+/// is the same up to a symmetric permutation, so every
+/// permutation-invariant property (including whether MC64 helps) is
+/// unchanged. A router that changes its mind here is keying on
+/// storage, not on the matrix.
+fn reverse_permute(m: &CscMatrix) -> Result<CscMatrix, feral::FeralError> {
+    let n = m.n;
+    let mut rows = Vec::with_capacity(m.row_idx.len());
+    let mut cols = Vec::with_capacity(m.row_idx.len());
+    let mut vals = Vec::with_capacity(m.row_idx.len());
+    for j in 0..n {
+        for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+            let i = m.row_idx[k];
+            // (i, j) with i >= j maps to (n-1-i, n-1-j) with
+            // n-1-i <= n-1-j, so swap back into the lower triangle.
+            rows.push(n - 1 - j);
+            cols.push(n - 1 - i);
+            vals.push(m.values[k]);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals)
+}
+
+/// Knight-Ruiz ∞-norm equilibration, instrumented for sweep count and
+/// optionally warm-started. Mirrors `src/scaling/infnorm.rs`
+/// (`max_iter = 10`, `tol = 1e-8`) — this is a measurement copy, not a
+/// second implementation to be kept in sync.
+/// Result of one instrumented Knight-Ruiz run.
+struct KrRun {
+    d: Vec<f64>,
+    sweeps: usize,
+    converged: bool,
+    final_dev: f64,
+    guard_hits: usize,
+    subnormals: usize,
+}
+
+/// Knight-Ruiz oo-norm equilibration, instrumented for sweep count and
+/// optionally warm-started. Mirrors `src/scaling/infnorm.rs`
+/// (`max_iter = 10`, `tol = 1e-8`, the same guarded update) — this is a
+/// measurement copy, not a second implementation to be kept in sync.
+fn kr_sweeps(m: &CscMatrix, init: Option<&[f64]>) -> KrRun {
+    kr_sweeps_capped(m, init, 10)
+}
+
+/// Same, with an explicit sweep budget.
+fn kr_sweeps_capped(m: &CscMatrix, init: Option<&[f64]>, max_iter: usize) -> KrRun {
+    let n = m.n;
+    let mut d = match init {
+        Some(prev) if prev.len() == n => prev.to_vec(),
+        _ => vec![1.0f64; n],
+    };
+    let tol = 1e-8;
+    let mut row_max = vec![0.0f64; n];
+    let mut sweeps = 0;
+    let mut converged = false;
+    let mut final_dev = f64::INFINITY;
+    let mut guard_hits = 0;
+    for _ in 0..max_iter {
+        sweeps += 1;
+        for r in row_max.iter_mut() {
+            *r = 0.0;
+        }
+        for j in 0..n {
+            let dj = d[j];
+            let mut col_max = row_max[j];
+            for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                let i = m.row_idx[k];
+                let v = (d[i] * m.values[k] * dj).abs();
+                if i != j && v > row_max[i] {
+                    row_max[i] = v;
+                }
+                if v > col_max {
+                    col_max = v;
+                }
+            }
+            row_max[j] = col_max;
+        }
+        let mut max_dev = 0.0f64;
+        for i in 0..n {
+            let mv = row_max[i];
+            if mv > 0.0 {
+                // Exactly `crate::scaling::kr_guarded_update`.
+                let cand = d[i] / mv.sqrt();
+                if cand.is_finite() && cand > 0.0 {
+                    d[i] = cand;
+                } else {
+                    guard_hits += 1;
+                }
+                let dev = (mv - 1.0).abs();
+                if dev > max_dev {
+                    max_dev = dev;
+                }
+            }
+        }
+        final_dev = max_dev;
+        if max_dev < tol {
+            converged = true;
+            break;
+        }
+    }
+    let subnormals = d.iter().filter(|x| x.is_subnormal()).count();
+    KrRun {
+        d,
+        sweeps,
+        converged,
+        final_dev,
+        guard_hits,
+        subnormals,
+    }
+}
+
+/// Collect the iterate dumps for one problem, in order.
+fn iterates(dir: &Path, limit: usize) -> Vec<(String, CscMatrix)> {
+    let mut paths: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "mtx"))
+            .collect(),
+        Err(_) => return Vec::new(),
+    };
+    paths.sort();
+    paths
+        .into_iter()
+        .take(limit)
+        .filter_map(|p| {
+            let name = p.file_stem()?.to_string_lossy().to_string();
+            let csc = read_mtx(&p).ok()?.to_csc().ok()?;
+            Some((name, csc))
+        })
+        .collect()
+}
+
+/// Part 1 + 2: the #153 six.
+fn issue_153() {
+    println!("=== #153: what the six downstream KKTs route to, and what KR actually costs ===\n");
+    let base = Path::new("data/matrices/kkt-mittelmann");
+    for prob in [
+        "clnlbeam",
+        "dtoc1nd",
+        "steering_12800",
+        "rocket_12800",
+        "marine_1600",
+        "dtoc2",
+    ] {
+        let its = iterates(&base.join(prob), 3);
+        if its.is_empty() {
+            println!("{:<16} (no .mtx dumps found)", prob);
+            continue;
+        }
+        let (_, m0) = &its[0];
+        println!(
+            "{}  n={} nnz={}  Auto -> {:?}",
+            prob,
+            m0.n,
+            m0.nnz(),
+            pick_scaling_strategy(m0)
+        );
+        let t = Instant::now();
+        let r0 = kr_sweeps(m0, None);
+        let ms0 = t.elapsed().as_secs_f64() * 1e3;
+        println!(
+            "    iter0 cold : {:>2} sweeps {:>7.2} ms  converged={} final_dev={:.3e} guard={} subnormal_d={}",
+            r0.sweeps, ms0, r0.converged, r0.final_dev, r0.guard_hits, r0.subnormals
+        );
+        for (idx, (_, m)) in its.iter().enumerate().skip(1) {
+            let t = Instant::now();
+            let rc = kr_sweeps(m, None);
+            let msc = t.elapsed().as_secs_f64() * 1e3;
+            let t = Instant::now();
+            let rw = kr_sweeps(m, Some(&r0.d));
+            let msw = t.elapsed().as_secs_f64() * 1e3;
+            println!(
+                "    iter{} cold : {:>2} sweeps {:>7.2} ms  converged={} final_dev={:.3e} guard={} subnormal_d={}",
+                idx, rc.sweeps, msc, rc.converged, rc.final_dev, rc.guard_hits, rc.subnormals
+            );
+            println!(
+                "    iter{} warm : {:>2} sweeps {:>7.2} ms  converged={} final_dev={:.3e} guard={} subnormal_d={}   (started from iter0 d)",
+                idx, rw.sweeps, msw, rw.converged, rw.final_dev, rw.guard_hits, rw.subnormals
+            );
+        }
+        // Does the shipped router's gate see an arrow head here once
+        // degrees are counted symmetrically? (#134B on the inputs
+        // pounce actually sends.)
+        let gs = stored_gates(m0);
+        let gy = symmetric_gates(m0);
+        println!(
+            "    gates      : stored d1={} md={} -> {:?}   symmetric d1={} md={}",
+            gs.diag_only,
+            gs.max_deg,
+            gs.route(m0.n),
+            gy.diag_only,
+            gy.max_deg,
+        );
+        println!();
+    }
+}
+
+/// Part 3: the router gates, stored vs symmetric, over the corpus.
+fn issue_134b() {
+    println!("\n\n=== #134B: router gates, stored lower-triangle vs symmetric degree ===\n");
+
+    // (a) The reversal experiment on the calibration panel.
+    println!("(a) symmetric reversal P(i) = n-1-i on the calibration panel:\n");
+    println!(
+        "{:<18} {:>7} {:>26} {:>26}",
+        "matrix", "n", "as stored (route)", "reversed (route)"
+    );
+    let kkt = Path::new("data/matrices/kkt");
+    for fam in [
+        "VESUVIO", "VESUVIOU", "MUONSINE", "CRESC132", "ACOPP30", "AVION2",
+    ] {
+        let its = iterates(&kkt.join(fam), 1);
+        let Some((_, m)) = its.first() else {
+            println!("{:<18} (no dump)", fam);
+            continue;
+        };
+        let Ok(rev) = reverse_permute(m) else {
+            println!("{:<18} (permute failed)", fam);
+            continue;
+        };
+        let g = stored_gates(m);
+        let gr = stored_gates(&rev);
+        println!(
+            "{:<18} {:>7} {:>26} {:>26}",
+            fam,
+            m.n,
+            format!(
+                "d1={} md={} {:?}",
+                g.diag_only,
+                g.max_deg,
+                pick_scaling_strategy(m)
+            ),
+            format!(
+                "d1={} md={} {:?}",
+                gr.diag_only,
+                gr.max_deg,
+                pick_scaling_strategy(&rev)
+            ),
+        );
+    }
+
+    // (b) Corpus sweep: where do the two gate definitions disagree?
+    println!("\n(b) corpus sweep over data/matrices/kkt (one iterate per family):\n");
+    let mut total = 0;
+    let mut agree = 0;
+    let mut flips: Vec<(String, usize, usize, usize, usize, usize)> = Vec::new();
+    let mut dirs: Vec<PathBuf> = match std::fs::read_dir(kkt) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .collect(),
+        Err(e) => {
+            println!("  cannot read corpus: {}", e);
+            return;
+        }
+    };
+    dirs.sort();
+    for dir in dirs {
+        let its = iterates(&dir, 1);
+        let Some((_, m)) = its.first() else {
+            continue;
+        };
+        total += 1;
+        let gs = stored_gates(m);
+        let gy = symmetric_gates(m);
+        let rs = gs.route(m.n);
+        let ry = gy.route(m.n);
+        if rs == ry {
+            agree += 1;
+        } else {
+            let name = dir
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            flips.push((
+                name,
+                m.n,
+                gs.diag_only,
+                gs.max_deg,
+                gy.diag_only,
+                gy.max_deg,
+            ));
+        }
+    }
+    println!(
+        "  {} families read, {} route the same either way, {} flip",
+        total,
+        agree,
+        flips.len()
+    );
+    if !flips.is_empty() {
+        println!(
+            "\n  {:<20} {:>8} {:>10} {:>8} {:>10} {:>8}",
+            "family", "n", "stored d1", "stored md", "sym d1", "sym md"
+        );
+        for (name, n, sd, sm, yd, ym) in flips.iter().take(60) {
+            println!(
+                "  {:<20} {:>8} {:>10} {:>8} {:>10} {:>8}",
+                name, n, sd, sm, yd, ym
+            );
+        }
+        if flips.len() > 60 {
+            println!("  ... and {} more", flips.len() - 60);
+        }
+    }
+}
+
+/// Part 4: does the MC64 warm scaling cache actually hit across a
+/// real IPM iterate sequence? `marine_1600` routes to
+/// `Mc64Symmetric` and has 18 dumped iterates, so it is the fixture
+/// that can answer "warm-path scaling never warms" for the MC64 half.
+/// `dtoc1nd` routes to InfNorm and is the control: the cache is
+/// gated off by design there, so it must report zero hits.
+fn cache_hits() {
+    println!(
+        "\n\n=== #153: does the MC64 warm scaling cache hit across an iterate sequence? ===\n"
+    );
+    let base = Path::new("data/matrices/kkt-mittelmann");
+    for prob in ["marine_1600", "dtoc1nd", "rocket_12800"] {
+        let its = iterates(&base.join(prob), 20);
+        if its.is_empty() {
+            continue;
+        }
+        let route = pick_scaling_strategy(&its[0].1);
+        println!("{}  ({} iterates, Auto -> {:?})", prob, its.len(), route);
+        let mut solver = Solver::new().with_parallel(false);
+        let mut prev_hits = 0;
+        for (i, (_, m)) in its.iter().enumerate() {
+            let t = Instant::now();
+            let st = solver.factor(m, None);
+            let ms = t.elapsed().as_secs_f64() * 1e3;
+            let hits = solver.mc64_cache_hit_count();
+            println!(
+                "    iter {:>2}: {:>8.1} ms  cache_hit={}  status={:?}",
+                i,
+                ms,
+                if hits > prev_hits { "YES" } else { "no " },
+                st
+            );
+            prev_hits = hits;
+        }
+        println!(
+            "    total cache hits: {} / {}",
+            solver.mc64_cache_hit_count(),
+            its.len()
+        );
+        println!();
+    }
+}
+
+/// Part 5: KR is cap-bound, not tolerance-bound, on working iterates.
+/// So the question is not "does warm start converge sooner" but "how
+/// good a scaling does each budget buy". Sweep the cap, cold vs
+/// warm-started, and report the equilibration quality reached.
+fn kr_budget() {
+    println!("\n=== #153: KR quality per sweep budget (cold vs warm-started) ===\n");
+    let base = Path::new("data/matrices/kkt-mittelmann");
+    for prob in ["clnlbeam", "dtoc1nd", "marine_1600", "rocket_12800"] {
+        let its = iterates(&base.join(prob), 2);
+        if its.len() < 2 {
+            continue;
+        }
+        let d0 = kr_sweeps_capped(&its[0].1, None, 10).d;
+        println!(
+            "{}  (quality = max_i |rowmax_i - 1| after the budget)",
+            prob
+        );
+        println!(
+            "    {:>6}  {:>12}  {:>12}",
+            "budget", "cold dev", "warm dev"
+        );
+        for cap in [1usize, 2, 3, 5, 10] {
+            let c = kr_sweeps_capped(&its[1].1, None, cap);
+            let w = kr_sweeps_capped(&its[1].1, Some(&d0), cap);
+            println!(
+                "    {:>6}  {:>12.3e}  {:>12.3e}",
+                cap, c.final_dev, w.final_dev
+            );
+        }
+        println!();
+    }
+}
+
+fn main() {
+    issue_153();
+    cache_hits();
+    kr_budget();
+    issue_134b();
+}

--- a/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
+++ b/crates/feral-diagnostics/src/bin/probe_scaling_levers.rs
@@ -418,7 +418,14 @@ fn cache_hits() {
         "\n\n=== #153: does the MC64 warm scaling cache hit across an iterate sequence? ===\n"
     );
     let base = Path::new("data/matrices/kkt-mittelmann");
-    for prob in ["marine_1600", "dtoc1nd", "rocket_12800"] {
+    for prob in [
+        "clnlbeam",
+        "dtoc1nd",
+        "steering_12800",
+        "rocket_12800",
+        "marine_1600",
+        "dtoc2",
+    ] {
         let its = iterates(&base.join(prob), 20);
         if its.is_empty() {
             continue;

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,158 +1,131 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-14T18:06:07Z
+Generated: 2026-08-15T19:31:04Z
 
 ## Latest Session
-File: dev/sessions/2026-08-14-02.md
+File: dev/sessions/2026-08-14-03.md
 ```
-# Session 2026-08-14-02
+# Session 2026-08-14-03
+
+## Benchmark numbers are slightly worse than last session — reported first, per protocol
+
+All four exit-partition p90 buckets moved up relative to session
+2026-08-14-02, run four hours earlier on the same machine:
+
+| bucket | 08-13-04 | 08-14-02 | **this session** | target | verdict |
+|---|---|---|---|---|---|
+| dense small-frontal (<200) p90 | 1.61 | 1.57 | **1.58** | <= 2.0 | PASS |
+| dense medium (<500) p90 | 2.09 | 1.96 | **2.00** | <= 3.0 | PASS |
+| sparse small-frontal (<200) p90 | 1.54 | 1.50 | **1.54** | <= 2.0 | PASS |
+| sparse medium (<500) p90 | 1.54 | 1.50 | **1.54** | <= 3.0 | PASS |
+
+All four still PASS, and every one of them sits inside the band the last
+three sessions have bounced around in. This session is the strongest
+available evidence that the band *is* noise rather than drift: the only
+non-version, non-changelog edits were **doc comments**. The compiled code
+is byte-for-byte the same solver session 08-14-02 measured at 1.57 / 1.96
+/ 1.50 / 1.50. A harness that reports a 0.04 spread on identical codegen
+is telling you its own resolution, not the solver's.
+
+Sparse factor tail this run: geomean 0.44, p50 0.30, p90 1.54, p99 3.25,
+max 9.14. Against the tail recorded in the 0.15.1 release commit (geomean
+0.44, p90 1.57, p99 3.45, max 12.40) the tail is *better*; against the
+0.15.0-era baseline it quotes (geomean 0.43, p90 1.54, p99 3.30, max
+8.70) the max is still worse. Unchanged conclusion from that release: the
+n=225-458 CUTEst matrices set these tails and nothing in the LU work
+touches them.
 
 ## Goal
-Fix the open issues in the 161-168 range rather than commenting on them:
-land #167 (threshold-Markowitz LU), resolve #161 (kernel vs SuperLU), and
-settle #166 (QPLIB_3225 under the triangularized ordering).
+
+Release 0.16.0. The #161-#168 + #171 arc was merged but undelivered —
+crates.io still served 0.15.1, so none of it had reached discopt.
 
 ## Accomplished
 
-### #167 threshold-Markowitz LU -- implemented, merged, closed
-`SparseLu::factor_markowitz` picks each pivot to minimise `(r_i-1)(c_j-1)`
-subject to `|a_ij| >= u*max_k|a_kj|`. On 16 preserved LP bases,
-`factor_nnz()/nnz(B)` geomean **2.77x -> 1.06x** vs AMD-full, zero fill on
-10 of 16. Wall geomean vs AMD-full 4.92x (was 3.50x before the in-place
-rank-1 update, which was the real lever -- the original per-column Vec
-rebuild cost one allocation per (pivot, column) pair).
-Reported honestly, and repeated here: the Suhl-Suhl singleton fast path
-**failed** at its stated purpose (fill 1.07x -> 1.06x, wall 3.43x -> 3.50x,
-i.e. slightly worse) and was kept only because Markowitz subsumes it at
-cost 0. Markowitz also **loses** to the cheap peel on near-triangular bases
-(QPLIB_0911_rlt0, bump 29: peel 1.10ms vs Markowitz 4.32ms) and wins on
-bump-heavy ones (QPLIB_1143_rlt1, bump 624: 4.87ms vs peel 31.77ms).
-Commits 04756ac, 48382c7, 0e8e976; PR #170 merged as bd78bad.
+**0.16.0 shipped, verified live on both registries.**
 
-### #161 kernel vs SuperLU -- re-measured on merged main, closed
-SuperLU reproduced its original numbers exactly (213,132 factor-nnz, 7.26x
-fill, 11.13ms on QPLIB_1157), so old and new numbers are comparable.
-Both named defects are fixed:
-- factorization: dense-bump 10.91ms = parity with SuperLU's 11.13ms;
-  Markowitz 6.73ms at fill 1.74x = **1.65x faster at 4.2x less fill**.
-- solve: at the SHIPPED `hyper_sparse_max_density=0.10`, ftran p50
-  88.42us -> 7.92us = **11.17x**; btran 0.98x (neutral).
-Two reframings recorded:
-- SuperLU's own solve is **not** work-proportional either: same factor,
-  unit rhs 107.2us vs dense rhs 106.0us. #161 measured feral against
-  itself on that axis; against the reference it was never a feral-specific
-  defect, and at 7.92us it is now a feral advantage.
-- #161's premise "the ordering is not the problem, our fill matches
-  COLAMD" was a true observation with a false conclusion. AMD-on-A^T A and
-  COLAMD are the same algorithm class; matching the reference *inside* a
-  class cannot detect that the class leaves 4x on the table. That premise
-  is what made this expensive to find.
-Opened **#171** for what remains: all three measured levers (dense bump,
-Markowitz, AMF) are off by default and the shipped config is still 4.03x
-SuperLU on QPLIB_1157. That is a defaults decision, not a kernel defect.
-
-### #166 QPLIB_3225 under the triangularized ordering -- closed, not reproducible
-Two feral worktrees off `3209fad` differing in **exactly one line**
-(`analyze` -> `analyze_with(default)` vs `analyze` -> `analyze_triangularized`),
-verified by `diff -r --brief`; two discopt worktrees pinned at `bce881ff`
+- `c681c2a` release commit -> PR #173 (all checks pass) -> merge `6fc92d6`
+  -> tag `v0.16.0` -> GitHub release.
+- crates.io `feral` max_version **0.16.0**, newest_version 0.16.0. Queried
+  with a `User-Agent` and sanity-checked against `serde` (1.0.229), per the
+  method note in the global agent instructions.
+- PyPI `feral-solver` **0.16.0**, 5 files: macOS universal2, manylinux
+  x86_64, manylinux aarch64, win_amd64, sdist.
+- The six ordering crates correctly stayed at **0.2.1**. None changed since
+  v0.15.1, so `release.yml`'s "already exists on crates.io index" path
+  treated them as success. The checklist's staleness guard confirmed this
+  was intentional and not a silent skip of changed code.
 ```
 
 ## Git Status
 ```
+810080d docs: session checkpoint 2026-08-14-03 (0.16.0 released)
 6fc92d6 Merge pull request #173 from jkitchin/release/0.16.0
 c681c2a release: feral v0.16.0
 c9c3adc docs: session checkpoint 2026-08-14-02 (161-168 closed, #171 landed)
 ec67e85 Merge pull request #172 from jkitchin/feat/171-lu-defaults
-d5048b9 feat(lu)!: default SparseLu::factor to threshold-Markowitz pivoting
 ```
 
 ## Test Status
 ```
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 423 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.45s
+test result: ok. 423 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.43s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-14-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-14-03.md)
 
 
-No regression to report. All four exit-partition buckets are equal or
-better than session 2026-08-13-04, the last session that actually ran the
-bench:
+=== Dense perf vs canonical oracles (154481 matrices with oracle timings) ===
 
-| bucket | 08-13-04 | this session |
-|---|---|---|
-| dense small-frontal (<200) p90 | 1.61 | **1.57** |
-| dense medium (<500) p90 | 2.09 | **1.96** |
-| sparse small-frontal (<200) p90 | 1.54 | **1.50** |
-| sparse medium (<500) p90 | 1.54 | **1.50** |
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153472       0.24       0.10       2.15      38.21      88.39
+solve/MUMPS        153472       0.10       0.08       0.40       4.82      37.54
+factor/SSIDS       154393       0.02       0.01       0.46      10.36      25.77
+solve/SSIDS        154393       1.32       1.00       7.00      60.50     432.28
+nnzL/MUMPS         153472       1.53       1.00       5.67      35.32      99.41
+nnzL/SSIDS         154393       2.23       1.78       5.27      61.86     103.86
 
-Read this as run-to-run variation, not as a benefit of this session's
-work: `bin/bench` measures the LDL^T/KKT path, and #171 changed only the
-LU basis factorization, which that harness does not exercise. The
-practical content is that session 04's reported dense p90 regression
-(1.57 -> 1.61, 1.96 -> 2.09) did not persist.
 
-MCONCON                  3000       0.85       0.89       1.62
-HATFLDH                  3000       0.42       0.45       0.55
-CONCON                   3000       0.82       0.88       1.66
-PALMER7A                 3000       0.27       0.30       0.33
-DJTL                     3000       0.09       0.10       0.22
-PALMER5A                 3000       0.29       0.30       0.33
-HS90                     3000       0.20       0.20       0.30
-SSI                      3000       0.20       0.22       0.27
-HATFLDBNE                3000       0.38       0.40       0.82
-MGH10LS                  3000       0.20       0.22       0.25
-HS92                     3000       0.35       0.40       0.44
-AVION2                   2682       1.41       1.46       1.92
-CERI651ALS               2331       0.27       0.27       0.40
-PFIT4                    2286       0.23       0.25       0.30
-CERI651C                 2233       0.28       0.30       0.40
-CERI651CLS               2227       0.26       0.27       0.40
-BATCH                    2054       1.28       1.34       1.66
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
 
-Top 10 worst factor-ratio vs MUMPS:
-name                             n    feral(μs)    mumps(μs)      ratio
-KIRBY2_0007                    458         1065          119       8.95
-KIRBY2_0006                    458         1003          127       7.90
-KIRBY2_0008                    458          930          122       7.62
-KIRBY2_0009                    458          847          128       6.62
-KIRBY2_0010                    458          776          133       5.83
-KIRBY2_0011                    458          670          120       5.58
-GROUPING_0243                  225          591          111       5.32
-GROUPING_0031                  225          564          109       5.17
-GROUPING_0045                  225          563          113       4.98
-GROUPING_0231                  225          556          113       4.92
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.54       3.25       9.14
+solve/MUMPS        153560       0.07       0.08       0.14       0.66       2.31
+factor/SSIDS       154500       0.04       0.03       0.32       0.95       1.97
+solve/SSIDS        154500       0.93       1.00       2.44       8.00      30.00
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.57     <= 2.0     PASS
-medium (<500)            152145     1.96     <= 3.0     PASS
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.50     <= 2.0     PASS
-medium (<500)            153560     1.50     <= 3.0     PASS
-
+small-frontal (<200)     153455     1.54     <= 2.0     PASS
+medium (<500)            153560     1.54     <= 3.0     PASS
 ```
 
 ## Recent Decisions
@@ -348,5 +321,13 @@ tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
-
-(truncated from      360 lines to 350 line budget)
+tests/sparse_postorder.rs
+tests/sparse_refined.rs
+tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
+tests/stress_tests.rs
+tests/symbolic_profiler.rs
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
+```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-15T19:31:04Z
+Generated: 2026-08-15T21:30:01Z
 
 ## Latest Session
 File: dev/sessions/2026-08-14-03.md
@@ -59,26 +59,26 @@ crates.io still served 0.15.1, so none of it had reached discopt.
 
 ## Git Status
 ```
-810080d docs: session checkpoint 2026-08-14-03 (0.16.0 released)
-6fc92d6 Merge pull request #173 from jkitchin/release/0.16.0
-c681c2a release: feral v0.16.0
-c9c3adc docs: session checkpoint 2026-08-14-02 (161-168 closed, #171 landed)
-ec67e85 Merge pull request #172 from jkitchin/feat/171-lu-defaults
+45c80f3 perf(scaling): keep the router's symmetric pass off the common path
+e9470ca fix(scaling): count symmetric degree in the router's head gate (#134B)
+8acb1be docs(scaling): research + plan for router permutation-invariance (#134B)
+14b3865 diag: size the KR warm-start lever against steady-state routes
+e78f29e diag: probe the two open scaling levers (#153, #134B)
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
@@ -86,7 +86,7 @@ test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ..
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 423 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.43s
+test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.44s
 
 ```
 
@@ -161,26 +161,26 @@ Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
 `dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
 
 ## Recent Tried-and-Rejected
-two discopt worktrees pinned at `bce881ff` via `[patch.crates-io]`, two
-extension `.so`s with distinct md5s loaded by `PYTHONPATH`, each arm
-asserting its own module path before solving. Slower to build, but it
-measures the thing the issue is about.
 
-## 2026-08-14 — #171: plain `cargo test` as the verification gate
+**Also:** this hypothesis had already been falsified six days earlier in
+`dev/research/scaling-warm-start-2026-08-09.md` (zero iteration reduction on
+6 fixtures; "lower the cap" ranked worst on risk/benefit, cap 5 giving
+3.7e-1 vs 1.4e-2 — 26x worse). That note was not read before recommending
+the work, which is the protocol step — read `dev/research/` and this file
+*before* writing code — that exists to prevent exactly this.
 
-**Tried.** Verifying the Markowitz-default change with `cargo test`.
+**Sizing was also wrong.** The lever was first sized off what
+`pick_scaling_strategy` returns, but the sticky-`Auto` pin (#51/#65) means
+the steady-state route can differ: `mc64_cache_hit_count()` shows dtoc1nd at
+14/20 hits and marine at 12/18, i.e. both run MC64, not InfNorm. Only 2 of
+the 6 #153 fixtures (clnlbeam, steering_12800) actually run KR, so the lever
+was ~7-12%, not the 10-20% first reported. Size scaling levers off the
+observed route, not the picker.
 
-**Why it failed.** `cargo test` stops after the first failing test *target*.
-Four consecutive runs each reported exactly one failing binary, so the same
-"the suite is green except X" conclusion was drawn — and was wrong — three
-times. Run 5's log contains zero occurrences of `lu_sparse_rhs`: that binary
-never executed. The true blast radius was seven test sites across five
-files.
-
-**Replaced with.** `cargo test --no-fail-fast`, which surfaced all of them
-in one pass (864 passed, 0 failed). For any change to a default that every
-test inherits, fail-fast turns one measurement into N sequential ones and
-hides the scope.
+**Not rejected:** warm@10 — the same sweep budget, better conditioning
+(geomean 3x-100x lower final deviation). That is free quality, not a
+speedup, and would need downstream iterative-refinement counts to justify.
+Recorded as option 2 in the 2026-08-09 note; still open.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,109 +1,127 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-15T22:04:50Z
+Generated: 2026-08-15T22:22:29Z
 
 ## Latest Session
-File: dev/sessions/2026-08-15-01.md
+File: dev/sessions/2026-08-15-02.md
 ```
-# Session 2026-08-15-01
+# Session 2026-08-15-02
 
-## Benchmark note (mandatory unfavorable-comparison section)
+## BENCHMARK NUMBERS ARE WORSE THAN LAST SESSION
 
-The first bench run of this session **regressed both dense buckets** against
-the 2026-08-14-03 baseline. It was chased to root cause and fixed, not filed
-as noise. Final numbers beat the baseline:
+Reported first, per the hard rule in CLAUDE.md.
 
-| bucket                       | 08-13-04 | 08-14-02 | 08-14-03 | this session (first) | **this session (final)** | target | verdict |
-|------------------------------|----------|----------|----------|----------------------|--------------------------|--------|---------|
-| dense small-frontal (<200) p90 | 1.61   | 1.57     | 1.58     | **1.66**             | **1.54**                 | ≤ 2.0  | PASS    |
-| dense medium (<500) p90        | 2.09   | 1.96     | 2.00     | **2.13**             | **1.91**                 | ≤ 3.0  | PASS    |
-| sparse small-frontal (<200) p90| 1.54   | 1.50     | 1.54     | 1.50                 | 1.50                     | ≤ 2.0  | PASS    |
-| sparse medium (<500) p90       | 1.54   | 1.50     | 1.54     | 1.51                 | 1.51                     | ≤ 3.0  | PASS    |
+    partition                  2026-08-15-01   this session   delta
+    dense  small-frontal (<200)     1.54           1.61        +0.07
+    dense  medium (<500)            1.91           2.00        +0.09
+    sparse small-frontal (<200)     1.50           1.67        +0.17
+    sparse medium (<500)            1.51           1.67        +0.16
 
-Cause of the regression: the first cut of the #134B fix allocated an
-`n`-length degree accumulator on every `pick_scaling_strategy` call. The
-router runs per factor and the dense partition is ~148k sub-millisecond
-factorizations, so an unconditional per-call allocation is visible (+5%
-small-frontal, +6.5% medium) even though it is O(n+nnz) against an
-O(n^1.5+) factorization. Fixed in `45c80f3` by ordering the gates so the
-allocation stays off the common path.
+All four partitions regressed. All four still PASS their targets.
+
+**No Rust source changed this session.** `git diff --stat fbb1a9d HEAD
+-- src/ crates/ tests/` is empty; the only changes are `dev/`
+documents. So this is not a code regression — it is run-to-run
+variance on the same binary.
+
+That conclusion is itself worth recording, because it bears on a claim
+made last session. 2026-08-15-01 reported a dense small-frontal
+sequence of 1.58 (baseline) -> 1.66 (regression I introduced) -> 1.54
+(after the gate reordering), and I described the final number as
+"beating the baseline". Today's run puts the same unchanged code at
+1.61. A +0.07 swing with zero code change means the bench's noise
+floor on this metric is at least as large as the 1.58 -> 1.54
+"improvement" I claimed. **The gate-reordering fix should be regarded
+as having removed the 1.66 regression, not as having beaten the
+baseline.** The 1.66 measurement is still meaningful (it exceeded the
+noise band), but the final 0.04 is not.
+
+Action for a future session: establish the bench's noise floor by
+running it N times on an unchanged binary, and record a
+minimum-detectable-difference so per-session comparisons stop
+over-reading sub-0.1 movements. Until then, treat p90 deltas under
+~0.15 as noise.
+
+Also note the worst-ratio table is now **6 of 10 KIRBY2 iterates**
+(worst 9.22, up from 8.95), plus GROUPING_0205 — i.e. the outlier
+family this session diagnosed dominates the tail more clearly than
+before.
 
 ## Goal
 
-Pick up issue #153 (KR scaling warm-start) and issue #134 item B (the
-scaling router's lower-triangle-blind gates). Both were carried in from
-triage with a stated premise; measure both before implementing either.
+Investigate the two items carried out of 2026-08-15-01, both approved
+by the user:
 
-## Accomplished
-
-### #134 item B — router permutation-invariance (shipped)
-
-`pick_scaling_strategy`'s dense-head gate now counts **symmetric degree**
-instead of stored lower-triangle column length.
-
-- **Bug confirmed and resized.** Under the pure relabeling `P(i) = n-1-i`,
-  VESUVIO's head reports stored max degree 1026 one way and 11 the other and
-  the route flips `Mc64Symmetric` → `InfNorm`. Over the full 1004-family
-  corpus (`kkt` + `kkt-mittelmann` + `kkt-expansion`) the old router was
-  permutation-invariant on only **841**.
-- **Fix measured against the shipped router**, not a reimplementation:
-  invariance **841 → 890**, **15 route changes, 15 gains, 0 losses**. The
-  change is monotone — symmetric degree is never below stored degree — so no
-  family can lose MC64.
-- **Movers priced** over every iterate: inertia identical under both routes
-  on all 15; factor-time ratio median 0.98 (range 0.95–1.19); accuracy
-  neutral or better on 14 (CHAIN 5.02e-6 → 1.42e-8, SOSQP1 8.49e-6 →
-  1.95e-6). MSS1 is the one unfavorable mover (+19% time, 1.43e-1 → 6.15e-1
-  forward error) but neither route solves it and the Policy 4 fallback test
+1. **#153 remainder** — MC64 warm-cache miss cost. marine_1600 spends
+   ~19% of a 1784 ms solve in cache-missed MC64 recomputes. Decide
+   whether `GROWTH_FACTOR`/`GROWTH_COUNT` can be tightened without
 ```
 
 ## Git Status
 ```
+3029905 docs(compress): localize the KIRBY2 factor-ratio outlier to LdltCompress
 fbb1a9d docs: session checkpoint 2026-08-15-01 (#134B shipped, #153 falsified)
 45c80f3 perf(scaling): keep the router's symmetric pass off the common path
 e9470ca fix(scaling): count symmetric degree in the router's head gate (#134B)
 8acb1be docs(scaling): research + plan for router permutation-invariance (#134B)
-14b3865 diag: size the KR warm-start lever against steady-state routes
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.57s
+test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.85s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-15-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-15-02.md)
 
+
+**No Rust source changed this session** (`git diff --stat fbb1a9d HEAD
+-- src/ crates/ tests/` is empty; the only changes are `dev/`
+documents). The run below is therefore a re-measurement of unchanged
+code and is expected to reproduce 2026-08-15-01.
+
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(us)    mumps(us)      ratio
+KIRBY2_0007                    458         1097          119       9.22
+KIRBY2_0006                    458         1075          127       8.46
+KIRBY2_0008                    458          971          122       7.96
+KIRBY2_0010                    458          992          133       7.46
+LAKES_0144                     168          372           54       6.89
+KIRBY2_0009                    458          879          128       6.87
+KIRBY2_0011                    458          820          120       6.83
+LAKES_0146                     168          350           54       6.48
+GROUPING_0205                  225          700          111       6.31
+QPCBLEND_0030                  157          362           60       6.03
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.54     <= 2.0     PASS
-medium (<500)            152145     1.91     <= 3.0     PASS
+small-frontal (<200)     147982     1.61     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.50     <= 2.0     PASS
-medium (<500)            153560     1.51     <= 3.0     PASS
+small-frontal (<200)     153455     1.67     <= 2.0     PASS
+medium (<500)            153560     1.67     <= 3.0     PASS
 
 ```
 
@@ -140,26 +158,26 @@ Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
 `dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
 
 ## Recent Tried-and-Rejected
+**Refuted by measurement.** `diag_symbolic_stages_argv` on
+KIRBY2_0007:
 
-**Also:** this hypothesis had already been falsified six days earlier in
-`dev/research/scaling-warm-start-2026-08-09.md` (zero iteration reduction on
-6 fixtures; "lower the cap" ranked worst on risk/benefit, cap 5 giving
-3.7e-1 vs 1.4e-2 — 26x worse). That note was not read before recommending
-the work, which is the protocol step — read `dev/research/` and this file
-*before* writing code — that exists to prevent exactly this.
+    TOTAL 1182 us
+      ldlt_compress   972   82.2%
+      renumber         57    4.8%
+      ordering         32    2.7%
 
-**Sizing was also wrong.** The lever was first sized off what
-`pick_scaling_strategy` returns, but the sticky-`Auto` pin (#51/#65) means
-the steady-state route can differ: `mc64_cache_hit_count()` shows dtoc1nd at
-14/20 hits and marine at 12/18, i.e. both run MC64, not InfNorm. Only 2 of
-the 6 #153 fixtures (clnlbeam, steering_12800) actually run KR, so the lever
-was ~7-12%, not the 10-20% first reported. Size scaling levers off the
-observed route, not the picker.
+Ordering is 32 us — 2.7% of symbolic and ~3% of the reported
+`factor_us`. Eliminating AMD cost entirely could not move the ratio.
+The cost is `ldlt_compress` (the MC64 matching feeding Duff-Pralet
+compression), which is a different subsystem from the one the
+hypothesis named.
 
-**Not rejected:** warm@10 — the same sweep budget, better conditioning
-(geomean 3x-100x lower final deviation). That is free quality, not a
-speedup, and would need downstream iterative-refinement counts to justify.
-Recorded as option 2 in the 2026-08-09 note; still open.
+A second prediction in the same hypothesis — that feral was producing
+more fill than MUMPS — is also refuted: the numeric driver is 127 us
+and `num_c ~ num_n` (149 vs 143 us), so the factorization is not the
+problem in either time or fill.
+
+Superseded by `dev/research/ldlt-compress-cost-benefit-2026-08-15.md`.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,131 +1,110 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-15T21:30:01Z
+Generated: 2026-08-15T22:04:50Z
 
 ## Latest Session
-File: dev/sessions/2026-08-14-03.md
+File: dev/sessions/2026-08-15-01.md
 ```
-# Session 2026-08-14-03
+# Session 2026-08-15-01
 
-## Benchmark numbers are slightly worse than last session — reported first, per protocol
+## Benchmark note (mandatory unfavorable-comparison section)
 
-All four exit-partition p90 buckets moved up relative to session
-2026-08-14-02, run four hours earlier on the same machine:
+The first bench run of this session **regressed both dense buckets** against
+the 2026-08-14-03 baseline. It was chased to root cause and fixed, not filed
+as noise. Final numbers beat the baseline:
 
-| bucket | 08-13-04 | 08-14-02 | **this session** | target | verdict |
-|---|---|---|---|---|---|
-| dense small-frontal (<200) p90 | 1.61 | 1.57 | **1.58** | <= 2.0 | PASS |
-| dense medium (<500) p90 | 2.09 | 1.96 | **2.00** | <= 3.0 | PASS |
-| sparse small-frontal (<200) p90 | 1.54 | 1.50 | **1.54** | <= 2.0 | PASS |
-| sparse medium (<500) p90 | 1.54 | 1.50 | **1.54** | <= 3.0 | PASS |
+| bucket                       | 08-13-04 | 08-14-02 | 08-14-03 | this session (first) | **this session (final)** | target | verdict |
+|------------------------------|----------|----------|----------|----------------------|--------------------------|--------|---------|
+| dense small-frontal (<200) p90 | 1.61   | 1.57     | 1.58     | **1.66**             | **1.54**                 | ≤ 2.0  | PASS    |
+| dense medium (<500) p90        | 2.09   | 1.96     | 2.00     | **2.13**             | **1.91**                 | ≤ 3.0  | PASS    |
+| sparse small-frontal (<200) p90| 1.54   | 1.50     | 1.54     | 1.50                 | 1.50                     | ≤ 2.0  | PASS    |
+| sparse medium (<500) p90       | 1.54   | 1.50     | 1.54     | 1.51                 | 1.51                     | ≤ 3.0  | PASS    |
 
-All four still PASS, and every one of them sits inside the band the last
-three sessions have bounced around in. This session is the strongest
-available evidence that the band *is* noise rather than drift: the only
-non-version, non-changelog edits were **doc comments**. The compiled code
-is byte-for-byte the same solver session 08-14-02 measured at 1.57 / 1.96
-/ 1.50 / 1.50. A harness that reports a 0.04 spread on identical codegen
-is telling you its own resolution, not the solver's.
-
-Sparse factor tail this run: geomean 0.44, p50 0.30, p90 1.54, p99 3.25,
-max 9.14. Against the tail recorded in the 0.15.1 release commit (geomean
-0.44, p90 1.57, p99 3.45, max 12.40) the tail is *better*; against the
-0.15.0-era baseline it quotes (geomean 0.43, p90 1.54, p99 3.30, max
-8.70) the max is still worse. Unchanged conclusion from that release: the
-n=225-458 CUTEst matrices set these tails and nothing in the LU work
-touches them.
+Cause of the regression: the first cut of the #134B fix allocated an
+`n`-length degree accumulator on every `pick_scaling_strategy` call. The
+router runs per factor and the dense partition is ~148k sub-millisecond
+factorizations, so an unconditional per-call allocation is visible (+5%
+small-frontal, +6.5% medium) even though it is O(n+nnz) against an
+O(n^1.5+) factorization. Fixed in `45c80f3` by ordering the gates so the
+allocation stays off the common path.
 
 ## Goal
 
-Release 0.16.0. The #161-#168 + #171 arc was merged but undelivered —
-crates.io still served 0.15.1, so none of it had reached discopt.
+Pick up issue #153 (KR scaling warm-start) and issue #134 item B (the
+scaling router's lower-triangle-blind gates). Both were carried in from
+triage with a stated premise; measure both before implementing either.
 
 ## Accomplished
 
-**0.16.0 shipped, verified live on both registries.**
+### #134 item B — router permutation-invariance (shipped)
 
-- `c681c2a` release commit -> PR #173 (all checks pass) -> merge `6fc92d6`
-  -> tag `v0.16.0` -> GitHub release.
-- crates.io `feral` max_version **0.16.0**, newest_version 0.16.0. Queried
-  with a `User-Agent` and sanity-checked against `serde` (1.0.229), per the
-  method note in the global agent instructions.
-- PyPI `feral-solver` **0.16.0**, 5 files: macOS universal2, manylinux
-  x86_64, manylinux aarch64, win_amd64, sdist.
-- The six ordering crates correctly stayed at **0.2.1**. None changed since
-  v0.15.1, so `release.yml`'s "already exists on crates.io index" path
-  treated them as success. The checklist's staleness guard confirmed this
-  was intentional and not a silent skip of changed code.
+`pick_scaling_strategy`'s dense-head gate now counts **symmetric degree**
+instead of stored lower-triangle column length.
+
+- **Bug confirmed and resized.** Under the pure relabeling `P(i) = n-1-i`,
+  VESUVIO's head reports stored max degree 1026 one way and 11 the other and
+  the route flips `Mc64Symmetric` → `InfNorm`. Over the full 1004-family
+  corpus (`kkt` + `kkt-mittelmann` + `kkt-expansion`) the old router was
+  permutation-invariant on only **841**.
+- **Fix measured against the shipped router**, not a reimplementation:
+  invariance **841 → 890**, **15 route changes, 15 gains, 0 losses**. The
+  change is monotone — symmetric degree is never below stored degree — so no
+  family can lose MC64.
+- **Movers priced** over every iterate: inertia identical under both routes
+  on all 15; factor-time ratio median 0.98 (range 0.95–1.19); accuracy
+  neutral or better on 14 (CHAIN 5.02e-6 → 1.42e-8, SOSQP1 8.49e-6 →
+  1.95e-6). MSS1 is the one unfavorable mover (+19% time, 1.43e-1 → 6.15e-1
+  forward error) but neither route solves it and the Policy 4 fallback test
 ```
 
 ## Git Status
 ```
+fbb1a9d docs: session checkpoint 2026-08-15-01 (#134B shipped, #153 falsified)
 45c80f3 perf(scaling): keep the router's symmetric pass off the common path
 e9470ca fix(scaling): count symmetric degree in the router's head gate (#134B)
 8acb1be docs(scaling): research + plan for router permutation-invariance (#134B)
 14b3865 diag: size the KR warm-start lever against steady-state routes
-e78f29e diag: probe the two open scaling levers (#153, #134B)
 ```
 
 ## Test Status
 ```
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.44s
+test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.57s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-14-03.md)
-
-
-=== Dense perf vs canonical oracles (154481 matrices with oracle timings) ===
-
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153472       0.24       0.10       2.15      38.21      88.39
-solve/MUMPS        153472       0.10       0.08       0.40       4.82      37.54
-factor/SSIDS       154393       0.02       0.01       0.46      10.36      25.77
-solve/SSIDS        154393       1.32       1.00       7.00      60.50     432.28
-nnzL/MUMPS         153472       1.53       1.00       5.67      35.32      99.41
-nnzL/SSIDS         154393       2.23       1.78       5.27      61.86     103.86
-
-
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
-
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.44       0.30       1.54       3.25       9.14
-solve/MUMPS        153560       0.07       0.08       0.14       0.66       2.31
-factor/SSIDS       154500       0.04       0.03       0.32       0.95       1.97
-solve/SSIDS        154500       0.93       1.00       2.44       8.00      30.00
-nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
-nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-15-01.md)
 
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+small-frontal (<200)     147982     1.54     <= 2.0     PASS
+medium (<500)            152145     1.91     <= 3.0     PASS
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.54     <= 2.0     PASS
-medium (<500)            153560     1.54     <= 3.0     PASS
+small-frontal (<200)     153455     1.50     <= 2.0     PASS
+medium (<500)            153560     1.51     <= 3.0     PASS
+
 ```
 
 ## Recent Decisions

--- a/dev/journal/2026-08-15-01.org
+++ b/dev/journal/2026-08-15-01.org
@@ -1,0 +1,131 @@
+#+TITLE: Session journal 2026-08-15-01
+#+STARTUP: showeverything
+
+* 09:40 :scaling:issue-153:issue-134b:probe:
+Opened the two levers carried out of the 0.16.0 checkpoint. Wrote
+=crates/feral-diagnostics/src/bin/probe_scaling_levers.rs= (read-only) to
+answer them with numbers instead of reasoning from source: what the six
+#153 KKTs route to, how many Knight-Ruiz sweeps they actually burn, whether
+the MC64 warm scaling cache hits across an iterate sequence, and how the
+router's gates behave under a symmetric relabeling.
+
+* 09:55 :issue-153:correction:mc64-cache:
+CORRECTION to my own triage. I characterised #153's "warm-path scaling
+never warms" as an unreachable code path, i.e. a bug. That is wrong. The
+value-bounded MC64 scaling cache exists and hits:
+
+: marine_1600  12 hits / 18 iterates
+: dtoc1nd      14 hits / 20 iterates
+: rocket_12800  0 hits /  2 iterates
+
+rocket's 0/2 is the fixture, not the code: its two dumps have different
+patterns (332,793 vs 435,190 stored nnz), so the pattern fingerprint
+correctly invalidates. marine's misses (iters 1, 5, 9, 10, 11) are the
+value-bound check rejecting value drift, which is the #38 inertia-drift
+guard doing its job.
+
+The miss cost is real and large. On marine_1600 a hit factors in 25-30 ms
+and a miss in 87-127 ms -- the Hungarian is ~3x the entire rest of the
+factorization. Six of 18 iterates pay it; closing that gap is worth roughly
+334 ms of 1784 ms (~19%) on that sequence, but only by relaxing a guard
+that exists for a correctness reason.
+
+* 10:10 :issue-153:infnorm:knight-ruiz:finding:
+The InfNorm half is a different problem than #153 assumes, and a sharper
+one. KR is *cap-bound, not tolerance-bound* on every working iterate:
+
+: matrix          iter0 cold          iter1 cold
+: clnlbeam        10 sweeps dev 2.2e-2 (capped)   10 sweeps dev 2.1e-2 (capped)
+: dtoc1nd          6 sweeps dev 4.4e-16 CONVERGED 10 sweeps dev 3.5e-2 (capped)
+: steering_12800   4 sweeps dev 7.7e-12 CONVERGED 10 sweeps dev 1.8e-2 (capped)
+: rocket_12800    10 sweeps dev 1.3e-2 (capped)   10 sweeps dev 2.1e-2 (capped)
+: marine_1600     10 sweeps dev 4.5e-3 (capped)   10 sweeps dev 1.4e-2 (capped)
+: dtoc2            5 sweeps dev 2.2e-16 CONVERGED
+
+Only the iterate-0 KKT ever reaches =tol = 1e-8=. From iterate 1 on, every
+matrix burns the full =max_iter = 10= and exits 6-7 orders of magnitude
+short. So scaling "not warming" here is not a missing cache -- the
+algorithm never finishes, and there is no converged answer to cache. This
+is #134 item D's "always reports =Applied= even unconverged" showing up as
+the normal case rather than an edge case.
+
+* 10:25 :issue-153:warm-start:measurement:
+Warm-starting the KR iteration from the previous iterate's =d= does NOT
+reduce the sweep count -- every warm run still hits the cap. It buys
+*quality* instead, 1-2 orders of magnitude at every budget:
+
+: matrix     budget   cold dev   warm dev
+: clnlbeam        1    5.16e4    9.39e-2
+:                 5    4.93e-1   5.57e-3
+:                10    2.10e-2   1.74e-4
+: dtoc1nd         5    6.91e-1   2.50e-2
+:                10    3.49e-2   7.90e-4
+: marine_1600     5    3.59e-1   3.25e-2
+:                10    1.38e-2   1.03e-3
+: rocket_12800    5    4.94e-1   2.21e-1
+:                10    2.11e-2   7.77e-3
+
+The lever this exposes: warm-started KR at 5 sweeps is already better
+equilibrated than cold KR at 10 on clnlbeam (5.6e-3 vs 2.1e-2) and dtoc1nd
+(2.5e-2 vs 3.5e-2). That is a 2x cut in KR cost at equal-or-better scaling
+quality. KR measures 4-6 ms on these against warm factor times of 11-30 ms,
+so ~10-20% of the factorization.
+
+Caveat, stated before anyone builds it: this is not bit-identical. A
+different starting point reaches a different fixed point, which changes
+pivoting and could move inertia on edge cases. It needs the corpus inertia
+gate and =golden_bits=, and it is a candidate for opt-in rather than
+default.
+
+* 10:40 :issue-134b:router:confirmed:
+The routing bug is real, and the reversal experiment is decisive. Applying
+the symmetric relabeling P(i) = n-1-i -- which cannot change any
+permutation-invariant property of the matrix, including whether MC64 helps:
+
+: matrix     as stored                      reversed
+: VESUVIO    d1=1025 md=1026 Mc64Symmetric  d1=2058 md=11 InfNorm
+: VESUVIOU   d1=1025 md=1026 Mc64Symmetric  d1=2058 md=11 InfNorm
+: MUONSINE   d1=512  md=512  Mc64Symmetric  d1=1025 md=4  InfNorm
+: CRESC132   d1=2654 md=2657 Mc64Symmetric  d1=2656 md=8  InfNorm
+
+All four are in the documented 6x-243x MC64-benefit class. The router keys
+on storage, not on the matrix.
+
+* 10:55 :issue-134b:correction:calibration:
+CORRECTION, second one. Two things I asserted when prioritising #134B are
+not supported by the data.
+
+1. The issue's prescribed fix -- "compute symmetric degrees ... in the same
+   O(n+nnz) pass" -- breaks the router if applied literally to both gates.
+   A slack column's symmetric degree is 2 (its diagonal plus the border
+   entry), never 1, so the degree-1 count collapses to zero for every arrow
+   matrix. Corpus sweep over =data/matrices/kkt=: 568 families read, 26
+   flip route, and the 26 include VESUVIO, VESUVIOU, VESUVIA, MUONSINE and
+   CRESC132 -- all of them to InfNorm. The literal fix would break the
+   router on exactly the class it was calibrated for.
+
+   The gate that *is* permutation-invariant is symmetric degree <= 2 for
+   the slack-mass count, plus symmetric degree for the dense-head count.
+   But that is not a drop-in either: it pushes ACOPP30 from md=29 to md=43
+   and ACOPR30 from 43 to 47, both across the >32 head gate, and ACOPP30 is
+   a documented MC64-hurts case (Policy 4 fallback). The 32 threshold needs
+   re-validating against the 2026-05-17 panel before any of this ships.
+
+2. I claimed the trailing-border case "is plausibly costing real time on
+   real inputs today" because duals-last is the IPOPT convention that
+   pounce and discopt feed us. Not supported. The pounce dumps store the
+   dense coupling where the router can see it -- rocket_12800 stored
+   d1=38400 md=38401 and marine_1600 stored d1=38392 md=6401, both routing
+   to Mc64Symmetric on stored counts. Across 568 corpus families, zero are
+   currently misrouted by a trailing border.
+
+   So #134B is a robustness fix against an input ordering we have no dumps
+   of, not a speedup on anything in hand. It should be prioritised as such.
+
+* 11:05 :planning:
+Net: the order in the 0.16.0 checkpoint was wrong. #153's InfNorm
+warm-start is the measurable win (~10-20% of factor on the InfNorm-routed
+KKTs, quantified above); #153's MC64 half is a guard-tuning question with a
+correctness cost; #134B is a real bug with no measured payoff and a
+recalibration dependency. Reporting all three to the user before writing
+any implementation.

--- a/dev/journal/2026-08-15-01.org
+++ b/dev/journal/2026-08-15-01.org
@@ -129,3 +129,43 @@ KKTs, quantified above); #153's MC64 half is a guard-tuning question with a
 correctness cost; #134B is a real bug with no measured payoff and a
 recalibration dependency. Reporting all three to the user before writing
 any implementation.
+
+* 11:40 :issue-153:sizing:correction:
+Followed up on the open question I flagged: which strategy each of the six
+actually *runs* at steady state, not which one the picker returns at
+iterate 0. A cache hit is only possible if MC64 ran (the =mc64_ran= gate
+requires it), so the hit counter is a sufficient probe. Ran all six:
+
+: matrix          picker@0        hits      steady-state route
+: clnlbeam        InfNorm         0 / 2     InfNorm  (pattern stable, so 0 is real)
+: steering_12800  InfNorm         0 / 3     InfNorm  (pattern stable, so 0 is real)
+: dtoc1nd         InfNorm        14 / 20    MC64     (sticky-Auto pin moved it)
+: rocket_12800    Mc64Symmetric   0 / 2     MC64     (pattern changes between the only 2 dumps)
+: marine_1600     Mc64Symmetric  12 / 18    MC64
+: dtoc2           InfNorm         0 / 1     unknown -- only one usable dump
+
+So the InfNorm-routed set is *two* of the six, not four. dtoc1nd looked
+like an InfNorm matrix from the picker and is not: its 14 cache hits prove
+the Hungarian ran, so the sticky-Auto pin (#65 fallback or #51) moved it
+onto MC64 after the first factor. My earlier sizing of the KR warm-start
+lever assumed four InfNorm matrices and is therefore too generous.
+
+Corrected sizing, using the same warm sequences:
+
+: matrix          warm factor   KR (10 sweeps)   KR share   halved -> saves
+: clnlbeam           30.2 ms        4.1 ms        13.6%       ~7% of factor
+: steering_12800     25.5 ms        6.0 ms        23.5%      ~12% of factor
+
+~7-12% on the two matrices that actually run InfNorm, not 10-20% across
+four. The lever is real but narrower than I reported.
+
+* 11:50 :corpus:data-quality:
+=dtoc2_0001.mtx= and =dtoc2_0002.mtx= fail to load:
+
+: read_mtx failed: IoError("... line 849754: non-finite value 'inf'")
+
+The reader is correct to reject them -- the dumps contain a literal =inf=.
+dtoc2 therefore has exactly one usable iterate in the repo, so every dtoc2
+claim in #153 (including its 1.29x ratio and its 21.0% scaling share) rests
+on a single matrix. Not a feral bug; a corpus gap to note before anyone
+uses dtoc2 as a fixture.

--- a/dev/journal/2026-08-15-01.org
+++ b/dev/journal/2026-08-15-01.org
@@ -169,3 +169,253 @@ dtoc2 therefore has exactly one usable iterate in the repo, so every dtoc2
 claim in #153 (including its 1.29x ratio and its 21.0% scaling share) rests
 on a single matrix. Not a feral bug; a corpus gap to note before anyone
 uses dtoc2 as a fixture.
+
+* 12:20 :protocol-miss:issue-153:prior-art:
+Protocol miss on my part, caught late. The Normal Session Protocol says to
+read =dev/research/= and search =dev/tried-and-rejected.md= *before writing
+any code* on a new feature. I recommended the KR warm-start to the user
+first and searched afterwards. The prior art exists and is six days old:
+
+: dev/research/scaling-warm-start-2026-08-09.md
+: examples/probe_kr_warmstart.rs   (checked-in reproducer)
+
+That note already falsified "warm-start reduces the sweep count" and
+already rejected "lower the cap" (cold KR at cap 5 measured ~26x worse
+equilibrated than at cap 10 on HYDCAR20). It identifies the true cause,
+which my probe re-derived independently today: Ruiz-style equilibration
+converges linearly at ratio ~1/2, so from dev ~1e-2 at the cap, reaching
+tol=1e-8 needs ~30 sweeps, and max_iter=10 truncates rather than converges.
+
+My independent re-derivation is a consistency check on the note, not a new
+finding. The only genuinely unmeasured thing I brought was the
+*combination* the note did not try: carry d forward AND spend fewer sweeps.
+
+* 12:35 :issue-153:falsified:knight-ruiz:
+The combination is falsified too. Tested as the shipping comparison -- a
+cold chain (every iterate restarts from d=1 at 10 sweeps, i.e. today)
+against a warm chain (iterate 0 pays 10, every later iterate starts from
+the previous d and pays k) -- over the longest stable-pattern run in each
+corpus, scored on the equilibration actually delivered:
+
+: matrix                    k=2      k=3      k=5     k=10   (warm@k wins)
+: steering_12800 [InfNorm]  0/2      0/2      0/2     2/2
+: TWIRISM1       [note fx]  0/6      0/6      4/6     5/6
+: marine_1600    [MC64]     9/16     9/16    14/16   16/16
+
+On =steering_12800= -- one of the only two matrices that actually runs
+InfNorm at steady state -- warm@5 loses 2 of 2 iterates against cold@10.
+warm@2 and warm@3 lose everywhere. The reduced-budget warm chain does not
+pay.
+
+My earlier "warm@5 beats cold@10" claim came from a single iterate pair
+(iterate 0 -> iterate 1) on clnlbeam and dtoc1nd. Over full runs it does
+not replicate. A single pair was not enough evidence to recommend a change,
+and I should not have offered it as a sized lever.
+
+What IS confirmed, and matches the note's own Option 2: warm-starting at
+the *unchanged* 10-sweep budget improves quality at zero speed cost --
+steering 2/2, TWIRISM1 5/6, marine 16/16, geometric mean of the delivered
+dev improving 3x to 100x. That is free conditioning, not a speedup, and
+its payoff would have to be measured in downstream refinement counts.
+
+* 12:40 :planning:revised:
+Revised disposition of the three items the user green-lit:
+1. KR warm-start for speed -- NOT implementing. Falsified twice now
+   (2026-08-09 note, and today's chain experiment). Recording here rather
+   than re-litigating it a third time next session.
+2. MC64 warm-cache miss cost -- still real (marine: 87-127 ms miss vs
+   25-30 ms hit, 6 of 18 iterates). Proceeding to investigate.
+3. #134B router permutation-invariance -- still real and unaffected by any
+   of the above. Proceeding to implement.
+
+* 13:10 :134b:calibration:measured:
+Built the permutation-invariant candidate gate and calibrated it over
+the corpus. Both gates computed on SYMMETRIC degree (degree of column
+j in the full matrix, not the stored lower triangle); slack mass
+counts columns with symmetric degree <= slack_max AND a nonzero
+diagonal. Head gate unchanged at >32.
+
+Corpus sweep, 568 families, one iterate each:
+
+| slack_max | route changes | gain MC64 | lose MC64 | invariant under reversal |
+|-----------+---------------+-----------+-----------+--------------------------|
+|         1 |            26 |         0 |        26 |                  568/568 |
+|         2 |             8 |         3 |         5 |                  568/568 |
+|         3 |             6 |         3 |         3 |                  568/568 |
+
+Control: the SHIPPED router is not invariant on 27 of 568 families.
+The candidate is invariant on 568/568 at every slack_max. That is the
+bug, measured, and the fix, measured.
+
+Documented calibration panel (function doc comment, journal
+2026-05-17-01 14:30) is fully preserved at slack_max=2:
+VESUVIO/VESUVIOU/VESUVIA/MUONSINE/CRESC132 stay Mc64Symmetric,
+ACOPP30 stays InfNorm. And unlike today, VESUVIO stays Mc64Symmetric
+when symmetrically reversed (today it flips to InfNorm).
+
+My pre-measurement worry that the 32 head threshold would need
+recalibrating was WRONG. ACOPP30's symmetric max degree is 29, same
+side of the 32 gate as its stored 29. ACOPR30 goes 43 -> 47, still
+above 32, still Mc64Symmetric -- unchanged verdict. No threshold move
+is needed.
+
+
+* 13:35 :134b:correction:incomplete-sweep:
+CORRECTION to 13:10. That sweep covered only data/matrices/kkt (568
+families). The corpus has three roots -- kkt, kkt-mittelmann,
+kkt-expansion -- 1004 families total, and kkt-mittelmann is where the
+"MC64 hurts clnlbeam" evidence that calibrated the shipped thresholds
+lives. Sweeping one root and calling it "the corpus" was wrong.
+
+Corrected numbers over all 1004 families:
+
+| slack_max | route changes | gain MC64 | lose MC64 | invariant |
+|-----------+---------------+-----------+-----------+-----------|
+|         1 |           124 |         0 |       124 | 1004/1004 |
+|         2 |           143 |        54 |        89 | 1004/1004 |
+|         3 |           138 |        68 |        70 | 1004/1004 |
+
+Shipped router NOT invariant on 163 of 1004 (was 27 of 568). So the
+BUG is ~3x bigger than I reported: 16% of the corpus routes on an
+artifact of index order.
+
+But the FIX as drafted is also ~18x more disruptive than I reported:
+143 route changes, not 8. And the slack_max=2 "lose MC64" list
+includes marine_1600, rocket_12800, ROCKET, STEERING, robot_a/b/c,
+robot_1600, pinene_3200, gasoil_3200, qcqp1500-*, TWIRISM1 -- the
+large IPM families that dominate feral's real workload and where the
+MC64 cache is measurably paying (marine: 12/18 hits, 25-30 ms hit vs
+87-127 ms miss, measured this session at 10:55).
+
+The clean 8x separation I reported at 13:10 (arrow >= 0.44 vs
+non-arrow <= 0.056) was an artifact of looking only at the textbook
+arrow families in kkt. It does not hold on the full corpus.
+
+Root cause of the mismatch: stored "nnz_col == 1 && diag" means "j has
+no coupling to any LATER index", not "j has low coupling". For a
+leading-border arrow KKT those coincide (slack couples only to the
+head, stored in the head's earlier column, so symmetric degree is 2).
+For the large IPM KKTs they do not -- their stored-degree-1 columns
+have several couplings to earlier indices. A single small slack_max
+cannot cover both. Measuring the actual symmetric-degree distribution
+of the columns the shipped gate counts, before proposing another gate.
+
+
+* 14:05 :134b:design-table:decided:
+Measured the full design space. Gate (a) and gate (b) can each be
+computed on stored or symmetric degree, independently -- 4 variants,
+1004 families:
+
+| variant                 | changes | gain | lose | invariant  |
+|-------------------------+---------+------+------+------------|
+| shipped (stored,stored) |       0 |    0 |    0 |  841/1004  |
+| (stored a, sym b)       |      15 |   15 |    0 |  890/1004  |
+| (sym a, stored b)       |     102 |   13 |   89 |  923/1004  |
+| (sym a, sym b)          |     143 |   54 |   89 | 1004/1004  |
+
+Reversed-VESUVIO (the duals-last shape #134B is actually about):
+
+| variant           | VESUVIO | MUONSINE | CRESC132 |
+|-------------------+---------+----------+----------|
+| shipped           | InfNorm | InfNorm  | InfNorm  |
+| (stored a, sym b) | MC64    | MC64     | MC64     |
+| (sym a, stored b) | InfNorm | InfNorm  | InfNorm  |
+| (sym a, sym b)    | MC64    | MC64     | MC64     |
+
+Two conclusions:
+
+1. Gate (b) alone fixes the reported bug. Fixing gate (b) restores
+   MC64 on all three reversed arrow KKTs. Fixing gate (a) alone does
+   NOT -- it is strictly worse (89 losses, bug unfixed). That rules
+   out the "half fix in the other direction".
+
+2. Gate (b) alone is MONOTONE. Symmetric degree >= stored degree, so
+   the head gate can only become easier to pass: 15 changes, 15 gains,
+   0 losses. No family loses MC64, so none of the large IPM workloads
+   (marine_1600, rocket_12800, pinene_3200, robot_*, STEERING) are
+   touched, and the 2026-05-17 calibration panel is preserved by
+   construction on the InfNorm side -- clnlbeam's symmetric max degree
+   is 5 and ACOPP30's is 29, both still under 32.
+
+Full invariance (sym a, sym b) is NOT shippable on this evidence: 89
+families would lose MC64, including marine_1600 and rocket_12800 where
+the MC64 cache is measurably paying. Justifying that needs IPM-outcome
+data on 89 families, not a routing-parity argument. Filing as the
+remaining scope of #134B rather than pretending it is done.
+
+* 14:20 :134b:pricing:measured:
+Priced all 15 gate-(b) gainers over every iterate (min-of-3 factor,
+rhs = A*1, forward error ||x-1||_inf):
+
+- Inertia: identical under both routes on all 15. No inertia risk.
+- Time (MC64/InfNorm): median 0.98, range 0.95-1.19. MC64 is free to
+  slightly faster on 14 of 15.
+- Accuracy: neutral or better on 14. CHAIN 5.02e-6 -> 1.42e-8,
+  SOSQP1 8.49e-6 -> 1.95e-6, C-RELOAD 2.04e-10 -> 1.07e-10.
+
+One unfavorable case, reported rather than buried: MSS1 (n=163) is the
+only family where the change costs both time (0.872 -> 1.037 ms,
++19%) and accuracy (1.43e-1 -> 6.15e-1). Both figures are forward
+error on a system neither route actually solves -- 1e-1 forward error
+means MSS1 is too ill-conditioned for this metric to separate the
+routes. Pre-existing, not caused by the change, but MC64 does not
+help it. Absolute cost is 0.17 ms.
+
+Decision: ship the gate (b) fix. Defer gate (a).
+
+
+* 16:55 :134b:implemented:tests:
+Shipped the gate (b) fix. Four new tests; two failed before the change
+(route_is_invariant_under_index_reversal, trailing_border_routes_to_mc64)
+and pass after. Verified by calling the SHIPPED router, not a local
+reimplementation: 1004 families, invariance 841 -> 890, 15 route
+changes, 15 gains, 0 losses. Matches the prediction exactly.
+
+Two existing fixtures had to be corrected. Assertions unchanged; only
+the matrices they build changed:
+
+- `shape_csc(100, 60, 4)` was documented as "the clnlbeam shape:
+  narrow band" but coupled all 40 non-slack columns to the SAME 4 row
+  indices -- a 4-spoke star of symmetric degree 41, not a band. Stored
+  counting cannot tell a star from a band (both report 5); symmetric
+  counting can. External oracle: the real clnlbeam matrix has
+  symmetric max degree 5, measured this session, so the band is the
+  faithful fixture. Added `banded_csc`.
+- The 32-boundary test moved to `arrow_leading(n, head)`, whose head
+  has symmetric degree exactly `head` by construction and is therefore
+  checkable by hand. The old fixture's symmetric degree depended on
+  how many non-slack columns happened to reach a given row -- I would
+  have been deriving the expected value from my own implementation.
+
+* 17:10 :134b:regression:bench:fixed:
+Session-end bench REGRESSED on the dense buckets and I chased it
+rather than filing it as noise:
+
+| bucket                  | 08-14-03 | first run | after fix |
+|-------------------------+----------+-----------+-----------|
+| dense small-frontal p90 |     1.58 |      1.66 |      1.54 |
+| dense medium p90        |     2.00 |      2.13 |      1.91 |
+| sparse small-frontal    |     1.54 |      1.50 |      1.50 |
+| sparse medium           |     1.54 |      1.51 |      1.51 |
+
+Cause: the first cut allocated an n-length degree accumulator on every
+`pick_scaling_strategy` call. The dense partition is ~148k
+sub-millisecond factorizations, so a per-factor allocation is visible
+-- +5% on small-frontal, +6.5% on medium.
+
+Fix: order the gates so the allocation is off the common path. Gate
+(a) is allocation-free and rejects most of the corpus, so decide it
+first and return InfNorm. Then, because symmetric degree is never
+below stored degree, a stored column that already clears 32 settles
+gate (b) with no second pass. The accumulator is allocated only for
+matrices that pass gate (a) AND have no stored column above 32 -- the
+genuinely ambiguous case, which is exactly where the trailing-border
+KKTs live. Semantics identical: re-verified 890/1004, 15 gains, 0
+losses.
+
+Both dense buckets now beat the 08-14-03 baseline (1.58 -> 1.54,
+2.00 -> 1.91). Lesson: a router that runs per-factor is on the hot
+path for the tiny-IPM tail even though it is O(n+nnz) against an
+O(n^1.5+) factorization -- allocation, not asymptotics, is what shows
+up there.
+

--- a/dev/journal/2026-08-15-02.org
+++ b/dev/journal/2026-08-15-02.org
@@ -1,0 +1,261 @@
+#+TITLE: Session 2026-08-15-02
+#+DATE: 2026-08-15
+
+* 09:05 :orient:mc64:prior-art:
+User approved doing both items from the end of 2026-08-15-01: (a) the
+MC64 warm-cache miss-cost probe (#153 remainder), (b) the KIRBY2
+factor-ratio outlier (8.95x vs MUMPS, worst in the bench).
+
+Searched =dev/tried-and-rejected.md= before starting, per protocol.
+Found a direct hit at line 2087: "2026-05-21 — B2 value-bounded MC64
+scaling cache: gate metric confounded by IPM delta".
+
+That entry does not merely record a failed attempt; it records a
+ROOT CAUSE that predicts my proposed probe's outcome:
+
+- The gate measures diagonal dominance of D0*A*D0. On a KKT the
+  (2,2) block carries a delta-regularized diagonal (~1e-8) against
+  ~1 off-diagonals, so the ratio is ~1/delta.
+- As the IPM drives delta -> 0, the ratio explodes 1e8 -> 1e10.
+  The gate is tracking the barrier trajectory, not scaling staleness.
+- Recorded verdict: "There is no GROWTH_FACTOR value that separates
+  'delta shrank' (safe to reuse) from 'matching changed' (unsafe)."
+- pinene_3200 measured max_ratio vs budget: iter2 1.906e8/1.162e8,
+  iter3 7.770e8/5.180e8, iter4 2.486e10/1.657e10, iter5
+  5.562e10/3.708e10. All FAIL. Cache hits: 0.
+
+Implication: my plan to "check whether misses cluster just past the
+threshold, then tighten GROWTH_FACTOR" is the exact approach already
+rejected with a mechanism. Each pinene miss IS ~1.5x past budget --
+i.e. "just past the threshold" -- but the margin is set by how fast
+delta moved that iterate, not by gate slack. Tightening only shifts
+which iterate crosses.
+
+CONCLUSION: do not tune GROWTH_FACTOR. The remaining live question is
+narrower: marine_1600 hits 12/18 and misses 6/18, which is a DIFFERENT
+regime from pinene (0 hits). Is marine's miss set delta-confounded too?
+
+* 09:20 :kirby2:measured:surprise:
+Ran diag_factor_phases on the two worst bench outliers.
+
+  matrix          drv_us  prol%  permute% scaling% schur% cbextr% zerofil% dense_o% buildrow%
+  KIRBY2_0007        127  22.0%   0.8%    18.1%    1.6%   8.7%    2.5%     21.0%    2.5%
+  GROUPING_0243       82  26.7%   1.2%    20.6%   17.6%   5.6%    0.8%     11.1%    1.0%
+
+The bench reports KIRBY2_0007 feral factor = 1065 us, MUMPS = 119 us
+(ratio 8.95). But the numeric driver is only 127 us. So ~938 us
+(88%) is OUTSIDE the numeric factorization.
+
+Checked the accounting is fair before chasing it:
+- bench.rs times symbolic + numeric together as =factor_us=
+  (src/bin/bench.rs:1926) on the stated grounds that the oracles
+  report a single equivalent field.
+- Verified that claim against the oracle source: mumps_bench.F:191
+  sets =MP%JOB = 4= inside the timed region. JOB=4 is analyse +
+  factorize. So MUMPS's 119 us DOES include analysis.
+
+So the comparison is apples-to-apples and the conclusion stands:
+feral's SYMBOLIC phase is the KIRBY2 bottleneck, not the kernel.
+~938 us of symbolic vs MUMPS's 119 us for analyse+factor combined.
+
+This reframes the item. I had assumed a kernel/fill problem and
+proposed looking at front sizes. Wrong target.
+
+* 09:25 :kirby2:structure:
+KIRBY2_0007 structure (n=458, nnz_stored=1522):
+  symmetric degree: max=156, mean=5.6
+  degree histogram: 156 x2, 154 x3, 8 x151, 2 x302
+
+Five near-dense hub rows (deg ~155) over a bed of 302 degree-2 and
+151 degree-8 rows. KIRBY2 is a NIST StRD nonlinear regression
+problem; the hubs are the model parameters, each coupling to every
+data residual. Classic bordered/arrowhead KKT.
+
+MUMPS oracle sidecar reports factor_nnz = 7672 for n=458 -- i.e. the
+factor is genuinely sparse, so a correct ordering does exist and
+MUMPS finds it. Working hypothesis for the symbolic cost: the near-
+dense hub rows are inflating AMD's quotient-graph work. To be
+confirmed by the per-stage breakdown.
+
+* 09:40 :kirby2:localized:ldlt-compress:
+Per-stage symbolic breakdown, diag_symbolic_stages_argv:
+
+  KIRBY2_0007 (n=458, nnz=1522)   TOTAL 1182 us
+    ldlt_compress   972   82.2%
+    renumber         57    4.8%
+    ordering         32    2.7%
+    (all else <2% each)
+
+  GROUPING_0243 (n=225, nnz=1475) TOTAL 477 us
+    ldlt_compress   291   61.0%
+    ordering         49   10.3%
+    renumber         45    9.4%
+
+The bottleneck is =ldlt_compress= -- the MUMPS ICNTL(12)=2 Duff-Pralet
+compression preprocessor, whose input is an MC64 matching. Ordering
+itself is 32 us (2.7%). My working hypothesis from 09:25 (AMD
+quotient-graph blowup on the near-dense hub rows) is WRONG and is
+recorded as such: AMD is not the cost.
+
+* 09:50 :kirby2:costbenefit:measured:
+probe_compress_costbenefit_argv (5-run median, symbolic+numeric,
+None vs LdltCompress):
+
+  matrix          n  | sym_n num_n tot_n | sym_c num_c tot_c | delta   delta%
+  KIRBY2_0007   458  |   155   143   297 |  1041   149  1191 |  +894  +301.0%
+  KIRBY2_0006   458  |   151   153   300 |   924   144  1094 |  +794  +264.7%
+  GROUPING_0243 225  |   104   122   226 |   364    97   461 |  +235  +104.0%
+  GROUPING_0031 225  |   103   113   216 |   308   100   410 |  +194   +89.8%
+
+All four: NONE wins. Critically =num_c ~ num_n= (149 vs 143 on
+KIRBY2_0007) -- compression delivers ZERO numeric benefit on these,
+so the entire MC64 cost is waste. This is the ORTHREGF pattern from
+2026-06-06-04, not the ROSEPETAL pattern (where num_c = num_n/8).
+
+Consequence for the bench: KIRBY2_0007 uncompressed total is 297 us
+against the MUMPS oracle's 119 us => ratio ~2.5x, versus the 8.95x
+the bench currently reports. The single worst factor-ratio outlier in
+the corpus is ~4x of pure preprocessing waste.
+
+Verified the bench comparison is fair before claiming this (see
+09:20): MUMPS oracle times JOB=4 = analyse+factorize.
+
+* 09:55 :prior-art:constraint:
+Re-read tried-and-rejected 2026-06-06-04 ("Scaling-aware LdltCompress
+skip"). Binding constraints on any fix:
+
+- Do NOT gate LdltCompress on the scaling strategy. Refuted: the MC64
+  is load-bearing (build_supermap walks the matching's cycle
+  structure), and scaling-reuse does not predict cost/benefit
+  (ROSEPETAL -75.7% win vs ORTHREGF +91.8% loss, both InfNorm).
+- The entry explicitly names the open lever: "an orthogonal
+  compression cost/benefit gate that estimates fill reduction vs
+  MC64+ordering cost", and records that "no cheap structural feature
+  yet separates ROSEPETAL (win) from ORTHREGF (loss)".
+
+What is new here and was not available in 2026-06-06-04: a CEILING
+argument that does not require predicting fill reduction. On
+KIRBY2_0007 the whole uncompressed numeric phase is 143 us. Even if
+compression drove numeric time to exactly zero it could save at most
+143 us, while costing 886 us of MC64. So compression is
+unconditionally a loss whenever
+
+    estimated MC64 cost >> total achievable numeric time
+
+independent of how good the compressed ordering would be. That is a
+cost/benefit gate that sidesteps the fill-prediction problem the
+prior session got stuck on. Feasibility note: uncompressed ordering
++ col_counts is 52 us on KIRBY2 (32 + 20), i.e. ~5% of the MC64 cost,
+so "look before you leap" is affordable in principle.
+
+NOT YET a proposal -- needs the corpus bucket size first (sweep
+running) and then research note + plan per protocol. Recording the
+idea now so the reasoning is dated and auditable.
+
+* 10:20 :compress:corpus:measured:
+Swept one iterate per family, 696 families with .mtx < 400 KB, 693
+parsed (probe_compress_costbenefit_argv).
+
+  LdltCompress engaged        : 514 / 693  (74%)
+  with tot_n >= 50us (signal) : 164  -> losers 157, winners 7
+  loser delta%                : p25 13.0  median 18.1  p75 26.2
+                                p90 52.3  max 696.4
+  aggregate waste             : 121945 us
+    GILBERT_0000 alone        :  87361 us (72%)
+    other 156 losers          :  34584 us (median 120 us each)
+
+Two readings, and the honest one matters. The aggregate number is
+72% one pathological matrix (GILBERT_0000, n=5001, +696%). But the
+DISTRIBUTED effect survives excluding it: a median 18.1% tax on 96%
+of families where compression engages.
+
+Sub-50us rows were filtered as timer noise -- 693-row raw set
+contains many n=2..5 families where "+100%" is 1us vs 2us.
+
+* 10:35 :compress:gate:validated:
+Oracle gate: skip compression when mc64_cost > T * num_n. No fill
+prediction needed -- num_n is the ENTIRE numeric phase, so an MC64
+costing more than T=1 times it cannot repay even under a compression
+that drove numeric time to zero.
+
+  T     skips losers   us recovered   winners broken
+  0.25    126/166         114860        1 (HAHN1, 79us, -9.7%)
+  0.50     56/166         106307        1 (HAHN1)
+  1.00     21/166          96991        0
+  2.00      6/166          93553        0
+
+Excluding GILBERT at T=0.25: skips 120/156, recovers 27436/34584 us
+(79%), breaks one 79us winner. ~347:1 trade.
+
+Validated against the 2026-06-06-04 counterexample pair:
+  ORTHREGF  mc64 4158 / num_n 1422 = 2.92 -> SKIP  (correct, +129% loser)
+  ex8_2_2   mc64  958 / num_n 144305 = 0.007 -> KEEP (correct, -3.0% winner)
+  SINQUAD2  ratio 0.18 -> KEEP (conservative miss; it is a +9.4% loser)
+
+So the ceiling ratio separates the pair that defeated the
+scaling-reuse signal in 2026-06-06-04.
+
+* 10:40 :data-quality:rosepetal:blocked:
+ROSEPETAL_0000 -- the flagship WINNER of the 2026-06-06-04 rejection
+-- cannot be re-measured. read_mtx rejects it:
+
+  IoError("declared nnz 2003000 does not match the 1460226 entries
+  in the file")
+
+Header says 2003000, file has 1460226 (73% present) => truncated.
+It is the only iterate in that family. data/matrices/ is gitignored
+(.gitignore:20) so the file is untracked: the truncation cannot be
+dated, diffed, or reverted.
+
+Same class as the known dtoc2_0001/0002 non-finite-value defect.
+
+Consequence, stated plainly: the counterexample that anchors the
+2026-06-06-04 rejection is currently unreproducible. I am NOT
+claiming that rejection was wrong -- its recorded numbers (MC64
+0.68s, numeric 5.72s -> 0.77s) give ratio 0.12, which the ceiling
+gate keeps comfortably. But that is now an argument from a recorded
+number, not from a measurement I can repeat.
+
+* 10:50 :compress:obstacle:design:
+The validated gate is an ORACLE -- mc64_cost and num_n are both
+measured after doing the work. Checked whether either is predictable.
+
+num_n: tractable. Uncompressed ordering + col_counts = 32 + 20 =
+52 us on KIRBY2 (~5% of the MC64 cost), and column counts give a
+standard flop estimate.
+
+mc64_cost: NOT predictable. Observed MC64 cost per row over the
+signal set:
+  min 0.0303  p25 0.0560  median 0.0972  p75 0.2061  max 17.3509 us/row
+a 573x spread. An estimator keyed on n (or n,nnz) is wrong by orders
+of magnitude precisely on the tail where the win lives.
+
+Proposed instead: do not predict the cost, BOUND it. Run MC64 under
+a work budget proportional to the predicted flops, counted in
+augmenting-path edge scans, and abandon to the already-computed
+uncompressed ordering if exceeded.
+
+Counted work, not wall clock -- a time-based abort would make the
+factorization machine- and load-dependent, which this project
+actively guards against (probe_value_determinism, diag_par_repeat).
+
+Not implemented. Open questions recorded in the research note:
+threading a counter through mc64::compute_matching without
+perturbing the non-aborted result; whether abandoning disturbs
+cached_mc64 state the #38 staleness guard relies on; budget
+calibration.
+
+* 10:55 :mc64:closed:
+Item (2) from the user's approved list (MC64 warm-cache miss cost) is
+CLOSED, not deferred. The 2026-05-21 entry supplies a mechanism, not
+just a negative result: the gate metric is 1/delta on a regularized
+KKT, so it tracks the barrier trajectory. No GROWTH_FACTOR separates
+safe from unsafe. My proposed "are misses just past threshold" probe
+would have measured exactly the confounded quantity -- pinene's
+misses ARE ~1.5x past budget, and that margin is set by delta's step,
+not by gate slack.
+
+Protocol note for myself: I pitched this lever to the user before
+searching tried-and-rejected. Same miss as the KR warm-start in
+2026-08-15-01. Two in two sessions. The search is cheap and belongs
+BEFORE the recommendation, not after the approval.

--- a/dev/plans/issue-134b-router-symmetric-head-gate.md
+++ b/dev/plans/issue-134b-router-symmetric-head-gate.md
@@ -1,0 +1,55 @@
+# Plan — issue #134 item B: symmetric head gate in `pick_scaling_strategy`
+
+**Research:** `dev/research/router-permutation-invariance-2026-08-15.md`
+**Scope:** gate (b) only. Gate (a) deferred with evidence (89-family
+MC64 loss, needs IPM-outcome data).
+
+## Change
+
+In `src/scaling/mod.rs::pick_scaling_strategy`, compute gate (b) —
+`max_col_nnz > MAX_COL_NNZ_FOR_INFNORM` — on the **symmetric** degree
+of each column rather than its stored lower-triangle nnz. Gate (a) is
+untouched.
+
+Symmetric degree of `j` = number of value-nonzero entries in row and
+column `j` of the full matrix, diagonal counted once. Computed by
+accumulating each stored off-diagonal `(i, j)` into both `deg[i]` and
+`deg[j]`, and each diagonal into `deg[j]` alone.
+
+Both the value-aware skip of explicit stored `0.0` (issue #47) and the
+`n == 0` early return are preserved.
+
+## Tests (written first)
+
+1. `route_is_invariant_under_index_reversal` — build the existing
+   arrow-KKT fixture, apply `P(i) = n-1-i` (remapping `(i,j)` with
+   `i>=j` to `(n-1-j, n-1-i)` to stay lower-triangular), assert both
+   forms route to `Mc64Symmetric`. **Fails before the change**: the
+   reversed form routes `InfNorm` today.
+2. `trailing_border_routes_to_mc64` — arrow KKT with the head in the
+   *last* column (duals-last / IPOPT convention), assert
+   `Mc64Symmetric`. Fails before the change.
+3. `banded_stays_infnorm` — clnlbeam-shaped banded KKT, high
+   `diag_only` ratio, small degree; assert `InfNorm` under both
+   orderings. Guards the gate that separates clnlbeam from VESUVIO.
+4. `explicit_zeros_do_not_change_route` — re-assert issue #47 against
+   the symmetric counter: padding a column with stored `0.0` must not
+   flip the route in either ordering.
+5. Existing router tests must pass unchanged.
+
+## Validation
+
+- `cargo test` full suite.
+- Re-run `probe_scaling_levers table` and confirm the shipped router
+  now reports 890/1004 invariant and 15 gains / 0 losses.
+- `cargo run --bin bench --release` — the 15 movers are small; expect
+  no partition movement.
+
+## Docs
+
+- Update the `pick_scaling_strategy` doc comment: gate (b) is now
+  symmetric degree; the "No allocations" claim is no longer true (one
+  `n`-length `usize` accumulator); note that the 2026-05-17 panel is
+  preserved because clnlbeam (sym 5) and ACOPP30 (sym 29) stay under 32.
+- `CHANGELOG.md` Unreleased — user-visible routing change.
+- Leave #134 item B open, retitled to the gate (a) remainder.

--- a/dev/research/ldlt-compress-cost-benefit-2026-08-15.md
+++ b/dev/research/ldlt-compress-cost-benefit-2026-08-15.md
@@ -1,0 +1,185 @@
+# LdltCompress cost/benefit — the KIRBY2 factor-ratio outlier
+
+Session 2026-08-15-02. Investigates the worst factor-ratio outlier in
+the bench (KIRBY2_0007, 8.95x vs MUMPS) and finds it is not a
+factorization problem at all.
+
+## Summary
+
+`LdltCompress` (the MUMPS `ICNTL(12)=2` Duff-Pralet compression
+preprocessor) engages on **74%** of corpus families and is a **net
+loss on 96%** of the families where its effect is measurable, at a
+**median cost of 18.1%** of total factor time. On the worst case it
+costs +696%. The MC64 matching it requires dominates symbolic time
+while delivering no fill reduction.
+
+An oracle gate keyed on "MC64 cost exceeds the achievable numeric
+saving" separates losers from winners cleanly. Implementing it
+requires solving a cost-prediction problem the 2026-06-06-04 session
+identified and did not solve; a deterministic work-budget design is
+proposed below that sidesteps prediction entirely.
+
+## Evidence
+
+### The outlier is symbolic, not numeric
+
+`diag_factor_phases` on KIRBY2_0007 (n=458, nnz=1522) reports a
+numeric driver wall of **127 us**, against a bench-reported
+`factor_us` of 1065 us. Per-stage symbolic breakdown
+(`diag_symbolic_stages_argv`):
+
+    KIRBY2_0007   TOTAL 1182 us
+      ldlt_compress   972   82.2%
+      renumber         57    4.8%
+      ordering         32    2.7%
+      (all else <2% each)
+
+Ordering is 2.7%. The initial hypothesis — that the five near-dense
+hub rows (symmetric degree ~155 over a bed of 302 degree-2 and 151
+degree-8 rows) blow up AMD's quotient graph — is **refuted**.
+
+### The comparison is fair
+
+Before attributing the gap, confirmed feral's `factor_us` (symbolic +
+numeric, `src/bin/bench.rs:1926`) is apples-to-apples with the oracle:
+`external_benchmarks/mumps_oracle/mumps_bench.F:191` sets
+`MP%JOB = 4` inside the timed region, and JOB=4 is analyse +
+factorize. MUMPS's 119 us does include analysis.
+
+### Compression buys nothing here
+
+`probe_compress_costbenefit_argv`, 5-run median, None vs LdltCompress:
+
+    matrix          n  | sym_n num_n tot_n | sym_c num_c tot_c | delta   delta%
+    KIRBY2_0007   458  |   155   143   297 |  1041   149  1191 |  +894  +301.0%
+    KIRBY2_0006   458  |   151   153   300 |   924   144  1094 |  +794  +264.7%
+    GROUPING_0243 225  |   104   122   226 |   364    97   461 |  +235  +104.0%
+    GROUPING_0031 225  |   103   113   216 |   308   100   410 |  +194   +89.8%
+
+`num_c ~ num_n` throughout — zero numeric benefit. Uncompressed,
+KIRBY2_0007 is 297 us against the oracle's 119 us, i.e. **~2.5x
+instead of 8.95x**.
+
+### Corpus sweep
+
+One iterate per family, 696 families with .mtx < 400 KB, 693 parsed:
+
+    LdltCompress engaged        : 514 / 693  (74%)
+    with tot_n >= 50us (signal) : 164  -> losers 157, winners 7
+    loser delta% distribution   : p25 13.0  median 18.1  p75 26.2
+                                  p90 52.3  max 696.4
+    aggregate waste             : 121945 us
+      GILBERT_0000 alone        :  87361 us (72% of the total)
+      other 156 losers          :  34584 us (median 120 us each)
+
+The aggregate figure is dominated by one pathological matrix, but the
+**distributed** effect is the real finding: a median 18.1% tax on 96%
+of the families where compression engages.
+
+## The gate
+
+Oracle form: skip compression when
+
+    mc64_cost > T * num_n
+
+where `num_n` is the uncompressed numeric time. The argument needs no
+fill prediction: `num_n` is the *entire* numeric phase, so even a
+compression that drove numeric time to exactly zero could not repay
+an MC64 costing more than `T=1` times it.
+
+Threshold sweep over the signal set (166 losers / 7 winners):
+
+    T     skips losers   us recovered   winners broken
+    0.25    126/166         114860        1  (HAHN1, 79 us, -9.7%)
+    0.50     56/166         106307        1  (HAHN1)
+    1.00     21/166          96991        0
+    2.00      6/166          93553        0
+    4.00      2/166          89940        0
+
+Excluding GILBERT, to check the win is not one matrix: at T=0.25 the
+gate skips 120/156 remaining losers and recovers 27436 us of 34584 us
+(79%), breaking one 79 us winner. A ~347:1 trade.
+
+### Validation against the 2026-06-06-04 counterexamples
+
+`dev/tried-and-rejected.md:2364` rejected a *scaling-aware* compression
+skip and named ROSEPETAL (win) vs ORTHREGF (loss) as the pair no cheap
+feature separates. Re-measured:
+
+    ORTHREGF_0000  6405 | 1692  1422  3183 | 5850 1420 7294 | +4111 +129.2%
+    ex8_2_2_0000   9453 | 2355 144305 146601| 3313 138835 142148 | -4453 -3.0%
+    SINQUAD2_0000  5000 | 1277  1665  2924 | 1582 1622 3199 |  +275  +9.4%
+
+- ORTHREGF: mc64 4158 us vs num_n 1422 us -> ratio 2.92, **skipped**.
+  Correct (it is a +129% loser).
+- ex8_2_2: mc64 958 us vs num_n 144305 us -> ratio 0.007, **kept**.
+  Correct (it is a -3.0% winner).
+- SINQUAD2: ratio 0.18, **kept** — a conservative miss (it is a +9.4%
+  loser). The gate errs toward keeping compression.
+
+So the ceiling ratio does separate the pair that defeated the
+scaling-reuse signal.
+
+**ROSEPETAL could not be re-measured.** Its only iterate is truncated:
+the header declares 2003000 entries and the file contains 1460226, so
+`read_mtx` rejects it. `data/matrices/` is gitignored
+(`.gitignore:20`), so the file is untracked and the corruption cannot
+be dated or reverted. This is the same class of data defect as the
+known `dtoc2_0001/0002` non-finite-value bug. Consequence: the
+flagship counterexample of the 2026-06-06-04 rejection is currently
+unreproducible. Its recorded numbers (MC64 0.68 s, numeric 5.72 s ->
+0.77 s) do satisfy the ceiling gate — ratio 0.68/5.72 = 0.12, well
+under every threshold in the sweep, so the gate would **keep**
+ROSEPETAL — but that rests on recorded values, not a fresh
+measurement.
+
+## The implementation obstacle
+
+The gate above is an **oracle**: both `mc64_cost` and `num_n` are
+measured after doing the work. Neither is available at the decision
+point.
+
+`num_n` is tractable: the uncompressed ordering plus `col_counts` is
+32 + 20 = 52 us on KIRBY2 (~5% of the MC64 cost), and column counts
+give a standard flop prediction.
+
+`mc64_cost` is **not** cheaply predictable. Across the signal set the
+observed MC64 cost per row spans
+
+    min 0.0303  p25 0.0560  median 0.0972  p75 0.2061  max 17.3509 us/row
+
+a **573x spread**. Any estimator keyed on `n` (or `n` and `nnz`) will
+be wrong by orders of magnitude on the tail — which is exactly where
+the win is.
+
+### Proposed design: deterministic work budget
+
+Do not predict the MC64 cost — *bound* it:
+
+1. Run the uncompressed ordering and `col_counts` first (~5% overhead).
+2. Predict uncompressed numeric flops from the column counts.
+3. Run the MC64 matching under a **work budget** proportional to that
+   flop prediction, counted in augmenting-path edge scans — not wall
+   clock.
+4. If the matching exceeds its budget, abandon it and fall through to
+   the uncompressed ordering already computed in step 1.
+
+Counting work rather than time keeps the outcome deterministic and
+machine-independent, which a wall-clock abort would not (cf. the
+determinism probes `probe_value_determinism`, `diag_par_repeat`). The
+fallback path is free because step 1 already produced a usable
+ordering.
+
+Open questions before implementing:
+- Where in `mc64::compute_matching` a work counter can be threaded
+  without disturbing the matching result on the non-aborted path.
+- Whether abandoning changes `cached_mc64` state that the numeric
+  phase or the #38 staleness guard depends on.
+- Calibration of the budget constant against the T sweep above.
+
+## Status
+
+Research only. No code changed. Constraints from
+`dev/tried-and-rejected.md:2364` respected: this does **not** gate on
+the scaling strategy, and does not treat the MC64 as speculative —
+`build_supermap` genuinely consumes the matching.

--- a/dev/research/router-permutation-invariance-2026-08-15.md
+++ b/dev/research/router-permutation-invariance-2026-08-15.md
@@ -1,0 +1,144 @@
+# Scaling router permutation-invariance (issue #134 item B)
+
+**Date:** 2026-08-15
+**Status:** gate (b) fix justified and scoped; gate (a) deferred with evidence
+**Probe:** `crates/feral-diagnostics/src/bin/probe_scaling_levers.rs`
+(`134b`, `price`, `marg`, `spec`, `table` sections — all read-only)
+
+## The claim under test
+
+Issue #134 item B says `pick_scaling_strategy` counts stored
+lower-triangle columns only, so a *trailing* dense border dodges the
+`>32` head gate and forfeits the documented 6×–243× MC64 wins. The
+IPOPT duals-last convention that pounce and discopt emit produces
+exactly that shape.
+
+## The bug is real, and bigger than filed
+
+`CscMatrix` stores only `row >= col`. Under the pure relabeling
+`P(i) = n-1-i` — which changes nothing about the matrix as an operator
+— the arrow head moves from column 0 to the last column and its mass
+redistributes one entry per earlier column:
+
+| family   | stored max deg | reversed | shipped route | reversed route |
+|----------|----------------|----------|---------------|----------------|
+| VESUVIO  | 1026           | 11       | Mc64Symmetric | InfNorm        |
+| VESUVIOU | 1026           | 11       | Mc64Symmetric | InfNorm        |
+| MUONSINE | 512            | 4        | Mc64Symmetric | InfNorm        |
+| CRESC132 | 2657           | 8        | Mc64Symmetric | InfNorm        |
+
+Over the **full** corpus — `data/matrices/kkt`, `kkt-mittelmann`, and
+`kkt-expansion`, 1004 families — the shipped router is
+permutation-invariant on only **841**. 163 families (16%) route on an
+artifact of index order.
+
+> An earlier sweep in this session covered only `data/matrices/kkt`
+> (568 families) and reported 27. That undercounted by 6× and, worse,
+> omitted `kkt-mittelmann`, which is where the clnlbeam "MC64 hurts"
+> evidence that calibrated the shipped thresholds lives.
+
+## Both gates break, but only one is fixable now
+
+Gate (a) is `#{j : stored nnz(j) == 1 and diag(j) != 0} / n >= 0.30`.
+Gate (b) is `max_j stored nnz(j) > 32`. Each can independently be
+recomputed on **symmetric** degree (degree of `j` in the full matrix).
+Four variants, 1004 families:
+
+| variant                 | route changes | gain | lose | invariant |
+|-------------------------|---------------|------|------|-----------|
+| shipped (stored, stored)| 0             | 0    | 0    | 841/1004  |
+| **(stored a, sym b)**   | **15**        | **15** | **0** | **890/1004** |
+| (sym a, stored b)       | 102           | 13   | 89   | 923/1004  |
+| (sym a, sym b)          | 143           | 54   | 89   | 1004/1004 |
+
+Reversed-VESUVIO check — does the variant fix the duals-last shape?
+
+| variant           | VESUVIO | MUONSINE | CRESC132 |
+|-------------------|---------|----------|----------|
+| shipped           | InfNorm | InfNorm  | InfNorm  |
+| (stored a, sym b) | MC64    | MC64     | MC64     |
+| (sym a, stored b) | InfNorm | InfNorm  | InfNorm  |
+| (sym a, sym b)    | MC64    | MC64     | MC64     |
+
+**Gate (b) alone fixes the reported bug.** Gate (a) alone does not, and
+costs 89 MC64 losses doing it — strictly worse on both axes.
+
+**Gate (b) alone is monotone.** Symmetric degree ≥ stored degree, so
+the head gate can only get easier: 15 changes, all gains, zero losses.
+No family loses MC64. The 2026-05-17 calibration panel survives by
+construction on the InfNorm side — clnlbeam's symmetric max degree is
+5 and ACOPP30's is 29, both still under 32, so neither can cross.
+
+## Why gate (a) cannot be made invariant today
+
+The obvious invariant reading of gate (a) is "fraction of columns with
+symmetric degree ≤ 2 and a nonzero diagonal": in an arrow KKT a slack
+column carries its diagonal plus one coupling to the head, regardless
+of which end the head sits at.
+
+That reading is correct for textbook arrow KKTs and wrong for the
+corpus. Symmetric degree of the columns the shipped gate counts:
+
+| family       | n      | min | med | p90 | max |
+|--------------|--------|-----|-----|-----|-----|
+| MUONSINE     | 1537   | 3   | 4   | 4   | 4   |
+| VESUVIO      | 3083   | 5   | 8   | 8   | 11  |
+| STEERING     | 3599   | 3   | 5   | 6   | 6   |
+| marine_1600  | 76807  | 5   | 10  | 10  | 10  |
+| pinene_3200  | 127995 | 5   | 9   | 17  | 17  |
+| MSQRTA       | 2048   | 64  | 64  | 64  | 64  |
+| LEUVEN3      | 4173   | 1   | 20  | 236 | 379 |
+
+There is no single `slack_max` in that spread. The shipped gate does
+not measure "slack mass"; it measures *"j has no coupling to any later
+index"*, which is a property of the ordering, not of the matrix.
+
+Sweeping `slack_max ∈ {1,2,3}` confirms it: 124 / 143 / 138 route
+changes, and at `slack_max = 2` the 89 losers include **marine_1600,
+rocket_12800, ROCKET, STEERING, robot_a/b/c, robot_1600, pinene_3200,
+gasoil_3200, qcqp1500-\***, TWIRISM1 — the large IPM families that
+dominate feral's real workload, and where the MC64 cache is measurably
+paying (marine: 12/18 hits this session, 25–30 ms hit vs 87–127 ms
+miss).
+
+Taking MC64 away from those needs IPM-outcome data on 89 families. A
+routing-parity argument is not sufficient evidence. Deferred, not done.
+
+## Pricing the 15 gate-(b) gainers
+
+Every iterate, min-of-3 factor, `rhs = A·1`, forward error `‖x−1‖∞`:
+
+- **Inertia identical** under both routes on all 15. No inertia risk.
+- **Time** (MC64/InfNorm): median 0.98, range 0.95–1.19. Free or
+  faster on 14 of 15.
+- **Accuracy** neutral or better on 14. CHAIN 5.02e-6 → 1.42e-8;
+  SOSQP1 8.49e-6 → 1.95e-6; C-RELOAD 2.04e-10 → 1.07e-10.
+
+Movers: MSS1, BIGBANK, BLOWEYA, BLOWEYB, BLOWEYC, C-RELOAD, CHAIN,
+CLEUVEN2, CMPC1, LEUVEN1, LEUVEN2, SOSQP1, SOSQP2, arki0003, arki0009.
+
+**Unfavorable case.** MSS1 (n=163) is the one family where the change
+costs both time (0.872 → 1.037 ms, +19%) and accuracy (1.43e-1 →
+6.15e-1). Both numbers are forward error on a system neither route
+solves — at 1e-1 the metric cannot separate the routes, so this is
+ill-conditioning, not a regression the change introduces. Absolute
+cost 0.17 ms. Recorded because it is the only mover MC64 does not
+help.
+
+## Decision
+
+Ship `(stored a, sym b)`. Defer gate (a) to an outcome-driven study.
+
+Cost: gate (b) needs an `n`-length degree accumulator, so the router
+loses its "no allocations" property. One O(n + nnz) pass becomes two.
+Negligible against the factorization it precedes.
+
+## Prior art consulted
+
+- `dev/research/mc64-dense-column-2026-06-06.md`
+- `dev/research/lever-c-adaptive-scaling.md`
+- `dev/tried-and-rejected.md` (2026-04-28 MUMPS missing-diagonal skip:
+  heuristics ported from another solver's literature must be validated
+  against the input regime feral actually sees)
+- `pick_scaling_strategy` doc comment, threshold panel from
+  `dev/journal/2026-05-17-01.org` §14:30

--- a/dev/sessions/2026-08-15-01.md
+++ b/dev/sessions/2026-08-15-01.md
@@ -1,0 +1,154 @@
+# Session 2026-08-15-01
+
+## Benchmark note (mandatory unfavorable-comparison section)
+
+The first bench run of this session **regressed both dense buckets** against
+the 2026-08-14-03 baseline. It was chased to root cause and fixed, not filed
+as noise. Final numbers beat the baseline:
+
+| bucket                       | 08-13-04 | 08-14-02 | 08-14-03 | this session (first) | **this session (final)** | target | verdict |
+|------------------------------|----------|----------|----------|----------------------|--------------------------|--------|---------|
+| dense small-frontal (<200) p90 | 1.61   | 1.57     | 1.58     | **1.66**             | **1.54**                 | ≤ 2.0  | PASS    |
+| dense medium (<500) p90        | 2.09   | 1.96     | 2.00     | **2.13**             | **1.91**                 | ≤ 3.0  | PASS    |
+| sparse small-frontal (<200) p90| 1.54   | 1.50     | 1.54     | 1.50                 | 1.50                     | ≤ 2.0  | PASS    |
+| sparse medium (<500) p90       | 1.54   | 1.50     | 1.54     | 1.51                 | 1.51                     | ≤ 3.0  | PASS    |
+
+Cause of the regression: the first cut of the #134B fix allocated an
+`n`-length degree accumulator on every `pick_scaling_strategy` call. The
+router runs per factor and the dense partition is ~148k sub-millisecond
+factorizations, so an unconditional per-call allocation is visible (+5%
+small-frontal, +6.5% medium) even though it is O(n+nnz) against an
+O(n^1.5+) factorization. Fixed in `45c80f3` by ordering the gates so the
+allocation stays off the common path.
+
+## Goal
+
+Pick up issue #153 (KR scaling warm-start) and issue #134 item B (the
+scaling router's lower-triangle-blind gates). Both were carried in from
+triage with a stated premise; measure both before implementing either.
+
+## Accomplished
+
+### #134 item B — router permutation-invariance (shipped)
+
+`pick_scaling_strategy`'s dense-head gate now counts **symmetric degree**
+instead of stored lower-triangle column length.
+
+- **Bug confirmed and resized.** Under the pure relabeling `P(i) = n-1-i`,
+  VESUVIO's head reports stored max degree 1026 one way and 11 the other and
+  the route flips `Mc64Symmetric` → `InfNorm`. Over the full 1004-family
+  corpus (`kkt` + `kkt-mittelmann` + `kkt-expansion`) the old router was
+  permutation-invariant on only **841**.
+- **Fix measured against the shipped router**, not a reimplementation:
+  invariance **841 → 890**, **15 route changes, 15 gains, 0 losses**. The
+  change is monotone — symmetric degree is never below stored degree — so no
+  family can lose MC64.
+- **Movers priced** over every iterate: inertia identical under both routes
+  on all 15; factor-time ratio median 0.98 (range 0.95–1.19); accuracy
+  neutral or better on 14 (CHAIN 5.02e-6 → 1.42e-8, SOSQP1 8.49e-6 →
+  1.95e-6). MSS1 is the one unfavorable mover (+19% time, 1.43e-1 → 6.15e-1
+  forward error) but neither route solves it and the Policy 4 fallback test
+  `auto_falls_back_to_infnorm_on_mss1_0009` still passes.
+- **2026-05-17 threshold panel preserved**: clnlbeam symmetric max degree 5,
+  ACOPP30 29, both still under the `32` gate — so no recalibration was
+  needed, contrary to my pre-measurement expectation.
+- Tests: 4 new, 2 of which failed before the change. `cargo test
+  --no-fail-fast`: **868 passed, 0 failed**. Clippy clean.
+
+Commits: `8acb1be` (note + plan), `e9470ca` (fix), `45c80f3` (perf).
+
+### #153 — KR warm-start (falsified, not implemented)
+
+Measured rather than built. See Abandoned Approaches.
+
+### Corrections to my own triage
+
+Both premises I carried into this session were wrong, and one recommendation
+I made mid-session was overturned by my own follow-up measurement:
+
+1. "#153's warm path never warms, i.e. unreachable code" — **wrong**. The
+   MC64 cache hits: marine 12/18, dtoc1nd 14/20. rocket's 0/2 is a fixture
+   artifact (patterns differ, 332,793 vs 435,190 nnz); marine's misses are
+   the #38 value-bound guard rejecting drift by design.
+2. "#134B is costing real time today via trailing borders" — **unsupported**
+   as stated. Zero of 568 `kkt` families are misrouted by a trailing border
+   today. The bug is real but it is a latent correctness bug about relabeling,
+   not a measured current time loss.
+3. My first corpus sweep covered only `data/matrices/kkt` (568 families) and
+   reported 27 non-invariant. The real corpus is 1004 across three roots and
+   the answer is 163 — and the omitted root, `kkt-mittelmann`, is where the
+   clnlbeam evidence that calibrated the thresholds lives.
+
+## Decisions Made
+
+- **Ship gate (b), defer gate (a).** Measured the full 2×2 design space
+  (each gate on stored or symmetric degree). Gate (b) alone fixes the
+  reported bug (restores MC64 on reversed VESUVIO/MUONSINE/CRESC132) and is
+  monotone. Gate (a) alone does **not** fix it and costs 89 MC64 losses.
+  Full invariance costs 143 route changes including `marine_1600`,
+  `rocket_12800`, `pinene_3200`, `robot_*` and `STEERING` — the large IPM
+  families that dominate the real workload. Justifying that needs
+  IPM-outcome data, not a routing-parity argument.
+- **Gate (a) has no invariant reformulation at a fixed threshold.** The
+  slack columns it counts have symmetric degrees spanning 2 (ROCKET) to 64
+  (MSQRTA) to 379 (LEUVEN3). The gate does not measure "slack mass"; it
+  measures "j has no coupling to any later index", a property of the
+  ordering. Recorded in the research note.
+- **Two test fixtures corrected, assertions unchanged.**
+  `shape_csc(100, 60, 4)` was documented as "the clnlbeam shape: narrow
+  band" but coupled all 40 non-slack columns to the same 4 rows — a star of
+  symmetric degree 41. External oracle: real clnlbeam has symmetric max
+  degree 5. The 32-boundary test moved to a fixture whose head degree is
+  exactly `head` by construction, so the expected value is hand-checkable
+  rather than derived from the implementation under test.
+
+## Abandoned Approaches
+
+- **KR warm-start for speed (#153)** — falsified twice and appended to
+  `dev/tried-and-rejected.md`. Chain experiment over full runs: warm@k wins
+  0/2 (k=2,3,5) on steering_12800, the only #153 fixture that actually
+  routes to `InfNorm`. Only warm@10 — same cost as today — wins
+  consistently, which is quality not speed. The hypothesis had already been
+  falsified on 2026-08-09; **I recommended the work before reading
+  `dev/research/` and `dev/tried-and-rejected.md`, which is the protocol
+  step that exists to prevent exactly this.** My "warm@5 beats cold@10"
+  reading came from a single iterate pair and did not replicate.
+
+## Corpus data-quality note
+
+`dtoc2_0001.mtx` and `dtoc2_0002.mtx` fail to load:
+`IoError("... line 849754: non-finite value 'inf'")`. dtoc2 therefore has
+exactly one usable iterate, so every dtoc2 claim in #153 rests on a single
+matrix. Not a feral bug; a corpus gap to note before anyone uses dtoc2 as a
+fixture.
+
+## Benchmark Results
+
+```
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.54     <= 2.0     PASS
+medium (<500)            152145     1.91     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.50     <= 2.0     PASS
+medium (<500)            153560     1.51     <= 3.0     PASS
+```
+
+## Next Session Should
+
+1. **#153 MC64 warm-cache miss cost** — the one lever from this session that
+   is still real and unmeasured at the fix level. marine_1600: a cache hit
+   factors in 25–30 ms, a miss in 87–127 ms, and 6 of 18 iterates miss
+   (~334 ms of 1784 ms, ~19%). Investigate why marine misses at iterates 1,
+   5, 9, 10, 11 and whether `GROWTH_FACTOR`/`GROWTH_COUNT` can be tightened
+   without losing the #38 drift protection.
+2. **#134B remainder — gate (a) invariance.** Needs IPM-outcome data on the
+   89 families that any invariant reformulation would strip of MC64.
+   Retitle #134 item B to this remainder; the head gate half is done.
+   Prior art: `dev/research/router-permutation-invariance-2026-08-15.md`.
+3. **Consider warm@10 KR** (option 2 of the 2026-08-09 note): same sweep
+   budget, geomean 3×–100× lower final deviation. Free conditioning; would
+   need downstream iterative-refinement counts to justify.
+4. Fix or quarantine the two non-finite `dtoc2` iterates.

--- a/dev/sessions/2026-08-15-02.md
+++ b/dev/sessions/2026-08-15-02.md
@@ -1,0 +1,259 @@
+# Session 2026-08-15-02
+
+## BENCHMARK NUMBERS ARE WORSE THAN LAST SESSION
+
+Reported first, per the hard rule in CLAUDE.md.
+
+    partition                  2026-08-15-01   this session   delta
+    dense  small-frontal (<200)     1.54           1.61        +0.07
+    dense  medium (<500)            1.91           2.00        +0.09
+    sparse small-frontal (<200)     1.50           1.67        +0.17
+    sparse medium (<500)            1.51           1.67        +0.16
+
+All four partitions regressed. All four still PASS their targets.
+
+**No Rust source changed this session.** `git diff --stat fbb1a9d HEAD
+-- src/ crates/ tests/` is empty; the only changes are `dev/`
+documents. So this is not a code regression — it is run-to-run
+variance on the same binary.
+
+That conclusion is itself worth recording, because it bears on a claim
+made last session. 2026-08-15-01 reported a dense small-frontal
+sequence of 1.58 (baseline) -> 1.66 (regression I introduced) -> 1.54
+(after the gate reordering), and I described the final number as
+"beating the baseline". Today's run puts the same unchanged code at
+1.61. A +0.07 swing with zero code change means the bench's noise
+floor on this metric is at least as large as the 1.58 -> 1.54
+"improvement" I claimed. **The gate-reordering fix should be regarded
+as having removed the 1.66 regression, not as having beaten the
+baseline.** The 1.66 measurement is still meaningful (it exceeded the
+noise band), but the final 0.04 is not.
+
+Action for a future session: establish the bench's noise floor by
+running it N times on an unchanged binary, and record a
+minimum-detectable-difference so per-session comparisons stop
+over-reading sub-0.1 movements. Until then, treat p90 deltas under
+~0.15 as noise.
+
+Also note the worst-ratio table is now **6 of 10 KIRBY2 iterates**
+(worst 9.22, up from 8.95), plus GROUPING_0205 — i.e. the outlier
+family this session diagnosed dominates the tail more clearly than
+before.
+
+## Goal
+
+Investigate the two items carried out of 2026-08-15-01, both approved
+by the user:
+
+1. **#153 remainder** — MC64 warm-cache miss cost. marine_1600 spends
+   ~19% of a 1784 ms solve in cache-missed MC64 recomputes. Decide
+   whether `GROWTH_FACTOR`/`GROWTH_COUNT` can be tightened without
+   losing the issue-#38 drift protection.
+2. **KIRBY2 factor-ratio outlier** — 8.95x vs MUMPS, the worst entry
+   in the bench's worst-ratio table, on a 458-row matrix.
+
+Investigation only was authorized. No implementation of a fix was
+approved this session.
+
+## Benchmark Results
+
+**No Rust source changed this session** (`git diff --stat fbb1a9d HEAD
+-- src/ crates/ tests/` is empty; the only changes are `dev/`
+documents). The run below is therefore a re-measurement of unchanged
+code and is expected to reproduce 2026-08-15-01.
+
+```
+Top 10 worst factor-ratio vs MUMPS:
+name                             n    feral(us)    mumps(us)      ratio
+KIRBY2_0007                    458         1097          119       9.22
+KIRBY2_0006                    458         1075          127       8.46
+KIRBY2_0008                    458          971          122       7.96
+KIRBY2_0010                    458          992          133       7.46
+LAKES_0144                     168          372           54       6.89
+KIRBY2_0009                    458          879          128       6.87
+KIRBY2_0011                    458          820          120       6.83
+LAKES_0146                     168          350           54       6.48
+GROUPING_0205                  225          700          111       6.31
+QPCBLEND_0030                  157          362           60       6.03
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.61     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.67     <= 2.0     PASS
+medium (<500)            153560     1.67     <= 3.0     PASS
+```
+
+## Accomplished
+
+### Item 1 — MC64 warm-cache miss cost: CLOSED, not deferred
+
+Searched `dev/tried-and-rejected.md` before starting, per protocol.
+Found the 2026-05-21 B2 entry (line ~2087), which supplies a
+**mechanism**, not merely a negative result:
+
+- The gate measures diagonal dominance of `D₀·A·D₀`. On a regularized
+  KKT the (2,2)-block rows carry a δ-sized diagonal (~1e-8) against
+  ~1 off-diagonals, so the dominance ratio *is* ~1/δ.
+- As the IPM drives δ→0 the ratio climbs 1e8→1e10. The gate tracks
+  the barrier trajectory, not scaling staleness.
+- Recorded verdict: no `GROWTH_FACTOR` separates "δ shrank" (safe)
+  from "matching changed" (unsafe — corrupts inertia, #38).
+
+This predicts the probe I had proposed. pinene_3200's misses are all
+~1.5x past budget — "clusters just past the threshold" is true and
+carries no information, because the margin is set by δ's step size.
+
+Not re-measured on marine_1600 (12/18 hits vs pinene's 0/18 is a
+different regime), and that gap is recorded rather than papered over.
+It does not rescue the approach: the lever is the same confounded
+metric either way.
+
+### Item 2 — KIRBY2 outlier localized to `LdltCompress`
+
+The outlier is **not** a factorization problem.
+
+`diag_factor_phases`: numeric driver 127 us against a bench-reported
+`factor_us` of 1065 us. Per-stage symbolic
+(`diag_symbolic_stages_argv`):
+
+    KIRBY2_0007   TOTAL 1182 us
+      ldlt_compress   972   82.2%
+      renumber         57    4.8%
+      ordering         32    2.7%
+
+Confirmed the comparison is fair before attributing anything:
+`src/bin/bench.rs:1926` times symbolic+numeric together, and
+`external_benchmarks/mumps_oracle/mumps_bench.F:191` sets
+`MP%JOB = 4` (analyse + factorize) inside its timed region — the
+oracle's 119 us does include analysis.
+
+Compression delivers **zero** numeric benefit on these matrices
+(`probe_compress_costbenefit_argv`, 5-run median):
+
+    matrix          n  | sym_n num_n tot_n | sym_c num_c tot_c | delta   delta%
+    KIRBY2_0007   458  |   155   143   297 |  1041   149  1191 |  +894  +301.0%
+    KIRBY2_0006   458  |   151   153   300 |   924   144  1094 |  +794  +264.7%
+    GROUPING_0243 225  |   104   122   226 |   364    97   461 |  +235  +104.0%
+    GROUPING_0031 225  |   103   113   216 |   308   100   410 |  +194   +89.8%
+
+Uncompressed, KIRBY2_0007 is 297 us against the oracle's 119 us —
+**~2.5x rather than 8.95x**.
+
+### Corpus sweep — the effect is not one matrix
+
+One iterate per family, 696 families with .mtx < 400 KB, 693 parsed:
+
+    LdltCompress engaged        : 514 / 693  (74%)
+    with tot_n >= 50us (signal) : 164  ->  losers 157, winners 7
+    loser delta%                : p25 13.0  median 18.1  p75 26.2
+                                  p90 52.3  max 696.4
+    aggregate waste             : 121945 us
+      GILBERT_0000 alone        :  87361 us (72% of total)
+      other 156 losers          :  34584 us (median 120 us each)
+
+Stated plainly: the aggregate figure is 72% a single pathological
+matrix. The finding that survives that is the **distributed** one —
+a median 18.1% tax on 96% of families where compression engages.
+
+### A gate that separates the 2026-06-06-04 counterexamples
+
+Oracle gate: skip compression when `mc64_cost > T · num_n`. Needs no
+fill prediction — `num_n` is the entire numeric phase, so an MC64
+costing more than `T=1` times it cannot repay even under a
+compression that drove numeric time to zero.
+
+    T     skips losers   us recovered   winners broken
+    0.25    126/166         114860        1  (HAHN1, 79 us, -9.7%)
+    0.50     56/166         106307        1  (HAHN1)
+    1.00     21/166          96991        0
+    2.00      6/166          93553        0
+
+Excluding GILBERT at T=0.25: skips 120/156, recovers 27436/34584 us
+(79%), breaks one 79 us winner — a ~347:1 trade.
+
+Against the pair that defeated the scaling-reuse signal:
+
+    ORTHREGF  mc64 4158 / num_n 1422   = 2.92   -> SKIP (correct, +129% loser)
+    ex8_2_2   mc64  958 / num_n 144305 = 0.007  -> KEEP (correct,  -3.0% winner)
+    SINQUAD2  ratio 0.18                        -> KEEP (conservative miss; +9.4% loser)
+
+### Honest limits of the above
+
+- **Improves the worst-case tail, not the p90.** Small-frontal p90 is
+  1.57 over ~148k matrices; removing a handful of outliers will not
+  move it.
+- **The gate is an oracle.** Both inputs are measured after the work.
+  `num_n` is tractable (uncompressed ordering + col_counts is 52 us
+  on KIRBY2, ~5% of the MC64 cost). `mc64_cost` is **not**: observed
+  cost per row spans 0.0303 to 17.3509 us/row, a **573x** spread, so
+  no estimator keyed on n or nnz survives the tail where the win is.
+- Proposed instead (not implemented): bound the cost rather than
+  predict it — run MC64 under a work budget counted in
+  augmenting-path edge scans, deterministic rather than wall-clock,
+  falling back to the ordering already computed.
+
+## Decisions Made
+
+None. Nothing was shipped and no architectural commitment was made;
+`dev/decisions.md` is untouched.
+
+## Abandoned Approaches
+
+Both appended to `dev/tried-and-rejected.md`:
+
+1. **MC64 warm-cache miss cost via `GROWTH_FACTOR` tuning** — closed
+   against the 2026-05-21 mechanism, with the protocol lesson that I
+   pitched the lever before searching the reject log (the same miss
+   as the KR warm-start one session earlier).
+2. **KIRBY2 outlier attributed to AMD dense-row handling** —
+   refuted by measurement. Ordering is 32 us (2.7% of symbolic), so
+   eliminating AMD cost entirely could not move the ratio. The
+   companion prediction that feral was over-filling relative to MUMPS
+   is also refuted (`num_c` 149 vs `num_n` 143 us).
+
+## Data Quality Issue Found
+
+`data/matrices/kkt-expansion/ROSEPETAL/ROSEPETAL_0000.mtx` is
+**truncated** — the header declares 2003000 entries and the file
+contains 1460226 (73%). `read_mtx` rejects it. It is the only iterate
+in that family, and `data/matrices/` is gitignored (`.gitignore:20`),
+so the file is untracked and the truncation cannot be dated, diffed,
+or reverted.
+
+ROSEPETAL is the flagship *winner* anchoring the 2026-06-06-04
+rejection of a compression gate. Its recorded numbers (MC64 0.68 s,
+numeric 5.72 s → 0.77 s) give ratio 0.12, which the ceiling gate keeps
+comfortably — so this does not indicate that rejection was wrong. But
+that is now an argument from a logged number rather than a repeatable
+measurement.
+
+Same class as the known `dtoc2_0001/0002` non-finite-value defect.
+
+## Next Session Should
+
+1. **Decide on the LdltCompress work-budget gate** (needs user
+   go-ahead — it touches `mc64::compute_matching` and possibly the
+   #38 staleness guard). If approved: research note is already
+   written, so next steps are the plan, then tests, then implement.
+   Open questions recorded in
+   `dev/research/ldlt-compress-cost-benefit-2026-08-15.md`:
+   - where a work counter can thread through
+     `mc64::compute_matching` without perturbing the non-aborted
+     matching result;
+   - whether abandoning a matching disturbs `cached_mc64` state that
+     the #38 guard depends on;
+   - budget calibration against the T sweep.
+2. **Repair or quarantine the corrupt corpus files** — ROSEPETAL_0000
+   (truncated) and dtoc2_0001/0002 (non-finite values). Consider a
+   corpus integrity check in CI, since `data/matrices/` being
+   untracked means silent corruption is undetectable by git.
+3. **#134B remainder** — gate (a) invariance. Needs IPM-outcome data
+   on the 89 families any invariant reformulation would strip of
+   MC64. Issue #134 item B should be retitled to this remainder.
+4. Consider warm@10 KR (option 2 of the 2026-08-09 note): same sweep
+   budget, geomean 3x-100x lower final deviation. Conditioning, not
+   speed.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5403,3 +5403,53 @@ files.
 in one pass (864 passed, 0 failed). For any change to a default that every
 test inherits, fail-fast turns one measurement into N sequential ones and
 hides the scope.
+
+## 2026-08-15 — #153: warm-starting Knight-Ruiz to save scaling sweeps
+
+**Tried.** Seeding `compute_infnorm`'s equilibration vector `d` from the
+previous IPM iterate's converged `d` instead of `d = 1`, and cutting the
+10-sweep cap to 2/3/5 on the strength of the warm start. Motivation: KR is
+cap-bound, not tolerance-bound — measured this session, only iterate-0 KKTs
+reach `tol = 1e-8` (dtoc1nd 6 sweeps → 4.4e-16, steering 4 → 7.7e-12,
+dtoc2 5 → 2.2e-16); from iterate 1 on all six fixtures burn the full 10 and
+exit at dev 1e-2 to 3e-2, so the tolerance is unreachable by construction.
+
+**Why it failed.** Warm-starting at a *reduced* cap loses. Chain experiment
+over full runs — every iterate warm-started from its predecessor, scored
+against a cold `d = 1` run at cap 10, counting per-iterate wins:
+
+| matrix                   | k=2  | k=3  | k=5   | k=10  |
+|--------------------------|------|------|-------|-------|
+| steering_12800 [InfNorm] | 0/2  | 0/2  | 0/2   | 2/2   |
+| TWIRISM1                 | 0/6  | 0/6  | 4/6   | 5/6   |
+| marine_1600 [MC64]       | 9/16 | 9/16 | 14/16 | 16/16 |
+
+Only warm@10 — the same cost as today — wins consistently. Every reduced
+cap loses on the one fixture that actually routes to `InfNorm`
+(steering_12800: 0/2 at k=2, 3 and 5), which is the only fixture where the
+lever could pay at all.
+
+An earlier reading that "warm@5 beats cold@10" came from a **single iterate
+pair** and did not replicate over full runs. The geometric-mean statistic
+that produced it is contaminated by iterate 0, which converges under both
+schedules; the per-iterate win count is the clean statistic.
+
+**Also:** this hypothesis had already been falsified six days earlier in
+`dev/research/scaling-warm-start-2026-08-09.md` (zero iteration reduction on
+6 fixtures; "lower the cap" ranked worst on risk/benefit, cap 5 giving
+3.7e-1 vs 1.4e-2 — 26x worse). That note was not read before recommending
+the work, which is the protocol step — read `dev/research/` and this file
+*before* writing code — that exists to prevent exactly this.
+
+**Sizing was also wrong.** The lever was first sized off what
+`pick_scaling_strategy` returns, but the sticky-`Auto` pin (#51/#65) means
+the steady-state route can differ: `mc64_cache_hit_count()` shows dtoc1nd at
+14/20 hits and marine at 12/18, i.e. both run MC64, not InfNorm. Only 2 of
+the 6 #153 fixtures (clnlbeam, steering_12800) actually run KR, so the lever
+was ~7-12%, not the 10-20% first reported. Size scaling levers off the
+observed route, not the picker.
+
+**Not rejected:** warm@10 — the same sweep budget, better conditioning
+(geomean 3x-100x lower final deviation). That is free quality, not a
+speedup, and would need downstream iterative-refinement counts to justify.
+Recorded as option 2 in the 2026-08-09 note; still open.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5453,3 +5453,78 @@ observed route, not the picker.
 (geomean 3x-100x lower final deviation). That is free quality, not a
 speedup, and would need downstream iterative-refinement counts to justify.
 Recorded as option 2 in the 2026-08-09 note; still open.
+
+---
+
+## 2026-08-15-02 — MC64 warm-cache miss cost: re-proposed, then found already rejected with a mechanism
+
+**Approach.** Reduce the MC64 warm-cache miss rate by tightening
+`GROWTH_FACTOR` / `GROWTH_COUNT` in `src/scaling/value_bound.rs`.
+Motivation was a marine_1600 measurement from 2026-08-15-01: cache hit
+25-30 ms vs miss 87-127 ms, 6 of 18 iterates missing, ~334 ms of a
+1784 ms solve (~19%). Proposed probe: log each miss and by how much it
+exceeded the threshold; if misses cluster just past the gate, tighten.
+
+**Rejected — the 2026-05-21 B2 entry (above, line ~2087) already
+supplies the mechanism, and it predicts this probe's outcome.**
+
+The gate measures diagonal dominance of `D₀·A·D₀`. On a regularized
+KKT the (2,2)-block rows carry a δ-sized diagonal (~1e-8) against ~1
+off-diagonals, so the dominance ratio *is* ~1/δ. As the IPM drives
+δ→0 the ratio climbs 1e8→1e10. The gate tracks the barrier
+trajectory, not scaling staleness.
+
+The proposed probe would have measured exactly the confounded
+quantity. pinene_3200's recorded misses are max_ratio/budget =
+1.906e8/1.162e8, 7.770e8/5.180e8, 2.486e10/1.657e10,
+5.562e10/3.708e10 — every one is ~1.5x past budget, i.e. "clusters
+just past the threshold" is TRUE and means nothing. The margin is set
+by how far δ moved that iterate. Tightening or loosening only shifts
+which iterate crosses; it cannot separate "δ shrank" (safe) from
+"matching changed" (unsafe, corrupts inertia — issue #38).
+
+**Not re-measured on marine_1600.** marine hits 12/18 where pinene
+hits 0/18, so marine is a different regime and it remains formally
+unmeasured whether its specific misses are δ-driven. That does not
+rescue the approach: the lever being tuned is the same confounded
+metric either way.
+
+**Lesson (mine, not the code's).** I recommended this lever to the
+user before searching `tried-and-rejected.md`. The same miss occurred
+one session earlier on the KR warm-start (2026-08-15-01). The search
+costs one grep and belongs *before* the recommendation, not after the
+approval. Two consecutive sessions have now spent user goodwill
+re-proposing work that was already closed with evidence.
+
+---
+
+## 2026-08-15-02 — KIRBY2 factor-ratio outlier attributed to AMD dense-row handling
+
+**Hypothesis.** KIRBY2_0007 (n=458) is the worst factor-ratio outlier
+in the bench at 8.95x MUMPS. Its structure is a bordered/arrowhead KKT
+— symmetric degree histogram `156 x2, 154 x3, 8 x151, 2 x302`, i.e.
+five near-dense hub rows over a sparse bed. Predicted that feral's AMD
+was blowing up on the quotient-graph work those hub rows induce, where
+MUMPS detects and defers dense rows, and that the fix would be a
+dense-row threshold.
+
+**Refuted by measurement.** `diag_symbolic_stages_argv` on
+KIRBY2_0007:
+
+    TOTAL 1182 us
+      ldlt_compress   972   82.2%
+      renumber         57    4.8%
+      ordering         32    2.7%
+
+Ordering is 32 us — 2.7% of symbolic and ~3% of the reported
+`factor_us`. Eliminating AMD cost entirely could not move the ratio.
+The cost is `ldlt_compress` (the MC64 matching feeding Duff-Pralet
+compression), which is a different subsystem from the one the
+hypothesis named.
+
+A second prediction in the same hypothesis — that feral was producing
+more fill than MUMPS — is also refuted: the numeric driver is 127 us
+and `num_c ~ num_n` (149 vs 143 us), so the factorization is not the
+problem in either time or fill.
+
+Superseded by `dev/research/ldlt-compress-cost-benefit-2026-08-15.md`.

--- a/src/scaling/mod.rs
+++ b/src/scaling/mod.rs
@@ -692,8 +692,10 @@ fn max_off_diag_ratio(matrix: &CscMatrix, scaling: &[f64]) -> f64 {
 /// its use below and
 /// `dev/research/router-permutation-invariance-2026-08-15.md`.
 ///
-/// One O(n+nnz) pass over the column pointers and row indices, plus
-/// an `n`-length degree accumulator.
+/// One O(n+nnz) allocation-free pass decides both gates for every
+/// matrix whose densest stored column already clears the threshold, or
+/// which fails the slack-mass gate. Only the ambiguous remainder pays
+/// a second pass and an `n`-length degree accumulator.
 pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
     /// Maximum stored column nnz for the Auto policy to consider the
     /// matrix "banded enough" that InfNorm is the safe choice even
@@ -704,18 +706,8 @@ pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
     if n == 0 {
         return ScalingStrategy::InfNorm;
     }
-    // Issue #134 item B: gate (b) counts *symmetric* degree — the
-    // degree of index `j` in the full matrix — not the stored
-    // lower-triangle column length. `CscMatrix` stores only one
-    // triangle, so a stored column length answers "how many couplings
-    // does `j` have to indices on one side of it", which is a property
-    // of the index order rather than of the matrix. Under the pure
-    // relabeling `P(i) = n-1-i` a leading arrow head of size 1026
-    // reports a stored max of 11 and the route flips. The IPOPT
-    // variable convention (duals last) puts the head at the trailing
-    // end, so this is the shape POUNCE and discopt actually emit.
-    let mut deg = vec![0usize; n];
     let mut diag_only = 0usize;
+    let mut max_stored = 0usize;
     for j in 0..n {
         let start = matrix.col_ptr[j];
         let end = matrix.col_ptr[j + 1];
@@ -733,15 +725,12 @@ pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
                 continue;
             }
             nnz_col += 1;
-            let i = matrix.row_idx[k];
-            deg[j] += 1;
-            if i == j {
+            if matrix.row_idx[k] == j {
                 diag_nonzero = true;
-            } else {
-                // The mirrored entry is not stored; credit it to the
-                // other index so both ends of the coupling see it.
-                deg[i] += 1;
             }
+        }
+        if nnz_col > max_stored {
+            max_stored = nnz_col;
         }
         // Gate (a) is deliberately left on stored counting. The
         // invariant reading ("symmetric degree <= 2 plus a diagonal")
@@ -756,10 +745,49 @@ pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
             diag_only += 1;
         }
     }
-    let max_col_nnz = deg.iter().copied().max().unwrap_or(0);
-    let has_arrow_head = max_col_nnz > MAX_COL_NNZ_FOR_INFNORM;
-    let has_slack_mass = diag_only as f64 / n as f64 >= 0.3;
-    if has_arrow_head && has_slack_mass {
+    // Gate (a) first: it is allocation-free and rejects most of the
+    // corpus, so deciding it here keeps the symmetric pass off the
+    // common path.
+    if (diag_only as f64) / (n as f64) < 0.3 {
+        return ScalingStrategy::InfNorm;
+    }
+    // Gate (b), issue #134 item B: the head gate counts *symmetric*
+    // degree — the degree of index `j` in the full matrix — not the
+    // stored lower-triangle column length. `CscMatrix` stores only one
+    // triangle, so a stored column length answers "how many couplings
+    // does `j` have to indices on one side of it", which is a property
+    // of the index order rather than of the matrix. Under the pure
+    // relabeling `P(i) = n-1-i` a leading arrow head of size 1026
+    // reports a stored max of 11 and the route flips. The IPOPT
+    // variable convention (duals last) puts the head at the trailing
+    // end, so this is the shape POUNCE and discopt actually emit.
+    //
+    // Symmetric degree is never below stored degree, so a stored
+    // column that already clears the threshold settles the gate and
+    // the second pass can be skipped. The `n`-length accumulator is
+    // therefore only allocated for matrices that pass the slack-mass
+    // gate *and* have no stored column above the threshold — the
+    // genuinely ambiguous case, which is where the trailing-border
+    // KKTs live.
+    if max_stored > MAX_COL_NNZ_FOR_INFNORM {
+        return ScalingStrategy::Mc64Symmetric;
+    }
+    let mut deg = vec![0usize; n];
+    for j in 0..n {
+        for k in matrix.col_ptr[j]..matrix.col_ptr[j + 1] {
+            if matrix.values[k] == 0.0 {
+                continue;
+            }
+            let i = matrix.row_idx[k];
+            deg[j] += 1;
+            if i != j {
+                // The mirrored entry is not stored; credit it to the
+                // other index so both ends of the coupling see it.
+                deg[i] += 1;
+            }
+        }
+    }
+    if deg.iter().copied().max().unwrap_or(0) > MAX_COL_NNZ_FOR_INFNORM {
         ScalingStrategy::Mc64Symmetric
     } else {
         ScalingStrategy::InfNorm

--- a/src/scaling/mod.rs
+++ b/src/scaling/mod.rs
@@ -672,10 +672,28 @@ fn max_off_diag_ratio(matrix: &CscMatrix, scaling: &[f64]) -> f64 {
 ///
 /// `32` sits an order of magnitude above ACOPP30's max (29) and an
 /// order of magnitude below MUONSINE's (512), giving the widest
-/// possible margin on either side of the validation panel.
+/// possible margin on either side of the validation panel. The panel
+/// is unchanged by the symmetric-degree switch below: clnlbeam's
+/// symmetric max degree is 5 and ACOPP30's is 29, so neither can
+/// cross 32, while every YES row keeps a head in the hundreds.
 ///
-/// One O(n+nnz) pass over the column pointers and row indices.
-/// No allocations.
+/// **Permutation invariance (issue #134 item B).** Gate (b) counts
+/// the symmetric degree of each index, not the stored lower-triangle
+/// column length. A stored column length measures couplings to one
+/// side of `j` only, so it depends on the index order: under the pure
+/// relabeling `P(i) = n-1-i`, VESUVIO's head reports 1026 one way and
+/// 11 the other, and the route flips to `InfNorm`. That is the
+/// duals-last shape the IPOPT variable convention produces. Measured
+/// over the 1004-family corpus, the stored form is invariant on 841
+/// and the symmetric form on 890; the switch is monotone (symmetric
+/// degree >= stored degree) so it moves 15 families and all 15 gain
+/// MC64 — inertia identical on all 15, factor time ratio median 0.98.
+/// Gate (a) is knowingly still order-dependent; see the comment at
+/// its use below and
+/// `dev/research/router-permutation-invariance-2026-08-15.md`.
+///
+/// One O(n+nnz) pass over the column pointers and row indices, plus
+/// an `n`-length degree accumulator.
 pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
     /// Maximum stored column nnz for the Auto policy to consider the
     /// matrix "banded enough" that InfNorm is the safe choice even
@@ -686,8 +704,18 @@ pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
     if n == 0 {
         return ScalingStrategy::InfNorm;
     }
+    // Issue #134 item B: gate (b) counts *symmetric* degree — the
+    // degree of index `j` in the full matrix — not the stored
+    // lower-triangle column length. `CscMatrix` stores only one
+    // triangle, so a stored column length answers "how many couplings
+    // does `j` have to indices on one side of it", which is a property
+    // of the index order rather than of the matrix. Under the pure
+    // relabeling `P(i) = n-1-i` a leading arrow head of size 1026
+    // reports a stored max of 11 and the route flips. The IPOPT
+    // variable convention (duals last) puts the head at the trailing
+    // end, so this is the shape POUNCE and discopt actually emit.
+    let mut deg = vec![0usize; n];
     let mut diag_only = 0usize;
-    let mut max_col_nnz = 0usize;
     for j in 0..n {
         let start = matrix.col_ptr[j];
         let end = matrix.col_ptr[j + 1];
@@ -705,17 +733,30 @@ pub fn pick_scaling_strategy(matrix: &CscMatrix) -> ScalingStrategy {
                 continue;
             }
             nnz_col += 1;
-            if matrix.row_idx[k] == j {
+            let i = matrix.row_idx[k];
+            deg[j] += 1;
+            if i == j {
                 diag_nonzero = true;
+            } else {
+                // The mirrored entry is not stored; credit it to the
+                // other index so both ends of the coupling see it.
+                deg[i] += 1;
             }
         }
-        if nnz_col > max_col_nnz {
-            max_col_nnz = nnz_col;
-        }
+        // Gate (a) is deliberately left on stored counting. The
+        // invariant reading ("symmetric degree <= 2 plus a diagonal")
+        // is correct for textbook arrow KKTs and wrong for the corpus:
+        // the slack columns this gate counts have symmetric degrees
+        // spanning 2 (ROCKET) to 64 (MSQRTA) to 379 (LEUVEN3), so no
+        // single threshold reproduces it, and every candidate strips
+        // MC64 from 89 families including marine_1600 and
+        // rocket_12800. See
+        // `dev/research/router-permutation-invariance-2026-08-15.md`.
         if nnz_col == 1 && diag_nonzero {
             diag_only += 1;
         }
     }
+    let max_col_nnz = deg.iter().copied().max().unwrap_or(0);
     let has_arrow_head = max_col_nnz > MAX_COL_NNZ_FOR_INFNORM;
     let has_slack_mass = diag_only as f64 / n as f64 >= 0.3;
     if has_arrow_head && has_slack_mass {
@@ -743,6 +784,36 @@ mod tests {
     /// enough that `1 + dense_off > MAX_COL_NNZ_FOR_INFNORM` (= 32),
     /// the non-slack columns form an "arrow head" that triggers the
     /// dense-column gate in `pick_scaling_strategy`.
+    /// Build a genuinely banded KKT: `diag_only` diagonal-only slack
+    /// columns followed by `n - diag_only` columns carrying the
+    /// diagonal plus couplings to the next `bandwidth` indices. Every
+    /// index has symmetric degree at most `2 * bandwidth + 1`, so the
+    /// shape stays under the head gate however it is relabeled.
+    fn banded_csc(n: usize, diag_only: usize, bandwidth: usize) -> CscMatrix {
+        let mut col_ptr = vec![0usize];
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        for j in 0..n {
+            row_idx.push(j);
+            values.push(2.0);
+            if j >= diag_only {
+                for d in 1..=bandwidth {
+                    if j + d < n {
+                        row_idx.push(j + d);
+                        values.push(0.5);
+                    }
+                }
+            }
+            col_ptr.push(row_idx.len());
+        }
+        CscMatrix {
+            n,
+            col_ptr,
+            row_idx,
+            values,
+        }
+    }
+
     fn shape_csc(n: usize, diag_only: usize, dense_off: usize) -> CscMatrix {
         assert!(diag_only <= n);
         let n_dense = n - diag_only;
@@ -880,12 +951,19 @@ mod tests {
 
     #[test]
     fn pick_scaling_strategy_picks_infnorm_for_banded_high_diag_only() {
-        // The clnlbeam shape: large n, high diag_only ratio (0.40)
-        // but narrow band (max_col_nnz=5). Must route to InfNorm —
-        // this is the entire motivation for adding the dense-column
-        // gate. See `dev/journal/2026-05-17-01.org` §14:30.
-        // 60 slack cols + 40 banded cols (diag + 4 earlier rows).
-        let csc = shape_csc(100, 60, 4);
+        // The clnlbeam shape: large n, high diag_only ratio but
+        // narrow band. Must route to InfNorm — this is the entire
+        // motivation for adding the dense-column gate. See
+        // `dev/journal/2026-05-17-01.org` §14:30.
+        //
+        // 60 slack cols + 40 banded cols (diag + the 4 *following*
+        // indices). This fixture used to be `shape_csc(100, 60, 4)`,
+        // which coupled all 40 non-slack columns to the same 4 row
+        // indices — a 4-spoke star of symmetric degree 41, not a band.
+        // Stored-column counting could not tell the difference (both
+        // report 5); symmetric counting can, and the real clnlbeam has
+        // symmetric max degree 5, so the band is the faithful fixture.
+        let csc = banded_csc(100, 60, 4);
         assert_eq!(pick_scaling_strategy(&csc), ScalingStrategy::InfNorm);
     }
 
@@ -910,13 +988,22 @@ mod tests {
 
     #[test]
     fn pick_scaling_strategy_max_col_nnz_threshold_boundary() {
-        // diag_only/n satisfied for both (50/100=0.50 ≥ 0.30).
-        // Only the dense-column degree varies across the boundary at 32.
-        // 50 slacks + 50 cols of (1 diag + 31 off) = 32 nnz → fails gate.
-        let at32 = shape_csc(100, 50, 31);
+        // diag_only/n satisfied for both (99/100 = 0.99 ≥ 0.30).
+        // Only the head degree varies across the boundary at 32.
+        //
+        // `arrow_leading(n, head)` gives index 0 a symmetric degree of
+        // exactly `head` — its own diagonal plus `head - 1` couplings
+        // — and every other index a degree of 1 or 2. The degree is
+        // therefore fixed by construction and checkable by hand, which
+        // the previous `shape_csc` fixture's was not: its symmetric
+        // degree depended on how many non-slack columns happened to
+        // reach a given row.
+        //
+        // head = 32 → max symmetric degree 32, not > 32 → fails gate.
+        let at32 = arrow_leading(100, 32);
         assert_eq!(pick_scaling_strategy(&at32), ScalingStrategy::InfNorm);
-        // 50 slacks + 50 cols of (1 diag + 32 off) = 33 nnz → passes.
-        let at33 = shape_csc(100, 50, 32);
+        // head = 33 → max symmetric degree 33 → passes.
+        let at33 = arrow_leading(100, 33);
         assert_eq!(pick_scaling_strategy(&at33), ScalingStrategy::Mc64Symmetric);
     }
 
@@ -1526,6 +1613,181 @@ mod tests {
         assert!(
             relres <= 1e-6,
             "Auto solve relres {relres:.3e} exceeds 1e-6"
+        );
+    }
+
+    // ---- issue #134 item B: permutation-invariant head gate ----
+
+    /// A leading-border arrow KKT stored as the lower triangle:
+    /// column 0 carries the diagonal plus `head - 1` couplings, every
+    /// other column carries its diagonal alone. Symmetric degree of
+    /// index 0 is `head`; every other index has degree 1 or 2.
+    fn arrow_leading(n: usize, head: usize) -> CscMatrix {
+        assert!(head <= n);
+        let mut col_ptr = vec![0usize];
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        for j in 0..n {
+            row_idx.push(j);
+            values.push(1.0);
+            if j == 0 {
+                for i in 1..head {
+                    row_idx.push(i);
+                    values.push(0.1);
+                }
+            }
+            col_ptr.push(row_idx.len());
+        }
+        CscMatrix {
+            n,
+            col_ptr,
+            row_idx,
+            values,
+        }
+    }
+
+    /// Relabel by `P(i) = n-1-i`. This is a pure renaming of the
+    /// indices — the matrix is the same operator up to a symmetric
+    /// permutation, so the scaling router must not change its mind.
+    /// An entry `(i, j)` with `i >= j` maps to `(n-1-j, n-1-i)`, which
+    /// is again lower-triangular.
+    fn reverse_labels(m: &CscMatrix) -> CscMatrix {
+        let n = m.n;
+        let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+        for j in 0..n {
+            for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                let i = m.row_idx[k];
+                let (ni, nj) = (n - 1 - j, n - 1 - i);
+                cols[nj].push((ni, m.values[k]));
+            }
+        }
+        let mut col_ptr = vec![0usize];
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        for c in cols.iter_mut() {
+            c.sort_by_key(|e| e.0);
+            for (i, v) in c.iter() {
+                row_idx.push(*i);
+                values.push(*v);
+            }
+            col_ptr.push(row_idx.len());
+        }
+        CscMatrix {
+            n,
+            col_ptr,
+            row_idx,
+            values,
+        }
+    }
+
+    /// Issue #134 item B. The head gate must see the arrow head
+    /// whichever end of the index range it sits at. Before the
+    /// symmetric-degree fix the reversed form reported
+    /// `max_col_nnz = 2` and routed to `InfNorm`, forfeiting the
+    /// documented 6×–243× MC64 win on the duals-last KKTs that the
+    /// IPOPT variable convention produces.
+    #[test]
+    fn route_is_invariant_under_index_reversal() {
+        let a = arrow_leading(200, 40);
+        let b = reverse_labels(&a);
+        assert_eq!(pick_scaling_strategy(&a), ScalingStrategy::Mc64Symmetric);
+        assert_eq!(
+            pick_scaling_strategy(&b),
+            ScalingStrategy::Mc64Symmetric,
+            "reversing the index order is a pure relabeling; the route must not change"
+        );
+    }
+
+    /// The trailing-border shape directly: the dense coupling lives in
+    /// the *last* index, so the stored lower triangle spreads it one
+    /// entry per earlier column and no stored column is dense.
+    #[test]
+    fn trailing_border_routes_to_mc64() {
+        let m = reverse_labels(&arrow_leading(300, 64));
+        let max_stored = (0..m.n)
+            .map(|j| m.col_ptr[j + 1] - m.col_ptr[j])
+            .max()
+            .unwrap_or(0);
+        assert!(
+            max_stored <= 2,
+            "fixture should hide the head from stored counting, got {max_stored}"
+        );
+        assert_eq!(pick_scaling_strategy(&m), ScalingStrategy::Mc64Symmetric);
+    }
+
+    /// The clnlbeam guard. A banded KKT has a high diag_only ratio but
+    /// small degree by construction; MC64 hurts it 4.36× in iterations
+    /// (Mittelmann sweep 2026-05-16). Widening gate (b) to symmetric
+    /// degree must not let a banded matrix through — symmetric degree
+    /// is still far under 32 — in either index order.
+    #[test]
+    fn banded_stays_infnorm_under_both_orderings() {
+        let n = 400;
+        let mut col_ptr = vec![0usize];
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        for j in 0..n {
+            row_idx.push(j);
+            values.push(2.0);
+            for d in 1..=2 {
+                if j + d < n {
+                    row_idx.push(j + d);
+                    values.push(0.5);
+                }
+            }
+            col_ptr.push(row_idx.len());
+        }
+        let m = CscMatrix {
+            n,
+            col_ptr,
+            row_idx,
+            values,
+        };
+        assert_eq!(pick_scaling_strategy(&m), ScalingStrategy::InfNorm);
+        assert_eq!(
+            pick_scaling_strategy(&reverse_labels(&m)),
+            ScalingStrategy::InfNorm
+        );
+    }
+
+    /// Issue #47 against the symmetric counter: an explicit stored
+    /// `0.0` is not coupling, so padding the head with zeros must not
+    /// change the route in either index order.
+    #[test]
+    fn explicit_zeros_do_not_change_route_either_ordering() {
+        let base = arrow_leading(200, 40);
+        // Pad column 1 with 40 explicit zeros. Value-blind counting
+        // would make it a second "dense" column.
+        let mut col_ptr = vec![0usize];
+        let mut row_idx = Vec::new();
+        let mut values = Vec::new();
+        for j in 0..base.n {
+            for k in base.col_ptr[j]..base.col_ptr[j + 1] {
+                row_idx.push(base.row_idx[k]);
+                values.push(base.values[k]);
+            }
+            if j == 1 {
+                for i in 2..42 {
+                    row_idx.push(i);
+                    values.push(0.0);
+                }
+            }
+            col_ptr.push(row_idx.len());
+        }
+        let padded = CscMatrix {
+            n: base.n,
+            col_ptr,
+            row_idx,
+            values,
+        };
+        assert_eq!(
+            pick_scaling_strategy(&padded),
+            pick_scaling_strategy(&base),
+            "explicit zeros must not move the route"
+        );
+        assert_eq!(
+            pick_scaling_strategy(&reverse_labels(&padded)),
+            pick_scaling_strategy(&reverse_labels(&base))
         );
     }
 }


### PR DESCRIPTION
## Summary

Two sessions of scaling-router work. One source change (issue #134 item B);
the rest is diagnostics and session documentation.

**Source change — `src/scaling/mod.rs`:**
- `e9470ca` — the router's head gate now counts *symmetric* degree instead of
  stored lower-triangle column length, so routing no longer depends on index
  order. A trailing dense border (the IPOPT duals-last convention) previously
  dodged the `>32` gate and forfeited MC64.
- `45c80f3` — keeps the symmetric pass off the common path (gate (a) first,
  early-accept via monotonicity), because an unconditional allocation per
  router call is measurable against ~148k sub-millisecond factorizations.

Measured over 1004 corpus families: permutation-invariance 841 → 890,
15 route changes, **15 gains, 0 losses**. Inertia identical on all 15.
4 new tests; `cargo test --no-fail-fast` 868 passed / 0 failed.

## Scope honesty

- **This fixes a latent bug, not a live one.** Zero families are misrouted
  today. The gain is that relabeling can no longer change the route.
- **Gate (a) is deliberately left non-invariant.** Every invariant
  reformulation measured strips MC64 from 89 families including marine_1600,
  rocket_12800 and STEERING. Evidence in
  `dev/research/router-permutation-invariance-2026-08-15.md`; #134 item B
  should be retitled to that remainder.
- **MSS1 is the one unfavorable mover** (+19% time, forward error
  1.43e-1 → 6.15e-1). Neither route solves it, and
  `auto_falls_back_to_infnorm_on_mss1_0009` still passes.

## Benchmark caveat — please read before trusting any p90 in these commits

The final session re-ran the bench with **zero source change** and all four
partitions moved: dense small-frontal 1.54 → 1.61, dense medium 1.91 → 2.00,
sparse 1.50/1.51 → 1.67/1.67. All still PASS.

Consequence, recorded in `dev/sessions/2026-08-15-02.md`: the bench noise floor
on these metrics is at least ±0.15, so the 1.58 → 1.54 improvement claimed for
`45c80f3` is inside the noise. That commit should be read as **removing the 1.66
regression it introduced**, not as beating baseline. A follow-up should
establish the noise floor properly by running N times on an unchanged binary.

## Also included

- Diagnostics (`e78f29e`, `14b3865`, extended `probe_scaling_levers`) — read-only
  corpus measurement, no semantics.
- `dev/research/ldlt-compress-cost-benefit-2026-08-15.md` — the worst
  factor-ratio outlier (KIRBY2, 9.22x MUMPS) is not the kernel: 82% of its
  symbolic time is `ldlt_compress`, delivering zero numeric benefit. Diagnosed
  only, **not fixed**; the sizing sweep excluded large matrices, so its
  "median 18.1% tax" figure should not be read as a wall-clock claim.
- Two entries in `dev/tried-and-rejected.md`: the MC64 warm-cache miss lever
  (closed against the 2026-05-21 mechanism) and a refuted AMD dense-row
  hypothesis.
- Corpus data defect found: `ROSEPETAL_0000.mtx` is truncated (header declares
  2003000 entries, file has 1460226). `data/matrices/` is gitignored, so corpus
  corruption is currently invisible to git. Second instance after `dtoc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pjkXyqUk3G1tbBrzibbge
