### PR TITLE
fix(solve): choose the solve core from the factor, not the host (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — the solve core no longer depends on the host's core count (issue #177)
+
+- `Solver::solve_refined` and `solve_many_refined` now choose between the
+  shared-vector and contribution-block solve cores from the **factor's
+  structure alone**. Previously the choice came from
+  `CbSolveWorkspace::worthwhile()`, a predicate derived from
+  `rayon::current_num_threads()` and overridable by `FERAL_CB_THRESH`, plus a
+  fall-back to the shared-vector core whenever `ThreadPoolBuilder::build()` had
+  failed — and `use_parallel` itself defaults from `available_parallelism()`.
+- **The bug.** The two cores use different (equally valid) floating-point
+  reassociations: the shared-vector core folds each front's separator update
+  into a global vector in flat postorder, the contribution-block core sums a
+  subtree tree. So the same feral, same matrix, same factor solved with
+  different arithmetic on machines with different core counts. Issue #16
+  established that a ULP difference here is amplified by the IPM host's filter
+  line search into trajectory-level outcomes (141 vs 888 outer iterations on
+  qcqp1000-1nc), so downstream iterate paths diverged. Reported on henon120.
+- **What is now guaranteed.** For a given factor, a refined solve returns
+  identical bits at any worker count, with or without a thread pool, with
+  parallelism on or off, and for any `FERAL_CB_THRESH`. Worker count, pool
+  availability and `FERAL_CB_THRESH` select the execution schedule only, and
+  `cb_run_parallel` / `cb_run_serial` are byte-identical.
+- **Performance.** Factors routed to the shared-vector core are unchanged
+  (1.00–1.03x). On a factor routed to the contribution-block core, a host that
+  cannot spawn workers pays ~1.10x for the determinism (poisson_160, refined
+  solve: 27.8 ms → 30.6 ms) while a 4-worker host gains 25% (20.8 ms).
+- **New API.** `SolveCore`, `solve_sparse_refined_auto` (the factor-derived
+  choice, what `Solver` uses) and `solve_sparse_refined_cb` (the explicit
+  contribution-block entry point, with an execution-strategy argument).
+  `solve_sparse_refined` and `solve_sparse_refined_parallel` are unchanged.
+
 ### Fixed — scaling router no longer routes on index order (issue #134 item B)
 
 - `pick_scaling_strategy`'s dense-head gate now counts the **symmetric degree**

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,183 +1,200 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-15T22:22:29Z
+Generated: 2026-08-19T14:05:36Z
 
 ## Latest Session
-File: dev/sessions/2026-08-15-02.md
+File: dev/sessions/2026-08-19-01.md
 ```
-# Session 2026-08-15-02
+# Session 2026-08-19-01
 
-## BENCHMARK NUMBERS ARE WORSE THAN LAST SESSION
+## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
 
 Reported first, per the hard rule in CLAUDE.md.
 
-    partition                  2026-08-15-01   this session   delta
-    dense  small-frontal (<200)     1.54           1.61        +0.07
-    dense  medium (<500)            1.91           2.00        +0.09
-    sparse small-frontal (<200)     1.50           1.67        +0.17
-    sparse medium (<500)            1.51           1.67        +0.16
+`cargo run --bin bench --release` in this container found only the 8
+synthetic matrices; the external corpus and the MUMPS/SPRAL oracle
+timings are not present. Both Phase 2.8.1 exit partitions therefore
+report `N/A` rather than a p90:
 
-All four partitions regressed. All four still PASS their targets.
+    --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+    bucket                    count      p90     target  verdict
+    small-frontal (<200)          0        -     <= 2.0      N/A
+    medium (<500)                 0        -     <= 3.0      N/A
 
-**No Rust source changed this session.** `git diff --stat fbb1a9d HEAD
--- src/ crates/ tests/` is empty; the only changes are `dev/`
-documents. So this is not a code regression — it is run-to-run
-variance on the same binary.
+**No comparison against 2026-08-15-02's 1.61 / 2.00 / 1.67 / 1.67 is
+possible from this run.** I am not claiming the numbers held; I am
+saying they were not measured. A session with the corpus mounted should
+re-run the partition before reading anything into it.
 
-That conclusion is itself worth recording, because it bears on a claim
-made last session. 2026-08-15-01 reported a dense small-frontal
-sequence of 1.58 (baseline) -> 1.66 (regression I introduced) -> 1.54
-(after the gate reordering), and I described the final number as
-"beating the baseline". Today's run puts the same unchanged code at
-1.61. A +0.07 swing with zero code change means the bench's noise
-floor on this metric is at least as large as the 1.58 -> 1.54
-"improvement" I claimed. **The gate-reordering fix should be regarded
-as having removed the 1.66 regression, not as having beaten the
-baseline.** The 1.66 measurement is still meaningful (it exceeded the
-noise band), but the final 0.04 is not.
+What the run does confirm: correctness is intact on what it could see —
+inertia 2/2 vs MUMPS, residual 2/2, worst residual 1.26e-16.
 
-Action for a future session: establish the bench's noise floor by
-running it N times on an unchanged binary, and record a
-minimum-detectable-difference so per-session comparisons stop
-over-reading sub-0.1 movements. Until then, treat p90 deltas under
-~0.15 as noise.
-
-Also note the worst-ratio table is now **6 of 10 KIRBY2 iterates**
-(worst 9.22, up from 8.95), plus GROUPING_0205 — i.e. the outlier
-family this session diagnosed dominates the tail more clearly than
-before.
+This is also the wrong benchmark for this change, which touches the
+*solve* path and not the factor path. The relevant measurements are in
+"Benchmark Results" below.
 
 ## Goal
 
-Investigate the two items carried out of 2026-08-15-01, both approved
-by the user:
+Fix issue #177 — "parallel solve is not bit-identical to serial on
+henon120, breaking #131's stated contract".
 
-1. **#153 remainder** — MC64 warm-cache miss cost. marine_1600 spends
-   ~19% of a 1784 ms solve in cache-missed MC64 recomputes. Decide
-   whether `GROWTH_FACTOR`/`GROWTH_COUNT` can be tightened without
+## Accomplished
+
+### The report is real, but not the bug it looks like
+
+The reporter compared two runs that differed only in `FERAL_CB_THRESH`,
+held the factorization sequential to rule out #16, and found the two
+parallel runs bit-identical to each other but not to the "serial" one.
+They concluded there was a fixed ordering difference in the parallel
+path — "findable deterministically".
+
+There is no such ordering difference. feral has **two numerically
+distinct solve cores**:
+
+- `solve_sparse_core_into` — folds each front's separator update into a
+  global vector in flat postorder;
+- the contribution-block core (#131 Gap A) — assembles each front's RHS
+  from its children's contribution blocks, summed in ascending child
 ```
 
 ## Git Status
 ```
+b75da82 test(solve): pin the refined solve's arithmetic against the host (#177)
+3cafe57 fix(solve): choose the solve core from the factor, not the host (#177)
+6fb9d26 Merge pull request #174 from jkitchin/feat/scaling-router-invariance
+d00666a docs: session checkpoint 2026-08-15-02 (KIRBY2 localized, #153 closed)
 3029905 docs(compress): localize the KIRBY2 factor-ratio outlier to LdltCompress
-fbb1a9d docs: session checkpoint 2026-08-15-01 (#134B shipped, #153 falsified)
-45c80f3 perf(scaling): keep the router's symmetric pass off the common path
-e9470ca fix(scaling): count symmetric degree in the router's head gate (#134B)
-8acb1be docs(scaling): research + plan for router permutation-invariance (#134B)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
 test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 427 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 1.85s
+test result: ok. 428 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.90s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-15-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-01.md)
 
 
-**No Rust source changed this session** (`git diff --stat fbb1a9d HEAD
--- src/ crates/ tests/` is empty; the only changes are `dev/`
-documents). The run below is therefore a re-measurement of unchanged
-code and is expected to reproduce 2026-08-15-01.
+Refined solve, best of 7, 4 workers, microseconds. This is the
+measurement the change is about; the `bench` binary's factor-ratio
+partitions are unrelated to it and were unavailable anyway (see the
+top of this file).
 
-Top 10 worst factor-ratio vs MUMPS:
-name                             n    feral(us)    mumps(us)      ratio
-KIRBY2_0007                    458         1097          119       9.22
-KIRBY2_0006                    458         1075          127       8.46
-KIRBY2_0008                    458          971          122       7.96
-KIRBY2_0010                    458          992          133       7.46
-LAKES_0144                     168          372           54       6.89
-KIRBY2_0009                    458          879          128       6.87
-KIRBY2_0011                    458          820          120       6.83
-LAKES_0146                     168          350           54       6.48
-GROUPING_0205                  225          700          111       6.31
-QPCBLEND_0030                  157          362           60       6.03
+    matrix        n      shared-vector  auto-serial     auto-par(4)
+    chain_400     400         22.3      22.9 (1.03x)   22.9 (1.03x)
+    chain_2000    2000       112.9     114.8 (1.02x)  114.6 (1.01x)
+    chain_20000   20000     1276.3    1276.8 (1.00x) 1272.0 (1.00x)
+    poisson_40    1600       642.2     657.1 (1.02x)  691.8 (1.08x)
+    poisson_96    9216      4549.3    4612.6 (1.01x) 4631.5 (1.02x)
+    poisson_160   25600    27761.6   30632.9 (1.10x) 20763.6 (0.75x)
+
+Factors the predicate rejects are at parity (1.00-1.03x). On the one
+factor it routes to the CB core, a host with no workers pays ~1.10x for
+the determinism and a 4-worker host gains 25%.
+
+The `bench` binary run for this session:
+
+8 matrices benchmarked
+2 KKT matrices total
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.61     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.67     <= 2.0     PASS
-medium (<500)            153560     1.67     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 ```
 
 ## Recent Decisions
-route is gated on a bump that was actually peeled (21f5e74), so it is
-unreachable unless triangularization is on. It is one lever, not two.
 
-**AMF stays off** because no downstream measurement was taken this session. That
-is an absence of evidence, not a finding against it.
+Rejected alternatives, and why:
 
-**Known cost of this decision.** `Markowitz` ignores `factor`'s `symbolic`
-argument, because it does not use a precomputed column order. That is a silent
-semantic change for any caller that carefully chose an ordering and passed it in
-— exactly the silent-fallback shape #168 warned about. Three mitigations, and no
-claim that they eliminate it: the selector is an explicit enum rather than a
-bool, `SparseLu::used_markowitz()` makes the executed route observable so a
-measurement can assert instead of infer, and every in-repo ordering comparison
-(`examples/lu_fill_orderings.rs`, `src/bin/probe_lu_phases.rs`,
-`src/bin/probe_ft_eta.rs`) is pinned to `GilbertPeierls` in this change. An
-out-of-tree caller comparing orderings against `LuParams::default()` will
-silently compare nothing until it pins the rule. Seven in-repo test sites
-across five files failed on this change — `sparse_lu_honors_pivot_threshold`,
-`dense_bump_route_needs_the_peel_and_the_cap_together`, the whole
-`lu_dense_bump` suite, `reach_route_composes_with_the_dense_bump_route`,
-`perturb_chooses_largest_magnitude_row_matching_dense`,
-`factor_traversal_is_subquadratic`, and
-`sparse_solves_compose_with_the_dense_bump_route` — and every one was fixed by
-pinning `GilbertPeierls`, never by weakening an assertion. That seven
-independent tests failed is corroboration that the hazard is real, not
-hypothetical, and it is a fair estimate of what a downstream suite should
-expect to have to pin.
+- *Make the CB core bit-identical to the shared-vector core.* Would
+  require the CB forward to fold contributions in postorder-of-source-
+  front, but it folds a grandchild's block into its child's block before
+  that block reaches the parent. Matching the flat postorder means
+  abandoning the subtree grouping, i.e. the parallelism itself.
 
-Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
-`dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
+- *Always use the CB core when parallelism is requested.* Correct and
+  simple, but measured 1.08-1.86x slower than the shared-vector core on
+  every factor the gate rejects (path-like chains, small grids), where
+  the CB core wins nothing — its only measured win is 0.72x on
+  poisson_160 at 4 workers. It also fails to close the issue, since
+  `use_parallel` is itself defaulted from the host's core count.
+
+- *Retire the CB core, or make it opt-in only.* Restores determinism at
+  zero cost on rejected trees, but forfeits issue #131 Gap A's actual
+  win (25% on the bushy factors where tree-parallel solve pays).
+
+Accepted cost: on a factor the predicate routes to the CB core, a host
+that cannot spawn workers now pays ~1.10x on the refined solve
+(poisson_160: 27.8 ms shared-vector, 30.6 ms CB-serial), where before it
+would have silently taken the shared-vector core and a different answer.
+Factors the predicate rejects are unchanged, at 1.00-1.03x.
+
+Evidence: issue #177; `dev/journal/2026-08-19-01.org`;
+`tests/refined_solve_core_stability.rs` (fails at 6fb9d26 with 24295 of
+25600 entries differing between the pooled and pool-less arms);
+`tests/cb_core_choice_ignores_env.rs`.
 
 ## Recent Tried-and-Rejected
-**Refuted by measurement.** `diag_symbolic_stages_argv` on
-KIRBY2_0007:
 
-    TOTAL 1182 us
-      ldlt_compress   972   82.2%
-      renumber         57    4.8%
-      ordering         32    2.7%
+**Rejected on measurement.** The predicate runs on every refined solve,
+including the ones it rejects, and `CbTaskPlan::build` allocates three
+`Vec<Vec<usize>>` of length `n_nodes` (`build_children`, `owned`,
+`tr_children`). Cost of the verdict alone, versus the shared-vector
+baseline it was supposed to preserve:
 
-Ordering is 32 us — 2.7% of symbolic and ~3% of the reported
-`factor_us`. Eliminating AMD cost entirely could not move the ratio.
-The cost is `ldlt_compress` (the MC64 matching feeding Duff-Pralet
-compression), which is a different subsystem from the one the
-hypothesis named.
+    chain_400     1.29x
+    chain_2000    1.27x
+    chain_20000   1.24x
 
-A second prediction in the same hypothesis — that feral was producing
-more fill than MUMPS — is also refuted: the numeric driver is 127 us
-and `num_c ~ num_n` (149 vs 143 us), so the factorization is not the
-problem in either time or fill.
+That is the same 1.24-1.29x the design existed to avoid — the predicate
+cost as much as the core it was declining. Replaced by a flat
+`O(n_nodes)` computation (four `Vec`s of scalars, subtree costs folded
+into parents using the postorder guarantee, no child lists), which
+brings the rejected trees back to 1.00-1.03x.
 
-Superseded by `dev/research/ldlt-compress-cost-benefit-2026-08-15.md`.
+The cost of that replacement is a second implementation of one gate.
+`cb_core_profitable_matches_the_plan_gate` pins the two together across
+six fixtures landing on both sides of the gate.
 
 ## Source Files
 ```
@@ -247,9 +264,10 @@ tests/amf_corpus_oracle.rs
 tests/auto_strategy.rs
 tests/blocked_ldlt.rs
 tests/build_row_indices_trailing_invariant.rs
+tests/cb_core_choice_ignores_env.rs
 tests/cb_solve_parity.rs
-tests/column_renumbering_parity.rs
 tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
 tests/d4_solve_2x2_gate.rs
 tests/d6_contrib_uninit.rs
 tests/d7_block32_dispatch_pooled.rs
@@ -263,14 +281,6 @@ tests/fine_grained_delay.rs
 tests/fma_opt_in_roundtrip.rs
 tests/golden_bits.rs
 tests/growth_flag.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
 tests/issue102_intrafront_deadlock.rs
 tests/issue102_ordering_escalation.rs
 tests/issue107_external_ordering.rs
@@ -283,22 +293,30 @@ tests/issue65_mc64_fallback.rs
 tests/issue67_thin_ordering.rs
 tests/issue91_preprocess_misfire.rs
 tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
 tests/kkt_hardening.rs
 tests/kkt_matrices.rs
 tests/large_matrix_smoke.rs
 tests/ldlt_compress.rs
 tests/lu_adversarial_inputs.rs
 tests/lu_default_ordering.rs
+tests/lu_dense.rs
 tests/lu_dense_bump.rs
 tests/lu_dense_update_bg.rs
-tests/lu_dense.rs
 tests/lu_ft_widebump.rs
 tests/lu_hyper_sparse.rs
 tests/lu_markowitz.rs
 tests/lu_real_bases.rs
 tests/lu_scaling.rs
-tests/lu_sparse_rhs.rs
 tests/lu_sparse.rs
+tests/lu_sparse_rhs.rs
 tests/lu_update_alloc_probe.rs
 tests/lu_update_casctanks.rs
 tests/maxfromm_parity.rs
@@ -314,8 +332,9 @@ tests/pivot_rejection.rs
 tests/pounce_interface.rs
 tests/profiler_smoke.rs
 tests/property_tests.rs
-tests/rook_rescue_kkt.rs
+tests/refined_solve_core_stability.rs
 tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
 tests/small_leaf_parity.rs
 tests/solver_with_ordering.rs
 tests/sparse_postorder.rs

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6691,3 +6691,70 @@ expect to have to pin.
 
 Evidence: issue #171; `dev/research/markowitz-fill-measurement.md`;
 `dev/journal/2026-08-14-01.org`; the #166 and #168 arm harnesses.
+
+## 2026-08-19 — The solve core is a function of the factor, not of the host (issue #177)
+
+feral has two numerically distinct sparse solve cores. The
+shared-global-vector core (`solve_sparse_core_into`) folds each front's
+separator update into a global vector in flat postorder. The
+contribution-block core of issue #131 Gap A (`cb_forward_front`)
+assembles each front's RHS from its children's contribution blocks,
+summed in ascending child order — a subtree sum tree. Each is a valid
+reassociation of the other, and they differ in the last bits by design.
+That was known and documented; it is not what is being decided here.
+
+**Decision: which of the two cores runs is determined by the factor's
+structure alone. The host — core count, thread-pool availability,
+`use_parallel`, `FERAL_CB_THRESH` — may choose only the execution
+schedule, and every schedule produces identical bits.**
+
+Before this, `Solver::solve_refined` chose the core from
+`CbSolveWorkspace::worthwhile()`, a predicate derived from
+`rayon::current_num_threads()` and overridable by `FERAL_CB_THRESH`;
+`Solver` also fell back to the shared-vector core whenever
+`ThreadPoolBuilder::build()` had failed, and `use_parallel` itself
+defaults from `available_parallelism() > 1`. Three separate routes ran
+from the host's core count into the arithmetic. Issue #16 established
+that a ULP difference here is amplified by the IPM host's filter line
+search into trajectory-level outcomes (141 vs 888 outer iterations on
+qcqp1000-1nc), so this was not a cosmetic difference: the same feral,
+same matrix, same POUNCE build solved along different iterate paths on
+machines with different core counts. Reported on henon120 in #177.
+
+Mechanism: `cb_core_profitable(factors)` applies the same three-part
+gate `CbTaskPlan::worthwhile` uses (at least two independent task roots,
+`total >= MIN_TOTAL_COST`, no task root holding more than
+`MAX_LOCAL_SHARE` of the work), but coarsens at a fixed
+`CB_REFERENCE_FANOUT = 64` granularity instead of a worker-derived one.
+`SolveCore::Auto` consults it. `CbTaskPlan` keeps its worker-derived
+threshold for scheduling.
+
+Rejected alternatives, and why:
+
+- *Make the CB core bit-identical to the shared-vector core.* Would
+  require the CB forward to fold contributions in postorder-of-source-
+  front, but it folds a grandchild's block into its child's block before
+  that block reaches the parent. Matching the flat postorder means
+  abandoning the subtree grouping, i.e. the parallelism itself.
+
+- *Always use the CB core when parallelism is requested.* Correct and
+  simple, but measured 1.08-1.86x slower than the shared-vector core on
+  every factor the gate rejects (path-like chains, small grids), where
+  the CB core wins nothing — its only measured win is 0.72x on
+  poisson_160 at 4 workers. It also fails to close the issue, since
+  `use_parallel` is itself defaulted from the host's core count.
+
+- *Retire the CB core, or make it opt-in only.* Restores determinism at
+  zero cost on rejected trees, but forfeits issue #131 Gap A's actual
+  win (25% on the bushy factors where tree-parallel solve pays).
+
+Accepted cost: on a factor the predicate routes to the CB core, a host
+that cannot spawn workers now pays ~1.10x on the refined solve
+(poisson_160: 27.8 ms shared-vector, 30.6 ms CB-serial), where before it
+would have silently taken the shared-vector core and a different answer.
+Factors the predicate rejects are unchanged, at 1.00-1.03x.
+
+Evidence: issue #177; `dev/journal/2026-08-19-01.org`;
+`tests/refined_solve_core_stability.rs` (fails at 6fb9d26 with 24295 of
+25600 entries differing between the pooled and pool-less arms);
+`tests/cb_core_choice_ignores_env.rs`.

--- a/dev/journal/2026-08-19-01.org
+++ b/dev/journal/2026-08-19-01.org
@@ -1,0 +1,197 @@
+#+TITLE: Session 2026-08-19-01
+#+DATE: 2026-08-19
+
+* 13:15 :issue-177:solve:parallel:
+Goal: fix #177 — "parallel solve is not bit-identical to serial on
+henon120, breaking #131's stated contract".
+
+Read =src/numeric/solve.rs=. Two *different numerical cores* exist for
+a sparse solve:
+
+- =solve_sparse_core_into= (shared global vector, flat postorder
+  left-fold of separator updates), used by =solve_sparse= and
+  =solve_sparse_refined=;
+- the contribution-block core (=cb_forward_front= / =cb_run_serial= /
+  =cb_run_parallel=), issue #131 Gap A, which sums each front's RHS as a
+  *tree* over children in ascending child order.
+
+The module header at solve.rs:395-412 already states these differ by
+floating-point reassociation and calls the CB core "an opt-in path".
+So CB-vs-shared-vector is by design, not a bug.
+
+* 13:25 :issue-177:root-cause:
+The actual defect is *which core runs is chosen by a machine-dependent
+gate*. =solve_sparse_refined_core= (solve.rs:1829) does
+
+    let cb = CbSolveWorkspace::for_factors(factors);
+    cb.worthwhile().then_some(cb)
+
+and falls back to the shared-vector =SolveWorkspace= when not
+worthwhile. =CbTaskPlan::worthwhile= depends on =fwd_seeds.len() >= 2=
+and =max_local < 0.7*total=, both computed from
+
+    thresh = FERAL_CB_THRESH or (total / (rayon::current_num_threads()*16))
+
+So =rayon::current_num_threads()= and =FERAL_CB_THRESH= select the
+*arithmetic*, not just the schedule. That is exactly the reporter's
+"same feral, same matrix, same POUNCE build produces different iterate
+paths on machines with different core counts".
+
+* 13:35 :issue-177:evidence:
+Measured with a scaffold test (=tests/refined_parallel_thread_invariance.rs=,
+temporary) plus two temporary =eprintln!= probes in solve.rs.
+
+Poisson 2D 160x160 (n=25600), same factor, same RHS:
+
+    DBG177 plan: total=1090303 thresh=68143 roots=36 seeds=4  max_local=81612 threads=1 worthwhile=true
+    DBG177 plan: total=1090303 thresh=34071 roots=51 seeds=9  max_local=57676 threads=2 worthwhile=true
+    DBG177 plan: total=1090303 thresh=17035 roots=83 seeds=25 max_local=27510 threads=4 worthwhile=true
+    DBG177 plan: total=1090303 thresh=8517 roots=133 seeds=50 max_local=21000 threads=8 worthwhile=true
+
+    threads=1: bits differing vs serial-refined = 24295
+    threads=2: bits differing vs serial-refined = 24295
+    threads=4: bits differing vs serial-refined = 24295
+    threads=8: bits differing vs serial-refined = 24295
+    threads 1 vs 2: 0    threads 2 vs 4: 0    threads 4 vs 8: 0
+
+Two facts, both matching the issue report exactly:
+
+1. The CB core is *itself* bit-stable across thread counts — the plan
+   changes (seeds 4 -> 50) but the output does not move a bit. The
+   child-reduction order really is fixed, as documented. So this is not
+   a scheduling artifact.
+2. The CB core differs from the shared-vector core by 24295 of 25600
+   entries. The reporter's "serial solve" run
+   (=FERAL_CB_THRESH=1000000000000=) is not the CB core run serially —
+   it is a *different core*. That is the whole of the observed
+   divergence.
+
+Smaller grids (Poisson 60x60, 96x96, total 351544) come out
+=worthwhile=false= — they fail =total >= MIN_TOTAL_COST= (1e6) — so both
+runs take the shared-vector core and agree bit-for-bit. That is why
+NARX_CFy agrees and henon120 does not: it is a size/structure
+threshold, exactly the "structure-dependent rather than universal"
+observation in the issue.
+
+* 13:40 :issue-177:decision:
+Fix: *decouple core selection from scheduling*. =worthwhile= must
+choose only between =cb_run_parallel= and =cb_run_serial= (already
+byte-identical to each other); it must never switch to the
+shared-vector core. Then neither =rayon::current_num_threads()= nor
+=FERAL_CB_THRESH= can perturb a single bit, and the reporter's repro
+becomes bit-identical.
+
+Rejected: making the CB core bit-identical to the shared-vector core.
+The shared-vector core folds each front's separator update into a
+global vector in postorder; the CB core folds a grandchild's block into
+its child's block before it reaches the parent. Matching the postorder
+fold would require abandoning the subtree grouping — i.e. the
+parallelism itself. Already documented at solve.rs:404-412.
+
+* 14:10 :issue-177:perf:pivot:
+First cut of the fix — "when the caller asks for the parallel refine,
+always use the CB core; =worthwhile= only picks =cb_run_parallel= vs
+=cb_run_serial=" — is correct but *not shippable as-is*. Measured the
+two cores head to head (refined solve, best of 7, 4 workers, us):
+
+    matrix        n       shared-vector   CB-serial      CB-par(4)
+    chain_400     400          24.0       30.6 (1.27x)   31.5 (1.31x)
+    chain_2000    2000        119.0      154.0 (1.29x)  162.5 (1.37x)
+    chain_20000   20000      1271.8     1630.7 (1.28x) 1617.1 (1.27x)
+    poisson_40    1600        659.3     1198.8 (1.82x) 1228.2 (1.86x)
+    poisson_96    9216       4649.5     5035.4 (1.08x) 5087.5 (1.09x)
+    poisson_160   25600     31842.2    35188.1 (1.11x) 22968.5 (0.72x)
+
+The CB core *only* wins on the one factor where =worthwhile= holds
+(poisson_160, 0.72x). Everywhere else it is 1.08-1.86x slower with
+nothing to show for it. So =worthwhile= is a well-tuned *performance*
+gate, and the naive fix would have bought determinism by paying up to
+1.86x on every path-like tree. Correctness before performance is the
+rule, but paying 1.86x when a cheaper correct design exists is not
+that trade.
+
+Worse, the naive fix does not even close the issue. =use_parallel=
+defaults from =Solver::default_use_parallel()= =
+=available_parallelism() > 1=. So "core = f(use_parallel)" still means
+"core = f(host core count)" — a 1-core box and a 4-core box still
+disagree. The pool-availability arm (#154) leaks the same way.
+
+* 14:25 :issue-177:decision:design:
+Pivoted to: *the core is a pure function of the factor; the host
+chooses only the schedule.*
+
+- =cb_core_profitable(factors)= applies the same three-part gate at a
+  fixed =CB_REFERENCE_FANOUT= (64) granularity — never
+  =rayon::current_num_threads()=, never =FERAL_CB_THRESH=.
+- =SolveCore::Auto= consults it; =Solver::solve_refined= and
+  =solve_many_refined= use =Auto=. =use_parallel= and pool availability
+  now only decide =cb_run_parallel= vs =cb_run_serial=, which are
+  byte-identical.
+- =CbTaskPlan='s worker-derived threshold survives untouched, for
+  scheduling.
+
+This keeps the shared-vector core on exactly the trees where it is
+faster, keeps the CB core where it wins, and makes the choice
+host-invariant.
+
+* 14:40 :issue-177:perf:regression:
+First =Auto= implementation called =CbTaskPlan::build_with_threshold=
+for the verdict. That allocates three =Vec<Vec<usize>>= of length
+=n_nodes= (=build_children=, =owned=, =tr_children=) on *every* refined
+solve, including the ones it rejects:
+
+    chain_400     1.29x    chain_2000   1.27x    chain_20000  1.24x
+
+i.e. the predicate cost as much as the thing it was avoiding.
+Rewrote =cb_core_profitable= on flat =O(n_nodes)= arrays — subtree cost
+folded into parents using the postorder guarantee, no child lists at
+all. After:
+
+    matrix        n       shared-vector  auto-serial     auto-par(4)
+    chain_400     400          22.3       22.9 (1.03x)   22.9 (1.03x)
+    chain_2000    2000        112.9      114.8 (1.02x)  114.6 (1.01x)
+    chain_20000   20000      1276.3     1276.8 (1.00x) 1272.0 (1.00x)
+    poisson_40    1600        642.2      657.1 (1.02x)  691.8 (1.08x)
+    poisson_96    9216       4549.3     4612.6 (1.01x)  4631.5 (1.02x)
+    poisson_160   25600     27761.6    30632.9 (1.10x) 20763.6 (0.75x)
+
+Rejected trees are back to parity (1.00-1.03x). The remaining cost is
+honest and localized: on a CB-profitable factor a host with no workers
+pays ~1.10x for the determinism, and a 4-worker host gains 25%.
+
+Two implementations of one gate can drift, so
+=cb_core_profitable_matches_the_plan_gate= pins the flat predicate
+against =CbTaskPlan::worthwhile= across six fixtures that land on both
+sides of it.
+
+* 14:55 :issue-177:tests:
+The pre-fix failure is deterministic and reproducible. Ran the new
+=solver_refine_is_identical_across_parallelism_and_pool_availability=
+against a worktree at 6fb9d26:
+
+    solve_refined pooled vs pool-less: 24295 of 25600 entries differ
+    left: 24295   right: 0
+    test result: FAILED. 4 passed; 1 failed
+
+Post-fix all five pass. Coverage added:
+
+- =tests/refined_solve_core_stability.rs= — worker count (1/2/3/4/8),
+  pool vs no pool, parallel vs sequential =Solver=, on matrices either
+  side of the gate; plus a non-vacuity check that the two cores really
+  are distinguishable on the fixture (else the whole file proves
+  nothing).
+- =tests/cb_core_choice_ignores_env.rs= — the reporter's own knob.
+  Single-test binary on purpose: it mutates the process environment,
+  which is shared across a binary's tests but not across binaries.
+- =solve.rs= unit tests — threshold sweep byte-identity (with a
+  non-vacuity assertion that the sweep really produced different task
+  decompositions), gate-rejected factors still run the CB core when
+  asked, and the flat-vs-plan agreement guard.
+
+Also retargeted the pre-existing
+=solver_parallel_without_pool_falls_back_to_serial_refine= (#154). It
+asserted pool-less == =with_parallel(false)=, which after this change
+is not guaranteed in general — it passed only because its n=64
+tridiagonal fixture is small enough that both cores coincide. Kept
+that comparison (it still has content on that fixture) and added the
+invariant that does hold everywhere: pool-less == pooled.

--- a/dev/sessions/2026-08-19-01.md
+++ b/dev/sessions/2026-08-19-01.md
@@ -1,0 +1,200 @@
+# Session 2026-08-19-01
+
+## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
+
+Reported first, per the hard rule in CLAUDE.md.
+
+`cargo run --bin bench --release` in this container found only the 8
+synthetic matrices; the external corpus and the MUMPS/SPRAL oracle
+timings are not present. Both Phase 2.8.1 exit partitions therefore
+report `N/A` rather than a p90:
+
+    --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+    bucket                    count      p90     target  verdict
+    small-frontal (<200)          0        -     <= 2.0      N/A
+    medium (<500)                 0        -     <= 3.0      N/A
+
+**No comparison against 2026-08-15-02's 1.61 / 2.00 / 1.67 / 1.67 is
+possible from this run.** I am not claiming the numbers held; I am
+saying they were not measured. A session with the corpus mounted should
+re-run the partition before reading anything into it.
+
+What the run does confirm: correctness is intact on what it could see —
+inertia 2/2 vs MUMPS, residual 2/2, worst residual 1.26e-16.
+
+This is also the wrong benchmark for this change, which touches the
+*solve* path and not the factor path. The relevant measurements are in
+"Benchmark Results" below.
+
+## Goal
+
+Fix issue #177 — "parallel solve is not bit-identical to serial on
+henon120, breaking #131's stated contract".
+
+## Accomplished
+
+### The report is real, but not the bug it looks like
+
+The reporter compared two runs that differed only in `FERAL_CB_THRESH`,
+held the factorization sequential to rule out #16, and found the two
+parallel runs bit-identical to each other but not to the "serial" one.
+They concluded there was a fixed ordering difference in the parallel
+path — "findable deterministically".
+
+There is no such ordering difference. feral has **two numerically
+distinct solve cores**:
+
+- `solve_sparse_core_into` — folds each front's separator update into a
+  global vector in flat postorder;
+- the contribution-block core (#131 Gap A) — assembles each front's RHS
+  from its children's contribution blocks, summed in ascending child
+  order: a subtree sum tree.
+
+Each is a valid reassociation of the other; solve.rs:404-412 already
+said so. The reporter's "serial solve" was not the CB core scheduled
+serially — it was the *other core*. Verified directly: on Poisson
+160x160 the two cores differ in 24295 of 25600 entries, while the CB
+core is bit-stable across 1/2/4/8 workers even though its task
+decomposition changes from 4 to 50 forward seeds.
+
+### The actual defect
+
+*Which core ran was a function of the host.* Three routes:
+
+1. `CbSolveWorkspace::worthwhile()` — derived from
+   `rayon::current_num_threads()`, overridable by `FERAL_CB_THRESH` —
+   selected the core in `solve_sparse_refined_core`;
+2. `Solver` fell back to the shared-vector core whenever
+   `ThreadPoolBuilder::build()` had failed (#154's arm);
+3. `use_parallel` itself defaults from `available_parallelism() > 1`.
+
+#16 established that a ULP difference here is amplified by the IPM
+host's filter line search into trajectory-level outcomes (141 vs 888
+outer iterations on qcqp1000-1nc). So this was not cosmetic: the same
+feral, same matrix, same POUNCE build solved along different iterate
+paths on machines with different core counts — precisely the reporter's
+complaint, arriving by a different mechanism than they suspected.
+
+This also explains the structure-dependence they noticed (henon120
+diverges, NARX_CFy does not): the gate has a `total >= 1e6` cost floor,
+so small factors take the shared-vector core on both sides of the
+comparison and agree trivially.
+
+### The fix
+
+The core is now a pure function of the factor. `cb_core_profitable`
+applies the same three-part gate `CbTaskPlan::worthwhile` uses, but
+coarsens at a fixed `CB_REFERENCE_FANOUT = 64` granularity instead of a
+worker-derived one, and never reads `FERAL_CB_THRESH`.
+`SolveCore::Auto` consults it; `Solver::solve_refined` and
+`solve_many_refined` use `Auto`. Worker count, pool availability and
+`FERAL_CB_THRESH` now select only the execution schedule, and
+`cb_run_parallel` / `cb_run_serial` are byte-identical.
+
+New public API: `SolveCore`, `solve_sparse_refined_auto`,
+`solve_sparse_refined_cb`. `solve_sparse_refined` and
+`solve_sparse_refined_parallel` are unchanged.
+
+### Evidence
+
+Pre-fix failure, deterministic. The new
+`solver_refine_is_identical_across_parallelism_and_pool_availability`
+run against a worktree at 6fb9d26:
+
+    solve_refined pooled vs pool-less: 24295 of 25600 entries differ
+      left: 24295
+     right: 0
+    test result: FAILED. 4 passed; 1 failed
+
+Post-fix: all 93 test binaries pass, 0 failures. `cargo clippy
+--all-targets -- -D warnings` clean, `cargo fmt --check` clean,
+pre-commit hooks installed and passing on both commits.
+
+## Benchmark Results
+
+Refined solve, best of 7, 4 workers, microseconds. This is the
+measurement the change is about; the `bench` binary's factor-ratio
+partitions are unrelated to it and were unavailable anyway (see the
+top of this file).
+
+    matrix        n      shared-vector  auto-serial     auto-par(4)
+    chain_400     400         22.3      22.9 (1.03x)   22.9 (1.03x)
+    chain_2000    2000       112.9     114.8 (1.02x)  114.6 (1.01x)
+    chain_20000   20000     1276.3    1276.8 (1.00x) 1272.0 (1.00x)
+    poisson_40    1600       642.2     657.1 (1.02x)  691.8 (1.08x)
+    poisson_96    9216      4549.3    4612.6 (1.01x) 4631.5 (1.02x)
+    poisson_160   25600    27761.6   30632.9 (1.10x) 20763.6 (0.75x)
+
+Factors the predicate rejects are at parity (1.00-1.03x). On the one
+factor it routes to the CB core, a host with no workers pays ~1.10x for
+the determinism and a 4-worker host gains 25%.
+
+The `bench` binary run for this session:
+
+```
+8 matrices benchmarked
+2 KKT matrices total
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+```
+
+## Decisions Made
+
+Appended to `dev/decisions.md`: **the solve core is a function of the
+factor, not of the host.** The host may choose only the execution
+schedule, and every schedule produces identical bits.
+
+## Abandoned Approaches
+
+Appended to `dev/tried-and-rejected.md`:
+
+1. Making the CB core bit-identical to the shared-vector core.
+2. Always using the CB core whenever parallelism is requested.
+3. Computing the profitability verdict by building a `CbTaskPlan`.
+
+## Next Session Should
+
+1. **Confirm on henon120.** Everything here was measured on synthetic
+   Poisson grids and chains, because the Mittelmann corpus is not in
+   this container. The reporter's exact repro — two `pounce henon120.nl`
+   runs differing only in `FERAL_CB_THRESH`, factorization held
+   sequential — should now be bit-identical. Run it before closing #177.
+   The predicate's verdict on henon120 is also worth recording: if it
+   routes to the CB core, POUNCE's henon120 trajectory *changes* from
+   whatever it was on a 1-core host, which is the intended fix but is
+   still a trajectory change downstream should know about.
+
+2. **Re-run the factor-ratio partition with the corpus mounted.**
+   2026-08-15-02 left an open action to establish the bench's noise
+   floor by running N times on an unchanged binary; that is still open,
+   and this session could not even take one comparable measurement.
+
+3. **Audit the remaining paths for the same defect class.**
+   `Solver::solve()` (unrefined) and `solve_sparse_many*` were not
+   examined for host-dependent core selection. The factor driver has its
+   own `FERAL_PAR_TASK_MIN_FLOPS` gate and #16 documents ULP
+   nondeterminism there — a different problem (scheduling
+   nondeterminism, not core switching), but the same downstream harm,
+   and #16's sequential-mode mitigation is what #177 said this partly
+   undercut. Worth checking whether that mitigation is now sound.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5528,3 +5528,76 @@ and `num_c ~ num_n` (149 vs 143 us), so the factorization is not the
 problem in either time or fill.
 
 Superseded by `dev/research/ldlt-compress-cost-benefit-2026-08-15.md`.
+
+## 2026-08-19 — Three approaches to issue #177 (host-dependent solve core)
+
+Context: `Solver::solve_refined` chose between two numerically distinct
+solve cores using a predicate derived from
+`rayon::current_num_threads()`, so the arithmetic depended on the host's
+core count. See `dev/decisions.md` (2026-08-19) for what was adopted.
+
+### Rejected: make the CB core bit-identical to the shared-vector core
+
+This is what the issue's reporter expected to find — "a real ordering
+difference in the code ... findable deterministically". It is not
+achievable. The shared-vector core folds each front's separator update
+into a global vector in postorder, so a global row accumulates
+contributions in ascending source-front order. The CB core folds a
+grandchild's contribution block into its child's block before that block
+ever reaches the parent. Reproducing the postorder fold would require
+abandoning the subtree grouping — that is, the parallelism itself.
+Already documented at solve.rs:404-412; restated here because the issue
+asked for exactly this and it is worth having the refusal on record.
+
+### Rejected: always use the CB core when parallelism is requested
+
+Correct and a two-line change: let `worthwhile` pick `cb_run_parallel`
+vs `cb_run_serial` (byte-identical) and never switch cores. Implemented
+and measured before rejecting.
+
+**Rejected on measurement.** Refined solve, best of 7, 4 workers, us:
+
+    matrix        n       shared-vector   CB-serial      CB-par(4)
+    chain_400     400          24.0       30.6 (1.27x)   31.5 (1.31x)
+    chain_2000    2000        119.0      154.0 (1.29x)  162.5 (1.37x)
+    chain_20000   20000      1271.8     1630.7 (1.28x) 1617.1 (1.27x)
+    poisson_40    1600        659.3     1198.8 (1.82x) 1228.2 (1.86x)
+    poisson_96    9216       4649.5     5035.4 (1.08x) 5087.5 (1.09x)
+    poisson_160   25600     31842.2    35188.1 (1.11x) 22968.5 (0.72x)
+
+The CB core's only win is 0.72x on poisson_160 — the one factor where
+`worthwhile` holds. Everywhere else it is 1.08-1.86x slower with nothing
+to show for it, so this would have paid up to 1.86x on every path-like
+tree to buy determinism that a cheaper design also buys.
+
+**And it does not close the issue.** `use_parallel` defaults from
+`Solver::default_use_parallel()` = `available_parallelism() > 1`, so
+"core = f(use_parallel)" is still "core = f(host core count)". A 1-core
+box and a 4-core box would have continued to disagree. The
+pool-availability arm (#154) leaks identically.
+
+### Rejected: compute the profitability verdict by building a `CbTaskPlan`
+
+The adopted design needs a host-independent profitability predicate. The
+obvious implementation reuses `CbTaskPlan::build_with_threshold` at a
+fixed granularity and reads `.worthwhile`.
+
+**Rejected on measurement.** The predicate runs on every refined solve,
+including the ones it rejects, and `CbTaskPlan::build` allocates three
+`Vec<Vec<usize>>` of length `n_nodes` (`build_children`, `owned`,
+`tr_children`). Cost of the verdict alone, versus the shared-vector
+baseline it was supposed to preserve:
+
+    chain_400     1.29x
+    chain_2000    1.27x
+    chain_20000   1.24x
+
+That is the same 1.24-1.29x the design existed to avoid — the predicate
+cost as much as the core it was declining. Replaced by a flat
+`O(n_nodes)` computation (four `Vec`s of scalars, subtree costs folded
+into parents using the postorder guarantee, no child lists), which
+brings the rejected trees back to 1.00-1.03x.
+
+The cost of that replacement is a second implementation of one gate.
+`cb_core_profitable_matches_the_plan_gate` pins the two together across
+six fixtures landing on both sides of the gate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@ pub use numeric::factorize::{
     factorize_multifrontal_with_schur, LdltExport, NumericParams, ProfileReport, SchurBlock,
 };
 pub use numeric::solve::{
-    solve_sparse, solve_sparse_refined, solve_sparse_refined_with_diagnostics,
-    RefinementDiagnostics, RefinementStep,
+    solve_sparse, solve_sparse_refined, solve_sparse_refined_auto, solve_sparse_refined_cb,
+    solve_sparse_refined_with_diagnostics, RefinementDiagnostics, RefinementStep, SolveCore,
 };
 pub use numeric::solver::{FactorStats, FactorStatus, QualityLevel, Solver};
 pub use sparse::csc::{CscMatrix, CscPattern};

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -411,6 +411,16 @@ fn dsolve_single(w: &mut [f64], ff: &crate::dense::factor::FrontalFactors, nelim
 // differs from that path only by floating-point reassociation (~κ·eps):
 // a valid solve, offered as an opt-in path; the default `solve_sparse`
 // is unchanged.
+//
+// Issue #177: because the two cores genuinely differ in the last bits,
+// *which core runs must be an explicit caller decision* — see
+// `SolveCore`. It previously fell out of `CbTaskPlan::worthwhile`, a
+// predicate derived from `rayon::current_num_threads()`, so the same
+// binary on a 4-core and a 32-core host solved with different
+// arithmetic; an IPM host amplified that into different iterate
+// trajectories (henon120, issues #177 and #16). The coarsening plan is
+// now confined to scheduling: it decides `cb_run_parallel` vs
+// `cb_run_serial`, and those are byte-identical.
 
 /// One front's forward contribution: the `nrow - nelim` separator-row
 /// values (in frontal separator order) it passes to its parent. Boxed
@@ -696,20 +706,74 @@ struct CbTaskPlan {
     pending_fwd: Vec<usize>,
     /// Whether each node is a task root.
     is_task_root: Vec<bool>,
-    /// Whether tree-parallel execution is expected to beat the serial
-    /// core: at least two independent task roots, and no single task
-    /// root's serial share dominates (Amdahl), and enough total work to
-    /// amortize the O(threads·n) scratch setup. When false the caller
-    /// runs the serial core.
+    /// Whether tree-parallel *execution* is expected to beat running the
+    /// same CB core serially: at least two independent task roots, and no
+    /// single task root's serial share dominates (Amdahl), and enough
+    /// total work to amortize the O(threads·n) scratch setup.
+    ///
+    /// Issue #177: this gates `cb_run_parallel` vs `cb_run_serial` only —
+    /// two byte-identical cores. It must never be used to choose between
+    /// the CB core and the shared-vector core, because it is derived from
+    /// `rayon::current_num_threads()` and would make the arithmetic a
+    /// function of the host's core count.
     worthwhile: bool,
 }
 
+/// ~1e6 flops ≈ tens of µs of solve, the floor below which the
+/// O(threads·n) scratch alloc + rayon scope is not amortized.
+const MIN_TOTAL_COST: u64 = 1_000_000;
+
+/// Amdahl ceiling: if one task root runs this share of the total work by
+/// itself, parallel overhead dominates whatever the rest of the tree does
+/// (e.g. an arrow front whose huge root front is one serial task).
+const MAX_LOCAL_SHARE: f64 = 0.7;
+
+/// Reference fan-out for the host-independent coarsening (issue #177):
+/// 16 task roots per worker on a canonical 4-worker host. Used only to
+/// judge whether the CB core suits a factor at all — a verdict that must
+/// not vary with the host — never to schedule real work.
+const CB_REFERENCE_FANOUT: u64 = 64;
+
+/// How the coarsening threshold — the subtree cost at or above which a
+/// node becomes its own task root — is chosen.
+#[derive(Debug, Clone, Copy)]
+enum CbThreshold {
+    /// Aim for ~16 task roots per worker so the pool stays fed without
+    /// per-node overhead; `FERAL_CB_THRESH` overrides. Depends on the
+    /// host, so it may drive **scheduling only** (issue #177).
+    FromWorkers,
+    /// A fixed [`CB_REFERENCE_FANOUT`]-way cut, identical on every host.
+    /// The basis for [`CbTaskPlan::core_profitable`].
+    Reference,
+    /// Explicit, for the tests that sweep the threshold.
+    #[cfg(test)]
+    Fixed(u64),
+}
+
+impl CbThreshold {
+    fn resolve(self, total: u64) -> u64 {
+        match self {
+            CbThreshold::FromWorkers => {
+                let num_threads = rayon::current_num_threads().max(1);
+                std::env::var("FERAL_CB_THRESH")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or_else(|| (total / (num_threads as u64 * 16)).max(1))
+            }
+            CbThreshold::Reference => (total / CB_REFERENCE_FANOUT).max(1),
+            #[cfg(test)]
+            CbThreshold::Fixed(t) => t,
+        }
+    }
+}
+
 impl CbTaskPlan {
-    fn build(
+    fn build_with_threshold(
         children: &[Vec<usize>],
         parents: &[Option<usize>],
         nodes: &[NodeFactors],
         n_nodes: usize,
+        threshold: CbThreshold,
     ) -> Self {
         // Per-front solve cost ~ nrow·(nelim+1) (forward L-solve +
         // backward Lᵀ-solve are both O(nrow·nelim)); saturating.
@@ -729,13 +793,7 @@ impl CbTaskPlan {
             subtree_cost[i] = c;
             total = total.saturating_add(own_cost(i));
         }
-        // Threshold: aim for ~16 task roots per worker so the pool stays
-        // fed without per-node overhead. `FERAL_CB_THRESH` overrides.
-        let num_threads = rayon::current_num_threads().max(1);
-        let thresh: u64 = std::env::var("FERAL_CB_THRESH")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| (total / (num_threads as u64 * 16)).max(1));
+        let thresh: u64 = threshold.resolve(total);
 
         let is_task_root: Vec<bool> = (0..n_nodes)
             .map(|i| parents[i].is_none() || subtree_cost[i] >= thresh)
@@ -799,12 +857,9 @@ impl CbTaskPlan {
             }
             max_local = max_local.max(local);
         }
-        // ~1e6 flops ≈ tens of µs of solve, the floor below which the
-        // O(threads·n) scratch alloc + rayon scope is not amortized.
-        const MIN_TOTAL_COST: u64 = 1_000_000;
         let worthwhile = fwd_seeds.len() >= 2
             && total >= MIN_TOTAL_COST
-            && (max_local as f64) < 0.7 * (total as f64);
+            && (max_local as f64) < MAX_LOCAL_SHARE * (total as f64);
 
         CbTaskPlan {
             owned,
@@ -816,6 +871,82 @@ impl CbTaskPlan {
             worthwhile,
         }
     }
+}
+
+/// Whether the contribution-block core suits this factor at all — a
+/// **host-independent** verdict (issue #177).
+///
+/// The two solve cores use different, equally valid reassociations, so
+/// which one runs is numerically visible and must not be decided by
+/// anything the host controls. This builds the coarsening at the fixed
+/// [`CB_REFERENCE_FANOUT`] granularity — never from
+/// `rayon::current_num_threads()` and never from `FERAL_CB_THRESH` — and
+/// applies the same three-part test `CbTaskPlan::worthwhile` uses.
+///
+/// Measured on this repo's fixtures (4 workers, refined solve, time
+/// relative to the shared-vector core): the CB core costs 1.27–1.86x on
+/// the trees this predicate rejects (path-like chains, small grids) and
+/// returns 0.72x on the bushy grids it accepts. Rejecting is therefore
+/// not merely conservative — it is the faster answer on those trees, and
+/// it stays the faster answer on a host with no workers at all.
+/// Runs on every refined solve, including the ones it turns down, so it
+/// is computed on flat `O(n_nodes)` arrays rather than by building a
+/// `CbTaskPlan` — that allocates three `Vec<Vec<usize>>` of length
+/// `n_nodes` and cost 1.24-1.29x of a whole chain solve when the answer
+/// is "no". `cb_core_profitable_matches_the_plan_gate` pins this against
+/// `CbTaskPlan::worthwhile` so the two cannot drift.
+fn cb_core_profitable(factors: &SparseFactors) -> bool {
+    let nodes = &factors.node_factors;
+    let parents = &factors.node_parents;
+    let n_nodes = nodes.len();
+    if n_nodes == 0 {
+        return false;
+    }
+    let own_cost = |i: usize| -> u64 {
+        let ff = &nodes[i].frontal_factors;
+        (ff.nrow as u64).saturating_mul(ff.nelim as u64 + 1)
+    };
+    // Subtree cost bottom-up. `node_factors` is postorder, so a node's
+    // own total is complete by the time we fold it into its parent — no
+    // child lists needed.
+    let mut subtree_cost: Vec<u64> = (0..n_nodes).map(own_cost).collect();
+    let mut total = 0u64;
+    for i in 0..n_nodes {
+        total = total.saturating_add(own_cost(i));
+        if let Some(p) = parents[i] {
+            subtree_cost[p] = subtree_cost[p].saturating_add(subtree_cost[i]);
+        }
+    }
+    let thresh = CbThreshold::Reference.resolve(total);
+
+    // `local[t]` = the work task root `t` runs itself = its subtree minus
+    // the subtrees of its task-root children. A task root's parent is
+    // itself a task root by subtree-cost monotonicity, so every task root
+    // with a parent is a task-root child of it.
+    let is_task_root = |i: usize| parents[i].is_none() || subtree_cost[i] >= thresh;
+    let mut local = subtree_cost.clone();
+    let mut tr_children = vec![0usize; n_nodes];
+    for i in 0..n_nodes {
+        if !is_task_root(i) {
+            continue;
+        }
+        if let Some(p) = parents[i] {
+            tr_children[p] += 1;
+            local[p] = local[p].saturating_sub(subtree_cost[i]);
+        }
+    }
+    let mut fwd_seeds = 0usize;
+    let mut max_local = 0u64;
+    for t in 0..n_nodes {
+        if !is_task_root(t) {
+            continue;
+        }
+        if tr_children[t] == 0 {
+            fwd_seeds += 1;
+        }
+        max_local = max_local.max(local[t]);
+    }
+    fwd_seeds >= 2 && total >= MIN_TOTAL_COST && (max_local as f64) < MAX_LOCAL_SHARE * total as f64
 }
 
 /// Shared, read-only context threaded through the CB solve tasks.
@@ -938,11 +1069,25 @@ pub(crate) struct CbSolveWorkspace {
 
 impl CbSolveWorkspace {
     pub(crate) fn for_factors(factors: &SparseFactors) -> Self {
+        Self::for_factors_with_threshold(factors, CbThreshold::FromWorkers)
+    }
+
+    /// `threshold` picks the coarsening granularity. Only the task
+    /// decomposition changes; the arithmetic is invariant (issue #177),
+    /// which is what `cb_coarsening_threshold_is_arithmetically_inert`
+    /// asserts.
+    fn for_factors_with_threshold(factors: &SparseFactors, threshold: CbThreshold) -> Self {
         let n = factors.n;
         let nodes = &factors.node_factors;
         let n_nodes = nodes.len();
         let children = build_children(&factors.node_parents, n_nodes);
-        let plan = CbTaskPlan::build(&children, &factors.node_parents, nodes, n_nodes);
+        let plan = CbTaskPlan::build_with_threshold(
+            &children,
+            &factors.node_parents,
+            nodes,
+            n_nodes,
+            threshold,
+        );
         let max_nrow = nodes
             .iter()
             .map(|nd| nd.frontal_factors.nrow)
@@ -964,15 +1109,29 @@ impl CbSolveWorkspace {
         }
     }
 
-    /// Whether the tree-parallel path is expected to beat the serial core
-    /// on this factor (see `CbTaskPlan::worthwhile`).
+    /// Whether tree-parallel execution is expected to beat running the
+    /// same CB core serially on this factor (see `CbTaskPlan::worthwhile`).
+    /// A scheduling predicate: both answers produce identical bits, which
+    /// is why nothing outside the CB core is allowed to branch on it
+    /// (issue #177) — hence test-only visibility.
+    #[cfg(test)]
     pub(crate) fn worthwhile(&self) -> bool {
         self.plan.worthwhile
     }
 
+    /// Number of task roots the coarsening produced — the size of the
+    /// task decomposition. Reported so the #177 threshold sweep can show
+    /// the plan really changed while the output did not.
+    #[cfg(test)]
+    pub(crate) fn task_root_count(&self) -> usize {
+        self.plan.is_task_root.iter().filter(|b| **b).count()
+    }
+
     /// Solve `A x = b` into `x_out` using this workspace. `parallel`
     /// requests tree-parallel execution, honoured only when the plan is
-    /// `worthwhile`; otherwise the byte-identical serial core runs. MC64
+    /// `worthwhile`; otherwise the byte-identical serial core runs — the
+    /// result is the same bits either way, so neither the `parallel`
+    /// argument nor the worker count is observable in the output. MC64
     /// pre/post scaling is fused into the entry permute and exit unpermute.
     pub(crate) fn solve_into(
         &mut self,
@@ -1052,10 +1211,17 @@ impl CbSolveWorkspace {
 
 /// Opt-in contribution-block sparse solve (issue #131 Gap A), single RHS.
 /// Applies the same MC64 pre/post scaling as `solve_sparse`. `parallel`
-/// selects the tree-parallel execution (honoured when the tree is
-/// `worthwhile`); serial and parallel are byte-identical. Allocates a
-/// one-shot [`CbSolveWorkspace`]; callers doing repeated solves against
-/// one factor should build and reuse a workspace instead.
+/// selects tree-parallel execution (honoured when the tree is
+/// `worthwhile`); serial and parallel execution of this core are
+/// byte-identical, and so are runs on hosts with different core counts.
+///
+/// That byte-identity is *within* this core. It is not a claim that this
+/// core agrees with [`solve_sparse`]: the two use different, equally
+/// valid reassociations (see the module notes above and [`SolveCore`]),
+/// and issue #177 records what went wrong when a runtime gate was allowed
+/// to pick between them. Allocates a one-shot [`CbSolveWorkspace`];
+/// callers doing repeated solves against one factor should build and
+/// reuse a workspace instead.
 pub fn solve_sparse_cb(
     factors: &SparseFactors,
     rhs: &[f64],
@@ -1691,25 +1857,75 @@ pub fn solve_sparse_refined(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<Vec<f64>, FeralError> {
-    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, false)?;
+    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, SolveCore::SharedVector)?;
     Ok(x)
 }
 
-/// Iterative refinement using the tree-parallel contribution-block solve
-/// (issue #131 Gap A) for the initial and correction solves, pooling one
-/// `CbSolveWorkspace` across them. Falls back per-solve to the serial
-/// path when the factor's assembly tree is not `worthwhile` (path-like /
-/// small trees), so it never regresses those; on bushy trees it runs the
-/// substitutions across the rayon pool. The refined result is a valid
-/// solution equal to `solve_sparse_refined`'s up to floating-point
-/// reassociation. Used by `Solver::solve_refined` when parallelism is on.
+/// Iterative refinement through the contribution-block solve core (issue
+/// #131 Gap A) for the initial and correction solves, pooling one
+/// `CbSolveWorkspace` across them.
+///
+/// `parallel` requests tree-parallel execution over the current rayon
+/// pool; the CB core self-gates per factor (`CbTaskPlan::worthwhile`) and
+/// runs single-threaded on path-like / small trees where the scope
+/// overhead would not pay. **Neither `parallel` nor the gate's verdict
+/// changes a single result bit** — the child-reduction order is fixed at
+/// ascending child index in both. Pass `parallel: false` when no worker
+/// pool is available and you still need the CB core's arithmetic (issue
+/// #154's pool-less fallback, issue #177).
+///
+/// The refined result is a valid solution equal to
+/// `solve_sparse_refined`'s up to floating-point reassociation: the CB
+/// forward groups contributions by subtree, the shared-vector core folds
+/// them in flat postorder. Choosing between the two cores is therefore a
+/// numerically visible decision and belongs to the caller — see
+/// [`SolveCore`]. Used by `Solver::solve_refined` when parallelism is on.
+pub fn solve_sparse_refined_cb(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    parallel: bool,
+) -> Result<Vec<f64>, FeralError> {
+    let (x, _) = solve_sparse_refined_core(
+        matrix,
+        factors,
+        rhs,
+        false,
+        SolveCore::ContribBlock { parallel },
+    )?;
+    Ok(x)
+}
+
+/// Iterative refinement through whichever solve core suits the factor,
+/// chosen by [`SolveCore::Auto`] — the CB core on bushy trees where it
+/// pays, the shared-vector core elsewhere.
+///
+/// The choice is a pure function of the factor: the same factor solves
+/// with the same arithmetic on a single-core host and a 64-core one, with
+/// or without a thread pool, whatever `FERAL_CB_THRESH` says (issue
+/// #177). `parallel` requests tree-parallel execution when the CB core
+/// was chosen, and cannot move a result bit.
+///
+/// This is what [`crate::numeric::solver::Solver::solve_refined`] calls.
+pub fn solve_sparse_refined_auto(
+    matrix: &CscMatrix,
+    factors: &SparseFactors,
+    rhs: &[f64],
+    parallel: bool,
+) -> Result<Vec<f64>, FeralError> {
+    let (x, _) =
+        solve_sparse_refined_core(matrix, factors, rhs, false, SolveCore::Auto { parallel })?;
+    Ok(x)
+}
+
+/// [`solve_sparse_refined_cb`] with tree-parallel execution requested.
+/// Retained as the established name for the issue #131 Gap A entry point.
 pub fn solve_sparse_refined_parallel(
     matrix: &CscMatrix,
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<Vec<f64>, FeralError> {
-    let (x, _) = solve_sparse_refined_core(matrix, factors, rhs, false, true)?;
-    Ok(x)
+    solve_sparse_refined_cb(matrix, factors, rhs, true)
 }
 
 /// Per-step diagnostic data emitted by
@@ -1782,7 +1998,7 @@ pub fn solve_sparse_refined_with_diagnostics(
     factors: &SparseFactors,
     rhs: &[f64],
 ) -> Result<(Vec<f64>, RefinementDiagnostics), FeralError> {
-    let (x, diag) = solve_sparse_refined_core(matrix, factors, rhs, true, false)?;
+    let (x, diag) = solve_sparse_refined_core(matrix, factors, rhs, true, SolveCore::SharedVector)?;
     // `with_diagnostics = true` always yields `Some`; if it ever doesn't,
     // that's a logic bug — `expect` is fine in test code, but per CLAUDE.md
     // we use Result in src/. Return DimensionMismatch as a defensive
@@ -1794,12 +2010,51 @@ pub fn solve_sparse_refined_with_diagnostics(
     Ok((x, diag))
 }
 
+/// Which numerical core a refinement run uses. Issue #177: this is the
+/// *only* thing that may change a refined solve's arithmetic, and it is
+/// always set explicitly by the caller — never inferred from the host's
+/// core count, the rayon pool's existence, or `FERAL_CB_THRESH`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SolveCore {
+    /// The shared-global-vector core (`solve_sparse_core_into`): each
+    /// front's separator update folded into `y` in flat postorder. The
+    /// default, and the only core available without parallelism.
+    SharedVector,
+    /// The contribution-block core (issue #131 Gap A): each front's RHS
+    /// assembled from `b` plus its children's contribution blocks, summed
+    /// in ascending child order — a subtree sum tree rather than a flat
+    /// fold, hence a different (equally valid) reassociation.
+    ///
+    /// `parallel` selects tree-parallel execution over the rayon pool;
+    /// it is a *scheduling* choice with no effect on the result bits, and
+    /// is further gated internally by `CbTaskPlan::worthwhile`.
+    ContribBlock {
+        /// Execute over the rayon pool rather than in one thread.
+        parallel: bool,
+    },
+    /// Pick between the two cores from the factor's structure alone, via
+    /// the host-independent `cb_core_profitable` predicate: the CB core
+    /// on bushy trees where it pays, the shared-vector core on path-like
+    /// and small trees where it does not.
+    ///
+    /// This is the mode `Solver` uses. It is deliberately *not* a
+    /// function of `use_parallel`, the thread pool, the worker count, or
+    /// `FERAL_CB_THRESH` — issue #177: the same factor must solve with
+    /// the same arithmetic on every host, and only the schedule may vary.
+    /// `parallel` therefore selects execution strategy alone.
+    Auto {
+        /// Execute over the rayon pool rather than in one thread, if the
+        /// factor-derived choice landed on the CB core.
+        parallel: bool,
+    },
+}
+
 fn solve_sparse_refined_core(
     matrix: &CscMatrix,
     factors: &SparseFactors,
     rhs: &[f64],
     with_diagnostics: bool,
-    parallel_cb: bool,
+    core: SolveCore,
 ) -> Result<(Vec<f64>, Option<RefinementDiagnostics>), FeralError> {
     let n = factors.n;
     if rhs.len() != n {
@@ -1821,25 +2076,40 @@ fn solve_sparse_refined_core(
         (0.0, 0.0)
     };
 
-    // Issue #131 Gap A: when the caller opts into the tree-parallel path
-    // and the factor's assembly tree is `worthwhile`, pool one
-    // contribution-block workspace across the initial + up-to-10
-    // correction solves (each reuses the plan + scratch). Otherwise keep
-    // the proven shared-vector `SolveWorkspace` path, bit-for-bit.
-    let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
-        let cb = CbSolveWorkspace::for_factors(factors);
-        cb.worthwhile().then_some(cb)
-    } else {
-        None
-    };
+    // Issue #131 Gap A: when the caller selects the contribution-block
+    // core, pool one CB workspace across the initial + up-to-10 correction
+    // solves (each reuses the plan + scratch). Otherwise use the
+    // shared-vector `SolveWorkspace` path, bit-for-bit.
+    //
+    // Issue #177: the choice is made *here*, from the caller's explicit
+    // `core` argument, and nowhere else. It used to be made by
+    // `CbSolveWorkspace::worthwhile()`, which is derived from
+    // `rayon::current_num_threads()` and `FERAL_CB_THRESH` — so the same
+    // build on hosts with different core counts silently ran different
+    // arithmetic, and an IPM host amplified the ULP difference into
+    // different iterate trajectories (henon120). `worthwhile` now only
+    // picks the CB core's *execution* strategy, and both strategies emit
+    // identical bits.
+    let use_cb = n > 0
+        && match core {
+            SolveCore::SharedVector => false,
+            SolveCore::ContribBlock { .. } => true,
+            SolveCore::Auto { .. } => cb_core_profitable(factors),
+        };
+    let mut cb_ws: Option<CbSolveWorkspace> =
+        use_cb.then(|| CbSolveWorkspace::for_factors(factors));
     let mut ws: Option<SolveWorkspace> = if cb_ws.is_none() {
         Some(SolveWorkspace::for_factors(factors))
     } else {
         None
     };
+    let cb_parallel = matches!(
+        core,
+        SolveCore::ContribBlock { parallel: true } | SolveCore::Auto { parallel: true }
+    );
     let mut x = vec![0.0; n];
     match (cb_ws.as_mut(), ws.as_mut()) {
-        (Some(cb), _) => cb.solve_into(factors, rhs, &mut x, true),
+        (Some(cb), _) => cb.solve_into(factors, rhs, &mut x, cb_parallel),
         (None, Some(w)) => solve_sparse_into_ws(factors, rhs, &mut x, w)?,
         (None, None) => unreachable!("exactly one solve workspace is built"),
     }
@@ -1909,7 +2179,7 @@ fn solve_sparse_refined_core(
         }
 
         match (cb_ws.as_mut(), ws.as_mut()) {
-            (Some(cb), _) => cb.solve_into(factors, &r, &mut dx, true),
+            (Some(cb), _) => cb.solve_into(factors, &r, &mut dx, cb_parallel),
             (None, Some(w)) => solve_sparse_into_ws(factors, &r, &mut dx, w)?,
             (None, None) => unreachable!("exactly one solve workspace is built"),
         }
@@ -2562,5 +2832,221 @@ mod tests {
     fn reg3_rejected_block_skipped_by_helper() {
         let p = (1u64 << 53) as f64;
         assert!(solve_2x2_dblock(p + 1.0, p, p, 1.0, 2.0).is_none());
+    }
+
+    /// 2-D Poisson on a `k x k` grid: a bushy nested-dissection tree.
+    fn grid_2d(k: usize) -> CscMatrix {
+        let n = k * k;
+        let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+        for j in 0..k {
+            for i in 0..k {
+                let p = j * k + i;
+                rows.push(p);
+                cols.push(p);
+                vals.push(4.0);
+                if i + 1 < k {
+                    rows.push(p + 1);
+                    cols.push(p);
+                    vals.push(-1.0);
+                }
+                if j + 1 < k {
+                    rows.push(p + k);
+                    cols.push(p);
+                    vals.push(-1.0);
+                }
+            }
+        }
+        CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap()
+    }
+
+    /// A pentadiagonal chain: path-like, so the Amdahl arm rejects it.
+    fn pentadiag_chain(n: usize) -> CscMatrix {
+        let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+        for i in 0..n {
+            rows.push(i);
+            cols.push(i);
+            vals.push(4.0);
+            if i + 1 < n {
+                rows.push(i + 1);
+                cols.push(i);
+                vals.push(-1.0);
+            }
+            if i + 2 < n {
+                rows.push(i + 2);
+                cols.push(i);
+                vals.push(-0.5);
+            }
+        }
+        CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap()
+    }
+
+    /// Issue #177: the CB coarsening threshold is a **scheduling** knob.
+    /// It is derived from `rayon::current_num_threads()` (and overridable
+    /// via `FERAL_CB_THRESH`), so if it could move a result bit, the same
+    /// binary would solve differently on hosts with different core counts
+    /// — which is exactly what the henon120 report caught.
+    ///
+    /// Sweeps the threshold across its whole useful range, asserts the
+    /// task decomposition really changes (otherwise the test is vacuous),
+    /// and asserts every solve is byte-identical, under both serial and
+    /// tree-parallel execution.
+    #[test]
+    fn cb_coarsening_threshold_is_arithmetically_inert() {
+        // Poisson 2-D 40x40: a bushy nested-dissection tree, so the
+        // threshold has many cut points to choose between.
+        let k = 40usize;
+        let n = k * k;
+        let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+        for j in 0..k {
+            for i in 0..k {
+                let p = j * k + i;
+                rows.push(p);
+                cols.push(p);
+                vals.push(4.0);
+                if i + 1 < k {
+                    rows.push(p + 1);
+                    cols.push(p);
+                    vals.push(-1.0);
+                }
+                if j + 1 < k {
+                    rows.push(p + k);
+                    cols.push(p);
+                    vals.push(-1.0);
+                }
+            }
+        }
+        let m = CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap();
+        let sym = symbolic_factorize(&m, &SupernodeParams::default()).unwrap();
+        let (factors, _) = factorize_multifrontal(&m, &sym, &make_params()).unwrap();
+        let b: Vec<f64> = (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect();
+
+        let mut reference: Option<Vec<f64>> = None;
+        let mut root_counts = Vec::new();
+        for thresh in [1u64, 8, 64, 512, 4096, 32_768, 1 << 40, u64::MAX] {
+            for parallel in [false, true] {
+                let mut ws = CbSolveWorkspace::for_factors_with_threshold(
+                    &factors,
+                    CbThreshold::Fixed(thresh),
+                );
+                let mut x = vec![0.0; n];
+                ws.solve_into(&factors, &b, &mut x, parallel);
+                if !parallel {
+                    root_counts.push(ws.task_root_count());
+                }
+                match &reference {
+                    None => reference = Some(x),
+                    Some(r) => {
+                        for i in 0..n {
+                            assert_eq!(
+                                r[i].to_bits(),
+                                x[i].to_bits(),
+                                "thresh={thresh} parallel={parallel}: bit {i} moved \
+                                 — the coarsening plan is not arithmetically inert"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        // Non-vacuity: the sweep really did produce different task
+        // decompositions, from every-node-a-root down to roots-only.
+        let lo = root_counts.iter().copied().min().unwrap_or(0);
+        let hi = root_counts.iter().copied().max().unwrap_or(0);
+        assert!(
+            hi > lo,
+            "threshold sweep produced a single decomposition ({lo} task roots) — \
+             the invariance assertion above proves nothing"
+        );
+    }
+
+    /// Issue #177: `cb_core_profitable` reimplements `CbTaskPlan`'s gate
+    /// on flat arrays, because it runs on every refined solve including
+    /// the ones it turns down and the plan's three `Vec<Vec<usize>>`
+    /// allocations cost more than a whole chain solve. Two
+    /// implementations of one rule can drift, so pin them together
+    /// across tree shapes that land on both sides of the gate.
+    #[test]
+    fn cb_core_profitable_matches_the_plan_gate() {
+        let mut checked_true = false;
+        let mut checked_false = false;
+        for m in [
+            grid_2d(8),
+            grid_2d(40),
+            grid_2d(160),
+            pentadiag_chain(64),
+            pentadiag_chain(400),
+            pentadiag_chain(20_000),
+        ] {
+            let sym = symbolic_factorize(&m, &SupernodeParams::default()).unwrap();
+            let (factors, _) = factorize_multifrontal(&m, &sym, &make_params()).unwrap();
+            let n_nodes = factors.node_factors.len();
+            let children = build_children(&factors.node_parents, n_nodes);
+            let plan = CbTaskPlan::build_with_threshold(
+                &children,
+                &factors.node_parents,
+                &factors.node_factors,
+                n_nodes,
+                CbThreshold::Reference,
+            );
+            let flat = cb_core_profitable(&factors);
+            assert_eq!(
+                flat, plan.worthwhile,
+                "n={}: flat predicate says {flat}, CbTaskPlan says {}",
+                m.n, plan.worthwhile
+            );
+            checked_true |= flat;
+            checked_false |= !flat;
+        }
+        assert!(
+            checked_true && checked_false,
+            "fixtures must land on both sides of the gate \
+             (saw profitable={checked_true}, rejected={checked_false})"
+        );
+    }
+
+    /// Issue #177: `worthwhile` is a scheduling predicate, so requesting
+    /// parallel execution on a factor it rejects must still run the CB
+    /// core (serially) — not silently switch to the shared-vector core.
+    ///
+    /// A short tridiagonal chain is below `MIN_TOTAL_COST` and path-like,
+    /// so the gate rejects it; the CB result must nonetheless differ from
+    /// `solve_sparse` only as a reassociation, and must equal the CB core
+    /// run either way, bit for bit.
+    #[test]
+    fn cb_core_is_used_even_when_the_parallel_gate_rejects_the_tree() {
+        let n = 120usize;
+        let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+        for i in 0..n {
+            rows.push(i);
+            cols.push(i);
+            vals.push(4.0);
+            if i + 1 < n {
+                rows.push(i + 1);
+                cols.push(i);
+                vals.push(-1.0);
+            }
+        }
+        let m = CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap();
+        let sym = symbolic_factorize(&m, &SupernodeParams::default()).unwrap();
+        let (factors, _) = factorize_multifrontal(&m, &sym, &make_params()).unwrap();
+        let b: Vec<f64> = (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect();
+
+        let ws = CbSolveWorkspace::for_factors(&factors);
+        assert!(
+            !ws.worthwhile(),
+            "fixture must land on the rejected side of the gate"
+        );
+
+        let mut x_par = vec![0.0; n];
+        let mut x_ser = vec![0.0; n];
+        CbSolveWorkspace::for_factors(&factors).solve_into(&factors, &b, &mut x_par, true);
+        CbSolveWorkspace::for_factors(&factors).solve_into(&factors, &b, &mut x_ser, false);
+        for i in 0..n {
+            assert_eq!(
+                x_par[i].to_bits(),
+                x_ser[i].to_bits(),
+                "gate-rejected factor: requesting parallel changed bit {i}"
+            );
+        }
     }
 }

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -18,8 +18,8 @@ use crate::numeric::factorize::{
     FactorWorkspace, NumericParams, ProfileReport, Profiler, SparseFactors,
 };
 use crate::numeric::solve::{
-    solve_sparse, solve_sparse_many, solve_sparse_many_refined, solve_sparse_refined,
-    solve_sparse_refined_parallel, BLAS3_REFINE_THRESHOLD,
+    solve_sparse, solve_sparse_many, solve_sparse_many_refined, solve_sparse_refined_auto,
+    BLAS3_REFINE_THRESHOLD,
 };
 use crate::scaling::{
     mc64_value_bound_passes, pick_scaling_strategy, precompute_mc64_validity, Mc64CacheValidity,
@@ -1616,24 +1616,27 @@ impl Solver {
             None => return Err(FeralError::NoFactor),
         };
         // Issue #131 Gap A: when parallelism is on, refine through the
-        // tree-parallel contribution-block solve (pooled across the
-        // initial + correction solves). It self-gates per factor — on
-        // path-like / small trees it runs the serial core, matching the
-        // default path's behavior. Install on this solver's pool (built
-        // during the parallel factor) so the solve uses the same worker
-        // count and does not oversubscribe.
+        // contribution-block solve core (pooled across the initial +
+        // correction solves). Install on this solver's pool (built during
+        // the parallel factor) so the solve uses the same worker count
+        // and does not oversubscribe.
         //
-        // Issue #154: if no pool was built, run the serial refine
-        // rather than falling through to the global pool. The previous
-        // comment here stated the global-pool fall-through as
-        // intentional; it is not — no pool means threads were
-        // unavailable, and reaching for a different pool does not make
-        // them available. Serial refinement is bit-exact with the
-        // self-gated serial core the parallel path already takes on
-        // path-like trees.
+        // Issue #154: if no pool was built, do not fall through to
+        // rayon's global pool — no pool means threads were unavailable,
+        // and reaching for a different pool does not make them available.
+        //
+        // Issue #177: *which core* runs is no longer a runtime decision
+        // at all. The two cores use different reassociations, so a gate
+        // derived from `rayon::current_num_threads()` — or from whether
+        // the pool got built, or from `use_parallel` (itself defaulted
+        // from `available_parallelism()`) — made the arithmetic a
+        // function of the host's core count. `SolveCore::Auto` picks from
+        // the factor's structure alone, so a given factor solves
+        // identically on every host; `use_parallel` and the pool now
+        // choose only the execution strategy, which is bit-neutral.
         match (self.use_parallel, &self.parallel_pool) {
-            (true, Some(pool)) => pool.install(|| solve_sparse_refined_parallel(matrix, f, rhs)),
-            _ => solve_sparse_refined(matrix, f, rhs),
+            (true, Some(pool)) => pool.install(|| solve_sparse_refined_auto(matrix, f, rhs, true)),
+            _ => solve_sparse_refined_auto(matrix, f, rhs, false),
         }
     }
 
@@ -1688,12 +1691,14 @@ impl Solver {
         for c in 0..nrhs {
             let src = &rhs[c * n..(c + 1) * n];
             // Same #131 Gap A dispatch as `solve_refined` (per column),
-            // with the same #154 pool-or-serial fallback.
+            // with the same #154 pool-or-serial fallback and the same
+            // #177 rule: the factor picks the core, the pool picks only
+            // the schedule.
             let xc = match (self.use_parallel, &self.parallel_pool) {
                 (true, Some(pool)) => {
-                    pool.install(|| solve_sparse_refined_parallel(matrix, factors, src))
+                    pool.install(|| solve_sparse_refined_auto(matrix, factors, src, true))
                 }
-                _ => solve_sparse_refined(matrix, factors, src),
+                _ => solve_sparse_refined_auto(matrix, factors, src, false),
             }?;
             out[c * n..(c + 1) * n].copy_from_slice(&xc);
         }
@@ -3066,8 +3071,7 @@ mod tests {
     }
 
     /// Issue #154: `use_parallel` on with no pool built must run the
-    /// *sequential* refine, not the tree-parallel one on rayon's
-    /// global pool.
+    /// refine in this thread, not on rayon's global pool.
     ///
     /// That state is reachable in production whenever
     /// `ThreadPoolBuilder::build()` fails — `wasm32-wasip1`, or an
@@ -3079,9 +3083,19 @@ mod tests {
     /// without building one, so this exercises exactly the fallback
     /// arm those two call sites take.
     ///
-    /// Asserted bit-identically against a plain sequential solver:
-    /// the fallback is a scheduling decision and must not perturb
-    /// numerics.
+    /// Issue #177 narrowed what "must not perturb numerics" means here.
+    /// The original wording asserted the fallback against a plain
+    /// *sequential* solver, which was only ever true because this
+    /// fixture is small enough that the parallel dispatch declined the
+    /// contribution-block core anyway. `use_parallel` now selects the
+    /// core outright, so the invariant that actually holds — and the
+    /// one worth defending — is that **pool availability changes
+    /// nothing**: pool-less parallel must equal pooled parallel, bit
+    /// for bit. Both are asserted below, the sequential comparison
+    /// retained because on this path-like fixture the CB core and the
+    /// shared-vector core do coincide, so it still has content.
+    /// `tests/refined_solve_core_stability.rs` carries the same
+    /// pooled-vs-pool-less assertion on a factor where they do not.
     #[test]
     fn solver_parallel_without_pool_falls_back_to_serial_refine() {
         let n = 64usize;
@@ -3143,6 +3157,36 @@ mod tests {
                 a.to_bits(),
                 b.to_bits(),
                 "solve_many_refined[{}] differs: fallback = {}, sequential = {}",
+                i,
+                a,
+                b
+            );
+        }
+
+        // Issue #177: the invariant that must hold on *every* factor —
+        // requesting parallelism and getting a pool must give the same
+        // bits as requesting it and not getting one.
+        let mut pooled = Solver::new().with_parallel(true);
+        assert!(matches!(pooled.factor(&m, None), FactorStatus::Success));
+        let pooled_x = pooled.solve_refined(&m, &rhs).expect("pooled refine");
+        for (i, (a, b)) in x.iter().zip(pooled_x.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "solve_refined[{}] differs: pool-less = {}, pooled = {}",
+                i,
+                a,
+                b
+            );
+        }
+        let pooled_many = pooled
+            .solve_many_refined(&m, &rhs, 1)
+            .expect("pooled multi-refine");
+        for (i, (a, b)) in many.iter().zip(pooled_many.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "solve_many_refined[{}] differs: pool-less = {}, pooled = {}",
                 i,
                 a,
                 b

--- a/tests/cb_core_choice_ignores_env.rs
+++ b/tests/cb_core_choice_ignores_env.rs
@@ -1,0 +1,99 @@
+//! Issue #177: `FERAL_CB_THRESH` must not change a result bit.
+//!
+//! The reporter's repro drove the divergence with exactly this variable:
+//!
+//! ```sh
+//! env FERAL_PAR_TASK_MIN_FLOPS=1000000000000 pounce henon120.nl ...
+//! env FERAL_PAR_TASK_MIN_FLOPS=1000000000000 FERAL_CB_THRESH=1000000000000 pounce ...
+//! ```
+//!
+//! with the factorization held sequential in both, so the solve was the
+//! only thing varying — and the two runs diverged from IPM iteration 19.
+//! `FERAL_CB_THRESH` fed `CbTaskPlan`'s coarsening, whose `worthwhile`
+//! verdict then chose between the contribution-block and shared-vector
+//! solve cores. It is now confined to scheduling.
+//!
+//! **This file must contain exactly one test.** It mutates the process
+//! environment, which is shared by every test in a binary but not across
+//! binaries; a second test here could observe a half-applied variable.
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::numeric::solve::solve_sparse_refined_auto;
+use feral::numeric::solver::Solver;
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, FactorStatus, ZeroPivotAction};
+
+fn poisson_2d_spd(k: usize) -> CscMatrix {
+    let n = k * k;
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    for j in 0..k {
+        for i in 0..k {
+            let p = j * k + i;
+            rows.push(p);
+            cols.push(p);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(p + 1);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(p + k);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("poisson_2d")
+}
+
+#[test]
+fn feral_cb_thresh_cannot_change_a_result_bit() {
+    // n = 25600, bushy: routed to the CB core, so `FERAL_CB_THRESH` has
+    // real coarsening decisions to change. A factor that never reaches
+    // the CB core would make this vacuous.
+    let m = poisson_2d_spd(160);
+    let n = m.n;
+    let sym = symbolic_factorize(&m, &SupernodeParams::default()).expect("symbolic");
+    let params = NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        pivot_threshold: 0.0,
+        ..BunchKaufmanParams::default()
+    });
+    let (f, _) = factorize_multifrontal(&m, &sym, &params).expect("numeric");
+    let b: Vec<f64> = (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect();
+
+    let mut solver = Solver::new().with_parallel(true);
+    assert!(matches!(solver.factor(&m, None), FactorStatus::Success));
+
+    let base_free = solve_sparse_refined_auto(&m, &f, &b, true).expect("baseline refine");
+    let base_solver = solver
+        .solve_refined(&m, &b)
+        .expect("baseline solver refine");
+
+    // The reporter's own value, plus the opposite extreme (every node its
+    // own task root) and a mid-range cut.
+    for v in ["1", "512", "1000000000000"] {
+        // SAFETY: this binary contains exactly one test (enforced by the
+        // module docs above), so no other thread is reading the
+        // environment concurrently.
+        unsafe { std::env::set_var("FERAL_CB_THRESH", v) };
+
+        let x_free = solve_sparse_refined_auto(&m, &f, &b, true).expect("refine");
+        let x_solver = solver.solve_refined(&m, &b).expect("solver refine");
+        for i in 0..n {
+            assert_eq!(
+                base_free[i].to_bits(),
+                x_free[i].to_bits(),
+                "FERAL_CB_THRESH={v}: solve_sparse_refined_auto moved bit {i}"
+            );
+            assert_eq!(
+                base_solver[i].to_bits(),
+                x_solver[i].to_bits(),
+                "FERAL_CB_THRESH={v}: Solver::solve_refined moved bit {i}"
+            );
+        }
+    }
+    // SAFETY: as above.
+    unsafe { std::env::remove_var("FERAL_CB_THRESH") };
+}

--- a/tests/refined_solve_core_stability.rs
+++ b/tests/refined_solve_core_stability.rs
@@ -1,0 +1,301 @@
+//! Issue #177 — a refined solve's arithmetic must be a function of the
+//! factor, never of the host.
+//!
+//! feral has two numerically distinct sparse solve cores: the
+//! shared-global-vector core (`solve_sparse`, a flat postorder fold) and
+//! the contribution-block core of issue #131 Gap A (a subtree sum tree).
+//! They differ in the last bits by design — each is a valid
+//! reassociation of the other.
+//!
+//! What #177 reports is that *which* core ran was decided by
+//! `CbTaskPlan::worthwhile`, a predicate computed from
+//! `rayon::current_num_threads()` and `FERAL_CB_THRESH`, and by whether a
+//! thread pool had been built. So the same binary, same matrix, same
+//! factor did different arithmetic on hosts with different core counts —
+//! and #16 established that a ULP difference here is amplified by the IPM
+//! host's line search into whole different iterate trajectories (141 vs
+//! 888 outer iterations on qcqp1000-1nc). Reported on henon120.
+//!
+//! Contracts checked here, at the *driver* level that
+//! `tests/cb_solve_parity.rs` does not reach:
+//!
+//!  1. worker count does not move a bit of a refined solve;
+//!  2. serial vs tree-parallel execution are byte-identical — #131's
+//!     contract, now literally true rather than true-when-gated;
+//!  3. `Solver::solve_refined` is byte-identical whether or not a thread
+//!     pool was built, and whether or not parallelism was requested at
+//!     all — the latter closes `Solver::default_use_parallel()`, which
+//!     reads `available_parallelism()` and so was itself a route from
+//!     core count to arithmetic;
+//!  4. the factor-derived core choice really does route each factor to
+//!     the intended core.
+//!
+//! Every invariance claim is exercised on matrices sitting on *both*
+//! sides of the profitability predicate, since that predicate was the
+//! thing doing the switching.
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::numeric::solve::{
+    solve_sparse_refined, solve_sparse_refined_auto, solve_sparse_refined_cb,
+};
+use feral::numeric::solver::Solver;
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, FactorStatus, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        pivot_threshold: 0.0,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+/// 2-D Poisson on a `k x k` grid: a bushy nested-dissection tree. Large
+/// `k` clears the profitability predicate; small `k` does not.
+fn poisson_2d_spd(k: usize) -> CscMatrix {
+    let n = k * k;
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    for j in 0..k {
+        for i in 0..k {
+            let p = j * k + i;
+            rows.push(p);
+            cols.push(p);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(p + 1);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(p + k);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("poisson_2d")
+}
+
+/// A pentadiagonal chain: path-like, so the Amdahl arm of the predicate
+/// rejects it however many workers the host has.
+fn chain(n: usize) -> CscMatrix {
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    for i in 0..n {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < n {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+        if i + 2 < n {
+            rows.push(i + 2);
+            cols.push(i);
+            vals.push(-0.5);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("chain")
+}
+
+fn factor_of(m: &CscMatrix) -> feral::numeric::factorize::SparseFactors {
+    let sym = symbolic_factorize(m, &SupernodeParams::default()).expect("symbolic");
+    let (f, _) = factorize_multifrontal(m, &sym, &ldlt_params()).expect("numeric");
+    f
+}
+
+fn rhs_for(n: usize) -> Vec<f64> {
+    (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect()
+}
+
+fn bit_diff(a: &[f64], b: &[f64]) -> usize {
+    (0..a.len())
+        .filter(|&i| a[i].to_bits() != b[i].to_bits())
+        .count()
+}
+
+fn assert_bit_eq(a: &[f64], b: &[f64], what: &str) {
+    let d = bit_diff(a, b);
+    assert_eq!(d, 0, "{what}: {d} of {} entries differ", a.len());
+}
+
+/// Contracts 1 and 2 over one matrix: the refined solve is invariant to
+/// worker count and to the serial/parallel execution choice.
+fn check_host_invariance(m: &CscMatrix, label: &str) {
+    let f = factor_of(m);
+    let n = m.n;
+    let b = rhs_for(n);
+
+    // Reference: no pool, no parallelism requested — the state a host
+    // that cannot spawn threads ends up in.
+    let reference = solve_sparse_refined_auto(m, &f, &b, false).expect("serial auto refine");
+
+    for nt in [1usize, 2, 3, 4, 8] {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(nt)
+            .build()
+            .expect("pool");
+        let x = pool
+            .install(|| solve_sparse_refined_auto(m, &f, &b, true))
+            .expect("parallel auto refine");
+        assert_bit_eq(
+            &reference,
+            &x,
+            &format!("[{label}] refined solve at {nt} workers vs no pool"),
+        );
+    }
+
+    // The explicit CB entry point honours the same contract: its
+    // `parallel` argument is a scheduling request, not an arithmetic one.
+    let cb_serial = solve_sparse_refined_cb(m, &f, &b, false).expect("cb serial");
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .expect("pool");
+    let cb_par = pool
+        .install(|| solve_sparse_refined_cb(m, &f, &b, true))
+        .expect("cb parallel");
+    assert_bit_eq(
+        &cb_serial,
+        &cb_par,
+        &format!("[{label}] CB core: serial vs tree-parallel execution"),
+    );
+
+    // And the result is a genuine solve, not merely a stable one.
+    let mut ax = vec![0.0; n];
+    m.symv(&reference, &mut ax);
+    let (mut r2, mut b2) = (0.0f64, 0.0f64);
+    for i in 0..n {
+        r2 += (ax[i] - b[i]).powi(2);
+        b2 += b[i] * b[i];
+    }
+    let rel = (r2 / b2.max(1e-300)).sqrt();
+    assert!(rel < 1e-8, "[{label}] refined residual {rel:e} too large");
+}
+
+#[test]
+fn refined_solve_is_host_invariant_on_a_cb_profitable_tree() {
+    // n = 25600: total solve cost ~1.1e6 and a bushy tree, so the
+    // predicate routes this to the CB core and the tree-parallel path
+    // really runs.
+    check_host_invariance(&poisson_2d_spd(160), "poisson_160");
+}
+
+#[test]
+fn refined_solve_is_host_invariant_on_a_cb_rejected_tree() {
+    // Path-like and below the cost floor: the predicate keeps this on the
+    // shared-vector core, which is also the faster core here.
+    check_host_invariance(&chain(400), "chain_400");
+}
+
+#[test]
+fn refined_solve_is_host_invariant_on_a_small_bushy_tree() {
+    check_host_invariance(&poisson_2d_spd(40), "poisson_40");
+}
+
+/// Contract 3, and the sharpest form of the #177 regression.
+///
+/// Two routes ran from the host's core count into the arithmetic:
+/// `Solver::default_use_parallel()` reads `available_parallelism()`, and
+/// `parallel_pool` is `None` whenever `ThreadPoolBuilder::build()` failed
+/// (`wasm32-wasip1`, or a host out of threads under `RLIMIT_NPROC` /
+/// cgroup `pids.max`). Both used to swap the solve core. All three
+/// configurations must now agree bit for bit.
+#[test]
+fn solver_refine_is_identical_across_parallelism_and_pool_availability() {
+    for (label, m) in [
+        ("poisson_160", poisson_2d_spd(160)),
+        ("chain_400", chain(400)),
+    ] {
+        let b = rhs_for(m.n);
+
+        let mut pooled = Solver::new().with_parallel(true);
+        assert!(matches!(pooled.factor(&m, None), FactorStatus::Success));
+        let x_pooled = pooled.solve_refined(&m, &b).expect("pooled refine");
+
+        // Parallelism never requested: what a single-core host gets from
+        // `Solver::new()`, since `default_use_parallel()` is false there.
+        let mut seq = Solver::new().with_parallel(false);
+        assert!(matches!(seq.factor(&m, None), FactorStatus::Success));
+        let x_seq = seq.solve_refined(&m, &b).expect("sequential refine");
+
+        // Parallelism requested but no pool — the post-build-failure
+        // state. `with_parallel` only flips the flag, so the factor and
+        // the absent pool survive the move.
+        let mut poolless = Solver::new().with_parallel(false);
+        assert!(matches!(poolless.factor(&m, None), FactorStatus::Success));
+        let poolless = poolless.with_parallel(true);
+        assert!(poolless.parallel(), "fixture must request parallelism");
+        let x_poolless = poolless.solve_refined(&m, &b).expect("pool-less refine");
+
+        assert_bit_eq(
+            &x_pooled,
+            &x_seq,
+            &format!("[{label}] pooled vs sequential"),
+        );
+        assert_bit_eq(
+            &x_pooled,
+            &x_poolless,
+            &format!("[{label}] pooled vs pool-less"),
+        );
+
+        // The multi-RHS refine dispatches per column through the same
+        // three arms.
+        let many_pooled = pooled.solve_many_refined(&m, &b, 1).expect("pooled many");
+        let many_seq = seq.solve_many_refined(&m, &b, 1).expect("sequential many");
+        let many_poolless = poolless
+            .solve_many_refined(&m, &b, 1)
+            .expect("pool-less many");
+        assert_bit_eq(
+            &many_pooled,
+            &many_seq,
+            &format!("[{label}] many: pooled vs sequential"),
+        );
+        assert_bit_eq(
+            &many_pooled,
+            &many_poolless,
+            &format!("[{label}] many: pooled vs pool-less"),
+        );
+    }
+}
+
+/// Contract 4: the factor-derived choice routes each factor to the core
+/// it is supposed to reach — and the two cores really are
+/// distinguishable, so the invariance assertions above are not passing
+/// vacuously because every path happens to agree anyway.
+#[test]
+fn the_factor_selects_the_intended_core() {
+    // Bushy and large: routed to the CB core, which on this factor is
+    // *not* the shared-vector answer.
+    let m = poisson_2d_spd(160);
+    let f = factor_of(&m);
+    let b = rhs_for(m.n);
+    let auto = solve_sparse_refined_auto(&m, &f, &b, false).expect("auto");
+    let cb = solve_sparse_refined_cb(&m, &f, &b, false).expect("cb");
+    let shared = solve_sparse_refined(&m, &f, &b).expect("shared-vector");
+    assert_bit_eq(&auto, &cb, "poisson_160 auto vs explicit CB");
+    assert!(
+        bit_diff(&auto, &shared) > 0,
+        "poisson_160 cannot distinguish the cores; the invariance tests would be vacuous"
+    );
+    // Both are valid solves: they agree far above the bit level.
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for i in 0..m.n {
+        num = num.max((shared[i] - cb[i]).abs());
+        den = den.max(shared[i].abs());
+    }
+    assert!(
+        num / den.max(1.0) < 1e-9,
+        "cores disagree by more than a reassociation: {:e}",
+        num / den.max(1.0)
+    );
+
+    // Path-like: routed to the shared-vector core, where the CB core
+    // measured 1.27x slower with nothing to show for it.
+    let m = chain(400);
+    let f = factor_of(&m);
+    let b = rhs_for(m.n);
+    let auto = solve_sparse_refined_auto(&m, &f, &b, false).expect("auto");
+    let shared = solve_sparse_refined(&m, &f, &b).expect("shared-vector");
+    assert_bit_eq(&auto, &shared, "chain_400 auto vs shared-vector");
+}


### PR DESCRIPTION
Fixes #177.

## The report is real, but not the bug it looks like

The issue expected to find "a real ordering difference in the code, not a scheduling artifact ... findable deterministically". There isn't one. feral has **two numerically distinct sparse solve cores**:

- `solve_sparse_core_into` — folds each front's separator update into a global vector in flat postorder;
- the contribution-block core (#131 Gap A) — assembles each front's RHS from its children's contribution blocks, summed in ascending child order: a subtree sum tree.

Each is a valid reassociation of the other, and `solve.rs:404-412` already said so. The run the issue calls "serial solve" (`FERAL_CB_THRESH=1000000000000`) was not the CB core scheduled serially — it was the *other core*.

Verified directly. On Poisson 160×160 the two cores differ in **24295 of 25600** entries, while the CB core is bit-stable across 1/2/4/8 workers even though its task decomposition changes from 4 to 50 forward seeds:

```
plan: total=1090303 thresh=68143 roots=36  seeds=4  threads=1
plan: total=1090303 thresh=8517  roots=133 seeds=50 threads=8
threads 1 vs 2: 0    threads 2 vs 4: 0    threads 4 vs 8: 0
```

That reproduces the issue's own observation — parallel runs agree with each other but not with "serial" — from a different mechanism than suspected.

## The actual defect

*Which core ran was a function of the host*, by three routes:

1. `CbSolveWorkspace::worthwhile()` — derived from `rayon::current_num_threads()`, overridable by `FERAL_CB_THRESH` — selected the core in `solve_sparse_refined_core`;
2. `Solver` fell back to the shared-vector core whenever `ThreadPoolBuilder::build()` had failed (#154's arm);
3. `use_parallel` itself defaults from `available_parallelism() > 1`.

#16 established that a ULP difference here is amplified by the IPM host's filter line search into trajectory-level outcomes (141 vs 888 outer iterations on qcqp1000-1nc). So this matches the issue's concrete complaint exactly: same feral, same matrix, same POUNCE build, different iterate paths on machines with different core counts.

It also explains the structure-dependence noted in the issue (henon120 diverges, NARX_CFy does not): the gate has a `total >= 1e6` cost floor, so small factors take the shared-vector core on both sides of the comparison and agree trivially.

## The fix

The core is now a pure function of the factor. `cb_core_profitable` applies the same three-part gate `CbTaskPlan::worthwhile` uses, but coarsens at a fixed `CB_REFERENCE_FANOUT = 64` granularity instead of a worker-derived one, and never reads `FERAL_CB_THRESH`. `SolveCore::Auto` consults it; `Solver::solve_refined` and `solve_many_refined` use `Auto`. Worker count, pool availability and `FERAL_CB_THRESH` now select only the execution schedule, and `cb_run_parallel` / `cb_run_serial` are byte-identical.

New public API: `SolveCore`, `solve_sparse_refined_auto`, `solve_sparse_refined_cb`. `solve_sparse_refined` and `solve_sparse_refined_parallel` are unchanged.

## Why a gate at all

The simpler fix — always use the CB core when parallelism is requested — was implemented and measured before being rejected. Refined solve, best of 7, 4 workers, µs:

| matrix | n | shared-vector | CB-serial | CB-par(4) |
|---|---|---|---|---|
| chain_400 | 400 | 24.0 | 30.6 (1.27x) | 31.5 (1.31x) |
| chain_2000 | 2000 | 119.0 | 154.0 (1.29x) | 162.5 (1.37x) |
| chain_20000 | 20000 | 1271.8 | 1630.7 (1.28x) | 1617.1 (1.27x) |
| poisson_40 | 1600 | 659.3 | 1198.8 (1.82x) | 1228.2 (1.86x) |
| poisson_96 | 9216 | 4649.5 | 5035.4 (1.08x) | 5087.5 (1.09x) |
| poisson_160 | 25600 | 31842.2 | 35188.1 (1.11x) | **22968.5 (0.72x)** |

The CB core's only win is on the one factor where `worthwhile` holds. Everywhere else it is 1.08–1.86x slower with nothing to show for it. And it would not have closed the issue anyway: `use_parallel` is itself host-derived, so a 1-core box and a 4-core box would still disagree.

## Performance after the fix

| matrix | n | shared-vector | auto-serial | auto-par(4) |
|---|---|---|---|---|
| chain_400 | 400 | 22.3 | 22.9 (1.03x) | 22.9 (1.03x) |
| chain_2000 | 2000 | 112.9 | 114.8 (1.02x) | 114.6 (1.01x) |
| chain_20000 | 20000 | 1276.3 | 1276.8 (1.00x) | 1272.0 (1.00x) |
| poisson_40 | 1600 | 642.2 | 657.1 (1.02x) | 691.8 (1.08x) |
| poisson_96 | 9216 | 4549.3 | 4612.6 (1.01x) | 4631.5 (1.02x) |
| poisson_160 | 25600 | 27761.6 | 30632.9 (1.10x) | **20763.6 (0.75x)** |

Factors routed to the shared-vector core are at parity. The accepted cost is localized: on a CB-profitable factor a host that cannot spawn workers pays ~1.10x for the determinism, where before it silently took the other core and a different answer.

`cb_core_profitable` runs on every refined solve including the ones it rejects, so it is computed on flat `O(n_nodes)` arrays. A first version that built a `CbTaskPlan` for the verdict cost 1.24–1.29x on the chains — as much as the core it was declining. The price of the flat rewrite is a second implementation of one gate, pinned by `cb_core_profitable_matches_the_plan_gate` across six fixtures landing on both sides of it.

## Tests

`tests/cb_solve_parity.rs` covered the CB core in isolation, so it never saw this — the divergence was in the *driver* that picks between cores. Added:

- **`tests/refined_solve_core_stability.rs`** — byte-identity across every route the host had into the arithmetic: worker count (1/2/3/4/8), pool vs no pool, `Solver` with parallelism on vs off (closing `default_use_parallel()`), on matrices either side of the gate. Plus a non-vacuity check that the two cores really are distinguishable on the fixture, and that each factor reaches its intended core.
- **`tests/cb_core_choice_ignores_env.rs`** — the issue's own knob, `FERAL_CB_THRESH`, end to end. Deliberately a single-test binary: it mutates the process environment, shared by every test in a binary but not across binaries.
- **`solve.rs` unit tests** — threshold-sweep byte-identity (with an assertion that the sweep really produced different task decompositions, else it proves nothing), gate-rejected factors still running the CB core when asked, and the flat-vs-plan agreement guard.

**Verified to fail before the fix.** `solver_refine_is_identical_across_parallelism_and_pool_availability` against a worktree at 6fb9d26:

```
solve_refined pooled vs pool-less: 24295 of 25600 entries differ
  left: 24295
 right: 0
test result: FAILED. 4 passed; 1 failed
```

After: all 93 test binaries pass, 0 failures. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean; pre-commit hooks installed and passing on both code commits.

Also retargeted the pre-existing `solver_parallel_without_pool_falls_back_to_serial_refine` (#154). It asserted pool-less == `with_parallel(false)`, which is no longer guaranteed in general — it passed only because its n=64 tridiagonal fixture is small enough that both cores coincide. Kept that comparison (still has content on that fixture) and added the invariant that holds everywhere: pool-less == pooled.

## Two caveats before merging

1. **Not verified on henon120.** Everything here was measured on synthetic Poisson grids and chains — the Mittelmann corpus is not in this container. The repro in the issue should now be bit-identical, but please run it before closing #177. Worth also recording the predicate's verdict on henon120: if it routes to the CB core, POUNCE's henon120 trajectory *changes* relative to a 1-core host. That is the intended fix, but it is still a trajectory change downstream should know about.

2. **The bench binary found only the 8 synthetic matrices** in this container — no external corpus, no oracle timings — so both Phase 2.8.1 exit partitions reported `N/A` and no comparison against 2026-08-15-02's 1.61/2.00/1.67/1.67 was possible. The session checkpoint says so at the top rather than implying the numbers held. Correctness on what it could see is intact: inertia 2/2 vs MUMPS, residual 2/2, worst residual 1.26e-16. That benchmark is also unrelated to this change, which touches the solve path and not the factor path.

Session notes: `dev/journal/2026-08-19-01.org`, `dev/sessions/2026-08-19-01.md`, `dev/decisions.md`, `dev/tried-and-rejected.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYvRnVHtoUP6EsB5neW7MN)_