### PR TITLE
Caller-capped iterative refinement and in-place solve entry points (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added — caller-capped iterative refinement and in-place solves (issue #178)
+
+- **`RefineOptions`** makes the refinement step budget a per-call parameter.
+  `RefineOptions::with_max_steps(k)` runs at most `k` correction steps;
+  `RefineOptions::default()` is today's budget (`DEFAULT_REFINE_MAX_STEPS = 10`)
+  and is bit-for-bit identical to the existing entry points. New `_opts` forms:
+  `solve_sparse_refined_opts`, `solve_sparse_refined_parallel_opts`,
+  `solve_sparse_refined_with_diagnostics_opts`, `solve_sparse_many_refined_opts`,
+  `Solver::solve_refined_opts`, `Solver::solve_many_refined_opts`.
+- **Why.** FERAL's 10-step budget is right for a caller that solves `Ax = b` and
+  keeps the answer, and wrong for a caller running its own refinement over the
+  same system. An interior-point host is the latter, so the two loops nest and
+  one augmented-system solve can cost up to `10 x 11 = 110` substitution passes —
+  measured at 60 % of back-solve time (147.3 s vs 58.3 s) on a 118 276-dimension
+  KKT system in pounce#698. The outer loop owns the convergence criterion; the
+  inner one drives a residual nobody consults.
+- **No default changed.** The cap is an upper bound only: the `eps*sqrt(n)`
+  relative-residual target, the 100x divergence guard, and the 2-strike plateau
+  exit all keep priority, and the best-iterate contract holds under every `k`, so
+  no cap can return an answer worse than `solve_sparse`. `k = 0` equals
+  `solve_sparse` bit-for-bit — and costs the same, since the residual matvec is
+  skipped rather than computed and discarded.
+- **In-place entry points.** `Solver::solve_into`, `solve_refined_into`,
+  `solve_many_into`, `solve_many_refined_into`, plus free-function
+  `solve_sparse_into`, `solve_sparse_refined_into`,
+  `solve_sparse_many_refined_into`. A host that owns its right-hand-side buffer
+  no longer pays an allocation plus copy-back per back-solve (`dim x nrhs`
+  doubles, ~946 KB per solve at the dimension above). Each is bit-identical to
+  its allocating twin; a wrong-length `rhs` or `x_out` returns
+  `DimensionMismatch` rather than panicking; `NoFactor` keeps precedence.
+  Aliasing `rhs` with `x_out` is unrepresentable in safe Rust rather than
+  checked at runtime.
+- The refined paths also lost an internal allocation: the caller's `x_out` is
+  now the best-iterate storage, and the multi-RHS refiner runs its initial
+  batched solve directly into it.
+
+
 ### Fixed — scaling router no longer routes on index order (issue #134 item B)
 
 - `pick_scaling_strategy`'s dense-head gate now counts the **symmetric degree**

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,161 +1,172 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-15T22:22:29Z
+Generated: 2026-08-19T13:38:18Z
 
 ## Latest Session
-File: dev/sessions/2026-08-15-02.md
+File: dev/sessions/2026-08-19-01.md
 ```
-# Session 2026-08-15-02
+# Session 2026-08-19-01
 
-## BENCHMARK NUMBERS ARE WORSE THAN LAST SESSION
+## BENCHMARK NOT COMPARABLE THIS SESSION — corpus absent
 
-Reported first, per the hard rule in CLAUDE.md.
+Reported first, per the hard rule in CLAUDE.md, because the honest
+statement is "not measured", not "unchanged".
 
-    partition                  2026-08-15-01   this session   delta
-    dense  small-frontal (<200)     1.54           1.61        +0.07
-    dense  medium (<500)            1.91           2.00        +0.09
-    sparse small-frontal (<200)     1.50           1.67        +0.17
-    sparse medium (<500)            1.51           1.67        +0.16
+`cargo run --bin bench --release` ran to completion, but
+`data/benchmark-config.toml` is **not present in this container**, so the
+harness fell back to its 8 synthetic matrices. Both Phase 2.8.1 exit
+partitions report `count = 0`, verdict `N/A`:
 
-All four partitions regressed. All four still PASS their targets.
+    partition                 count   p90   target  verdict
+    dense  small-frontal (<200)   0     -    <= 2.0    N/A
+    dense  medium (<500)          0     -    <= 3.0    N/A
+    sparse small-frontal (<200)   0     -    <= 2.0    N/A
+    sparse medium (<500)          0     -    <= 3.0    N/A
 
-**No Rust source changed this session.** `git diff --stat fbb1a9d HEAD
--- src/ crates/ tests/` is empty; the only changes are `dev/`
-documents. So this is not a code regression — it is run-to-run
-variance on the same binary.
+There is therefore **no comparison against 2026-08-15-02's numbers**
+(1.61 / 2.00 / 1.67 / 1.67). Not a regression and not an improvement —
+not measured. What did run passed: 2/2 inertia match vs MUMPS, 2/2
+residual pass, worst residual 1.26e-16 (densecol_kkt_300_0000).
 
-That conclusion is itself worth recording, because it bears on a claim
-made last session. 2026-08-15-01 reported a dense small-frontal
-sequence of 1.58 (baseline) -> 1.66 (regression I introduced) -> 1.54
-(after the gate reordering), and I described the final number as
-"beating the baseline". Today's run puts the same unchanged code at
-1.61. A +0.07 swing with zero code change means the bench's noise
-floor on this metric is at least as large as the 1.58 -> 1.54
-"improvement" I claimed. **The gate-reordering fix should be regarded
-as having removed the 1.66 regression, not as having beaten the
-baseline.** The 1.66 measurement is still meaningful (it exceeded the
-noise band), but the final 0.04 is not.
-
-Action for a future session: establish the bench's noise floor by
-running it N times on an unchanged binary, and record a
-minimum-detectable-difference so per-session comparisons stop
-over-reading sub-0.1 movements. Until then, treat p90 deltas under
-~0.15 as noise.
-
-Also note the worst-ratio table is now **6 of 10 KIRBY2 iterates**
-(worst 9.22, up from 8.95), plus GROUPING_0205 — i.e. the outlier
-family this session diagnosed dominates the tail more clearly than
-before.
+The changes this session are additive API surface with `Default`-valued
+wrappers proven bit-identical to the previous entry points, so the
+factor-ratio partitions are not expected to move; but "not expected to
+move" is a prediction, not a measurement, and it should be checked on a
+machine that has the corpus.
 
 ## Goal
 
-Investigate the two items carried out of 2026-08-15-01, both approved
-by the user:
+Fix [issue #178](https://github.com/jkitchin/feral/issues/178), filed
+from [pounce#698](https://github.com/jkitchin/pounce/issues/698). Two
+independent asks:
 
-1. **#153 remainder** — MC64 warm-cache miss cost. marine_1600 spends
-   ~19% of a 1784 ms solve in cache-missed MC64 recomputes. Decide
-   whether `GROWTH_FACTOR`/`GROWTH_COUNT` can be tightened without
+1. A caller-supplied cap on iterative-refinement correction steps. An
+   interior-point host runs its own refinement loop over the same
+   augmented system, so FERAL's inner 10-step budget is work whose
+   residual nobody consults — measured at 60 % of back-solve time on a
+   118 276-dimension KKT system.
+2. In-place (`*_into`) solve entry points, so a host that owns its
+   right-hand-side buffer stops paying an allocation plus copy-back per
+   back-solve.
+
+## Accomplished
+
+Both, plus the research note and plan the lifecycle requires.
+
+### Item 1 — `RefineOptions`
+
 ```
 
 ## Git Status
 ```
-3029905 docs(compress): localize the KIRBY2 factor-ratio outlier to LdltCompress
-fbb1a9d docs: session checkpoint 2026-08-15-01 (#134B shipped, #153 falsified)
-45c80f3 perf(scaling): keep the router's symmetric pass off the common path
-e9470ca fix(scaling): count symmetric degree in the router's head gate (#134B)
-8acb1be docs(scaling): research + plan for router permutation-invariance (#134B)
+22765f6 docs(changelog): record the issue #178 refinement cap and in-place solves
+ae169f9 feat(solver): capped and in-place solve entry points on Solver
+f23137b feat(solve): make the refinement step budget a per-call option
+eeee52a docs: research note and plan for a caller-capped refiner (issue #178)
+6fb9d26 Merge pull request #174 from jkitchin/feat/scaling-router-invariance
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.85s
+test result: ok. 425 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.54s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-15-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-01.md)
 
 
-**No Rust source changed this session** (`git diff --stat fbb1a9d HEAD
--- src/ crates/ tests/` is empty; the only changes are `dev/`
-documents). The run below is therefore a re-measurement of unchanged
-code and is expected to reproduce 2026-08-15-01.
+FERAL benchmark harness
+  ordering: default (symbolic_factorize heuristic)
+  scaling: default (SupernodeParams::default)
+Loading matrices from data/benchmark-config.toml ... not found
 
-Top 10 worst factor-ratio vs MUMPS:
-name                             n    feral(us)    mumps(us)      ratio
-KIRBY2_0007                    458         1097          119       9.22
-KIRBY2_0006                    458         1075          127       8.46
-KIRBY2_0008                    458          971          122       7.96
-KIRBY2_0010                    458          992          133       7.46
-LAKES_0144                     168          372           54       6.89
-KIRBY2_0009                    458          879          128       6.87
-KIRBY2_0011                    458          820          120       6.83
-LAKES_0146                     168          350           54       6.48
-GROUPING_0205                  225          700          111       6.31
-QPCBLEND_0030                  157          362           60       6.03
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10           21            1     (10, 0, 0)
+spd_50             50           45            2     (50, 0, 0)
+spd_100           100          220            5    (100, 0, 0)
+spd_200           200          926           41    (200, 0, 0)
+kkt_10_3           13            5            0     (10, 3, 0)
+kkt_30_10          40           31            1    (30, 10, 0)
+kkt_50_15          65           89            2    (50, 15, 0)
+kkt_100_30        130          339            7   (100, 30, 0)
+
+8 matrices benchmarked
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.61     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.67     <= 2.0     PASS
-medium (<500)            153560     1.67     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 ```
 
 ## Recent Decisions
-route is gated on a bump that was actually peeled (21f5e74), so it is
-unreachable unless triangularization is on. It is one lever, not two.
+measurement above: pounce defaults `feral_refine` to *on* for a
+documented case (`pinene_3200`) whose IPM tail stalls when the residual
+floor left by cascade-break's L-factor perturbation goes uncorrected.
+Zero steps loses that case. So the problem was never that 10 is too
+many — it is that 10 and 0 were the only two values expressible. The
+value that plausibly serves both is 1, and nobody could ask for it.
 
-**AMF stays off** because no downstream measurement was taken this session. That
-is an absence of evidence, not a finding against it.
+Two semantics follow from "cap, not target", and both are tested rather
+than merely documented. The existing exits — the `ε·√n` relative
+residual, the 100× divergence guard, the 2-strike plateau — keep
+priority, so raising `max_steps` can never add work to a system that has
+already converged. And the best-iterate contract holds under every value,
+so no cap can return an answer worse than `solve_sparse`'s.
 
-**Known cost of this decision.** `Markowitz` ignores `factor`'s `symbolic`
-argument, because it does not use a precomputed column order. That is a silent
-semantic change for any caller that carefully chose an ordering and passed it in
-— exactly the silent-fallback shape #168 warned about. Three mitigations, and no
-claim that they eliminate it: the selector is an explicit enum rather than a
-bool, `SparseLu::used_markowitz()` makes the executed route observable so a
-measurement can assert instead of infer, and every in-repo ordering comparison
-(`examples/lu_fill_orderings.rs`, `src/bin/probe_lu_phases.rs`,
-`src/bin/probe_ft_eta.rs`) is pinned to `GilbertPeierls` in this change. An
-out-of-tree caller comparing orderings against `LuParams::default()` will
-silently compare nothing until it pins the rule. Seven in-repo test sites
-across five files failed on this change — `sparse_lu_honors_pivot_threshold`,
-`dense_bump_route_needs_the_peel_and_the_cap_together`, the whole
-`lu_dense_bump` suite, `reach_route_composes_with_the_dense_bump_route`,
-`perturb_chooses_largest_magnitude_row_matching_dense`,
-`factor_traversal_is_subquadratic`, and
-`sparse_solves_compose_with_the_dense_bump_route` — and every one was fixed by
-pinning `GilbertPeierls`, never by weakening an assertion. That seven
-independent tests failed is corroboration that the hazard is real, not
-hypothetical, and it is a fair estimate of what a downstream suite should
-expect to have to pin.
+`max_steps = 0` returns before the residual matvec rather than after. The
+answer would be identical either way; the cost would not, and a caller
+opting out of refinement paying a `symv` and a `norm2` per solve would
+address only half of what was reported.
 
-Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
-`dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
+Measured on this branch (20 reps, release, single trial): on
+VESUVIO_0021, a pounce KKT that uses 4 corrections, the refined solve is
+7.31× the bare solve at the default and 3.07× at `k = 1`; `k = 0` is
+1.03×, i.e. inside the bare solve's own noise. The 2.4× per-call
+reduction is the same direction and rough magnitude as pounce#698's
+independently measured 2.6× per-iteration back-solve reduction.
+
+Evidence: issue #178; pounce#698 Observation 5;
+`dev/research/refinement-cap-2026-08-19.md`;
+`dev/plans/issue-178-refine-cap-and-inplace.md`;
+`dev/journal/2026-08-19-01.org`; `tests/issue178_refine_cap.rs`.
 
 ## Recent Tried-and-Rejected
 **Refuted by measurement.** `diag_symbolic_stages_argv` on
@@ -248,8 +259,8 @@ tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -263,6 +274,20 @@ tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/golden_bits.rs
 tests/growth_flag.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
+tests/issue127_pipeline_split.rs
+tests/issue128_supernode_nrow.rs
+tests/issue178_refine_cap.rs
+tests/issue178_solve_into.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
 tests/issue_15_cascade_arm_gate.rs
 tests/issue_17_robot_1600_cascade_off.rs
 tests/issue_18_narx_cfy_cascade_off.rs
@@ -271,34 +296,22 @@ tests/issue_38_static_pivot.rs
 tests/issue_46_saddle_kkt_cascade.rs
 tests/issue_55_delay_budget.rs
 tests/issue_55_n_tiny_counter.rs
-tests/issue102_intrafront_deadlock.rs
-tests/issue102_ordering_escalation.rs
-tests/issue107_external_ordering.rs
-tests/issue112_bg_update.rs
-tests/issue127_pipeline_split.rs
-tests/issue128_supernode_nrow.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
-tests/issue91_preprocess_misfire.rs
-tests/issue99_fma_front_gate.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
 tests/lu_default_ordering.rs
+tests/lu_dense.rs
 tests/lu_dense_bump.rs
 tests/lu_dense_update_bg.rs
-tests/lu_dense.rs
 tests/lu_ft_widebump.rs
 tests/lu_hyper_sparse.rs
 tests/lu_markowitz.rs
 tests/lu_real_bases.rs
 tests/lu_scaling.rs
-tests/lu_sparse_rhs.rs
 tests/lu_sparse.rs
+tests/lu_sparse_rhs.rs
 tests/lu_update_alloc_probe.rs
 tests/lu_update_casctanks.rs
 tests/maxfromm_parity.rs
@@ -314,8 +327,8 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6691,3 +6691,66 @@ expect to have to pin.
 
 Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
 `dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
+
+## 2026-08-19 — The refinement step budget is a per-call option, not a default change and not solver state (issue #178)
+
+FERAL's sparse iterative refinement ran a fixed budget of up to 10
+correction steps. Issue #178, filed from pounce#698, reported that this is
+the wrong budget for a caller that is *itself* iterating on the same
+system — an interior-point method — and measured the cost: on a
+118 276 × 118 276 augmented system, back-solve time was 147.3 s with
+FERAL's inner refinement on and 58.3 s with it off, 60 % of back-solve and
+20 % of wall time, and the unrefined run reached an objective *closer* to
+the MA57 reference than the refined one.
+
+**Decision: make the budget a per-call parameter carried by an options
+struct, `RefineOptions { max_steps }`, and change no default.**
+
+Three parts, each of which could have gone otherwise.
+
+**Per-call, not a `Solver` setting.** A stateful `set_refine_max_steps`
+would be a smaller diff at the call sites, but it makes a `&self` solve's
+behavior depend on prior mutation, and the ask is genuinely per-call: an
+IPM host may want one correction inside its own loop and the full budget
+for a final solve it keeps.
+
+**An options struct, not a bare `usize`.** The struct is one field today
+and looks like ceremony. It matches the repo's existing convention
+(`NumericParams`, `SupernodeParams`, `BunchKaufmanParams`, `LuParams`),
+and it means the next tunable anyone asks for — a caller-set residual
+target is the obvious candidate, since the `ε·√n` default is FERAL's
+choice and not the host's — is additive for every caller who constructs
+from `Default`, rather than another argument on six entry points.
+
+**The default stays at 10.** Issue #178 explicitly does not ask for a
+change, and the reason is worth recording because it cuts against the
+measurement above: pounce defaults `feral_refine` to *on* for a
+documented case (`pinene_3200`) whose IPM tail stalls when the residual
+floor left by cascade-break's L-factor perturbation goes uncorrected.
+Zero steps loses that case. So the problem was never that 10 is too
+many — it is that 10 and 0 were the only two values expressible. The
+value that plausibly serves both is 1, and nobody could ask for it.
+
+Two semantics follow from "cap, not target", and both are tested rather
+than merely documented. The existing exits — the `ε·√n` relative
+residual, the 100× divergence guard, the 2-strike plateau — keep
+priority, so raising `max_steps` can never add work to a system that has
+already converged. And the best-iterate contract holds under every value,
+so no cap can return an answer worse than `solve_sparse`'s.
+
+`max_steps = 0` returns before the residual matvec rather than after. The
+answer would be identical either way; the cost would not, and a caller
+opting out of refinement paying a `symv` and a `norm2` per solve would
+address only half of what was reported.
+
+Measured on this branch (20 reps, release, single trial): on
+VESUVIO_0021, a pounce KKT that uses 4 corrections, the refined solve is
+7.31× the bare solve at the default and 3.07× at `k = 1`; `k = 0` is
+1.03×, i.e. inside the bare solve's own noise. The 2.4× per-call
+reduction is the same direction and rough magnitude as pounce#698's
+independently measured 2.6× per-iteration back-solve reduction.
+
+Evidence: issue #178; pounce#698 Observation 5;
+`dev/research/refinement-cap-2026-08-19.md`;
+`dev/plans/issue-178-refine-cap-and-inplace.md`;
+`dev/journal/2026-08-19-01.org`; `tests/issue178_refine_cap.rs`.

--- a/dev/journal/2026-08-19-01.org
+++ b/dev/journal/2026-08-19-01.org
@@ -117,3 +117,43 @@ Evidence: 21 new tests in `tests/issue178_refine_cap.rs` (12) and
 `tests/issue178_solve_into.rs` (9), all passing; full suite
 `cargo test --workspace` green with 0 failures across 93 test binaries;
 `cargo clippy --all-targets -- -D warnings` clean.
+
+* 14:35 :issue-178:measurement:bench:
+Ran the mandatory session-end bench (`cargo run --bin bench --release`).
+**The benchmark corpus is not present in this container** —
+`data/benchmark-config.toml` is missing, so the harness fell back to its
+8 synthetic matrices and both Phase 2.8.1 partition tables report
+`count = 0`, verdict `N/A`. There is therefore **no comparison against
+2026-08-15-02's p90 numbers this session**. Not a regression, not an
+improvement — not measured. What did run passed: 2/2 inertia match vs
+MUMPS, 2/2 residual pass, worst residual 1.26e-16.
+
+So I measured the change directly instead, on real KKT matrices in the
+repo. Per-call cost of the single-RHS refined solve as a function of the
+new cap, 20 reps each, release build, one trial (no repeated trials —
+treat as indicative, not as a noise-bounded measurement):
+
+    matrix                  n      steps  bare     k=0     k=1     k=10
+    VESUVIO_0021          3083     5      0.077ms  1.03x   3.07x   7.31x
+    nuffield2_trap_iter1  26649    3      9.63ms   1.07x   2.13x   3.00x
+    twirism1_kkt           745     3      0.087ms  0.72x   2.04x   3.19x
+    sawpath_kkt           1575     3      0.069ms  0.91x   2.16x   3.16x
+
+Two things this confirms:
+
+1. `k = 0` costs what `solve_sparse` costs (0.72-1.07x, i.e. within the
+   noise of the bare solve). The early return *before* the residual
+   matvec is doing its job — had I returned after it, k=0 would sit
+   visibly above 1.0x on every row.
+2. On VESUVIO_0021 — a pounce KKT that uses 4 corrections before the
+   plateau exit — `k = 1` is 3.07x bare against the default's 7.31x, a
+   2.4x reduction in per-call refined-solve cost. That is the same
+   direction and rough magnitude as pounce#698's 2.6x per-iteration
+   back-solve reduction, measured independently at a different scale.
+
+The three matrices that stop at 3 steps do so via the 2-strike plateau
+(their residuals are large and non-decreasing — nuffield2_trap is the
+issue-54 repro and is genuinely near-singular), so their default is
+already close to `k = 2` and the cap has less to give. That is the
+expected shape: the cap pays off exactly where refinement would
+otherwise keep going.

--- a/dev/journal/2026-08-19-01.org
+++ b/dev/journal/2026-08-19-01.org
@@ -1,0 +1,119 @@
+#+TITLE: Session journal 2026-08-19-01
+#+STARTUP: showeverything
+
+* 13:20 :orient:issue-178:
+Task: fix https://github.com/jkitchin/feral/issues/178 — two independent
+asks from pounce#698.
+
+1. A caller-supplied cap on iterative-refinement correction steps.
+   Today `max_steps = 10` is hard-coded twice: `src/numeric/solve.rs:1873`
+   (single-RHS core) and `src/numeric/solve.rs:2007` (multi-RHS). An IPM
+   host runs its own refinement loop over the same system, so one of its
+   back-solves can cost up to 10x11 = 110 substitution passes.
+   Measured on pounce 0.10.0, 118276-dim augmented system: back-solve
+   147.3 s (refine on) vs 58.3 s (refine off), wall 487.2 vs 387.9 s.
+   The ask is explicitly NOT to change the default — only to make `k`
+   settable per call.
+
+2. In-place (`*_into`) solve entry points on `Solver`, so a host that
+   owns the RHS buffer does not pay `dim x nrhs` doubles of allocation
+   plus copy-back per back-solve.
+
+Code inspection findings:
+- `solve_sparse_refined_core` (`solve.rs:1797`) is the single funnel for
+  `solve_sparse_refined`, `solve_sparse_refined_parallel`, and
+  `solve_sparse_refined_with_diagnostics`. One cap parameter there covers
+  all three.
+- `solve_sparse_many_refined` (`solve.rs:1989`) is a separate loop with
+  its own copy of the constants; it needs the cap threaded independently.
+- `Solver::solve_many_refined` (`solver.rs:1661`) dispatches on
+  `BLAS3_REFINE_THRESHOLD`: wide solves go to `solve_sparse_many_refined`,
+  narrow ones (the IPM `nrhs = 2` case) run a per-column loop over
+  `solve_sparse_refined{,_parallel}`. Both arms need the cap.
+- `best_x` in both loops is already a `Vec` that is returned by value, so
+  the in-place ask and the cap ask touch the same lines — doing them in
+  one pass avoids editing the same loop twice.
+
+* 13:40 :issue-178:test-oracle:refinement:
+Needed a test oracle for "a solve that runs the full 10-step budget"
+(issue #178 verification item 1 is stated in terms of a run that returns
+`steps.len() == 11`). Probed the obvious candidates with
+`solve_sparse_refined_with_diagnostics`:
+
+    ill-conditioned bordered KKT (existing test matrix)  steps=1
+    singular 3x3 (ForceAccept zero pivot)                steps=3
+    Hilbert n=8/10/12/14/16/18/20/24/30/40               steps=4/5/7/7/5/3/4/4/3/3
+    KKT with (1,1) block eps=1e-14/1e-16/1e-18           steps=1
+
+None reach 11. The reason is structural, not incidental: when the factor
+is *exact*, refinement bottoms out on roundoff in two or three steps and
+the 2-strike plateau exit fires. Nothing that is merely ill-conditioned
+runs the budget.
+
+The situation the cap exists for is different — the factor is a genuinely
+perturbed approximate inverse (cascade-break L-factor perturbation,
+static pivot perturbation), so refinement converges *linearly* and keeps
+improving as long as it is allowed to. That is directly constructible
+through the public API, because it takes the matrix and the factor
+separately: factor `A + dA`, refine against `A`.
+
+Tridiagonal n=20, `A = tridiag(-1, 2, -1)`, factor of `A` with the
+diagonal perturbed by `delta*(1 + 0.01*j)`:
+
+    delta   steps  relative residual trajectory
+    1e-1    11     1.15e-1 -> 2.82e-3   (never converges, all 10 used)
+    3e-2    11     4.01e-2 -> 7.23e-5
+    1e-2    11     1.49e-2 -> 1.06e-7   ~3.3x per step, monotone
+    3e-3    11     4.85e-3 -> 3.35e-12
+    1e-3    11     1.67e-3 -> 1.50e-16
+    1e-4     6     1.70e-4 -> 3.07e-16  (converges, exits early)
+
+Picked `delta = 1e-2` as the full-budget case (11 steps, every step
+improving, so the run stops on the cap and nothing else) and
+`delta = 1e-4` as the "cap is not a target" case (6 steps under a cap of
+10, so raising the cap must change nothing). Both assertions are made
+explicitly in the tests, so if either matrix stops having the property
+the test fails loudly rather than passing vacuously.
+
+* 14:05 :issue-178:implementation:
+Implemented both asks. Design notes in
+`dev/research/refinement-cap-2026-08-19.md`, plan in
+`dev/plans/issue-178-refine-cap-and-inplace.md`.
+
+Item 1: `RefineOptions { max_steps }`, `Copy`, `Default` =
+`DEFAULT_REFINE_MAX_STEPS = 10`. Threaded through
+`solve_sparse_refined_core` and `solve_sparse_many_refined`, replacing
+both hard-coded `let max_steps = 10` sites. Chose an options struct over
+a bare `usize` parameter because the repo convention is params structs
+(`NumericParams`, `SupernodeParams`, `BunchKaufmanParams`, `LuParams`)
+and a later field addition stays source-compatible for callers that
+build from `Default`.
+
+`max_steps = 0` returns before the residual matvec, not after — otherwise
+opting out of refinement still costs a `symv` and a `norm2` per solve and
+the "all-or-nothing" complaint would only be half addressed. Verified
+bit-for-bit against `solve_sparse` / `solve_sparse_many`.
+
+Item 2: `solve_sparse_refined_core` and `solve_sparse_many_refined` now
+write into a caller `x_out` slice which *is* the `best_x` storage. That
+removes one n-length (resp. n*nrhs) allocation from the refined path
+itself, not only from the caller. Multi-RHS additionally runs its initial
+batched solve straight into `x_out` via `solve_sparse_many_into`, so the
+common "every column already converged" path does zero extra copies.
+
+`Solver` surface: `solve_into`, `solve_refined_opts`,
+`solve_refined_into`, `solve_many_into`, `solve_many_refined_opts`,
+`solve_many_refined_into`. The #131/#154 parallel-or-serial dispatch was
+duplicated between `solve_refined` and the narrow arm of
+`solve_many_refined`; both now go through one private `refine_into`, so
+the allocating and in-place forms cannot drift.
+
+Aliasing `rhs`/`x_out` (issue #178 asks for it to be supported or
+explicitly rejected): it is neither — it is unrepresentable, since
+`&[f64]` and `&mut [f64]` into one allocation cannot coexist. Documented
+on each entry point rather than guarded by an unreachable runtime check.
+
+Evidence: 21 new tests in `tests/issue178_refine_cap.rs` (12) and
+`tests/issue178_solve_into.rs` (9), all passing; full suite
+`cargo test --workspace` green with 0 failures across 93 test binaries;
+`cargo clippy --all-targets -- -D warnings` clean.

--- a/dev/plans/issue-178-refine-cap-and-inplace.md
+++ b/dev/plans/issue-178-refine-cap-and-inplace.md
@@ -1,0 +1,125 @@
+# Plan: caller-capped refinement + in-place solves (issue #178)
+
+Research note: `dev/research/refinement-cap-2026-08-19.md`.
+
+Two independent deliverables. Item 1 is the substantive one.
+
+## Item 1 — `RefineOptions` cap
+
+### New public type (`src/numeric/solve.rs`, re-exported at crate root)
+
+```rust
+pub const DEFAULT_REFINE_MAX_STEPS: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefineOptions { pub max_steps: usize }
+
+impl Default for RefineOptions { /* max_steps: DEFAULT_REFINE_MAX_STEPS */ }
+impl RefineOptions { pub fn with_max_steps(max_steps: usize) -> Self }
+```
+
+### Threading
+
+`solve_sparse_refined_core` gains an `opts: RefineOptions` parameter and
+uses `opts.max_steps` in place of the hard-coded `let max_steps = 10`.
+All three existing wrappers pass `RefineOptions::default()`, so they are
+unchanged by construction.
+
+New `_opts` entry points, each the existing one plus a trailing `opts`:
+
+- `solve_sparse_refined_opts`
+- `solve_sparse_refined_parallel_opts`
+- `solve_sparse_refined_with_diagnostics_opts`
+- `solve_sparse_many_refined_opts`
+
+`solve_sparse_many_refined` gains the same parameter internally and keeps
+its four-argument signature as a `Default` wrapper.
+
+`Solver` gains `solve_refined_opts(matrix, rhs, opts)` and
+`solve_many_refined_opts(matrix, rhs, nrhs, opts)`. `Solver::solve_many_refined`'s
+`BLAS3_REFINE_THRESHOLD` dispatch threads `opts` into both arms — the wide
+batched path and the narrow per-column loop.
+
+### `max_steps = 0` fast path
+
+After the initial solve, when `opts.max_steps == 0` and diagnostics are
+off, return immediately — before the residual matvec. This makes `k = 0`
+the same *computation* as `solve_sparse`, not just the same answer.
+Under diagnostics, `steps[0]` is still emitted (the matvec is the point
+there), and the loop simply does not run.
+
+Same treatment in the multi-RHS path: return the initial batched solve
+before the per-column residual sweep.
+
+## Item 2 — in-place entry points
+
+### Free functions (`src/numeric/solve.rs`)
+
+- `solve_sparse_into(factors, rhs, x_out)` — public wrapper over the
+  existing `pub(super) solve_sparse_into_ws`, building the workspace.
+- `solve_sparse_refined_core` writes the best iterate into a caller
+  `x_out: &mut [f64]` and returns only `Option<RefinementDiagnostics>`;
+  `x_out` *is* the `best_x` storage, so the refined path loses an
+  `n`-length allocation. The allocating wrappers become
+  `let mut x = vec![0.0; n]; core(..., &mut x)?; Ok(x)`.
+- `solve_sparse_many_refined_into(matrix, factors, rhs, nrhs, x_out, opts)`
+  — same restructuring for the multi-RHS loop.
+
+### `Solver` methods
+
+| allocating | in-place |
+|---|---|
+| `solve` | `solve_into(rhs, x_out)` |
+| `solve_refined` | `solve_refined_into(matrix, rhs, x_out, opts)` |
+| `solve_many` | `solve_many_into(rhs, nrhs, x_out)` |
+| `solve_many_refined` | `solve_many_refined_into(matrix, rhs, nrhs, x_out, opts)` |
+
+The refined `_into` variants take `opts` rather than spawning a second
+`_into_opts` name; `RefineOptions::default()` reproduces the allocating
+twin exactly.
+
+Every `_into` validates `x_out.len()` and returns
+`FeralError::DimensionMismatch` — never a panic, never a silent partial
+write. `NoFactor` precedence is unchanged (checked before dimensions, as
+the allocating twins do).
+
+Aliasing `rhs` / `x_out` is statically unrepresentable in safe Rust
+(`&[f64]` and `&mut [f64]` into one allocation cannot coexist). Documented
+on each `_into` method; no runtime check, because there is no reachable
+state to check for.
+
+## Tests (written before the implementation)
+
+Mapping to issue #178's verification list:
+
+1. **Cap is honoured.** On an ill-conditioned matrix whose default run
+   returns `steps.len() == 11`, the same solve under `k = 1` returns
+   `steps.len() == 2` — exactly one correction. Also `k = 3` -> 4.
+2. **Cap is a cap, not a target.** A well-conditioned system that exits
+   early under `k = 10` returns the identical step count and identical
+   `x` under a much larger `k` — raising the cap adds no work.
+3. **`k = 0` equals `solve_sparse` bit-for-bit** on the same factor
+   (`to_bits()` comparison, not a tolerance).
+4. **Best-iterate contract under any `k`.** For `k` in `0..=10`, the
+   returned residual norm is `<=` the unrefined solve's, and the returned
+   iterate matches the diagnostics' `returned_step`.
+5. **All four for the multi-RHS path**, with per-column independence:
+   a two-column RHS whose columns need different step counts must behave
+   the same capped as the single-RHS refiner does per column.
+6. **In-place bit-identity.** Each `_into` variant equals its allocating
+   twin bit-for-bit (`to_bits()`), on the same factor and RHS.
+7. **In-place dimension errors.** A wrong-length `x_out` returns
+   `DimensionMismatch`, and a no-factor solver returns `NoFactor` first.
+
+The ill-conditioned matrix for tests 1 and 4 must be one that genuinely
+runs the full budget under default options; the test asserts
+`steps.len() == 11` on the default run first, so it fails loudly rather
+than silently vacuously if the matrix stops being hard.
+
+## Out of scope
+
+- Changing any default. `DEFAULT_REFINE_MAX_STEPS` stays 10.
+- The C ABI. `feral_solve` already solves in place into its `rhs` buffer
+  and exposes no refinement knob; adding one is a separate ask.
+- pounce-side acceptance (issue #178 items 6 and 7) — the reporter runs
+  those against a build of this branch.

--- a/dev/research/refinement-cap-2026-08-19.md
+++ b/dev/research/refinement-cap-2026-08-19.md
@@ -1,0 +1,172 @@
+# Caller-capped iterative refinement (issue #178)
+
+Date: 2026-08-19. Motivating report: [feral#178], drawn from [pounce#698].
+
+## The question
+
+FERAL's sparse iterative refinement runs a fixed budget of up to 10
+correction steps. Is that budget right for *every* caller, and if not,
+what is the smallest interface change that lets a caller pick its own?
+
+## Why a fixed budget is defensible, and where it stops being so
+
+The 10-step budget is not arbitrary. It is MUMPS's `ICNTL(10)` default,
+and `dev/journal/2026-04-18-06.org` measured that below 10 some
+near-rank-deficient KKT matrices (CERI651C/ELS, HAHN1, MEYER3NE) bounce
+in and out of the machine-precision basin before settling. The same
+session added the 2-strike `max_stagnant_steps` plateau exit so the
+easy-case cost is not 10 steps for everyone. Both are still in place.
+
+That reasoning holds for a caller who solves `Ax = b` and *keeps the
+answer*. It does not hold for a caller that is itself iterating on the
+same system.
+
+An interior-point method is exactly that caller. Ipopt's
+`PDFullSpaceSolver` runs its own refinement loop over the augmented
+system (`min_refinement_steps = 1`, `max_refinement_steps = 10`,
+`residual_ratio_max = 1e-10`), computing the residual after each of its
+own back-solves and deciding from it whether to continue. When each of
+*those* back-solves is a `Solver::solve_refined`, the two loops nest:
+up to 10 x 11 = 110 substitution passes and 100 matvecs for one
+augmented-system solve.
+
+The loops are not redundant in a way that cancels. The outer loop owns
+the convergence criterion — it computes the residual ratio the host
+actually cares about. The inner loop drives a residual nobody consults
+toward a tolerance nobody set, and the host pays for every step of it.
+
+## Evidence
+
+From pounce#698, Observation 5. pounce 0.10.0 against feral 0.15.1, one
+direct-collocation NLP: 59 939 variables, 58 271 equality constraints,
+augmented system 118 276 x 118 276, ~1.09 M nonzeros,
+`hessian_approximation = limited-memory`. Same build, same options; only
+pounce's `feral_refine` switch differs.
+
+| | refine on | refine off | MA57 |
+|---|---|---|---|
+| Status | Optimal | Optimal | Optimal |
+| Iterations | 186 | 191 | 170 |
+| Back-solve | 147.3 s | 58.3 s | 22.3 s |
+| Factorization | 92.3 s | 82.1 s | 27.6 s |
+| Wall | 487.2 s | 387.9 s | 267.5 s |
+
+Turning the inner loop off cut back-solve 60% and wall time 20% *despite
+five more IPM iterations*. Per-iteration back-solve 0.792 s -> 0.305 s.
+
+Two things are worth stating plainly rather than glossed:
+
+- This is not the stagnation exit being absent. The 2-strike rule from
+  2026-04-18-06 is present in the measured 0.15.1 and the cost above is
+  what remains after it. Both `max_steps = 10` sites and the 2-strike
+  exit are unchanged on `main` at 0.16.0.
+- The accuracy case for the inner loop is *not visible* in these
+  numbers. The unrefined run reached an objective closer to the MA57
+  reference (7.4664668011e+01 vs 7.4678926542e+01, reference
+  7.4661943200e+01) than the refined run. The reporter does not read a
+  mechanism into the sign of that and neither do we; the honest summary
+  is that these runs do not show the inner loop buying accuracy.
+
+Nor is it a threading artefact: with `FERAL_PARALLEL=0` the back-solve is
+marginally *faster* serial (0.732 vs 0.792 s/iter). Threads help the
+factorization (1.21x), not this.
+
+## Why the default must not change
+
+pounce defaults `feral_refine` to on for a documented reason: the
+`pinene_3200` model's IPM tail stalls when the residual floor left by
+cascade-break's L-factor perturbation goes uncorrected. That is a real
+case where *some* correction is required. Zero steps loses it.
+
+So the shape of the problem is not "10 is too many" — it is that the
+only two values available are 10 and 0. A cap of `k = 1` is the value
+neither loop can currently express, and is very plausibly enough for
+`pinene_3200` at a tenth of the cost. Establishing that is pounce-side
+work (issue #178 acceptance items 6 and 7); FERAL's job is to make `k`
+expressible.
+
+Conclusion: add a per-call cap, default it to today's 10, change no
+default anywhere.
+
+## Interface shape
+
+Three candidates were considered.
+
+1. **A bare `max_steps: usize` parameter** on new `*_capped` entry
+   points. Smallest possible diff. Rejected because the next tunable
+   anyone asks for (a caller-set residual target, a stagnation budget)
+   forces either another parameter on every entry point or a second
+   round of renaming.
+2. **A `Solver`-level setting** (`set_refine_max_steps`). Rejected: the
+   ask is explicitly per-call, and a stateful cap on a `&self` solve
+   would make `solve_refined` non-reentrant in a way it is not today.
+3. **A small options struct**, `RefineOptions`, `Copy`, `Default`
+   reproducing today's behavior. Chosen. It matches the established
+   repo convention (`NumericParams`, `SupernodeParams`,
+   `BunchKaufmanParams`, `LuParams` are all params structs), and adding
+   a field later is backward compatible for callers that construct it
+   from `Default`.
+
+`RefineOptions::max_steps` counts *correction* steps, not total
+substitution passes: the initial solve always happens, so a call runs at
+most `1 + max_steps` passes. This matches how `RefinementDiagnostics`
+already numbers its steps (`steps[0]` is the unrefined solve), so the
+observable the reporter proposed to verify against needs no
+reinterpretation.
+
+`max_steps = 0` must be the same computation as an unrefined solve, not
+merely the same answer. That means the residual matvec and its norm have
+to be skipped too, not computed and discarded — otherwise `k = 0` costs
+a matvec more than `solve_sparse` and the "all-or-nothing" complaint is
+only half addressed. The one exception is the diagnostics entry point,
+which must still emit `steps[0]`; there the matvec is the point.
+
+## Precedence: a cap is a cap, not a target
+
+The existing exits — the `eps*sqrt(n)` relative-residual target, the
+100x divergence guard, the 2-strike plateau — all keep priority over
+`max_steps`. A well-conditioned system that converges in one step must
+still return after one step under `k = 10`. This falls out of the loop
+structure (`for step in 1..=max_steps` with the convergence test at the
+top of the body), but it is worth an explicit test because it is the
+property that makes the cap safe to hand to callers: raising `k` can
+never *add* work on a system that has already converged.
+
+Similarly the best-iterate contract is unaffected. The returned `x` is
+the iterate with the smallest `||r||_2` seen, which under any `k >= 0`
+includes the unrefined solve. A cap therefore cannot return an answer
+worse than `solve_sparse`'s — the guarantee stated in
+`solve_sparse_refined`'s doc comment holds for every `k`.
+
+## The in-place ask
+
+Independent and much smaller. Every `Solver` solve entry point returns an
+owned `Vec`; a host that already owns its RHS buffer pays an allocation
+plus a copy-back per back-solve — `dim x nrhs` doubles, ~946 KB at the
+dimension above. The internals already have the shape:
+`solve_sparse_into_ws` and `solve_sparse_many_into` take an out-slice.
+
+Two notes on doing this honestly:
+
+- The refined paths should write the *best iterate* directly into the
+  caller's slice rather than filling a `Vec` and copying at the end.
+  Using `x_out` as the `best_x` storage removes one `n`-length
+  allocation per call from the refined path itself, not just from the
+  caller. The working iterate `x` still needs its own buffer.
+- Aliasing `rhs` and `x_out`: issue #178 asks for it to be "supported or
+  rejected explicitly rather than silently wrong". In safe Rust it is
+  neither — it is *unrepresentable*, because `&[f64]` and `&mut [f64]`
+  into the same allocation cannot coexist. That is a stronger guarantee
+  than a runtime check, and the right response is to document it rather
+  than to add an unreachable branch. A C-ABI caller passing one pointer
+  twice is a different question, and the C ABI (`feral_solve`) already
+  solves in place into its own `rhs` buffer, so it does not arise there.
+
+## References
+
+- [feral#178](https://github.com/jkitchin/feral/issues/178)
+- [pounce#698](https://github.com/jkitchin/pounce/issues/698), Observation 5
+- `dev/journal/2026-04-18-06.org` — the 2-strike plateau exit and the
+  cap=2 / cap=3 / two-tier / 1-strike / 2-strike bench panel
+- Wachter & Biegler 2006; Ipopt `IpPDFullSpaceSolver.cpp` (the host loop)
+- MUMPS `ICNTL(10)` — origin of the 10-step default

--- a/dev/sessions/2026-08-19-01.md
+++ b/dev/sessions/2026-08-19-01.md
@@ -1,0 +1,224 @@
+# Session 2026-08-19-01
+
+## BENCHMARK NOT COMPARABLE THIS SESSION — corpus absent
+
+Reported first, per the hard rule in CLAUDE.md, because the honest
+statement is "not measured", not "unchanged".
+
+`cargo run --bin bench --release` ran to completion, but
+`data/benchmark-config.toml` is **not present in this container**, so the
+harness fell back to its 8 synthetic matrices. Both Phase 2.8.1 exit
+partitions report `count = 0`, verdict `N/A`:
+
+    partition                 count   p90   target  verdict
+    dense  small-frontal (<200)   0     -    <= 2.0    N/A
+    dense  medium (<500)          0     -    <= 3.0    N/A
+    sparse small-frontal (<200)   0     -    <= 2.0    N/A
+    sparse medium (<500)          0     -    <= 3.0    N/A
+
+There is therefore **no comparison against 2026-08-15-02's numbers**
+(1.61 / 2.00 / 1.67 / 1.67). Not a regression and not an improvement —
+not measured. What did run passed: 2/2 inertia match vs MUMPS, 2/2
+residual pass, worst residual 1.26e-16 (densecol_kkt_300_0000).
+
+The changes this session are additive API surface with `Default`-valued
+wrappers proven bit-identical to the previous entry points, so the
+factor-ratio partitions are not expected to move; but "not expected to
+move" is a prediction, not a measurement, and it should be checked on a
+machine that has the corpus.
+
+## Goal
+
+Fix [issue #178](https://github.com/jkitchin/feral/issues/178), filed
+from [pounce#698](https://github.com/jkitchin/pounce/issues/698). Two
+independent asks:
+
+1. A caller-supplied cap on iterative-refinement correction steps. An
+   interior-point host runs its own refinement loop over the same
+   augmented system, so FERAL's inner 10-step budget is work whose
+   residual nobody consults — measured at 60 % of back-solve time on a
+   118 276-dimension KKT system.
+2. In-place (`*_into`) solve entry points, so a host that owns its
+   right-hand-side buffer stops paying an allocation plus copy-back per
+   back-solve.
+
+## Accomplished
+
+Both, plus the research note and plan the lifecycle requires.
+
+### Item 1 — `RefineOptions`
+
+`RefineOptions { max_steps }` (`Copy`, `Default` =
+`DEFAULT_REFINE_MAX_STEPS = 10`) replaces the two hard-coded
+`let max_steps = 10` sites — `solve_sparse_refined_core` and
+`solve_sparse_many_refined`. New entry points, all with the existing
+names preserved as `Default` wrappers:
+
+- `solve_sparse_refined_opts`, `solve_sparse_refined_parallel_opts`,
+  `solve_sparse_refined_with_diagnostics_opts`,
+  `solve_sparse_many_refined_opts`
+- `Solver::solve_refined_opts`, `Solver::solve_many_refined_opts`
+
+**No default changed.** Issue #178 explicitly does not ask for one, and
+pounce cannot use `k = 0` either (its `pinene_3200` model stalls without
+some correction), so the fix is that `k` becomes expressible — not that
+10 becomes smaller.
+
+`max_steps = 0` returns *before* the residual matvec, not after, so
+opting out of refinement costs what `solve_sparse` costs. The
+diagnostics entry point is the deliberate exception: `steps[0]` carries
+that residual.
+
+### Item 2 — in-place entry points
+
+| allocating | in-place |
+|---|---|
+| `Solver::solve` | `solve_into(rhs, x_out)` |
+| `Solver::solve_refined` | `solve_refined_into(matrix, rhs, x_out, opts)` |
+| `Solver::solve_many` | `solve_many_into(rhs, nrhs, x_out)` |
+| `Solver::solve_many_refined` | `solve_many_refined_into(matrix, rhs, nrhs, x_out, opts)` |
+
+plus free functions `solve_sparse_into`, `solve_sparse_refined_into`,
+`solve_sparse_refined_parallel_into`, `solve_sparse_many_refined_into`.
+
+The refined cores now use the caller's `x_out` *as* the best-iterate
+storage, so they lost an internal `n`-length (resp. `n × nrhs`)
+allocation too; the multi-RHS refiner runs its initial batched solve
+straight into `x_out`, so its "every column already converged" fast path
+copies nothing.
+
+The `#131` Gap A / `#154` parallel-or-serial dispatch had been duplicated
+between `Solver::solve_refined` and the narrow arm of
+`solve_many_refined`. Both now go through one private `refine_into`, so
+the allocating and in-place forms cannot drift and the cap reaches every
+arm — including the `nrhs = 2` predictor-corrector shape below
+`BLAS3_REFINE_THRESHOLD`, which is what an IPM host actually calls.
+
+**Aliasing.** Issue #178 asks that aliasing `rhs` and `x_out` be
+"supported or rejected explicitly rather than silently wrong". It is
+neither: it is *unrepresentable*, because `&[f64]` and `&mut [f64]`
+into one allocation cannot coexist in safe Rust. That is stronger than a
+runtime check, so it is documented on each entry point rather than
+guarded by an unreachable branch.
+
+### Evidence
+
+21 new tests, one per item of issue #178's verification list:
+`tests/issue178_refine_cap.rs` (12) and `tests/issue178_solve_into.rs`
+(9). Full suite `cargo test --workspace` green — 0 failures across 93
+test binaries. `cargo clippy --all-targets -- -D warnings` clean.
+`cargo fmt --check` clean. Pre-commit hooks installed and passing on
+every commit.
+
+The test oracle for "a run that uses the full budget" needed work and is
+worth recording. Nothing merely ill-conditioned reaches 11 steps —
+probed the existing ill-conditioned KKT (1 step), a singular 3×3 (3),
+Hilbert n = 8…40 (3–7), and tiny-(1,1)-block KKTs (1). When the factor
+is *exact*, refinement bottoms out on roundoff and the 2-strike plateau
+fires. The case the cap exists for is a factor that is a genuinely
+perturbed approximate inverse, where refinement converges *linearly* —
+directly constructible because the API takes matrix and factor
+separately. A tridiagonal n = 20 refined against a 1 %-perturbed factor
+runs all 10 corrections with every step improving; the same at 0.01 %
+converges in 6. Both properties are asserted explicitly, so the tests
+fail loudly rather than passing vacuously if either matrix changes.
+
+Direct measurement of the change (20 reps, release, **one trial — no
+noise floor established, treat as indicative**):
+
+    matrix                  n      steps  bare      k=0    k=1    k=10
+    VESUVIO_0021          3083     5      0.077 ms  1.03x  3.07x  7.31x
+    nuffield2_trap_iter1  26649    3      9.63 ms   1.07x  2.13x  3.00x
+    twirism1_kkt           745     3      0.087 ms  0.72x  2.04x  3.19x
+    sawpath_kkt           1575     3      0.069 ms  0.91x  2.16x  3.16x
+
+`k = 0` sits within the bare solve's own noise on every row, confirming
+the pre-matvec early return. On VESUVIO_0021 — a pounce KKT that uses 4
+corrections — `k = 1` is 3.07× bare against the default's 7.31×, a 2.4×
+cut in per-call refined-solve cost, the same direction and rough
+magnitude as pounce#698's independently measured 2.6×. The three
+matrices that stop at 3 steps do so via the plateau exit, so their
+default is already near `k = 2` and the cap has less to give — the
+expected shape.
+
+## Benchmark Results
+
+```
+FERAL benchmark harness
+  ordering: default (symbolic_factorize heuristic)
+  scaling: default (SupernodeParams::default)
+Loading matrices from data/benchmark-config.toml ... not found
+
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10           21            1     (10, 0, 0)
+spd_50             50           45            2     (50, 0, 0)
+spd_100           100          220            5    (100, 0, 0)
+spd_200           200          926           41    (200, 0, 0)
+kkt_10_3           13            5            0     (10, 3, 0)
+kkt_30_10          40           31            1    (30, 10, 0)
+kkt_50_15          65           89            2    (50, 15, 0)
+kkt_100_30        130          339            7   (100, 30, 0)
+
+8 matrices benchmarked
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+```
+
+## Decisions Made
+
+- The refinement step budget becomes a **per-call** parameter carried by
+  an options struct, not a bare `usize` argument and not a `Solver`-level
+  setting. Recorded in `dev/decisions.md`.
+
+## Abandoned Approaches
+
+Nothing was implemented and then abandoned. Two interface shapes were
+rejected on paper before any code — a bare `max_steps: usize` parameter
+and a stateful `Solver::set_refine_max_steps` — with the reasoning in
+`dev/research/refinement-cap-2026-08-19.md` and the decision entry.
+Nothing to add to `dev/tried-and-rejected.md`: that log is for
+approaches that were tried and failed, and neither was tried.
+
+## Next Session Should
+
+1. **Re-run the bench on a machine that has the corpus.** This session
+   produced no p90 numbers, so the 2026-08-15-02 comparison is still
+   open. While there, the action carried from that session is also
+   still open: establish the bench's noise floor by running N times on
+   an unchanged binary and record a minimum-detectable-difference, so
+   sub-0.15 p90 deltas stop being over-read.
+2. **Hand issue #178 items 6 and 7 back to pounce.** The reporter offered
+   to run them against a build of this branch: the 118 276-dimension
+   model with `k = 1` should land near the 58.3 s "refine off" back-solve
+   rather than 147.3 s, and `pinene_3200` must still converge without the
+   tail stall that motivated `refine: true`. Item 7 is the one that
+   decides whether pounce can change its own default.
+3. **Consider whether the C ABI should expose the cap.** `feral_solve`
+   routes through `Solver::solve_many_refined` and has no refinement
+   knob; it was left alone deliberately (out of scope for #178, whose
+   consumer uses the Rust API). If another C consumer appears, this is
+   the natural follow-up.
+4. **Consider a `RefineOptions` residual target.** The struct exists
+   partly so this is additive when someone asks: a host that has its own
+   tolerance may want to set it rather than inherit `ε·√n`. Not asked
+   for yet — do not build it speculatively.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,10 @@ pub use numeric::factorize::{
     factorize_multifrontal_with_schur, LdltExport, NumericParams, ProfileReport, SchurBlock,
 };
 pub use numeric::solve::{
-    solve_sparse, solve_sparse_refined, solve_sparse_refined_with_diagnostics,
-    RefinementDiagnostics, RefinementStep,
+    solve_sparse, solve_sparse_into, solve_sparse_refined, solve_sparse_refined_into,
+    solve_sparse_refined_opts, solve_sparse_refined_with_diagnostics,
+    solve_sparse_refined_with_diagnostics_opts, RefineOptions, RefinementDiagnostics,
+    RefinementStep, DEFAULT_REFINE_MAX_STEPS,
 };
 pub use numeric::solver::{FactorStats, FactorStatus, QualityLevel, Solver};
 pub use sparse::csc::{CscMatrix, CscPattern};

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -70,6 +70,36 @@ pub fn solve_sparse(factors: &SparseFactors, rhs: &[f64]) -> Result<Vec<f64>, Fe
     Ok(x)
 }
 
+/// In-place form of [`solve_sparse`]: writes the solution into `x_out`
+/// instead of returning an owned `Vec` (issue #178 item 2).
+///
+/// Bit-for-bit identical to [`solve_sparse`] on the same factor and
+/// right-hand side. Returns [`FeralError::DimensionMismatch`] when
+/// `x_out.len() != factors.n` — never panics, and never leaves a partial
+/// write behind a length error.
+///
+/// Aliasing `rhs` and `x_out` is unrepresentable: `&[f64]` and
+/// `&mut [f64]` borrowing one allocation cannot coexist, so the compiler
+/// rejects the aliased call rather than this function having to.
+pub fn solve_sparse_into(
+    factors: &SparseFactors,
+    rhs: &[f64],
+    x_out: &mut [f64],
+) -> Result<(), FeralError> {
+    let n = factors.n;
+    if x_out.len() != n {
+        return Err(FeralError::DimensionMismatch {
+            expected: n,
+            got: x_out.len(),
+        });
+    }
+    if n == 0 && rhs.is_empty() {
+        return Ok(());
+    }
+    let mut ws = SolveWorkspace::for_factors(factors);
+    solve_sparse_into_ws(factors, rhs, x_out, &mut ws)
+}
+
 // N5 (`dev/research/repo-review-2026-06-09.md`) reproducing-test
 // instrumentation: counts `SolveWorkspace` constructions so a white-box
 // test can prove the condition estimator pools one workspace across its
@@ -1659,6 +1689,82 @@ fn gemm_scalar_block(
     }
 }
 
+/// Default cap on iterative-refinement **correction** steps: 10.
+///
+/// MUMPS's `ICNTL(10)` default. Below this, some near-rank-deficient KKT
+/// matrices (CERI651C/ELS, HAHN1, MEYER3NE) bounce in and out of the
+/// machine-precision basin before settling — see
+/// `dev/journal/2026-04-18-06.org`. Issue #178 makes the cap settable
+/// per call but explicitly does **not** change this default.
+pub const DEFAULT_REFINE_MAX_STEPS: usize = 10;
+
+/// Per-call knobs for the sparse iterative-refinement entry points.
+///
+/// `Default` reproduces FERAL's historical behavior exactly, so
+/// `solve_sparse_refined(a, f, b)` and
+/// `solve_sparse_refined_opts(a, f, b, RefineOptions::default())` are
+/// bit-for-bit identical.
+///
+/// # Why a cap exists (issue #178)
+///
+/// The 10-step budget is right for a caller that solves `Ax = b` and
+/// keeps the answer. It is wrong for a caller that is *itself* running
+/// iterative refinement over the same system — an interior-point method
+/// is exactly that. Ipopt's `PDFullSpaceSolver` computes the residual
+/// after each of its own back-solves and decides from it whether to
+/// continue; when each of those back-solves is a `solve_refined`, the
+/// two loops nest and one augmented-system solve can cost up to
+/// `10 × 11 = 110` substitution passes. The outer loop owns the
+/// convergence criterion; the inner loop drives a residual nobody
+/// consults toward a tolerance nobody set. Measured on a 118 276 × 118 276
+/// augmented system, that inner loop was 60 % of back-solve time
+/// (147.3 s vs 58.3 s) — see `dev/research/refinement-cap-2026-08-19.md`.
+///
+/// # Semantics
+///
+/// `max_steps` counts *corrections*, not total substitution passes: the
+/// initial solve always happens, so a call runs at most `1 + max_steps`
+/// passes. This matches how [`RefinementDiagnostics`] numbers its steps
+/// (`steps[0]` is the unrefined solve), so a run under `max_steps = k`
+/// yields at most `k + 1` entries.
+///
+/// It is a **cap, not a target**. The `ε·√n` relative-residual target,
+/// the 100× divergence guard, and the 2-strike plateau exit all keep
+/// priority, so raising `max_steps` can never add work to a system that
+/// has already converged. And the best-iterate contract is preserved
+/// under every value: the returned `x` is the iterate with the smallest
+/// `‖r‖₂` seen, which always includes the unrefined solve, so no cap can
+/// return an answer worse than [`solve_sparse`]'s.
+///
+/// `max_steps = 0` is the unrefined solve, bit-for-bit — and costs the
+/// same, since the residual matvec is skipped rather than computed and
+/// discarded. (Under the diagnostics entry point the matvec still runs:
+/// `steps[0]` is the point there.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefineOptions {
+    /// Maximum number of correction steps. See the type-level docs.
+    pub max_steps: usize,
+}
+
+impl Default for RefineOptions {
+    fn default() -> Self {
+        Self {
+            max_steps: DEFAULT_REFINE_MAX_STEPS,
+        }
+    }
+}
+
+impl RefineOptions {
+    /// Options capping refinement at `max_steps` correction steps.
+    ///
+    /// `RefineOptions::with_max_steps(1)` is the interior-point host's
+    /// case: one correction per call, leaving the convergence decision to
+    /// the host's own refinement loop.
+    pub fn with_max_steps(max_steps: usize) -> Self {
+        Self { max_steps }
+    }
+}
+
 /// Solve A·x = rhs using the sparse factorization with iterative refinement.
 ///
 /// Mirrors `crate::dense::solve::solve_refined` for the multifrontal path.
@@ -1691,8 +1797,39 @@ pub fn solve_sparse_refined(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<Vec<f64>, FeralError> {
-    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, false)?;
+    solve_sparse_refined_opts(matrix, factors, rhs, RefineOptions::default())
+}
+
+/// [`solve_sparse_refined`] with a caller-supplied correction-step cap
+/// (issue #178). `RefineOptions::default()` is bit-for-bit identical to
+/// [`solve_sparse_refined`]; see [`RefineOptions`] for what the cap does
+/// and does not override.
+pub fn solve_sparse_refined_opts(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    opts: RefineOptions,
+) -> Result<Vec<f64>, FeralError> {
+    let mut x = vec![0.0; factors.n];
+    solve_sparse_refined_core(matrix, factors, rhs, &mut x, false, false, opts)?;
     Ok(x)
+}
+
+/// In-place form of [`solve_sparse_refined_opts`]: writes the
+/// best-residual iterate into `x_out` (issue #178 item 2).
+///
+/// `x_out` *is* the best-iterate storage, so this saves the refiner an
+/// `n`-length allocation on top of saving the caller the copy-back.
+/// Returns [`FeralError::DimensionMismatch`] when `x_out.len() != factors.n`.
+pub fn solve_sparse_refined_into(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    x_out: &mut [f64],
+    opts: RefineOptions,
+) -> Result<(), FeralError> {
+    solve_sparse_refined_core(matrix, factors, rhs, x_out, false, false, opts)?;
+    Ok(())
 }
 
 /// Iterative refinement using the tree-parallel contribution-block solve
@@ -1708,8 +1845,32 @@ pub fn solve_sparse_refined_parallel(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<Vec<f64>, FeralError> {
-    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, true)?;
+    solve_sparse_refined_parallel_opts(matrix, factors, rhs, RefineOptions::default())
+}
+
+/// [`solve_sparse_refined_parallel`] with a caller-supplied
+/// correction-step cap (issue #178).
+pub fn solve_sparse_refined_parallel_opts(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    opts: RefineOptions,
+) -> Result<Vec<f64>, FeralError> {
+    let mut x = vec![0.0; factors.n];
+    solve_sparse_refined_core(matrix, factors, rhs, &mut x, false, true, opts)?;
     Ok(x)
+}
+
+/// In-place form of [`solve_sparse_refined_parallel_opts`].
+pub fn solve_sparse_refined_parallel_into(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    x_out: &mut [f64],
+    opts: RefineOptions,
+) -> Result<(), FeralError> {
+    solve_sparse_refined_core(matrix, factors, rhs, x_out, false, true, opts)?;
+    Ok(())
 }
 
 /// Per-step diagnostic data emitted by
@@ -1782,7 +1943,25 @@ pub fn solve_sparse_refined_with_diagnostics(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<(Vec<f64>, RefinementDiagnostics), FeralError> {
-    let (x, diag) = solve_sparse_refined_core(matrix, factors, rhs, true, false)?;
+    solve_sparse_refined_with_diagnostics_opts(matrix, factors, rhs, RefineOptions::default())
+}
+
+/// [`solve_sparse_refined_with_diagnostics`] with a caller-supplied
+/// correction-step cap (issue #178).
+///
+/// This is the observable the cap is verified against: a run under
+/// `max_steps = k` returns at most `k + 1` entries in
+/// [`RefinementDiagnostics::steps`], `steps[0]` being the unrefined
+/// solve. Unlike the non-diagnostic entry points, `max_steps = 0` still
+/// computes the initial residual — emitting `steps[0]` is the point.
+pub fn solve_sparse_refined_with_diagnostics_opts(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    opts: RefineOptions,
+) -> Result<(Vec<f64>, RefinementDiagnostics), FeralError> {
+    let mut x = vec![0.0; factors.n];
+    let diag = solve_sparse_refined_core(matrix, factors, rhs, &mut x, true, false, opts)?;
     // `with_diagnostics = true` always yields `Some`; if it ever doesn't,
     // that's a logic bug — `expect` is fine in test code, but per CLAUDE.md
     // we use Result in src/. Return DimensionMismatch as a defensive
@@ -1794,18 +1973,30 @@ pub fn solve_sparse_refined_with_diagnostics(
     Ok((x, diag))
 }
 
+/// Shared refinement loop behind every `solve_sparse_refined*` entry
+/// point. Writes the best-residual iterate into `x_out` — which doubles
+/// as the `best_x` storage, so the refined path holds one working vector
+/// and one residual vector, not three.
 fn solve_sparse_refined_core(
     matrix: &CscMatrix,
     factors: &SparseFactors,
     rhs: &[f64],
+    x_out: &mut [f64],
     with_diagnostics: bool,
     parallel_cb: bool,
-) -> Result<(Vec<f64>, Option<RefinementDiagnostics>), FeralError> {
+    opts: RefineOptions,
+) -> Result<Option<RefinementDiagnostics>, FeralError> {
     let n = factors.n;
     if rhs.len() != n {
         return Err(FeralError::DimensionMismatch {
             expected: n,
             got: rhs.len(),
+        });
+    }
+    if x_out.len() != n {
+        return Err(FeralError::DimensionMismatch {
+            expected: n,
+            got: x_out.len(),
         });
     }
 
@@ -1837,12 +2028,29 @@ fn solve_sparse_refined_core(
     } else {
         None
     };
-    let mut x = vec![0.0; n];
+    // The unrefined solve goes straight into the caller's buffer: it is
+    // the first (and, under `max_steps = 0`, the only) candidate for the
+    // best iterate.
     match (cb_ws.as_mut(), ws.as_mut()) {
-        (Some(cb), _) => cb.solve_into(factors, rhs, &mut x, true),
-        (None, Some(w)) => solve_sparse_into_ws(factors, rhs, &mut x, w)?,
+        (Some(cb), _) => cb.solve_into(factors, rhs, x_out, true),
+        (None, Some(w)) => solve_sparse_into_ws(factors, rhs, x_out, w)?,
         (None, None) => unreachable!("exactly one solve workspace is built"),
     }
+
+    // Issue #178: `max_steps = 0` must be the same *computation* as
+    // `solve_sparse`, not merely the same answer — otherwise a caller
+    // that opts out of refinement still pays a matvec and a norm per
+    // solve. Return before the residual is formed, and before the
+    // working iterate is even allocated. The diagnostics path is the
+    // exception: `steps[0]` carries that residual, so it runs the matvec
+    // and then simply skips the loop.
+    if opts.max_steps == 0 && !with_diagnostics {
+        return Ok(None);
+    }
+
+    // `x` is the working iterate the corrections accumulate into;
+    // `x_out` keeps the best one seen.
+    let mut x = x_out.to_vec();
 
     // Initial residual: compute A·x directly into r, then negate-add.
     let mut r = vec![0.0; n];
@@ -1852,7 +2060,6 @@ fn solve_sparse_refined_core(
     }
     let mut r_norm = norm2(&r);
 
-    let mut best_x = x.clone();
     let mut best_r_norm = r_norm;
     let mut stagnant_count: usize = 0;
     let mut dx = vec![0.0; n];
@@ -1870,7 +2077,13 @@ fn solve_sparse_refined_core(
     // single-strike exit kills) while still capping the easy-case cost.
     // Bench evidence (cap=2 / cap=3 / two-tier / 1-strike / 2-strike)
     // is in `dev/journal/2026-04-18-06.org`.
-    let max_steps = 10;
+    //
+    // Issue #178 made the step budget a per-call parameter
+    // (`RefineOptions::max_steps`, default `DEFAULT_REFINE_MAX_STEPS = 10`)
+    // so an interior-point host running its own refinement loop over the
+    // same system can ask for one correction instead of ten. It is a cap
+    // only: every exit below still takes priority over it.
+    let max_steps = opts.max_steps;
     let max_stagnant_steps = 2;
     let n_sqrt = (n as f64).sqrt();
     let threshold = f64::EPSILON * n_sqrt;
@@ -1927,7 +2140,7 @@ fn solve_sparse_refined_core(
         let improved = r_norm < best_r_norm;
         if improved {
             best_r_norm = r_norm;
-            best_x.copy_from_slice(&x);
+            x_out.copy_from_slice(&x);
             stagnant_count = 0;
             if with_diagnostics {
                 returned_step = step;
@@ -1970,7 +2183,7 @@ fn solve_sparse_refined_core(
     } else {
         None
     };
-    Ok((best_x, diag))
+    Ok(diag)
 }
 
 /// Multi-RHS solve with per-column iterative refinement, batched through
@@ -1992,6 +2205,40 @@ pub fn solve_sparse_many_refined(
     rhs: &[f64],
     nrhs: usize,
 ) -> Result<Vec<f64>, FeralError> {
+    solve_sparse_many_refined_opts(matrix, factors, rhs, nrhs, RefineOptions::default())
+}
+
+/// [`solve_sparse_many_refined`] with a caller-supplied correction-step
+/// cap (issue #178). The cap applies **per column**, exactly as the
+/// uncapped budget does: each column stops at the first of its own
+/// convergence, divergence, plateau, or `opts.max_steps`.
+pub fn solve_sparse_many_refined_opts(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    nrhs: usize,
+    opts: RefineOptions,
+) -> Result<Vec<f64>, FeralError> {
+    let mut x = vec![0.0; factors.n * nrhs];
+    solve_sparse_many_refined_into(matrix, factors, rhs, nrhs, &mut x, opts)?;
+    Ok(x)
+}
+
+/// In-place form of [`solve_sparse_many_refined_opts`]: writes the
+/// column-major best-iterate solution into `x_out` (issue #178 item 2).
+///
+/// `x_out` doubles as the per-column best-iterate storage, so this saves
+/// the refiner an `n × nrhs` allocation as well as the caller's
+/// copy-back. Returns [`FeralError::DimensionMismatch`] when `rhs` or
+/// `x_out` is not `n * nrhs` long.
+pub fn solve_sparse_many_refined_into(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    nrhs: usize,
+    x_out: &mut [f64],
+    opts: RefineOptions,
+) -> Result<(), FeralError> {
     let n = factors.n;
     if rhs.len() != n * nrhs {
         return Err(FeralError::DimensionMismatch {
@@ -1999,12 +2246,20 @@ pub fn solve_sparse_many_refined(
             got: rhs.len(),
         });
     }
+    if x_out.len() != n * nrhs {
+        return Err(FeralError::DimensionMismatch {
+            expected: n * nrhs,
+            got: x_out.len(),
+        });
+    }
     if nrhs == 0 || n == 0 {
-        return Ok(vec![0.0; n * nrhs]);
+        x_out.fill(0.0);
+        return Ok(());
     }
 
-    // Same constants as the single-RHS refiner (solve_sparse_refined_core).
-    let max_steps = 10;
+    // Same constants as the single-RHS refiner (solve_sparse_refined_core),
+    // including the issue #178 per-call step cap.
+    let max_steps = opts.max_steps;
     let max_stagnant_steps = 2;
     let threshold = f64::EPSILON * (n as f64).sqrt();
     let divergence_factor = 100.0;
@@ -2016,8 +2271,20 @@ pub fn solve_sparse_many_refined(
         }
     };
 
-    // Initial batched solve.
-    let mut x = solve_sparse_many(factors, rhs, nrhs)?;
+    // Initial batched solve, written straight into the caller's buffer:
+    // it is both the working iterate for the residual sweep below and
+    // the per-column best iterate. Bit-for-bit `solve_sparse_many`,
+    // which is the same call with a workspace it builds itself.
+    let mut ws = SolveManyWorkspace::for_factors(factors, nrhs);
+    solve_sparse_many_into(factors, rhs, nrhs, x_out, &mut ws)?;
+
+    // Issue #178: `max_steps = 0` is `solve_sparse_many`, and must cost
+    // the same — return before the per-column residual sweep rather than
+    // computing residuals nobody will act on.
+    if max_steps == 0 {
+        return Ok(());
+    }
+
     let mut best_rn = vec![0.0f64; nrhs];
     let mut bnorm = vec![0.0f64; nrhs];
 
@@ -2032,7 +2299,7 @@ pub fn solve_sparse_many_refined(
     let mut rc = vec![0.0f64; n];
     let mut active: Vec<usize> = Vec::new();
     for c in 0..nrhs {
-        matrix.symv(&x[c * n..(c + 1) * n], &mut rc);
+        matrix.symv(&x_out[c * n..(c + 1) * n], &mut rc);
         for i in 0..n {
             rc[i] = rhs[c * n + i] - rc[i];
         }
@@ -2043,11 +2310,13 @@ pub fn solve_sparse_many_refined(
         }
     }
     if active.is_empty() {
-        return Ok(x);
+        return Ok(());
     }
 
-    // Refinement is needed for at least one column.
-    let mut best_x = x.clone();
+    // Refinement is needed for at least one column. `x_out` holds the
+    // initial solve and from here on is the per-column *best* iterate;
+    // `x` is the working iterate the corrections accumulate into.
+    let mut x = x_out.to_vec();
     let mut stagnant = vec![0usize; nrhs];
     // Gather buffer sized to the (shrinking) active set; the leading
     // `n * active.len()` is used each step.
@@ -2084,7 +2353,7 @@ pub fn solve_sparse_many_refined(
 
             if rn < best_rn[c] {
                 best_rn[c] = rn;
-                best_x[c * n..(c + 1) * n].copy_from_slice(&x[c * n..(c + 1) * n]);
+                x_out[c * n..(c + 1) * n].copy_from_slice(&x[c * n..(c + 1) * n]);
                 stagnant[c] = 0;
             } else {
                 stagnant[c] += 1;
@@ -2102,7 +2371,7 @@ pub fn solve_sparse_many_refined(
         active = still;
     }
 
-    Ok(best_x)
+    Ok(())
 }
 
 fn norm2(v: &[f64]) -> f64 {

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -18,8 +18,9 @@ use crate::numeric::factorize::{
     FactorWorkspace, NumericParams, ProfileReport, Profiler, SparseFactors,
 };
 use crate::numeric::solve::{
-    solve_sparse, solve_sparse_many, solve_sparse_many_refined, solve_sparse_refined,
-    solve_sparse_refined_parallel, BLAS3_REFINE_THRESHOLD,
+    solve_sparse, solve_sparse_into, solve_sparse_many, solve_sparse_many_into,
+    solve_sparse_many_refined_into, solve_sparse_refined_into, solve_sparse_refined_parallel_into,
+    RefineOptions, SolveManyWorkspace, BLAS3_REFINE_THRESHOLD,
 };
 use crate::scaling::{
     mc64_value_bound_passes, pick_scaling_strategy, precompute_mc64_validity, Mc64CacheValidity,
@@ -1607,14 +1608,95 @@ impl Solver {
         }
     }
 
+    /// In-place [`Solver::solve`]: writes the solution into `x_out`
+    /// rather than returning an owned `Vec` (issue #178 item 2).
+    ///
+    /// A host that already owns its right-hand-side buffer otherwise
+    /// pays an allocation plus a copy-back of `n` doubles per
+    /// back-solve. Bit-for-bit identical to [`Solver::solve`] on the
+    /// same factor and right-hand side.
+    ///
+    /// Errors, in precedence order: [`FeralError::NoFactor`] when no
+    /// factor is stored, then [`FeralError::DimensionMismatch`] when
+    /// `x_out.len() != n`. Never panics.
+    ///
+    /// Aliasing `rhs` and `x_out` is unrepresentable in safe Rust —
+    /// `&[f64]` and `&mut [f64]` into one allocation cannot coexist — so
+    /// the compiler rejects the aliased call and this method does not
+    /// need to.
+    pub fn solve_into(&self, rhs: &[f64], x_out: &mut [f64]) -> Result<(), FeralError> {
+        match &self.last_factors {
+            Some(f) => solve_sparse_into(f, rhs, x_out),
+            None => Err(FeralError::NoFactor),
+        }
+    }
+
     /// Solve with iterative refinement against the original matrix
     /// and the stored factor. Returns `FeralError::NoFactor` if no
     /// factor is stored.
     pub fn solve_refined(&self, matrix: &CscMatrix, rhs: &[f64]) -> Result<Vec<f64>, FeralError> {
+        self.solve_refined_opts(matrix, rhs, RefineOptions::default())
+    }
+
+    /// [`Solver::solve_refined`] with a caller-supplied cap on the number
+    /// of refinement correction steps (issue #178).
+    ///
+    /// `RefineOptions::default()` is bit-for-bit identical to
+    /// [`Solver::solve_refined`]. `RefineOptions::with_max_steps(1)` is
+    /// the case an interior-point host wants: one correction per call,
+    /// leaving the convergence decision to the host's own refinement
+    /// loop, which is the loop that computes the residual ratio anyone
+    /// actually consults. See [`RefineOptions`] for the full semantics —
+    /// notably that the cap never overrides the convergence, divergence,
+    /// or plateau exits, and never returns an iterate worse than
+    /// [`Solver::solve`]'s.
+    pub fn solve_refined_opts(
+        &self,
+        matrix: &CscMatrix,
+        rhs: &[f64],
+        opts: RefineOptions,
+    ) -> Result<Vec<f64>, FeralError> {
         let f = match &self.last_factors {
             Some(f) => f,
             None => return Err(FeralError::NoFactor),
         };
+        let mut x = vec![0.0; f.n];
+        self.refine_into(matrix, f, rhs, &mut x, opts)?;
+        Ok(x)
+    }
+
+    /// In-place [`Solver::solve_refined_opts`]: writes the best-residual
+    /// iterate into `x_out` (issue #178 item 2).
+    ///
+    /// Pass `RefineOptions::default()` for the exact behavior of
+    /// [`Solver::solve_refined`]. Errors follow the same precedence as
+    /// [`Solver::solve_into`] — `NoFactor` before `DimensionMismatch`,
+    /// never a panic — and aliasing `rhs` with `x_out` is likewise
+    /// unrepresentable in safe Rust.
+    pub fn solve_refined_into(
+        &self,
+        matrix: &CscMatrix,
+        rhs: &[f64],
+        x_out: &mut [f64],
+        opts: RefineOptions,
+    ) -> Result<(), FeralError> {
+        let f = match &self.last_factors {
+            Some(f) => f,
+            None => return Err(FeralError::NoFactor),
+        };
+        self.refine_into(matrix, f, rhs, x_out, opts)
+    }
+
+    /// Shared body of the single-RHS refined entry points, so the
+    /// allocating and in-place forms cannot drift apart.
+    fn refine_into(
+        &self,
+        matrix: &CscMatrix,
+        factors: &SparseFactors,
+        rhs: &[f64],
+        x_out: &mut [f64],
+        opts: RefineOptions,
+    ) -> Result<(), FeralError> {
         // Issue #131 Gap A: when parallelism is on, refine through the
         // tree-parallel contribution-block solve (pooled across the
         // initial + correction solves). It self-gates per factor — on
@@ -1624,7 +1706,7 @@ impl Solver {
         // count and does not oversubscribe.
         //
         // Issue #154: if no pool was built, run the serial refine
-        // rather than falling through to the global pool. The previous
+        // rather than falling through to the global pool. An earlier
         // comment here stated the global-pool fall-through as
         // intentional; it is not — no pool means threads were
         // unavailable, and reaching for a different pool does not make
@@ -1632,8 +1714,9 @@ impl Solver {
         // self-gated serial core the parallel path already takes on
         // path-like trees.
         match (self.use_parallel, &self.parallel_pool) {
-            (true, Some(pool)) => pool.install(|| solve_sparse_refined_parallel(matrix, f, rhs)),
-            _ => solve_sparse_refined(matrix, f, rhs),
+            (true, Some(pool)) => pool
+                .install(|| solve_sparse_refined_parallel_into(matrix, factors, rhs, x_out, opts)),
+            _ => solve_sparse_refined_into(matrix, factors, rhs, x_out, opts),
         }
     }
 
@@ -1653,6 +1736,37 @@ impl Solver {
         }
     }
 
+    /// In-place [`Solver::solve_many`]: writes the column-major solution
+    /// into `x_out` (issue #178 item 2).
+    ///
+    /// Bit-for-bit identical to [`Solver::solve_many`]. `nrhs == 0` is a
+    /// no-op. Errors follow the same precedence as
+    /// [`Solver::solve_into`]: `NoFactor`, then `DimensionMismatch` when
+    /// `rhs` or `x_out` is not `n * nrhs` long. Never panics.
+    pub fn solve_many_into(
+        &self,
+        rhs: &[f64],
+        nrhs: usize,
+        x_out: &mut [f64],
+    ) -> Result<(), FeralError> {
+        let factors = match &self.last_factors {
+            Some(f) => f,
+            None => return Err(FeralError::NoFactor),
+        };
+        let n = factors.n;
+        if x_out.len() != n * nrhs {
+            return Err(FeralError::DimensionMismatch {
+                expected: n * nrhs,
+                got: x_out.len(),
+            });
+        }
+        if nrhs == 0 {
+            return Ok(());
+        }
+        let mut ws = SolveManyWorkspace::for_factors(factors, nrhs);
+        solve_sparse_many_into(factors, rhs, nrhs, x_out, &mut ws)
+    }
+
     /// Multi-RHS solve with per-column iterative refinement against
     /// the original matrix and the stored factor. Each column is
     /// refined independently — convergence is per-column, not all-
@@ -1664,14 +1778,67 @@ impl Solver {
         rhs: &[f64],
         nrhs: usize,
     ) -> Result<Vec<f64>, FeralError> {
-        let factors = match &self.last_factors {
-            Some(f) => f,
+        self.solve_many_refined_opts(matrix, rhs, nrhs, RefineOptions::default())
+    }
+
+    /// [`Solver::solve_many_refined`] with a caller-supplied cap on the
+    /// number of refinement correction steps (issue #178).
+    ///
+    /// The cap applies **per column**, matching the per-column
+    /// convergence this entry point already provides:
+    /// `RefineOptions::with_max_steps(1)` gives every column at most one
+    /// correction, and a column that converges sooner still stops sooner.
+    /// `RefineOptions::default()` is bit-for-bit identical to
+    /// [`Solver::solve_many_refined`].
+    pub fn solve_many_refined_opts(
+        &self,
+        matrix: &CscMatrix,
+        rhs: &[f64],
+        nrhs: usize,
+        opts: RefineOptions,
+    ) -> Result<Vec<f64>, FeralError> {
+        let n = match &self.last_factors {
+            Some(f) => f.n,
             None => return Err(FeralError::NoFactor),
         };
         if nrhs == 0 {
             return Ok(Vec::new());
         }
+        let mut out = vec![0.0; n * nrhs];
+        self.solve_many_refined_into(matrix, rhs, nrhs, &mut out, opts)?;
+        Ok(out)
+    }
+
+    /// In-place [`Solver::solve_many_refined_opts`]: writes the
+    /// column-major best-iterate solution into `x_out` (issue #178
+    /// item 2).
+    ///
+    /// Pass `RefineOptions::default()` for the exact behavior of
+    /// [`Solver::solve_many_refined`]. `nrhs == 0` is a no-op. Errors
+    /// follow the same precedence as [`Solver::solve_into`]: `NoFactor`,
+    /// then `DimensionMismatch`. Never panics.
+    pub fn solve_many_refined_into(
+        &self,
+        matrix: &CscMatrix,
+        rhs: &[f64],
+        nrhs: usize,
+        x_out: &mut [f64],
+        opts: RefineOptions,
+    ) -> Result<(), FeralError> {
+        let factors = match &self.last_factors {
+            Some(f) => f,
+            None => return Err(FeralError::NoFactor),
+        };
         let n = factors.n;
+        if x_out.len() != n * nrhs {
+            return Err(FeralError::DimensionMismatch {
+                expected: n * nrhs,
+                got: x_out.len(),
+            });
+        }
+        if nrhs == 0 {
+            return Ok(());
+        }
         if rhs.len() != n * nrhs {
             return Err(FeralError::DimensionMismatch {
                 expected: n * nrhs,
@@ -1682,22 +1849,14 @@ impl Solver {
         // #58); narrow solves (the IPM predictor-corrector, nrhs = 2)
         // keep the proven per-column loop, bit-identical.
         if nrhs >= BLAS3_REFINE_THRESHOLD {
-            return solve_sparse_many_refined(matrix, factors, rhs, nrhs);
+            return solve_sparse_many_refined_into(matrix, factors, rhs, nrhs, x_out, opts);
         }
-        let mut out = vec![0.0; n * nrhs];
         for c in 0..nrhs {
             let src = &rhs[c * n..(c + 1) * n];
-            // Same #131 Gap A dispatch as `solve_refined` (per column),
-            // with the same #154 pool-or-serial fallback.
-            let xc = match (self.use_parallel, &self.parallel_pool) {
-                (true, Some(pool)) => {
-                    pool.install(|| solve_sparse_refined_parallel(matrix, factors, src))
-                }
-                _ => solve_sparse_refined(matrix, factors, src),
-            }?;
-            out[c * n..(c + 1) * n].copy_from_slice(&xc);
+            let dst = &mut x_out[c * n..(c + 1) * n];
+            self.refine_into(matrix, factors, src, dst, opts)?;
         }
-        Ok(out)
+        Ok(())
     }
 
     /// Estimate `kappa_1(A) = ||A||_1 * ||A^{-1}||_1` via the

--- a/tests/issue178_refine_cap.rs
+++ b/tests/issue178_refine_cap.rs
@@ -1,0 +1,402 @@
+//! Issue #178 item 1 — a caller-supplied cap on iterative-refinement
+//! correction steps.
+//!
+//! An interior-point host runs its own refinement loop over the same
+//! augmented system, so FERAL's inner 10-step budget is work whose
+//! residual nobody consults. `RefineOptions::max_steps` lets that caller
+//! say "at most k corrections" per call. The default is unchanged
+//! (`DEFAULT_REFINE_MAX_STEPS == 10`).
+//!
+//! Test numbering follows the verification list in issue #178:
+//!   1. cap truncates the trajectory,
+//!   2. cap is a cap, not a target (existing exits keep priority),
+//!   3. `k = 0` equals `solve_sparse` bit-for-bit,
+//!   4. any `k` returns the best-residual iterate,
+//!   5. the same four on the multi-RHS path.
+//!
+//! Design note: `dev/research/refinement-cap-2026-08-19.md`.
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams, SparseFactors};
+use feral::numeric::solve::{
+    solve_sparse, solve_sparse_many, solve_sparse_many_refined, solve_sparse_many_refined_opts,
+    solve_sparse_refined, solve_sparse_refined_opts, solve_sparse_refined_with_diagnostics,
+    solve_sparse_refined_with_diagnostics_opts, RefineOptions, DEFAULT_REFINE_MAX_STEPS,
+};
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+/// Symmetric tridiagonal with `-1` off-diagonals and a caller-chosen
+/// diagonal, lower triangle in CSC.
+fn tridiag(n: usize, diag: impl Fn(usize) -> f64) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..n {
+        rows.push(j);
+        cols.push(j);
+        vals.push(diag(j));
+        if j + 1 < n {
+            rows.push(j + 1);
+            cols.push(j);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiag")
+}
+
+fn factorize(m: &CscMatrix) -> SparseFactors {
+    let sym = symbolic_factorize(m, &SupernodeParams::default()).expect("symbolic");
+    let (f, _) = factorize_multifrontal(m, &sym, &ldlt_params()).expect("numeric");
+    f
+}
+
+const N: usize = 20;
+
+/// The oracle for "a solve that runs the full budget".
+///
+/// FERAL's 2-strike plateau exit means a matrix factored *exactly* never
+/// reaches step 10 — refinement bottoms out on roundoff in two or three
+/// steps. The situation the cap exists for is the one where the factor is
+/// a genuinely perturbed approximate inverse (cascade-break's L-factor
+/// perturbation, static pivot perturbation), so refinement converges
+/// *linearly* and keeps improving for as long as it is allowed to run.
+///
+/// The public API takes the matrix and the factor separately, so that
+/// situation is directly constructible: factor `A + ΔA` and refine
+/// against `A`. With a 1 % diagonal perturbation the residual falls by
+/// ~3.3× per step and never reaches `ε·√n`, so the run uses all 10
+/// corrections with no stagnant step.
+///
+/// Returns `(A, factor-of-perturbed-A, rhs)`.
+fn full_budget_case() -> (CscMatrix, SparseFactors, Vec<f64>) {
+    let a = tridiag(N, |_| 2.0);
+    let perturbed = tridiag(N, |j| 2.0 + 1e-2 * (1.0 + (j as f64) * 0.01));
+    let factors = factorize(&perturbed);
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    (a, factors, rhs)
+}
+
+/// Same construction with a 100× smaller perturbation: refinement reaches
+/// the `ε·√n` target and exits on its own, well inside the budget. This
+/// is the "cap is not a target" case.
+fn early_exit_case() -> (CscMatrix, SparseFactors, Vec<f64>) {
+    let a = tridiag(N, |_| 2.0);
+    let perturbed = tridiag(N, |j| 2.0 + 1e-4 * (1.0 + (j as f64) * 0.01));
+    let factors = factorize(&perturbed);
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    (a, factors, rhs)
+}
+
+fn bits(v: &[f64]) -> Vec<u64> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+
+fn rel_residual(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0; n];
+    a.symv(x, &mut ax);
+    let mut rs = 0.0;
+    let mut bs = 0.0;
+    for i in 0..n {
+        let r = ax[i] - b[i];
+        rs += r * r;
+        bs += b[i] * b[i];
+    }
+    if bs > 0.0 {
+        (rs / bs).sqrt()
+    } else {
+        rs.sqrt()
+    }
+}
+
+/// Guard for the tests below: the default run really does use the whole
+/// budget on this case. If this ever stops holding, the cap tests that
+/// depend on it become vacuous, so it is asserted separately and loudly.
+#[test]
+fn default_run_uses_the_full_budget_on_a_perturbed_factor() {
+    let (a, f, rhs) = full_budget_case();
+    let (_, diag) = solve_sparse_refined_with_diagnostics(&a, &f, &rhs).expect("refine");
+    assert_eq!(
+        diag.steps.len(),
+        DEFAULT_REFINE_MAX_STEPS + 1,
+        "expected 1 initial + {} corrections, got {} steps: {:?}",
+        DEFAULT_REFINE_MAX_STEPS,
+        diag.steps.len(),
+        diag.steps
+            .iter()
+            .map(|s| s.relative_residual)
+            .collect::<Vec<_>>()
+    );
+    // Every step improved — no plateau exit was in play, so the run
+    // stopped on the cap and nothing else.
+    assert!(
+        diag.steps.iter().all(|s| s.improved),
+        "a step failed to improve; the run did not stop on the cap alone"
+    );
+}
+
+/// #178 verification 1 — `k` correction steps means `k + 1` entries.
+#[test]
+fn cap_truncates_the_trajectory_to_exactly_k_corrections() {
+    let (a, f, rhs) = full_budget_case();
+    for k in 0..=DEFAULT_REFINE_MAX_STEPS {
+        let (_, diag) = solve_sparse_refined_with_diagnostics_opts(
+            &a,
+            &f,
+            &rhs,
+            RefineOptions::with_max_steps(k),
+        )
+        .expect("refine");
+        assert_eq!(
+            diag.steps.len(),
+            k + 1,
+            "k = {k} should give 1 initial + {k} corrections, got {}",
+            diag.steps.len()
+        );
+    }
+}
+
+/// #178 verification 1, the specific case in the issue text: a solve that
+/// runs 11 steps by default returns exactly 2 under `k = 1` — one
+/// correction, not zero and not two.
+#[test]
+fn cap_of_one_gives_exactly_one_correction() {
+    let (a, f, rhs) = full_budget_case();
+    let (_, diag) =
+        solve_sparse_refined_with_diagnostics_opts(&a, &f, &rhs, RefineOptions::with_max_steps(1))
+            .expect("refine");
+    assert_eq!(diag.steps.len(), 2);
+    assert_eq!(diag.steps[1].step, 1);
+    assert!(
+        diag.steps[1].improved,
+        "the one correction should have improved the residual"
+    );
+    // And it is genuinely a correction: the answer differs from unrefined.
+    let unrefined = solve_sparse(&f, &rhs).expect("solve_sparse");
+    let capped =
+        solve_sparse_refined_opts(&a, &f, &rhs, RefineOptions::with_max_steps(1)).expect("refine");
+    assert_ne!(bits(&capped), bits(&unrefined));
+}
+
+/// #178 verification 2 — the cap is an upper bound, not a target. A
+/// system that converges early must return the same trajectory and the
+/// same iterate no matter how large the cap is.
+#[test]
+fn cap_is_a_cap_not_a_target() {
+    let (a, f, rhs) = early_exit_case();
+    let (x_default, d_default) =
+        solve_sparse_refined_with_diagnostics(&a, &f, &rhs).expect("refine");
+    assert!(
+        d_default.steps.len() < DEFAULT_REFINE_MAX_STEPS + 1,
+        "early-exit case unexpectedly used the whole budget ({} steps)",
+        d_default.steps.len()
+    );
+
+    for k in [DEFAULT_REFINE_MAX_STEPS, 25, 100] {
+        let (x, d) = solve_sparse_refined_with_diagnostics_opts(
+            &a,
+            &f,
+            &rhs,
+            RefineOptions::with_max_steps(k),
+        )
+        .expect("refine");
+        assert_eq!(
+            d.steps.len(),
+            d_default.steps.len(),
+            "raising the cap to {k} changed the step count"
+        );
+        assert_eq!(
+            bits(&x),
+            bits(&x_default),
+            "raising the cap to {k} changed x"
+        );
+    }
+}
+
+/// #178 verification 3 — `k = 0` is the unrefined solve, bit-for-bit.
+#[test]
+fn cap_zero_equals_solve_sparse_bit_for_bit() {
+    for (a, f, rhs) in [full_budget_case(), early_exit_case()] {
+        let plain = solve_sparse(&f, &rhs).expect("solve_sparse");
+        let capped = solve_sparse_refined_opts(&a, &f, &rhs, RefineOptions::with_max_steps(0))
+            .expect("refine");
+        assert_eq!(bits(&capped), bits(&plain));
+    }
+}
+
+/// #178 verification 4 — under any cap the returned iterate is the
+/// best-residual one, so no cap can return an answer worse than the
+/// unrefined solve.
+#[test]
+fn capped_result_is_never_worse_than_unrefined() {
+    let (a, f, rhs) = full_budget_case();
+    let unrefined_res = rel_residual(&a, &solve_sparse(&f, &rhs).expect("solve_sparse"), &rhs);
+
+    for k in 0..=DEFAULT_REFINE_MAX_STEPS {
+        let opts = RefineOptions::with_max_steps(k);
+        let (x, diag) =
+            solve_sparse_refined_with_diagnostics_opts(&a, &f, &rhs, opts).expect("refine");
+        let res = rel_residual(&a, &x, &rhs);
+        assert!(
+            res <= unrefined_res,
+            "k = {k} returned residual {res:.3e}, worse than unrefined {unrefined_res:.3e}"
+        );
+        // The returned iterate is the one `returned_step` names, and that
+        // step holds the smallest residual in the trajectory.
+        let best = diag
+            .steps
+            .iter()
+            .map(|s| s.residual_2norm)
+            .fold(f64::INFINITY, f64::min);
+        assert_eq!(diag.steps[diag.returned_step].residual_2norm, best);
+        // Non-allocating and allocating entry points agree.
+        let x2 = solve_sparse_refined_opts(&a, &f, &rhs, opts).expect("refine");
+        assert_eq!(bits(&x), bits(&x2));
+    }
+}
+
+/// The default-constructed options reproduce the existing entry points
+/// bit-for-bit — the guarantee that makes this a non-breaking change.
+#[test]
+fn default_options_are_bit_identical_to_the_uncapped_entry_points() {
+    for (a, f, rhs) in [full_budget_case(), early_exit_case()] {
+        let old = solve_sparse_refined(&a, &f, &rhs).expect("refine");
+        let new =
+            solve_sparse_refined_opts(&a, &f, &rhs, RefineOptions::default()).expect("refine");
+        assert_eq!(bits(&old), bits(&new));
+
+        let nrhs = 3;
+        let mut wide = Vec::with_capacity(N * nrhs);
+        for c in 0..nrhs {
+            for b in &rhs {
+                wide.push(b * ((c + 1) as f64));
+            }
+        }
+        let old_m = solve_sparse_many_refined(&a, &f, &wide, nrhs).expect("many refine");
+        let new_m = solve_sparse_many_refined_opts(&a, &f, &wide, nrhs, RefineOptions::default())
+            .expect("many refine");
+        assert_eq!(bits(&old_m), bits(&new_m));
+    }
+}
+
+// ---------------------------------------------------------------------
+// #178 verification 5 — the same four properties on the multi-RHS path,
+// where each column's step count is independent.
+// ---------------------------------------------------------------------
+
+/// Two columns whose refinement trajectories differ: column 0 is the
+/// full-budget case, column 1 (scaled by 1e6) converges no faster but
+/// carries a different `||b||`, and the third column is the zero RHS
+/// (exact in one solve). Built against the perturbed factor.
+fn many_case(nrhs: usize) -> (CscMatrix, SparseFactors, Vec<f64>) {
+    let (a, f, rhs) = full_budget_case();
+    let mut wide = vec![0.0; N * nrhs];
+    for c in 0..nrhs {
+        if c == nrhs - 1 {
+            continue; // last column stays the zero RHS
+        }
+        let scale = 10f64.powi(c as i32 * 3);
+        for i in 0..N {
+            wide[c * N + i] = rhs[i] * scale;
+        }
+    }
+    (a, f, wide)
+}
+
+/// `k = 0` on the multi-RHS refiner equals `solve_sparse_many`
+/// bit-for-bit, for both the per-column and the batched panel widths.
+#[test]
+fn many_cap_zero_equals_solve_sparse_many_bit_for_bit() {
+    for nrhs in [2usize, 20] {
+        let (a, f, wide) = many_case(nrhs);
+        let plain = solve_sparse_many(&f, &wide, nrhs).expect("solve_sparse_many");
+        let capped =
+            solve_sparse_many_refined_opts(&a, &f, &wide, nrhs, RefineOptions::with_max_steps(0))
+                .expect("many refine");
+        assert_eq!(bits(&capped), bits(&plain), "nrhs = {nrhs}");
+    }
+}
+
+/// Each column of the capped multi-RHS refiner equals the capped
+/// single-RHS refiner on that column, bit-for-bit — i.e. the cap applies
+/// per column, exactly as the uncapped budget does.
+#[test]
+fn many_cap_matches_the_single_rhs_refiner_per_column() {
+    let nrhs = 3;
+    let (a, f, wide) = many_case(nrhs);
+    for k in [0usize, 1, 2, 5, DEFAULT_REFINE_MAX_STEPS] {
+        let opts = RefineOptions::with_max_steps(k);
+        let many = solve_sparse_many_refined_opts(&a, &f, &wide, nrhs, opts).expect("many refine");
+        for c in 0..nrhs {
+            let col = &wide[c * N..(c + 1) * N];
+            let single = solve_sparse_refined_opts(&a, &f, col, opts).expect("refine");
+            assert_eq!(
+                bits(&many[c * N..(c + 1) * N]),
+                bits(&single),
+                "k = {k}, column {c}"
+            );
+        }
+    }
+}
+
+/// The multi-RHS cap is a cap, not a target: on the early-exit case,
+/// raising it past the point of convergence changes nothing.
+#[test]
+fn many_cap_is_a_cap_not_a_target() {
+    let nrhs = 4;
+    let (a, f, rhs) = early_exit_case();
+    let mut wide = vec![0.0; N * nrhs];
+    for c in 0..nrhs - 1 {
+        for i in 0..N {
+            wide[c * N + i] = rhs[i] * ((c + 1) as f64);
+        }
+    }
+    let base = solve_sparse_many_refined(&a, &f, &wide, nrhs).expect("many refine");
+    for k in [DEFAULT_REFINE_MAX_STEPS, 25, 100] {
+        let x =
+            solve_sparse_many_refined_opts(&a, &f, &wide, nrhs, RefineOptions::with_max_steps(k))
+                .expect("many refine");
+        assert_eq!(
+            bits(&x),
+            bits(&base),
+            "raising the multi-RHS cap to {k} changed X"
+        );
+    }
+}
+
+/// No cap can make a column worse than its unrefined solve.
+#[test]
+fn many_capped_result_is_never_worse_than_unrefined() {
+    let nrhs = 3;
+    let (a, f, wide) = many_case(nrhs);
+    let plain = solve_sparse_many(&f, &wide, nrhs).expect("solve_sparse_many");
+    for k in 0..=DEFAULT_REFINE_MAX_STEPS {
+        let x =
+            solve_sparse_many_refined_opts(&a, &f, &wide, nrhs, RefineOptions::with_max_steps(k))
+                .expect("many refine");
+        for c in 0..nrhs {
+            let col = &wide[c * N..(c + 1) * N];
+            let r_plain = rel_residual(&a, &plain[c * N..(c + 1) * N], col);
+            let r_capped = rel_residual(&a, &x[c * N..(c + 1) * N], col);
+            assert!(
+                r_capped <= r_plain,
+                "k = {k}, column {c}: capped {r_capped:.3e} worse than unrefined {r_plain:.3e}"
+            );
+        }
+    }
+}
+
+/// `RefineOptions::default()` is today's budget. Guards against a silent
+/// default change — issue #178 explicitly does not ask for one.
+#[test]
+fn the_default_budget_is_unchanged() {
+    assert_eq!(DEFAULT_REFINE_MAX_STEPS, 10);
+    assert_eq!(RefineOptions::default().max_steps, DEFAULT_REFINE_MAX_STEPS);
+}

--- a/tests/issue178_solve_into.rs
+++ b/tests/issue178_solve_into.rs
@@ -1,0 +1,216 @@
+//! Issue #178 item 2 — in-place solve entry points on `Solver`.
+//!
+//! A host that already owns its right-hand-side buffer had to accept an
+//! owned `Vec` from every solve entry point and copy it back: `dim ×
+//! nrhs` doubles per back-solve. The `*_into` variants write the solution
+//! into a caller slice instead.
+//!
+//! Verification per issue #178:
+//!   - each `_into` is bit-identical to its allocating twin,
+//!   - a dimension mismatch returns `DimensionMismatch`, never a panic,
+//!   - aliasing `rhs` / `x_out` is addressed explicitly (see the module
+//!     note below).
+//!
+//! **Aliasing.** Issue #178 asks that aliasing `rhs` and `x_out` be
+//! "supported or rejected explicitly rather than silently wrong". In safe
+//! Rust it is neither — it is unrepresentable: `&[f64]` and `&mut [f64]`
+//! borrowing one allocation cannot coexist, so no caller of these
+//! signatures can construct the aliased case. That is checked by the
+//! compiler on every build rather than by a test, which is why there is
+//! no aliasing test here. `tests/issue178_alias_rejected.rs` is not a
+//! file; the guarantee lives in the type signature.
+
+use feral::numeric::factorize::NumericParams;
+use feral::numeric::solve::RefineOptions;
+use feral::symbolic::SupernodeParams;
+use feral::{BunchKaufmanParams, CscMatrix, FeralError, Solver, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+/// Small indefinite bordered KKT — exercises 2×2 pivots, so the `_into`
+/// paths are compared on a factor whose solve is not trivially exact.
+fn kkt() -> CscMatrix {
+    CscMatrix::from_triplets(
+        6,
+        &[0, 4, 1, 5, 2, 4, 3, 5, 4, 5],
+        &[0, 0, 1, 1, 2, 2, 3, 3, 4, 5],
+        &[100.0, -1.0, 100.0, -1.0, 1e-6, 1.0, 1e-6, 1.0, -1e-4, -1e-4],
+    )
+    .expect("kkt")
+}
+
+fn solver_for(m: &CscMatrix) -> Solver {
+    let mut s = Solver::with_params(ldlt_params(), SupernodeParams::default());
+    let status = s.factor(m, None);
+    assert!(
+        s.factors().is_some(),
+        "factor failed with status {status:?}"
+    );
+    s
+}
+
+fn bits(v: &[f64]) -> Vec<u64> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+
+const RHS: [f64; 6] = [1.0, 2.0, 0.5, -0.25, -50.0, -75.0];
+
+#[test]
+fn solve_into_is_bit_identical_to_solve() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let want = s.solve(&RHS).expect("solve");
+    let mut got = vec![f64::NAN; m.n];
+    s.solve_into(&RHS, &mut got).expect("solve_into");
+    assert_eq!(bits(&got), bits(&want));
+}
+
+#[test]
+fn solve_refined_into_is_bit_identical_to_solve_refined() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let want = s.solve_refined(&m, &RHS).expect("solve_refined");
+    let mut got = vec![f64::NAN; m.n];
+    s.solve_refined_into(&m, &RHS, &mut got, RefineOptions::default())
+        .expect("solve_refined_into");
+    assert_eq!(bits(&got), bits(&want));
+}
+
+#[test]
+fn solve_refined_into_honours_the_cap() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let opts = RefineOptions::with_max_steps(0);
+    let want = s.solve(&RHS).expect("solve");
+    let mut got = vec![f64::NAN; m.n];
+    s.solve_refined_into(&m, &RHS, &mut got, opts)
+        .expect("solve_refined_into");
+    assert_eq!(bits(&got), bits(&want));
+
+    // ... and the allocating capped twin agrees.
+    let alloc = s
+        .solve_refined_opts(&m, &RHS, opts)
+        .expect("solve_refined_opts");
+    assert_eq!(bits(&alloc), bits(&want));
+}
+
+#[test]
+fn solve_many_into_is_bit_identical_to_solve_many() {
+    let m = kkt();
+    let s = solver_for(&m);
+    for nrhs in [1usize, 2, 20] {
+        let wide: Vec<f64> = (0..m.n * nrhs)
+            .map(|k| RHS[k % m.n] * (1.0 + (k / m.n) as f64))
+            .collect();
+        let want = s.solve_many(&wide, nrhs).expect("solve_many");
+        let mut got = vec![f64::NAN; m.n * nrhs];
+        s.solve_many_into(&wide, nrhs, &mut got)
+            .expect("solve_many_into");
+        assert_eq!(bits(&got), bits(&want), "nrhs = {nrhs}");
+    }
+}
+
+#[test]
+fn solve_many_refined_into_is_bit_identical_to_solve_many_refined() {
+    let m = kkt();
+    let s = solver_for(&m);
+    // Both sides of the BLAS3_REFINE_THRESHOLD (16) dispatch.
+    for nrhs in [1usize, 2, 20] {
+        let wide: Vec<f64> = (0..m.n * nrhs)
+            .map(|k| RHS[k % m.n] * (1.0 + (k / m.n) as f64))
+            .collect();
+        let want = s
+            .solve_many_refined(&m, &wide, nrhs)
+            .expect("solve_many_refined");
+        let mut got = vec![f64::NAN; m.n * nrhs];
+        s.solve_many_refined_into(&m, &wide, nrhs, &mut got, RefineOptions::default())
+            .expect("solve_many_refined_into");
+        assert_eq!(bits(&got), bits(&want), "nrhs = {nrhs}");
+    }
+}
+
+#[test]
+fn into_variants_reject_a_wrong_length_output_slice() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let n = m.n;
+
+    let mut short = vec![0.0; n - 1];
+    assert!(matches!(
+        s.solve_into(&RHS, &mut short),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+    assert!(matches!(
+        s.solve_refined_into(&m, &RHS, &mut short, RefineOptions::default()),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+
+    let wide: Vec<f64> = (0..n * 2).map(|k| RHS[k % n]).collect();
+    let mut wrong = vec![0.0; n * 3];
+    assert!(matches!(
+        s.solve_many_into(&wide, 2, &mut wrong),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+    assert!(matches!(
+        s.solve_many_refined_into(&m, &wide, 2, &mut wrong, RefineOptions::default()),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+}
+
+#[test]
+fn into_variants_reject_a_wrong_length_rhs() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let n = m.n;
+    let mut out = vec![0.0; n];
+    let short_rhs = vec![1.0; n - 1];
+    assert!(matches!(
+        s.solve_into(&short_rhs, &mut out),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+    assert!(matches!(
+        s.solve_refined_into(&m, &short_rhs, &mut out, RefineOptions::default()),
+        Err(FeralError::DimensionMismatch { .. })
+    ));
+}
+
+#[test]
+fn into_variants_report_no_factor_before_checking_dimensions() {
+    // A solver with no factor returns NoFactor even when the output slice
+    // is also wrong — same precedence as the allocating entry points.
+    let s = Solver::new();
+    let m = kkt();
+    let mut out = vec![0.0; 3];
+    assert!(matches!(
+        s.solve_into(&RHS, &mut out),
+        Err(FeralError::NoFactor)
+    ));
+    assert!(matches!(
+        s.solve_refined_into(&m, &RHS, &mut out, RefineOptions::default()),
+        Err(FeralError::NoFactor)
+    ));
+    assert!(matches!(
+        s.solve_many_into(&RHS, 1, &mut out),
+        Err(FeralError::NoFactor)
+    ));
+    assert!(matches!(
+        s.solve_many_refined_into(&m, &RHS, 1, &mut out, RefineOptions::default()),
+        Err(FeralError::NoFactor)
+    ));
+}
+
+#[test]
+fn solve_many_into_with_zero_columns_is_a_no_op() {
+    let m = kkt();
+    let s = solver_for(&m);
+    let empty: [f64; 0] = [];
+    let mut out: [f64; 0] = [];
+    s.solve_many_into(&empty, 0, &mut out).expect("nrhs = 0");
+    s.solve_many_refined_into(&m, &empty, 0, &mut out, RefineOptions::default())
+        .expect("nrhs = 0");
+}


### PR DESCRIPTION
Closes #178.

**This changes no defaults and, on its own, makes nothing faster.** It is opt-in surface: every existing entry point is bit-identical to `main`, and the default budget is still 10 correction steps. The saving is *available* to a caller that passes `k = 1`; it is not taken by anyone in this diff. Issue #178 explicitly asked for the default to be left alone.

## Why

FERAL's sparse refinement ran a fixed budget of up to 10 corrections. That is right for a caller that solves `Ax = b` and keeps the answer. It is wrong for a caller that is *itself* iterating on the same system — an interior-point method is exactly that. Ipopt's `PDFullSpaceSolver` computes the residual after each of its own back-solves and decides from it whether to continue; when each of those is a `Solver::solve_refined`, the loops nest and one augmented-system solve costs up to `10 × 11 = 110` substitution passes plus 100 matvecs. The outer loop owns the convergence criterion; the inner one drives a residual nobody consults toward a tolerance nobody set.

Measured in [pounce#698](https://github.com/jkitchin/pounce/issues/698) on a 118 276 × 118 276 augmented system: back-solve 147.3 s with FERAL's inner refinement on vs 58.3 s off — 60 % of back-solve, 20 % of wall time — and the unrefined run converged to an objective *closer* to the MA57 reference than the refined one.

The problem was never that 10 is too many. It is that 10 and 0 were the only expressible values, and pounce cannot use 0 either: its `pinene_3200` model stalls in the IPM tail when the residual floor left by cascade-break's L-factor perturbation goes uncorrected. The value that plausibly serves both is 1, and nobody could ask for it.

## What

### 1. `RefineOptions`

`RefineOptions { max_steps }` — `Copy`, `Default` = `DEFAULT_REFINE_MAX_STEPS = 10`. Replaces both hard-coded `let max_steps = 10` sites (`solve_sparse_refined_core`, `solve_sparse_many_refined`). New `_opts` forms; the existing names delegate with `Default`:

- `solve_sparse_refined_opts`, `solve_sparse_refined_parallel_opts`, `solve_sparse_refined_with_diagnostics_opts`, `solve_sparse_many_refined_opts`
- `Solver::solve_refined_opts`, `Solver::solve_many_refined_opts`

An options struct rather than a bare `usize`, to match the repo's params-struct convention (`NumericParams`, `BunchKaufmanParams`, `LuParams`) and to keep the obvious next request — a caller-set residual target — additive for anyone constructing from `Default`. A stateful `Solver::set_refine_max_steps` was rejected: the ask is per-call, and it would make a `&self` solve depend on prior mutation.

The cap reaches every arm. `Solver::solve_many_refined` dispatches on `BLAS3_REFINE_THRESHOLD = 16`, and the narrow arm duplicated the #131/#154 parallel-or-serial dispatch. Both now go through one private `refine_into`, so `nrhs = 2` — the predictor-corrector shape an IPM host actually calls — honours the cap like everything else, and the allocating and in-place forms cannot drift apart.

`max_steps = 0` returns *before* the residual matvec, not after. Same answer either way; the point is that opting out costs what `solve_sparse` costs rather than a `symv` and a `norm2` more. The diagnostics entry point is the deliberate exception — `steps[0]` carries that residual.

### 2. In-place entry points

| allocating | in-place |
|---|---|
| `Solver::solve` | `solve_into(rhs, x_out)` |
| `Solver::solve_refined` | `solve_refined_into(matrix, rhs, x_out, opts)` |
| `Solver::solve_many` | `solve_many_into(rhs, nrhs, x_out)` |
| `Solver::solve_many_refined` | `solve_many_refined_into(matrix, rhs, nrhs, x_out, opts)` |

plus free-function `solve_sparse_into`, `solve_sparse_refined_into`, `solve_sparse_refined_parallel_into`, `solve_sparse_many_refined_into`. A host that owns its RHS buffer no longer pays an allocation plus copy-back per back-solve (~946 KB at the dimension above).

The refined cores now use the caller's `x_out` *as* the best-iterate storage, so they also dropped an internal `n` (resp. `n × nrhs`) allocation of their own; the multi-RHS refiner runs its initial batched solve straight into `x_out`, so its "every column already converged" fast path copies nothing.

**Aliasing** `rhs` with `x_out` is neither supported nor rejected at runtime — it is *unrepresentable*, since `&[f64]` and `&mut [f64]` into one allocation cannot coexist. Documented on each entry point rather than guarded by an unreachable branch.

## Tests

21 new, one per item of #178's verification list — `tests/issue178_refine_cap.rs` (12) and `tests/issue178_solve_into.rs` (9).

Worth flagging how the full-budget oracle had to be built. **Nothing merely ill-conditioned reaches `steps.len() == 11`**: the existing ill-conditioned bordered KKT stops at 1 step, a singular 3×3 at 3, Hilbert n = 8…40 at 3–7, tiny-(1,1)-block KKTs at 1. With an *exact* factor, refinement bottoms out on roundoff in two or three steps and the 2-strike plateau fires. The budget is only reachable when the factor is a genuinely perturbed approximate inverse and refinement converges *linearly* — which is the cascade-break / static-perturbation case the cap exists for, and is constructible because the API takes matrix and factor separately. A tridiagonal n = 20 refined against a 1 %-perturbed factor runs all 10 corrections with every step improving; at 0.01 % it converges in 6. Both properties are asserted before any cap is tested, so the tests fail loudly rather than passing vacuously if either matrix changes.

Then: `k` corrections give exactly `k + 1` steps for k in 0..=10; raising the cap to 10 / 25 / 100 on the early-exit case leaves step count and `x` bit-identical; `k = 0` equals `solve_sparse` / `solve_sparse_many` bit-for-bit; under every k the returned residual is no worse than unrefined and the iterate is the one `returned_step` names; the multi-RHS path repeats all four with each column bit-identical to the capped single-RHS refiner. For the `_into` variants: bit-identity with each allocating twin at nrhs = 1, 2, 20; wrong-length `rhs` or `x_out` → `DimensionMismatch`; `NoFactor` keeps precedence; `nrhs = 0` is a no-op.

`cargo test --workspace` green — 0 failures across 93 test binaries. `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## What was not measured

**The session-end benchmark produced no comparable numbers.** `data/benchmark-config.toml` is not present in the container this ran in, so the harness fell back to its 8 synthetic matrices and both Phase 2.8.1 partitions report `count = 0` / verdict `N/A`. There is no comparison against 2026-08-15-02's p90 figures (1.61 / 2.00 / 1.67 / 1.67) — not a regression, not an improvement, **not measured**. Given the change is additive with `Default`-valued wrappers proven bit-identical, I do not expect those partitions to move, but that is a prediction and it should be checked on a machine that has the corpus before merge.

What I could measure — per-call cost of the single-RHS refined solve against the cap, on in-repo KKT matrices. 20 reps, release, **one trial, no noise floor established, so indicative rather than bounded**:

| matrix | n | steps | bare | k=0 | k=1 | k=10 |
|---|---|---|---|---|---|---|
| VESUVIO_0021 | 3 083 | 5 | 0.077 ms | 1.03× | 3.07× | 7.31× |
| nuffield2_trap_iter1 | 26 649 | 3 | 9.63 ms | 1.07× | 2.13× | 3.00× |
| twirism1_kkt | 745 | 3 | 0.087 ms | 0.72× | 2.04× | 3.19× |
| sawpath_kkt | 1 575 | 3 | 0.069 ms | 0.91× | 2.16× | 3.16× |

`k = 0` sits inside the bare solve's own noise on every row — the pre-matvec early return doing its job. On VESUVIO_0021, which uses 4 corrections before the plateau, `k = 1` is 3.07× bare against the default's 7.31×: a 2.4× cut in per-call refined-solve cost, the same direction and rough magnitude as pounce#698's independently measured 2.6× per-iteration reduction at a very different scale. The three matrices that stop at 3 steps do so via the plateau exit, so their default is already near `k = 2` and the cap has less to give — the expected shape.

## Still open

Issue #178's acceptance items 6 and 7 are pounce-side and only the reporter can run them: the 118 276-dimension model at `k = 1` landing near the 58.3 s "refine off" back-solve, and `pinene_3200` still converging without the tail stall that motivated `refine: true`. Item 7 is the one that decides whether pounce can change its own default. If it does not hold, this branch has cost nothing — every default is where it was.

Rationale and the rejected interface shapes: `dev/research/refinement-cap-2026-08-19.md`, `dev/plans/issue-178-refine-cap-and-inplace.md`, `dev/decisions.md`, `dev/journal/2026-08-19-01.org`, `dev/sessions/2026-08-19-01.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWDUwxega9AptiMEXxaL7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXWDUwxega9AptiMEXxaL7)_