### PR TITLE
fix(env): numeric FERAL_* knobs accept scientific notation and warn on errors (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — numeric `FERAL_*` knobs no longer ignore what you set them to (issue #176)
+
+- **`1e18` now means `1e18`.** Every numeric tuning knob was read as
+  `env::var(NAME).ok().and_then(|v| v.parse().ok()).unwrap_or(DEFAULT)`.
+  Scientific notation is not an integer literal, so `FERAL_CB_THRESH=1e18` and
+  `FERAL_PAR_TASK_MIN_FLOPS=1e18` parsed as nothing and were *silently* replaced
+  by the built-in default — while the docs and pounce's option help write those
+  same defaults as `1e6` / `1e8`. The reporter attributed two perf measurements
+  to paths they believed were switched off and were not.
+- **A value FERAL cannot use now says so.** An unparseable, negative, or
+  non-finite value prints one line to stderr —
+  `warning: FERAL_PIVTOL="-1" must be >= 0; falling back to the built-in default`
+  — before falling back, once per distinct value. A magnitude past the knob's
+  type (`1e30` on a `u64` knob) clamps to the maximum instead of falling back,
+  since that value means "switch this path off". Fractional input rounds rather
+  than truncating.
+- **Applies to every numeric knob**, not just the two reported:
+  `FERAL_CB_THRESH`, `FERAL_PAR_TASK_MIN_FLOPS`, `FERAL_PAR_MIN_SEEDS`,
+  `FERAL_INTRAFRONT_MIN_AREA`, `FERAL_PACKED_SIMD_MIN_WORK`, `FERAL_PIVTOL`,
+  `FERAL_STATIC_PIVOT`, `FERAL_AUTO_CB_BETA`, `FERAL_DENSE_MAX`,
+  `FERAL_SPARSE_MAX`, and the `feral-diagnostics` knobs. The policy lives in one
+  new module, `feral::env`; a test fails the build if a new knob parses its own
+  value locally again.
+- **No default and no gate changed** — only what a knob accepts and what it
+  reports when it refuses. `feral::numeric::factorize::par_task_min_flops()` and
+  `par_min_seeds()` are now public so a caller can confirm what the process
+  resolved a knob to.
+
+
 ### Added — caller-capped iterative refinement and in-place solves (issue #178)
 
 - **`RefineOptions`** makes the refinement step budget a per-call parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,30 @@ All notable changes to FERAL will be documented in this file.
   same defaults as `1e6` / `1e8`. The reporter attributed two perf measurements
   to paths they believed were switched off and were not.
 - **A value FERAL cannot use now says so.** An unparseable, negative, or
-  non-finite value prints one line to stderr —
+  `nan` value prints one line to stderr —
   `warning: FERAL_PIVTOL="-1" must be >= 0; falling back to the built-in default`
   — before falling back, once per distinct value. A magnitude past the knob's
   type (`1e30` on a `u64` knob) clamps to the maximum instead of falling back,
-  since that value means "switch this path off". Fractional input rounds rather
-  than truncating.
+  since that value means "switch this path off"; so do `1e400` and `inf`, which
+  are that same request written past the range of `f64`. On a float-valued knob
+  (`FERAL_PIVTOL`, `FERAL_STATIC_PIVOT`) `inf` has no such reading and is
+  refused. Fractional input rounds rather than truncating.
 - **Applies to every numeric knob**, not just the two reported:
   `FERAL_CB_THRESH`, `FERAL_PAR_TASK_MIN_FLOPS`, `FERAL_PAR_MIN_SEEDS`,
   `FERAL_INTRAFRONT_MIN_AREA`, `FERAL_PACKED_SIMD_MIN_WORK`, `FERAL_PIVTOL`,
   `FERAL_STATIC_PIVOT`, `FERAL_AUTO_CB_BETA`, `FERAL_DENSE_MAX`,
-  `FERAL_SPARSE_MAX`, and the `feral-diagnostics` knobs. The policy lives in one
-  new module, `feral::env`; a test fails the build if a new knob parses its own
-  value locally again.
+  `FERAL_SPARSE_MAX`, and the `feral-diagnostics` knobs — including the
+  unprefixed ones (`MAX_N`, `LIMIT`, `PROBE_REPS`, `START`, `STOP`, `ONLY`, ...),
+  which carried the identical defect and had only been hidden by not being named
+  `FERAL_*`. Comma-separated sweep lists (`FERAL_NEMIN_LIST`,
+  `FERAL_MERGE_BUDGET_LIST`) go through it too, via `env::u128_list_var` /
+  `env::usize_list_var`: a locally-parsed list drops its unusable tokens and
+  hands the caller a *shorter* sweep, so `0,1e3,1e6` ran one arm and reported
+  "no difference" from an experiment that never had a second arm. The policy
+  lives in one new module, `feral::env`; a source-scan test
+  (`tests/env_knob_scan.rs`) fails the build if any env read in `src/` or
+  `crates/` parses its own value locally again — with no exemption but
+  `feral::env` itself.
 - **No default and no gate changed** — only what a knob accepts and what it
   reports when it refuses. `feral::numeric::factorize::par_task_min_flops()` and
   `par_min_seeds()` are now public so a caller can confirm what the process

--- a/README.md
+++ b/README.md
@@ -302,9 +302,30 @@ the C ABI reads on `feral_new()`:
 | `FERAL_PARALLEL`      | off     | `on` enables the rayon-based parallel multifrontal driver             |
 | `FERAL_FACTOR_TRACE`  | off     | `on` streams per-factor wall + delayed-pivot counts to stderr         |
 | `FERAL_MC64_TRACE`    | off     | `on` streams per-call MC64 wall to stderr                             |
+| `FERAL_STATIC_PIVOT`  | off     | static-pivot perturbation threshold (any positive float)              |
 
 The defaults are the ones validated in the v0.4.0 Mittelmann sweep
 (see `CHANGELOG.md`).
+
+The scheduling and kernel gates are read where they are used rather than
+on `feral_new()`:
+
+| variable                    | default | effect                                                          |
+|-----------------------------|---------|-----------------------------------------------------------------|
+| `FERAL_PAR_TASK_MIN_FLOPS`  | `1e6`   | subtree flops at or above which a supernode becomes its own task |
+| `FERAL_PAR_MIN_SEEDS`       | `2`     | task-graph seeds below which the factorization runs sequentially |
+| `FERAL_CB_THRESH`           | derived | coarsening cutoff for the contribution-block solve core          |
+| `FERAL_INTRAFRONT_MIN_AREA` | `32768` | front area below which intra-front parallelism is off            |
+| `FERAL_PACKED_SIMD_MIN_WORK`| `1024`  | Schur work below which the packed SIMD kernel is skipped         |
+| `FERAL_DENSE_MAX`           | `1000`  | `bench` only: dense-BK size gate                                 |
+| `FERAL_SPARSE_MAX`          | none    | `bench` only: sparse size gate                                   |
+
+**Numeric knobs take `1e6`-style notation** as well as plain integers, and
+a value FERAL cannot use — unparseable, negative, non-finite — prints a
+warning to stderr and falls back to the default rather than being ignored
+in silence (issue #176). A magnitude past the knob's type clamps to that
+maximum, so `FERAL_PAR_TASK_MIN_FLOPS=1e30` reliably means "never
+parallelize". Boolean knobs take `on`/`1`/`true`/`yes`.
 
 ### Mittelmann NLP benchmark
 

--- a/README.md
+++ b/README.md
@@ -321,11 +321,20 @@ on `feral_new()`:
 | `FERAL_SPARSE_MAX`          | none    | `bench` only: sparse size gate                                   |
 
 **Numeric knobs take `1e6`-style notation** as well as plain integers, and
-a value FERAL cannot use — unparseable, negative, non-finite — prints a
-warning to stderr and falls back to the default rather than being ignored
-in silence (issue #176). A magnitude past the knob's type clamps to that
+a value FERAL cannot use — unparseable, negative, `nan` — prints a warning
+to stderr and falls back to the default rather than being ignored in
+silence (issue #176). A magnitude past the knob's type clamps to that
 maximum, so `FERAL_PAR_TASK_MIN_FLOPS=1e30` reliably means "never
-parallelize". Boolean knobs take `on`/`1`/`true`/`yes`.
+parallelize"; so do `1e400` and `inf`, which are the same request spelled
+past the range of `f64`. On a float-valued knob (`FERAL_PIVTOL`,
+`FERAL_STATIC_PIVOT`) there is no such reading, and `inf` is refused
+alongside `nan`.
+
+The knobs listed in the `feral_new()` table above that read as on/off
+(`FERAL_PARALLEL`, `FERAL_FACTOR_TRACE`, `FERAL_MC64_TRACE`,
+`FERAL_CASCADE_BREAK`) take `on`/`1`/`true`/`yes`. The stderr-tracing
+knobs used only by the diagnostics binaries have not been given a common
+vocabulary and are documented at their own call sites.
 
 ### Mittelmann NLP benchmark
 

--- a/crates/feral-diagnostics/src/bin/bench_issue8.rs
+++ b/crates/feral-diagnostics/src/bin/bench_issue8.rs
@@ -136,10 +136,10 @@ fn discover_iterates(family: &str) -> Vec<String> {
 }
 
 fn env_f64(key: &str, default: f64) -> f64 {
-    std::env::var(key)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
+    // Shared parse policy (issue #176): `1e6` notation parses, and a
+    // value that cannot be used warns instead of vanishing into the
+    // default.
+    feral::env::f64_var(key).unwrap_or(default)
 }
 
 fn main() {

--- a/crates/feral-diagnostics/src/bin/bench_solver_corpus.rs
+++ b/crates/feral-diagnostics/src/bin/bench_solver_corpus.rs
@@ -50,10 +50,10 @@ fn family_of(stem: &str) -> Option<&str> {
 }
 
 fn env_usize(key: &str, default: usize) -> usize {
-    std::env::var(key)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
+    // Shared parse policy (issue #176): `1e6` notation parses, and a
+    // value that cannot be used warns instead of vanishing into the
+    // default.
+    feral::env::usize_var(key).unwrap_or(default)
 }
 
 /// Discover families in the corpus root. Returns a map from family name

--- a/crates/feral-diagnostics/src/bin/diag_amf_vs_amd.rs
+++ b/crates/feral-diagnostics/src/bin/diag_amf_vs_amd.rs
@@ -56,10 +56,10 @@ struct PerMatrix {
 }
 
 fn env_usize(key: &str, default: usize) -> usize {
-    std::env::var(key)
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(default)
+    // Shared parse policy (issue #176): `1e6` notation parses, and a
+    // value that cannot be used warns instead of vanishing into the
+    // default.
+    feral::env::usize_var(key).unwrap_or(default)
 }
 
 fn main() {

--- a/crates/feral-diagnostics/src/bin/diag_compression_bench.rs
+++ b/crates/feral-diagnostics/src/bin/diag_compression_bench.rs
@@ -167,10 +167,7 @@ fn main() {
     let mut matrices = Vec::new();
     collect(Path::new("data/matrices/kkt"), &mut matrices);
     matrices.sort();
-    let sample_stride = std::env::var("SAMPLE_STRIDE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(500);
+    let sample_stride = feral::env::usize_var("SAMPLE_STRIDE").unwrap_or(500);
 
     println!();
     println!(

--- a/crates/feral-diagnostics/src/bin/diag_cond_parity.rs
+++ b/crates/feral-diagnostics/src/bin/diag_cond_parity.rs
@@ -373,10 +373,7 @@ fn main() {
         args.iter().map(PathBuf::from).collect()
     };
 
-    let max_n = std::env::var("FERAL_DIAG_MAX_N")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(50_000);
+    let max_n = feral::env::usize_var("FERAL_DIAG_MAX_N").unwrap_or(50_000);
     let verbose = std::env::var("FERAL_DIAG_VERBOSE")
         .map(|v| v == "1")
         .unwrap_or(false);

--- a/crates/feral-diagnostics/src/bin/diag_fill_parity.rs
+++ b/crates/feral-diagnostics/src/bin/diag_fill_parity.rs
@@ -347,10 +347,7 @@ fn walk_root(root: &Path, po: &mut PerOrdering, max_n: usize, verbose: bool) {
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let max_n: usize = std::env::var("FERAL_DIAG_MAX_N")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(50_000);
+    let max_n: usize = feral::env::usize_var("FERAL_DIAG_MAX_N").unwrap_or(50_000);
     let verbose = std::env::var("FERAL_DIAG_VERBOSE")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);

--- a/crates/feral-diagnostics/src/bin/diag_issue50_auto_validate.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_auto_validate.rs
@@ -141,16 +141,9 @@ fn run_auto(matrix: &CscMatrix) -> (Option<usize>, Option<u64>, String, String) 
 }
 
 fn main() {
-    let max_n: usize = env::var("MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(200_000);
-    let limit: Option<usize> = env::var("LIMIT").ok().and_then(|s| s.parse().ok());
-    let chain_only: bool = env::var("CHAIN_CATCH_ONLY")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1)
-        != 0;
+    let max_n: usize = feral::env::usize_var("MAX_N").unwrap_or(200_000);
+    let limit: Option<usize> = feral::env::usize_var("LIMIT");
+    let chain_only: bool = feral::env::usize_var("CHAIN_CATCH_ONLY").unwrap_or(1) != 0;
     let roots: Vec<PathBuf> = env::var("ROOTS")
         .unwrap_or_else(|_| "data/matrices/kkt,data/matrices/kkt-expansion".to_string())
         .split(',')

--- a/crates/feral-diagnostics/src/bin/diag_issue50_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_inventory.rs
@@ -209,11 +209,8 @@ fn run_one_method(matrix: &CscMatrix, method: OrderingMethod) -> Result<(usize, 
 }
 
 fn main() {
-    let max_n: usize = env::var("MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(200_000);
-    let limit: Option<usize> = env::var("LIMIT").ok().and_then(|s| s.parse().ok());
+    let max_n: usize = feral::env::usize_var("MAX_N").unwrap_or(200_000);
+    let limit: Option<usize> = feral::env::usize_var("LIMIT");
     let roots: Vec<PathBuf> = env::var("ROOTS")
         .unwrap_or_else(|_| "data/matrices/kkt,data/matrices/kkt-expansion".to_string())
         .split(',')

--- a/crates/feral-diagnostics/src/bin/diag_issue50_numeric_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_numeric_inventory.rs
@@ -218,16 +218,9 @@ fn run_one(matrix: &CscMatrix, method: OrderingMethod) -> (Option<usize>, Option
 }
 
 fn main() {
-    let max_n: usize = env::var("MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(200_000);
-    let limit: Option<usize> = env::var("LIMIT").ok().and_then(|s| s.parse().ok());
-    let chain_only: bool = env::var("CHAIN_CATCH_ONLY")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1)
-        != 0;
+    let max_n: usize = feral::env::usize_var("MAX_N").unwrap_or(200_000);
+    let limit: Option<usize> = feral::env::usize_var("LIMIT");
+    let chain_only: bool = feral::env::usize_var("CHAIN_CATCH_ONLY").unwrap_or(1) != 0;
     let roots: Vec<PathBuf> = env::var("ROOTS")
         .unwrap_or_else(|_| "data/matrices/kkt,data/matrices/kkt-expansion".to_string())
         .split(',')

--- a/crates/feral-diagnostics/src/bin/diag_mittelmann.rs
+++ b/crates/feral-diagnostics/src/bin/diag_mittelmann.rs
@@ -345,10 +345,7 @@ fn list_problems(filter: &[String]) -> Vec<PathBuf> {
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let verbose = std::env::var("DIAG_VERBOSE").is_ok();
-    let max_n: usize = std::env::var("FERAL_DIAG_MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(50_000);
+    let max_n: usize = feral::env::usize_var("FERAL_DIAG_MAX_N").unwrap_or(50_000);
     let problems = list_problems(&args);
     if problems.is_empty() {
         eprintln!("no problem directories matched");

--- a/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
+++ b/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
@@ -174,10 +174,7 @@ fn main() {
             Err(_) => [1, 4, 8, 16, 32, 64].into_iter().map(Arm::Nemin).collect(),
         },
     };
-    let pairs: usize = std::env::var("FERAL_NEMIN_PAIRS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(10);
+    let pairs: usize = feral::env::usize_var("FERAL_NEMIN_PAIRS").unwrap_or(10);
     let base_idx = arms.iter().position(|a| a.is_baseline());
 
     println!(

--- a/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
+++ b/crates/feral-diagnostics/src/bin/diag_nemin_post_simd.rs
@@ -155,23 +155,15 @@ fn main() {
     }
     // Budget mode takes precedence when both are set: the budget sweep
     // is the newer lever and holding `nemin` fixed is what isolates it.
-    let arms: Vec<Arm> = match std::env::var("FERAL_MERGE_BUDGET_LIST") {
-        Ok(s) => {
+    let arms: Vec<Arm> = match feral::env::u128_list_var("FERAL_MERGE_BUDGET_LIST") {
+        Some(budgets) => {
             let mut v: Vec<Arm> = vec![Arm::Budget(None)];
-            v.extend(
-                s.split(',')
-                    .filter_map(|t| t.trim().parse::<u128>().ok())
-                    .map(|b| Arm::Budget(Some(b))),
-            );
+            v.extend(budgets.into_iter().map(|b| Arm::Budget(Some(b))));
             v
         }
-        Err(_) => match std::env::var("FERAL_NEMIN_LIST") {
-            Ok(s) => s
-                .split(',')
-                .filter_map(|t| t.trim().parse().ok())
-                .map(Arm::Nemin)
-                .collect(),
-            Err(_) => [1, 4, 8, 16, 32, 64].into_iter().map(Arm::Nemin).collect(),
+        None => match feral::env::usize_list_var("FERAL_NEMIN_LIST") {
+            Some(nemins) => nemins.into_iter().map(Arm::Nemin).collect(),
+            None => [1, 4, 8, 16, 32, 64].into_iter().map(Arm::Nemin).collect(),
         },
     };
     let pairs: usize = feral::env::usize_var("FERAL_NEMIN_PAIRS").unwrap_or(10);

--- a/crates/feral-diagnostics/src/bin/diag_schur_parity.rs
+++ b/crates/feral-diagnostics/src/bin/diag_schur_parity.rs
@@ -490,18 +490,10 @@ fn main() {
         args.iter().map(PathBuf::from).collect()
     };
 
-    let max_n: usize = std::env::var("FERAL_DIAG_MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(2000);
-    let tol: f64 = std::env::var("FERAL_DIAG_TOL")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_TOL);
-    let slack: f64 = std::env::var("FERAL_DIAG_OPTIONB_SLACK")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_OPTIONB_SLACK);
+    let max_n: usize = feral::env::usize_var("FERAL_DIAG_MAX_N").unwrap_or(2000);
+    let tol: f64 = feral::env::f64_var("FERAL_DIAG_TOL").unwrap_or(DEFAULT_TOL);
+    let slack: f64 =
+        feral::env::f64_var("FERAL_DIAG_OPTIONB_SLACK").unwrap_or(DEFAULT_OPTIONB_SLACK);
     let verbose = std::env::var("FERAL_DIAG_VERBOSE")
         .ok()
         .map(|s| s != "0")

--- a/crates/feral-diagnostics/src/bin/diag_small_sparse_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_small_sparse_inventory.rs
@@ -171,7 +171,7 @@ fn run_one(matrix: &CscMatrix, method: OrderingMethod) -> (Option<usize>, Option
 }
 
 fn main() {
-    let limit: Option<usize> = env::var("LIMIT").ok().and_then(|s| s.parse().ok());
+    let limit: Option<usize> = feral::env::usize_var("LIMIT");
     let roots: Vec<PathBuf> = env::var("ROOTS")
         .unwrap_or_else(|_| "data/matrices/kkt,data/matrices/kkt-expansion".to_string())
         .split(',')

--- a/crates/feral-diagnostics/src/bin/feral_replay.rs
+++ b/crates/feral-diagnostics/src/bin/feral_replay.rs
@@ -88,14 +88,8 @@ fn main() {
         .nth(1)
         .expect("usage: feral_replay <prefix>");
     let fresh_each = std::env::var("FRESH").is_ok();
-    let start: usize = std::env::var("START")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let stop: usize = std::env::var("STOP")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(200);
+    let start: usize = feral::env::usize_var("START").unwrap_or(0);
+    let stop: usize = feral::env::usize_var("STOP").unwrap_or(200);
     if std::env::var("CB").is_ok() {
         eprintln!("[replay] cascade_break ON");
     }

--- a/crates/feral-diagnostics/src/bin/probe_fma_kernel.rs
+++ b/crates/feral-diagnostics/src/bin/probe_fma_kernel.rs
@@ -312,14 +312,8 @@ fn bench_one(shape: Shape, reps: usize, warmup: usize) {
 }
 
 fn main() {
-    let reps: usize = std::env::var("PROBE_REPS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_REPS);
-    let warmup: usize = std::env::var("PROBE_WARMUP")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_WARMUP);
+    let reps: usize = feral::env::usize_var("PROBE_REPS").unwrap_or(DEFAULT_REPS);
+    let warmup: usize = feral::env::usize_var("PROBE_WARMUP").unwrap_or(DEFAULT_WARMUP);
 
     println!(
         "probe_fma_kernel: reps={}, warmup={}, target_arch={}",

--- a/crates/feral-diagnostics/src/bin/probe_kkt_replay.rs
+++ b/crates/feral-diagnostics/src/bin/probe_kkt_replay.rs
@@ -44,8 +44,8 @@ fn build_solver() -> Solver {
     if env::var("SQD").is_ok() {
         s = s.with_sqd_mode(true);
     }
-    if let Ok(s_) = env::var("AUTO_CB") {
-        let beta: f64 = s_.parse().unwrap_or(0.05);
+    if env::var("AUTO_CB").is_ok() {
+        let beta = feral::env::f64_var("AUTO_CB").unwrap_or(0.05);
         s = s.with_auto_cascade_break(beta);
     }
     // Track B2: value-bounded MC64 scaling cache. On by default;
@@ -68,10 +68,7 @@ fn main() {
     }
 
     let fresh = env::var("FRESH").is_ok();
-    let max_iter: usize = env::var("MAX_ITER")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(200);
+    let max_iter: usize = feral::env::usize_var("MAX_ITER").unwrap_or(200);
 
     if fresh {
         eprintln!("[probe] FRESH solver every iteration");
@@ -85,8 +82,8 @@ fn main() {
     if env::var("SQD").is_ok() {
         eprintln!("[probe] SQD mode ON (diagonal pivots only)");
     }
-    if let Ok(s_) = env::var("AUTO_CB") {
-        let beta: f64 = s_.parse().unwrap_or(0.05);
+    if env::var("AUTO_CB").is_ok() {
+        let beta = feral::env::f64_var("AUTO_CB").unwrap_or(0.05);
         eprintln!("[probe] AUTO_CB ON (β={beta})");
     }
     if matches!(env::var("MC64_CACHE").as_deref(), Ok("0") | Ok("off")) {

--- a/crates/feral-diagnostics/src/bin/probe_rocket_residuals.rs
+++ b/crates/feral-diagnostics/src/bin/probe_rocket_residuals.rs
@@ -85,10 +85,8 @@ fn load(path: &str) -> Option<(usize, Vec<usize>, Vec<usize>, Vec<f64>, Vec<f64>
 
 fn build_solver(cb: bool) -> Solver {
     let mut np = NumericParams::default();
-    if let Ok(s) = std::env::var("PIVTOL") {
-        if let Ok(v) = s.parse::<f64>() {
-            np.bk.pivot_threshold = v;
-        }
+    if let Some(v) = feral::env::f64_var("PIVTOL") {
+        np.bk.pivot_threshold = v;
     }
     let mut s = Solver::with_params(np, SupernodeParams::default());
     if cb {
@@ -202,7 +200,7 @@ fn main() {
         .unwrap_or_else(|| "/tmp/rkt".to_string());
     let start: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
     let stop_arg: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(18);
-    let only: Option<usize> = std::env::var("ONLY").ok().and_then(|s| s.parse().ok());
+    let only: Option<usize> = feral::env::usize_var("ONLY");
     let synth = std::env::var("SYNTH").is_ok();
 
     let iter_range: Vec<usize> = if let Some(o) = only {

--- a/crates/feral-diagnostics/src/bin/probe_static_pivot_inertia.rs
+++ b/crates/feral-diagnostics/src/bin/probe_static_pivot_inertia.rs
@@ -95,7 +95,7 @@ fn main() {
         .unwrap_or_else(|| "/tmp/rkt".to_string());
     let start: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
     let stop_arg: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(18);
-    let only: Option<usize> = std::env::var("ONLY").ok().and_then(|s| s.parse().ok());
+    let only: Option<usize> = feral::env::usize_var("ONLY");
 
     let pivots_env =
         std::env::var("STATIC_PIVOTS").unwrap_or_else(|_| "0,1e-12,1e-10,1e-8,1e-6".to_string());

--- a/crates/feral-diagnostics/src/bin/probe_wide_supernode.rs
+++ b/crates/feral-diagnostics/src/bin/probe_wide_supernode.rs
@@ -405,10 +405,10 @@ fn print_result(label_prefix: &str, r: &ShapeResult) {
 }
 
 fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
+    // Shared parse policy (issue #176): `1e6` notation parses, and a
+    // value that cannot be used warns instead of vanishing into the
+    // default.
+    feral::env::usize_var(name).unwrap_or(default)
 }
 
 fn env_bool(name: &str, default: bool) -> bool {

--- a/crates/feral-diagnostics/src/bin/produce_dense_schur.rs
+++ b/crates/feral-diagnostics/src/bin/produce_dense_schur.rs
@@ -243,10 +243,7 @@ fn main() {
     } else {
         positional.iter().map(PathBuf::from).collect()
     };
-    let max_n: usize = std::env::var("FERAL_DIAG_MAX_N")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(2000);
+    let max_n: usize = feral::env::usize_var("FERAL_DIAG_MAX_N").unwrap_or(2000);
     let verbose = std::env::var("FERAL_DIAG_VERBOSE")
         .ok()
         .map(|s| s != "0")

--- a/crates/feral-diagnostics/src/bin/scaling_sweep.rs
+++ b/crates/feral-diagnostics/src/bin/scaling_sweep.rs
@@ -430,10 +430,7 @@ fn main() {
     let mut generated: Option<String> = None;
     let mut sizes: Vec<usize> = Vec::new();
     let mut pinned: Option<ScalingStrategy> = None;
-    let mut repeats: usize = std::env::var("SCALING_SWEEP_REPEATS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(5);
+    let mut repeats: usize = feral::env::usize_var("SCALING_SWEEP_REPEATS").unwrap_or(5);
     let mut out: Option<String> = std::env::var("SCALING_SWEEP_DUMP").ok();
 
     let mut i = 0;

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-19T15:29:43Z
+Generated: 2026-08-19T19:56:19Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-02.md
+File: dev/sessions/2026-08-19-03.md
 ```
-# Session 2026-08-19-02
+# Session 2026-08-19-03
 
 ## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
 
-Reported first, per the hard rule in CLAUDE.md.
+Reported first, per the hard rule in CLAUDE.md. `cargo run --bin bench
+--release` in this container found only the 8 synthetic matrices — the
+external corpus and the MUMPS/SPRAL oracle timings are not mounted — so
+both Phase 2.8.1 exit partitions report `N/A`, exactly as in
+2026-08-19-02. **No comparison against 2026-08-15-02's 1.61 / 2.00 /
+1.67 / 1.67 is possible from this run.** The numbers were not measured;
+I am not claiming they held.
 
-`cargo run --bin bench --release` in this container found only the 8
-synthetic matrices; the external corpus and the MUMPS/SPRAL oracle
-timings are not present. Both Phase 2.8.1 exit partitions therefore
-report `N/A` rather than a p90:
-
-    --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-    bucket                    count      p90     target  verdict
-    small-frontal (<200)          0        -     <= 2.0      N/A
-    medium (<500)                 0        -     <= 3.0      N/A
-
-**No comparison against 2026-08-15-02's 1.61 / 2.00 / 1.67 / 1.67 is
-possible from this run.** I am not claiming the numbers held; I am
-saying they were not measured. A session with the corpus mounted should
-re-run the partition before reading anything into it.
-
-What the run does confirm: correctness is intact on what it could see —
-inertia 2/2 vs MUMPS, residual 2/2, worst residual 1.26e-16.
-
-This is also the wrong benchmark for this change, which touches the
-*solve* path and not the factor path. The relevant measurements are in
-"Benchmark Results" below.
+This is also the wrong benchmark for this change: nothing in it touches
+factor or solve arithmetic. What the run does confirm is that the change
+is inert where it should be — inertia 2/2 vs MUMPS, residual 2/2, worst
+residual 1.26e-16 (`densecol_kkt_300_0000`), byte-for-byte the same
+figures 2026-08-19-02 reported.
 
 ## Goal
 
-Fix issue #177 — "parallel solve is not bit-identical to serial on
-henon120, breaking #131's stated contract".
+Fix issue #176 — `FERAL_CB_THRESH` and `FERAL_PAR_TASK_MIN_FLOPS`
+silently ignore unparseable values (e.g. `1e18`) instead of erroring.
 
 ## Accomplished
 
-### The report is real, but not the bug it looks like
+### The bug is one shape, copied eighteen times
 
-The reporter compared two runs that differed only in `FERAL_CB_THRESH`,
-held the factorization sequential to rule out #16, and found the two
-parallel runs bit-identical to each other but not to the "serial" one.
-They concluded there was a fixed ordering difference in the parallel
-path — "findable deterministically".
+Every numeric `FERAL_*` knob in the tree was read as
 
-There is no such ordering difference. feral has **two numerically
-distinct solve cores**:
+    std::env::var(NAME).ok().and_then(|v| v.parse().ok()).unwrap_or(DEFAULT)
 
-- `solve_sparse_core_into` — folds each front's separator update into a
-  global vector in flat postorder;
-- the contribution-block core (#131 Gap A) — assembles each front's RHS
-  from its children's contribution blocks, summed in ascending child
+`"1e18".parse::<u64>()` is `Err(InvalidDigit)`, `.ok()` discards it, and
+`unwrap_or` puts the default back. The knob is set; the process behaves
+as if it were unset; nothing is printed. The reporter's evidence:
+
+    $ FERAL_PAR_TASK_MIN_FLOPS=1e18 pounce NARX_CFy.nl --no-sol max_iter=1
+    task_plan: n_snodes=45736 n_tasks=21 seeds=11 cutoff=1000000 min_seeds=2
+
+`cutoff=1000000` is `PAR_TASK_MIN_FLOPS`, the built-in default. Two perf
+attributions in the sibling issue were taken from runs like this.
+
+The sweep the issue asked for found the same shape at 18 sites (the
+inventory is in `dev/research/env-knob-parsing-2026-08-19.md`), four of
+them behind local `env_usize`/`env_f64` copies in `feral-diagnostics`.
+
+### One parse policy, in one module
+
+New `src/env.rs` (`feral::env`), `u64_var` / `usize_var` / `f64_var` plus
+`_where` variants carrying a validity check. Each returns `Option<T>`,
+so every call site keeps its own default expression — including
 ```
 
 ## Git Status
 ```
-c154c92 docs: session checkpoint 2026-08-19-01 (#177 fixed)
-b75da82 test(solve): pin the refined solve's arithmetic against the host (#177)
-3cafe57 fix(solve): choose the solve core from the factor, not the host (#177)
-6fb9d26 Merge pull request #174 from jkitchin/feat/scaling-router-invariance
-d00666a docs: session checkpoint 2026-08-15-02 (KIRBY2 localized, #153 closed)
+2b84177 docs: document the numeric FERAL_* knobs and their parse policy (#176)
+12e3330 fix(knobs): route every numeric FERAL_* read through feral::env (#176)
+647202a feat(env): one parse policy for the numeric FERAL_* knobs (#176)
+45429f1 docs: research note and plan for the FERAL_* knob parse policy (#176)
+ffb7599 Merge pull request #180 from jkitchin/claude/quirky-bardeen-c3ynyz
 ```
 
 ## Test Status
@@ -86,37 +86,18 @@ test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 
-test result: ok. 428 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 3.11s
+test result: ok. 437 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.93s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-03.md)
 
-
-Refined solve, best of 7, 4 workers, microseconds. This is the
-measurement the change is about; the `bench` binary's factor-ratio
-partitions are unrelated to it and were unavailable anyway (see the
-top of this file).
-
-    matrix        n      shared-vector  auto-serial     auto-par(4)
-    chain_400     400         22.3      22.9 (1.03x)   22.9 (1.03x)
-    chain_2000    2000       112.9     114.8 (1.02x)  114.6 (1.01x)
-    chain_20000   20000     1276.3    1276.8 (1.00x) 1272.0 (1.00x)
-    poisson_40    1600       642.2     657.1 (1.02x)  691.8 (1.08x)
-    poisson_96    9216      4549.3    4612.6 (1.01x) 4631.5 (1.02x)
-    poisson_160   25600    27761.6   30632.9 (1.10x) 20763.6 (0.75x)
-
-Factors the predicate rejects are at parity (1.00-1.03x). On the one
-factor it routes to the CB core, a host with no workers pays ~1.10x for
-the determinism and a 4-worker host gains 25%.
-
-The `bench` binary run for this session:
 
 8 matrices benchmarked
-2 KKT matrices total
-KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
   Inertia match: 1/1 (100.0%)
   Residual pass: 1/1 (100.0%)
   Worst residual: 1.14e-15 (densecol_kkt_300_0000)
@@ -143,36 +124,36 @@ medium (<500)                 0        -     <= 3.0      N/A
 ```
 
 ## Recent Decisions
+   `feral_min_par_flops` help. The notation the docs teach must work.
+   The integer parse is tried first, so `18446744073709551615` stays
+   `u64::MAX` rather than round-tripping through 2^64.
+2. **A refused value warns on stderr, once per `(name, value)`, then
+   falls back.** Not an error: these knobs are read from inside a
+   factorization whose `Result` is reserved for *numerical* failure, and
+   turning an environment typo into a `FeralError` would hand pounce a
+   numeric-looking failure for an environment problem. The warn-and-fall-
+   back shape has precedent here — `FERAL_SCALING` has warned on an
+   unrecognized value since the X5 follow-up.
+3. **An above-range magnitude clamps to the type maximum** instead of
+   falling back. `FERAL_CB_THRESH=1e30` means "no subtree can reach this
+   cutoff"; falling back to the default there would be the reported bug
+   again, with the operator's intent inverted rather than merely lost.
+4. **Fractional input rounds half away from zero.** Truncation would
+   make `FERAL_PAR_MIN_SEEDS=0.9` mean 0 — "always parallel" — the
+   opposite of what the value asks for.
 
-Rejected alternatives, and why:
+Boolean and enum knobs are out of scope: they match a literal vocabulary
+rather than parsing a number.
 
-- *Make the CB core bit-identical to the shared-vector core.* Would
-  require the CB forward to fold contributions in postorder-of-source-
-  front, but it folds a grandchild's block into its child's block before
-  that block reaches the parent. Matching the flat postorder means
-  abandoning the subtree grouping, i.e. the parallelism itself.
+A source-scan test (`tests/env_knob_parsing.rs`) fails the build if a new
+`FERAL_*` read parses its own value locally, because the defect was one
+shape copied to eighteen sites, not one site. Two diagnostics-only
+comma-list knobs are exempted by name in that scan.
 
-- *Always use the CB core when parallelism is requested.* Correct and
-  simple, but measured 1.08-1.86x slower than the shared-vector core on
-  every factor the gate rejects (path-like chains, small grids), where
-  the CB core wins nothing — its only measured win is 0.72x on
-  poisson_160 at 4 workers. It also fails to close the issue, since
-  `use_parallel` is itself defaulted from the host's core count.
-
-- *Retire the CB core, or make it opt-in only.* Restores determinism at
-  zero cost on rejected trees, but forfeits issue #131 Gap A's actual
-  win (25% on the bushy factors where tree-parallel solve pays).
-
-Accepted cost: on a factor the predicate routes to the CB core, a host
-that cannot spawn workers now pays ~1.10x on the refined solve
-(poisson_160: 27.8 ms shared-vector, 30.6 ms CB-serial), where before it
-would have silently taken the shared-vector core and a different answer.
-Factors the predicate rejects are unchanged, at 1.00-1.03x.
-
-Evidence: issue #177; `dev/journal/2026-08-19-01.org`;
-`tests/refined_solve_core_stability.rs` (fails at 6fb9d26 with 24295 of
-25600 entries differing between the pooled and pool-less arms);
-`tests/cb_core_choice_ignores_env.rs`.
+Consequence for the public API: `numeric::factorize::par_task_min_flops`
+and `par_min_seeds` are `pub`, so a caller can confirm what value the
+process resolved a knob to. #176 could not be diagnosed from outside the
+process without that.
 
 ## Recent Tried-and-Rejected
 
@@ -212,6 +193,7 @@ src/dense/mod.rs
 src/dense/rook.rs
 src/dense/schur_kernel.rs
 src/dense/solve.rs
+src/env.rs
 src/error.rs
 src/inertia.rs
 src/io/mod.rs
@@ -274,6 +256,7 @@ tests/d7_block32_dispatch_pooled.rs
 tests/delayed_pivoting.rs
 tests/dense_fast_path.rs
 tests/dense_ldlt.rs
+tests/env_knob_parsing.rs
 tests/factor_scratch_parity.rs
 tests/factor_workspace_parity.rs
 tests/factors_ld_export.rs
@@ -348,5 +331,4 @@ tests/symbolic_profiler.rs
 tests/task_plan_parity.rs
 tests/threshold_consistency.rs
 tests/tiny_fast_path.rs
-
-(truncated from 351 lines to 350 line budget)
+```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6865,3 +6865,61 @@ Consequence for the public API: `numeric::factorize::par_task_min_flops`
 and `par_min_seeds` are `pub`, so a caller can confirm what value the
 process resolved a knob to. #176 could not be diagnosed from outside the
 process without that.
+
+## 2026-08-19 — #176 follow-up: `+inf` clamps, and the env source-scan carries no exemptions
+
+Review of PR #182 found the entry above stated the policy more broadly
+than the code enforced it, in two places. Both are corrected in the same
+PR; this entry supersedes those two sentences.
+
+**The clamp rule had a hole past `f64` range.** Item 3 above says an
+above-range magnitude clamps rather than falling back, "because falling
+back would be the reported bug again, with the operator's intent
+inverted". Measured against the shipped code:
+
+    1e30  -> 18446744073709551615   (clamped, as documented)
+    1e309 -> 1000000                (the default — intent inverted)
+
+`1e309` parses to `+inf`, which fell into the `is not a finite number`
+arm. An operator escalating past `1e30` to be *more* emphatic about
+"never parallelize" got aggressive parallelization. `+inf` now has its
+own arm ahead of the non-finite refusal and clamps like any other
+over-range magnitude; `-inf` and `nan` stay refused. The asymmetry with
+`parse_float` is deliberate — the unsigned knobs count work and saturate,
+the float knobs are thresholds and `inf` has no reading there.
+
+**The source scan is now unexempted, which cost 21 further conversions.**
+The scan matched the literal `env::var("FERAL_` and skipped any window
+containing `.split(`. Both narrowings were wrong in the same direction:
+
+- The literal-name match could not see `env::var(key)` inside a local
+  `fn env_usize(key: &str, ...)` helper — and four such helpers are
+  exactly what this PR converted, i.e. the guard would not have caught
+  the sites the PR describes as the sneakiest.
+- The `.split(` skip was written for two comma-list knobs but is a
+  pattern, not a name: every future list knob would have been exempt.
+  `FERAL_MERGE_BUDGET_LIST` documented `0,1e3,..` in its own usage text
+  and dropped the `1e3` — the sweep ran baseline-only and reported "no
+  difference" from an experiment with one arm.
+
+The scan now matches `env::var(` with any argument and exempts only
+`src/env.rs`. Making that pass required converting 21 further reads, all
+in `feral-diagnostics` and all *unprefixed* (`MAX_N`, `LIMIT`,
+`PROBE_REPS`, `SAMPLE_STRIDE`, `START`, `STOP`, `MAX_ITER`, `ONLY`,
+`PIVTOL`, `AUTO_CB`, `CHAIN_CATCH_ONLY`, `SCALING_SWEEP_REPEATS`). They
+had the identical defect; the `FERAL_` prefix was the only thing that had
+been hiding them. List knobs now go through `env::u128_list_var` /
+`env::usize_list_var`, which warn per refused token and return `None` —
+the caller's own default list — rather than a silently shortened sweep.
+
+**And the two tests are now in separate binaries.** `set_var` is sound
+only when no other thread reads the environment; libtest runs a binary's
+tests on concurrent threads, so a file whose header claims "cannot race
+tests in the same process" must actually contain one test. The
+behavioural test keeps `tests/env_knob_parsing.rs`; the source scan moved
+to `tests/env_knob_scan.rs`.
+
+Evidence: `src/env.rs` (`past_f64_range_clamps_like_any_other_magnitude`);
+`tests/env_knob_scan.rs` (fails with 21 offenders before the conversions);
+`tests/env_knob_parsing.rs` (`1e400` -> `u64::MAX`);
+`dev/research/env-knob-parsing-2026-08-19.md` addendum.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6821,3 +6821,47 @@ Evidence: issue #177; `dev/journal/2026-08-19-01.org`;
 `tests/refined_solve_core_stability.rs` (fails at 6fb9d26 with 24295 of
 25600 entries differing between the pooled and pool-less arms);
 `tests/cb_core_choice_ignores_env.rs`.
+
+## 2026-08-19 — Numeric `FERAL_*` knobs warn and fall back; they do not error, and they accept `1e6` notation (#176)
+
+Every numeric env knob was read with
+`env::var(NAME).ok().and_then(|v| v.parse().ok()).unwrap_or(DEFAULT)`,
+which discards the parse error. `FERAL_PAR_TASK_MIN_FLOPS=1e18` parsed
+as nothing and the built-in default was silently reinstated, so a
+measurement taken with the knob "set" was really a measurement of the
+default (issue #176, two such measurements).
+
+The parse policy now lives in exactly one module, `feral::env`, and is:
+
+1. **Scientific notation parses on integer knobs.** The defaults are
+   written `1e6` / `1e8` in the README and in pounce's
+   `feral_min_par_flops` help. The notation the docs teach must work.
+   The integer parse is tried first, so `18446744073709551615` stays
+   `u64::MAX` rather than round-tripping through 2^64.
+2. **A refused value warns on stderr, once per `(name, value)`, then
+   falls back.** Not an error: these knobs are read from inside a
+   factorization whose `Result` is reserved for *numerical* failure, and
+   turning an environment typo into a `FeralError` would hand pounce a
+   numeric-looking failure for an environment problem. The warn-and-fall-
+   back shape has precedent here — `FERAL_SCALING` has warned on an
+   unrecognized value since the X5 follow-up.
+3. **An above-range magnitude clamps to the type maximum** instead of
+   falling back. `FERAL_CB_THRESH=1e30` means "no subtree can reach this
+   cutoff"; falling back to the default there would be the reported bug
+   again, with the operator's intent inverted rather than merely lost.
+4. **Fractional input rounds half away from zero.** Truncation would
+   make `FERAL_PAR_MIN_SEEDS=0.9` mean 0 — "always parallel" — the
+   opposite of what the value asks for.
+
+Boolean and enum knobs are out of scope: they match a literal vocabulary
+rather than parsing a number.
+
+A source-scan test (`tests/env_knob_parsing.rs`) fails the build if a new
+`FERAL_*` read parses its own value locally, because the defect was one
+shape copied to eighteen sites, not one site. Two diagnostics-only
+comma-list knobs are exempted by name in that scan.
+
+Consequence for the public API: `numeric::factorize::par_task_min_flops`
+and `par_min_seeds` are `pub`, so a caller can confirm what value the
+process resolved a knob to. #176 could not be diagnosed from outside the
+process without that.

--- a/dev/journal/2026-08-19-03.org
+++ b/dev/journal/2026-08-19-03.org
@@ -76,3 +76,17 @@ value):
 Full suite: 96 test binaries, all `ok`, 0 FAILED. `cargo clippy
 --all-targets -- -D warnings` and the `-p feral-diagnostics` variant
 both clean.
+
+* 21:10 :issue176:bench:checkpoint:
+`cargo run --bin bench --release`: 8 synthetic matrices only (no
+external corpus in this container), so both Phase 2.8.1 exit partitions
+report N/A — same situation as 2026-08-19-02, and no comparison against
+2026-08-15-02's 1.61/2.00/1.67/1.67 is possible. Correctness figures
+identical to last session: inertia 2/2 vs MUMPS, residual 2/2, worst
+1.26e-16 (densecol_kkt_300_0000). Expected: this change touches no
+arithmetic.
+
+Checkpoint written to dev/sessions/2026-08-19-03.md; policy appended to
+decisions.md. Flagged for the next session that the sibling perf issue's
+two prior measurements are void — they were taken with knobs that were
+no-ops at the time.

--- a/dev/journal/2026-08-19-03.org
+++ b/dev/journal/2026-08-19-03.org
@@ -1,0 +1,78 @@
+* 19:45 :issue176:env:start:
+Session goal: issue #176 — `FERAL_CB_THRESH` and
+`FERAL_PAR_TASK_MIN_FLOPS` silently ignore unparseable values such as
+`1e18` and fall back to the built-in default with no warning.
+
+Reproduced the shape by reading, not running (the reporter's evidence is
+a pounce run against a corpus this container does not have):
+`src/numeric/solve.rs:788` and `src/numeric/factorize.rs:3431` both do
+`.ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(DEFAULT)`.
+`"1e18".parse::<u64>()` is an `Err(InvalidDigit)`, so the value is
+dropped on the floor.
+
+Swept the tree for the same shape: 16 numeric-valued read sites across
+`src/`, `src/bin/`, and `crates/feral-diagnostics` (four of them behind
+local `env_usize`/`env_f64` copies). All silent. Table in
+`dev/research/env-knob-parsing-2026-08-19.md`.
+
+Precedent found for the fix: `FERAL_SCALING` already warns on an
+unrecognized value (`src/capi.rs:110`) rather than falling through
+quietly. The numeric knobs will copy that message shape.
+
+* 20:05 :issue176:env:design:
+Wrote `src/env.rs`: `u64_var` / `usize_var` / `f64_var` (+ `_where`
+variants for the knobs with validity checks), each returning `Option<T>`
+so every call site keeps its own default expression — including
+`solve.rs`, whose default is a closure over `total` and thread count.
+
+Policy decisions and why:
+- integer parse tried *before* the f64 parse, because `u64::MAX as f64`
+  is 2^64: routing `18446744073709551615` through f64 would report a
+  clamp on a value that is exactly representable. Unit test
+  `u64_max_survives_exactly` pins this.
+- `1e30` on a u64 knob clamps to `u64::MAX` instead of falling back.
+  Falling back would be the #176 bug again — the operator asked for
+  "no path can reach this".
+- fractional input rounds (half away from zero), not truncates:
+  `FERAL_PAR_MIN_SEEDS=0.9` truncating to 0 would mean "always
+  parallel", the opposite of the request.
+- warn-once per (name, raw): `intrafront_min_area()` is read per front.
+
+9 unit tests green (`cargo test --lib env::`).
+
+* 20:30 :issue176:env:sweep:
+Converted 18 read sites. The source-scan test found two I had missed by
+reading (`diag_fill_parity.rs:350`, `produce_dense_schur.rs:246`) — the
+scan is worth more than the manual inventory, which is the point of
+keeping it.
+
+Test output before fixing those two:
+
+    these FERAL_* env reads parse locally instead of going through
+    feral::env, which is how issue #176 happened:
+    ["crates/.../diag_fill_parity.rs:350", "crates/.../produce_dense_schur.rs:246"]
+
+Exempted in the scan: `FERAL_NEMIN_LIST` and `FERAL_MERGE_BUDGET_LIST`
+(diagnostics-only comma lists that parse per token after `.split(',')`).
+
+* 20:40 :issue176:evidence:
+End-to-end, the reporter's own probe, now with the fix:
+
+    $ FERAL_DEBUG_TASK_PLAN=1 FERAL_PAR_TASK_MIN_FLOPS=1e18 \
+        cargo test --release --test parallel_parity -- --nocapture
+    task_plan: n_snodes=501 seeds=1 cutoff=1000000000000000000 min_seeds=2 -> sequential
+
+`cutoff` is the value that was set (issue #176 reported `cutoff=1000000`,
+the default, for the same input) and the plan falls back to sequential —
+the behaviour the operator was asking for.
+
+Warnings observed on the rejected values (stderr, one per distinct
+value):
+
+    warning: FERAL_PAR_TASK_MIN_FLOPS="1e18x" is not a number; falling back to the built-in default
+    warning: FERAL_PAR_TASK_MIN_FLOPS="1e30" is larger than this knob can hold; clamped to its maximum
+    warning: FERAL_PIVTOL="-1" must be >= 0; falling back to the built-in default
+
+Full suite: 96 test binaries, all `ok`, 0 FAILED. `cargo clippy
+--all-targets -- -D warnings` and the `-p feral-diagnostics` variant
+both clean.

--- a/dev/plans/env-knob-parsing.md
+++ b/dev/plans/env-knob-parsing.md
@@ -1,0 +1,37 @@
+# Plan — one parse policy for the numeric `FERAL_*` knobs (issue #176)
+
+Research note: `dev/research/env-knob-parsing-2026-08-19.md`.
+
+## Steps
+
+1. **`src/env.rs`** (new, `pub mod env`): `u64_var`, `usize_var`,
+   `f64_var` plus `_where` variants for the knobs with validity
+   constraints. Each returns `Option<T>`: `None` for unset *and* for
+   set-but-unusable (after warning), so every call site keeps its own
+   default expression, including the closure-shaped one in
+   `solve.rs`.
+   Pure `*_value(name, raw)` parsers underneath so the policy is
+   unit-testable without touching process env.
+2. **Tests first**: unit tests in `src/env.rs` against the oracle table
+   in the research note; `tests/env_knob_parsing.rs` for the real-env
+   path (own binary — it mutates process env) plus a source scan that
+   fails if any `env::var("FERAL_...")` in `src/` or `crates/*/src` is
+   followed by a bare `.parse()`, so a new knob cannot re-introduce the
+   silent shape.
+3. **Convert the call sites** in the inventory table, library first
+   (`solve.rs`, `factorize.rs`, `dense/factor.rs`, `capi.rs`), then the
+   bins, then the four local `env_usize`/`env_f64` copies in
+   `feral-diagnostics`.
+4. **Docs**: README env-knob table gains the numeric knobs and a note
+   that `1e6` notation is accepted and a bad value warns; CHANGELOG
+   Unreleased entry.
+
+## Non-goals
+
+- Boolean/enum knobs (`FERAL_PARALLEL`, `FERAL_PACKED_SIMD`, ...) —
+  they match a vocabulary, and `FERAL_SCALING` already warns.
+- Erroring out on a bad value (see the research note).
+- Any change to a knob's *default* or to what it gates. Scheduling and
+  numerics are untouched; `tests/task_plan_parity.rs`,
+  `tests/cb_core_choice_ignores_env.rs` and `tests/golden_bits.rs` must
+  stay green unchanged.

--- a/dev/research/env-knob-parsing-2026-08-19.md
+++ b/dev/research/env-knob-parsing-2026-08-19.md
@@ -107,10 +107,49 @@ so the oracle is this note plus the values in the issue text:
 
 - `1e18` -> 1_000_000_000_000_000_000 (the reporter's case, verbatim)
 - `1e6` -> 1_000_000, `1000000` -> 1_000_000 (the two spellings agree)
-- `""`, `"abc"`, `"1e"`, `"-1"`, `"nan"`, `"inf"` -> warn + `None`
+- `""`, `"abc"`, `"1e"`, `"-1"`, `"nan"`, `"-inf"` -> warn + `None`
 - `"1e30"` on a u64 knob -> clamp to `u64::MAX`, warn
+- `"1e400"`, `"inf"` on a u64 knob -> clamp to `u64::MAX`, warn. These
+  parse to `+inf`, which is the same request as `1e30` spelled past the
+  range of `f64`; routing them to the fallback instead would leave the
+  clamp rule with a hole an operator hits precisely by trying to be more
+  emphatic. On a *float* knob (`FERAL_PIVTOL`) there is no such reading
+  and `inf` stays refused — the asymmetry is deliberate: the unsigned
+  knobs count work and saturate, the float knobs are thresholds.
 - `"18446744073709551615"` -> exact `u64::MAX` (the integer path must be
   tried before the f64 path: `u64::MAX as f64` is not representable and
   would round to 2^64)
 
 The last row is why parsing goes integer-first and only then float.
+
+
+## Addendum, 2026-08-19 (review of PR #182)
+
+Two gaps the review found, both now closed, recorded here because each
+was a case of the policy being *stated* more broadly than it was
+*enforced*.
+
+1. **The clamp had a hole above `f64` range.** `1e30` clamped to
+   `u64::MAX`; `1e309` fell back to the default. Both are the operator
+   saying "never", and the second silently meant the opposite. Fixed by
+   giving `+inf` its own arm ahead of the non-finite refusal.
+
+2. **The source-scan guard was narrower than its claim.** It matched
+   only the literal `env::var("FERAL_`, so the local
+   `fn env_usize(key: &str, ...)` helpers — the sites easiest to
+   reintroduce, because the name is not visible at the read — could not
+   trip it; and it exempted anything containing `.split(`, which was
+   meant to spare two comma-list knobs but would have spared every
+   future one. The scan now matches `env::var(` with any argument and
+   carries no exemption but `src/env.rs`. Making it enforceable meant
+   converting 21 further sites, all in `feral-diagnostics` and all
+   unprefixed (`MAX_N`, `LIMIT`, `PROBE_REPS`, `START`, `STOP`,
+   `SAMPLE_STRIDE`, `ONLY`, `PIVTOL`, `AUTO_CB`, ...). They carried the
+   identical defect; only the `FERAL_` prefix had been hiding them.
+
+Also split: the behavioural test and the source scan now live in
+separate integration binaries (`tests/env_knob_parsing.rs`,
+`tests/env_knob_scan.rs`). The first mutates process-global environment
+under `unsafe`, which is sound only with no other thread reading the
+environment; libtest threads the tests in a binary, so "one test per
+binary" is what makes that claim true rather than merely asserted.

--- a/dev/research/env-knob-parsing-2026-08-19.md
+++ b/dev/research/env-knob-parsing-2026-08-19.md
@@ -1,0 +1,116 @@
+# `FERAL_*` numeric env knobs: silent fallback to the default (issue #176)
+
+Session 2026-08-19-03. Prereq reading: `issue-148-parallel-task-granularity.md`
+(what `FERAL_PAR_TASK_MIN_FLOPS` gates), `dev/sessions/2026-08-19-02.md`
+(the `FERAL_CB_THRESH` solve-core work that the reporter was measuring
+when they hit this).
+
+## The report
+
+Every numeric `FERAL_*` knob is read with the same shape:
+
+    std::env::var(NAME).ok().and_then(|v| v.parse::<T>().ok()).unwrap_or(DEFAULT)
+
+`parse::<u64>()` rejects `1e18`, `.ok()` throws the error away, and
+`unwrap_or` substitutes the default. The knob is *set*, the process
+behaves as if it were unset, and nothing is printed. The reporter's
+evidence (issue #176):
+
+    $ FERAL_PAR_TASK_MIN_FLOPS=1e18 pounce NARX_CFy.nl --no-sol max_iter=1
+    task_plan: n_snodes=45736 n_tasks=21 seeds=11 cutoff=1000000 min_seeds=2
+
+`cutoff=1000000` is `PAR_TASK_MIN_FLOPS`, the built-in default — the
+`1e18` did nothing. The same happened with `FERAL_CB_THRESH=1e18`. Two
+perf measurements were attributed to "this path costs nothing" when the
+path was in fact fully enabled and cost ~15%.
+
+`1e18` is the natural thing to type because the prose and the pounce
+option help write the defaults as `1e6` / `1e8`.
+
+## Inventory (the sweep the issue asks for)
+
+Every numeric-valued `FERAL_*` read in the tree, with what it accepts today:
+
+| site | knob | type | today |
+|---|---|---|---|
+| `src/numeric/solve.rs:788` | `FERAL_CB_THRESH` | u64 | silent default |
+| `src/numeric/factorize.rs:3431` | `FERAL_PAR_TASK_MIN_FLOPS` | u64 | silent default |
+| `src/numeric/factorize.rs:3423` | `FERAL_PAR_MIN_SEEDS` | usize | silent default |
+| `src/dense/factor.rs:728` | `FERAL_INTRAFRONT_MIN_AREA` | usize (>0) | silent default |
+| `src/dense/factor.rs:3870` | `FERAL_PACKED_SIMD_MIN_WORK` | usize | silent default |
+| `src/capi.rs:118` | `FERAL_PIVTOL` | f64 (finite, >=0) | silent default |
+| `src/capi.rs:125` | `FERAL_STATIC_PIVOT` | f64 (finite, >0) | silent default |
+| `src/capi.rs:155` | `FERAL_AUTO_CB_BETA` | f64 (finite, >=0) | silent default |
+| `src/bin/bench.rs:1159` | `FERAL_DENSE_MAX` | usize | silent default |
+| `src/bin/bench.rs:1174` | `FERAL_SPARSE_MAX` | usize | silent default |
+| `src/bin/probe_ft_eta.rs:51` | `FERAL_PIVTOL` | f64 | silent default |
+| `crates/feral-diagnostics/.../diag_amf_vs_amd.rs:58` | `FERAL_AUDIT_*` | usize | local `env_usize`, silent |
+| `crates/feral-diagnostics/.../bench_solver_corpus.rs:52` | `FERAL_BENCH_*` | usize | local `env_usize`, silent |
+| `crates/feral-diagnostics/.../probe_wide_supernode.rs:407` | probe knobs | usize | local `env_usize`, silent |
+| `crates/feral-diagnostics/.../bench_issue8.rs:138` | `FERAL_ISSUE8_*_GUARD_S` | f64 | local `env_f64`, silent |
+| `crates/feral-diagnostics/.../diag_*.rs` | `FERAL_DIAG_*` | usize/f64 | inline, silent |
+
+Boolean / enum knobs (`FERAL_PARALLEL`, `FERAL_PACKED_SIMD`,
+`FERAL_INTRAFRONT`, `FERAL_TRACE_SUPERNODE`, ...) are matched against a
+literal vocabulary rather than parsed and are out of scope here, with one
+precedent worth copying: `FERAL_SCALING` already warns on an
+unrecognized value (`src/capi.rs:110`, "X5 follow-up") instead of falling
+through silently. That is exactly the behaviour the numeric knobs lack.
+
+## Design
+
+One shared module, `src/env.rs`, public as `feral::env`, with the parse
+policy in exactly one place:
+
+- **Accept scientific / float notation.** `1e18`, `1e6`, `2.5e3` and
+  plain `1000000` all parse for the integer knobs. The docs write the
+  defaults in `1e6` notation, so the input the docs teach must work.
+- **Warn, never silently substitute.** A set-but-unusable value prints
+  one line to stderr in the established `FERAL_SCALING` shape:
+
+      warning: FERAL_PAR_TASK_MIN_FLOPS="1e" not a number; falling back to default
+
+  and only then falls back. The knob's *intent* is still lost, but the
+  measurement is no longer silently invalid — which is the actual
+  complaint in #176 ("a knob that silently no-ops is worse than one that
+  doesn't exist, because the measurement it produces looks valid").
+- **Warn once per (name, value)** — `par_task_min_flops()` is read once
+  per factorization and `intrafront_min_area()` once per front, so an
+  unconditional `eprintln!` would flood stderr on a corpus run.
+- **Clamp, don't reject, an above-range magnitude.** `1e30` on a u64
+  knob means "switch this path off"; clamping to `u64::MAX` honours that
+  intent, and the clamp is announced on stderr. Falling back to the
+  default here would reproduce the exact bug being fixed.
+- **Reject negatives and non-finite values** for the counting knobs
+  (they have no meaning as a flop count) with the same warning.
+
+### Why not "parse strictly and error out"
+
+The issue offers erroring as an option. Rejected: these are debugging
+knobs read from deep inside a factorization that returns
+`Result<_, FeralError>` for *numerical* failure. Turning a typo'd
+env var into a factorization error would give pounce a numeric-looking
+failure for an environment problem. A warning plus a documented,
+deterministic fallback keeps the failure legible without inventing a new
+error class.
+
+### Rounding
+
+`2.5` on an integer knob rounds half-away-from-zero (`f64::round`) to 3
+rather than truncating. Truncation would make `FERAL_PAR_MIN_SEEDS=0.9`
+mean 0 ("always parallel"), the opposite of what the value asks for.
+
+## Test oracle
+
+The parse policy is decided here, not derived from a reference solver,
+so the oracle is this note plus the values in the issue text:
+
+- `1e18` -> 1_000_000_000_000_000_000 (the reporter's case, verbatim)
+- `1e6` -> 1_000_000, `1000000` -> 1_000_000 (the two spellings agree)
+- `""`, `"abc"`, `"1e"`, `"-1"`, `"nan"`, `"inf"` -> warn + `None`
+- `"1e30"` on a u64 knob -> clamp to `u64::MAX`, warn
+- `"18446744073709551615"` -> exact `u64::MAX` (the integer path must be
+  tried before the f64 path: `u64::MAX as f64` is not representable and
+  would round to 2^64)
+
+The last row is why parsing goes integer-first and only then float.

--- a/dev/sessions/2026-08-19-03.md
+++ b/dev/sessions/2026-08-19-03.md
@@ -1,0 +1,158 @@
+# Session 2026-08-19-03
+
+## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
+
+Reported first, per the hard rule in CLAUDE.md. `cargo run --bin bench
+--release` in this container found only the 8 synthetic matrices — the
+external corpus and the MUMPS/SPRAL oracle timings are not mounted — so
+both Phase 2.8.1 exit partitions report `N/A`, exactly as in
+2026-08-19-02. **No comparison against 2026-08-15-02's 1.61 / 2.00 /
+1.67 / 1.67 is possible from this run.** The numbers were not measured;
+I am not claiming they held.
+
+This is also the wrong benchmark for this change: nothing in it touches
+factor or solve arithmetic. What the run does confirm is that the change
+is inert where it should be — inertia 2/2 vs MUMPS, residual 2/2, worst
+residual 1.26e-16 (`densecol_kkt_300_0000`), byte-for-byte the same
+figures 2026-08-19-02 reported.
+
+## Goal
+
+Fix issue #176 — `FERAL_CB_THRESH` and `FERAL_PAR_TASK_MIN_FLOPS`
+silently ignore unparseable values (e.g. `1e18`) instead of erroring.
+
+## Accomplished
+
+### The bug is one shape, copied eighteen times
+
+Every numeric `FERAL_*` knob in the tree was read as
+
+    std::env::var(NAME).ok().and_then(|v| v.parse().ok()).unwrap_or(DEFAULT)
+
+`"1e18".parse::<u64>()` is `Err(InvalidDigit)`, `.ok()` discards it, and
+`unwrap_or` puts the default back. The knob is set; the process behaves
+as if it were unset; nothing is printed. The reporter's evidence:
+
+    $ FERAL_PAR_TASK_MIN_FLOPS=1e18 pounce NARX_CFy.nl --no-sol max_iter=1
+    task_plan: n_snodes=45736 n_tasks=21 seeds=11 cutoff=1000000 min_seeds=2
+
+`cutoff=1000000` is `PAR_TASK_MIN_FLOPS`, the built-in default. Two perf
+attributions in the sibling issue were taken from runs like this.
+
+The sweep the issue asked for found the same shape at 18 sites (the
+inventory is in `dev/research/env-knob-parsing-2026-08-19.md`), four of
+them behind local `env_usize`/`env_f64` copies in `feral-diagnostics`.
+
+### One parse policy, in one module
+
+New `src/env.rs` (`feral::env`), `u64_var` / `usize_var` / `f64_var` plus
+`_where` variants carrying a validity check. Each returns `Option<T>`,
+so every call site keeps its own default expression — including
+`solve.rs`, whose default is a closure over the thread count.
+
+- Scientific notation parses on integer knobs. The docs and pounce's
+  option help write the defaults as `1e6` / `1e8`, so the notation the
+  docs teach has to work.
+- Integer parse is tried **before** the f64 parse: `u64::MAX as f64` is
+  2^64, so a float round-trip would report a clamp on
+  `18446744073709551615`, which is exactly representable.
+- A refused value warns once per `(name, value)` on stderr, in the shape
+  `FERAL_SCALING` already uses, then falls back.
+- An above-range magnitude **clamps** to the type maximum rather than
+  falling back: `1e30` means "switch this path off", and defaulting there
+  would reproduce the bug being fixed.
+- Fractional input rounds half away from zero, so
+  `FERAL_PAR_MIN_SEEDS=0.9` cannot truncate to 0 ("always parallel").
+
+### Evidence
+
+The reporter's own probe, with the fix:
+
+    $ FERAL_DEBUG_TASK_PLAN=1 FERAL_PAR_TASK_MIN_FLOPS=1e18 \
+        cargo test --release --test parallel_parity -- --nocapture
+    task_plan: n_snodes=501 seeds=1 cutoff=1000000000000000000 min_seeds=2 -> sequential
+
+The cutoff is now the value that was set, and the plan takes the
+sequential fallback — the behaviour the operator was asking for.
+Rejected values say so:
+
+    warning: FERAL_PAR_TASK_MIN_FLOPS="1e18x" is not a number; falling back to the built-in default
+    warning: FERAL_PAR_TASK_MIN_FLOPS="1e30" is larger than this knob can hold; clamped to its maximum
+    warning: FERAL_PIVTOL="-1" must be >= 0; falling back to the built-in default
+
+Tests: 9 unit tests in `src/env.rs` against the oracle table in the
+research note; `tests/env_knob_parsing.rs` asserts the end-to-end knob
+values (`par_task_min_flops()` and `par_min_seeds()` were made `pub` so
+the resolved value is observable at all — the question #176 could not
+answer from outside) and adds a **source scan** that fails if any
+`FERAL_*` env read parses its own value locally again. The scan caught
+two sites the manual inventory had missed (`diag_fill_parity.rs:350`,
+`produce_dense_schur.rs:246`).
+
+Full suite: 96 test binaries, all `ok`, 0 failed. `cargo clippy
+--all-targets -- -D warnings` clean on the root set and on
+`feral-diagnostics`.
+
+`tests/task_plan_parity.rs`, `tests/cb_core_choice_ignores_env.rs`, and
+`tests/golden_bits.rs` are unchanged and green: no default, no gate, and
+no arithmetic moved — only what a knob accepts and what it says when it
+refuses.
+
+## Benchmark Results
+
+```
+8 matrices benchmarked
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+```
+
+## Decisions Made
+
+- Numeric `FERAL_*` knobs warn and fall back rather than erroring out;
+  scientific notation is accepted; above-range magnitudes clamp.
+  Appended to `dev/decisions.md`.
+
+## Abandoned Approaches
+
+- None. Nothing was tried and rejected this session; the one design
+  alternative the issue raised (make a bad value a hard error) was
+  rejected on reading, before any code, and is recorded in the research
+  note and `decisions.md` rather than in `tried-and-rejected.md`.
+
+## Next Session Should
+
+1. Take the sibling perf issue the reporter was actually chasing — the
+   tree-parallel solve gate. Its two prior measurements are void: they
+   were taken with `FERAL_CB_THRESH=1e18` and
+   `FERAL_PAR_TASK_MIN_FLOPS=1e18`, both of which were no-ops at the
+   time. **Re-measure from scratch on this build**; do not carry the
+   "this path costs nothing" conclusion forward.
+2. Re-run the Phase 2.8.1 exit partition on a container with the
+   external corpus mounted — three consecutive sessions have now
+   reported `N/A` and the last real numbers are from 2026-08-15-02.
+3. Optional, small: the two diagnostics-only comma-list knobs
+   (`FERAL_NEMIN_LIST`, `FERAL_MERGE_BUDGET_LIST`) still `filter_map`
+   bad tokens away silently. They are exempted in the source scan with a
+   comment; a list-shaped `feral::env` reader would close the last gap.

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1156,10 +1156,7 @@ fn write_feral_sidecar(
 /// path will never touch (the bench corpus has n up to ~195k; a single
 /// dense allocation would OOM).
 fn dense_max_from_env() -> usize {
-    std::env::var("FERAL_DENSE_MAX")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(1000)
+    feral::env::usize_var("FERAL_DENSE_MAX").unwrap_or(1000)
 }
 
 /// `FERAL_SPARSE_MAX` — gate above which the sparse multifrontal loop skips
@@ -1171,10 +1168,7 @@ fn dense_max_from_env() -> usize {
 /// completes end-to-end. Skipped matrices count toward sp_total but are
 /// reported separately as "size-skipped".
 fn sparse_max_from_env() -> usize {
-    std::env::var("FERAL_SPARSE_MAX")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(usize::MAX)
+    feral::env::usize_var("FERAL_SPARSE_MAX").unwrap_or(usize::MAX)
 }
 
 /// Load metadata only (sidecar + oracle timings) for all KKT matrices in `dir`.

--- a/src/bin/probe_ft_eta.rs
+++ b/src/bin/probe_ft_eta.rs
@@ -48,10 +48,7 @@ fn to_dense(col: &SparseCol, m: usize) -> Vec<f64> {
 /// pivoting, feral's current default). Lower values (0.1, 0.01) enable the
 /// within-threshold diagonal/sparsity-preserving pivot — issue #133 Stage 1.
 fn pivtol_from_env() -> f64 {
-    std::env::var("FERAL_PIVTOL")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1.0)
+    feral::env::f64_var_where("FERAL_PIVTOL", ">= 0", |v| v >= 0.0).unwrap_or(1.0)
 }
 
 /// ‖B·x − rhs‖∞ / ‖rhs‖∞ for basis `b` (sparse columns) and solution `x`.

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -115,19 +115,14 @@ pub extern "C" fn feral_new() -> *mut FeralSolver {
         if let Some(strategy) = scaling_strategy_from_env_value(&scaling_raw) {
             np.scaling = strategy;
         }
-        if let Ok(s) = std::env::var("FERAL_PIVTOL") {
-            if let Ok(v) = s.parse::<f64>() {
-                if v.is_finite() && v >= 0.0 {
-                    np.bk.pivot_threshold = v;
-                }
-            }
+        // Both parsed through `crate::env`, which warns on a value it
+        // cannot use instead of leaving the default silently in place
+        // (issue #176).
+        if let Some(v) = crate::env::f64_var_where("FERAL_PIVTOL", ">= 0", |v| v >= 0.0) {
+            np.bk.pivot_threshold = v;
         }
-        if let Ok(s) = std::env::var("FERAL_STATIC_PIVOT") {
-            if let Ok(v) = s.parse::<f64>() {
-                if v.is_finite() && v > 0.0 {
-                    np.static_pivot_threshold = Some(v);
-                }
-            }
+        if let Some(v) = crate::env::f64_var_where("FERAL_STATIC_PIVOT", "> 0", |v| v > 0.0) {
+            np.static_pivot_threshold = Some(v);
         }
         if matches!(
             std::env::var("FERAL_WARN_PARTIAL_SINGULAR").as_deref(),
@@ -152,10 +147,7 @@ pub extern "C" fn feral_new() -> *mut FeralSolver {
             // n=24000 in late-IPM iters); FERAL_CASCADE_BREAK=on cuts
             // it to 2.4 s (5.6×). The auto-arm gives the same rescue
             // without per-problem opt-in.
-            let beta = std::env::var("FERAL_AUTO_CB_BETA")
-                .ok()
-                .and_then(|s| s.parse::<f64>().ok())
-                .filter(|v| v.is_finite() && *v >= 0.0)
+            let beta = crate::env::f64_var_where("FERAL_AUTO_CB_BETA", ">= 0", |v| v >= 0.0)
                 .unwrap_or(0.05);
             if beta > 0.0 {
                 solver = solver.with_auto_cascade_break(beta);

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -725,10 +725,7 @@ fn intrafront_min_area() -> usize {
     // one-shot read is the right semantics.
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
-        std::env::var("FERAL_INTRAFRONT_MIN_AREA")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&v| v > 0)
+        crate::env::usize_var_where("FERAL_INTRAFRONT_MIN_AREA", "> 0", |v| v > 0)
             .unwrap_or(INTRAFRONT_MIN_AREA)
     })
 }
@@ -3867,10 +3864,7 @@ fn apply_schur_panel_range_packed_impl(
     // panel before issue #148's review caught it.
     static MIN_WORK: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     let min_work = *MIN_WORK.get_or_init(|| {
-        std::env::var("FERAL_PACKED_SIMD_MIN_WORK")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(PACKED_SIMD_MIN_WORK)
+        crate::env::usize_var("FERAL_PACKED_SIMD_MIN_WORK").unwrap_or(PACKED_SIMD_MIN_WORK)
     });
     if use_simd && simd_work >= min_work {
         if fma {

--- a/src/env.rs
+++ b/src/env.rs
@@ -133,6 +133,13 @@ fn parse_unsigned(raw: &str, max: u128) -> Knob<u128> {
             }
         }
         Ok(v) if v.is_finite() => Knob::Bad("is negative, and this knob counts work"),
+        // `+inf` (any magnitude past f64 range, e.g. `1e400`) is the
+        // operator asking for "as large as possible". It clamps for the
+        // same reason `1e30` does: falling back to the default here
+        // would invert the intent rather than merely lose it, which is
+        // issue #176's failure mode. Anything else non-finite (`-inf`,
+        // `nan`) has no such reading.
+        Ok(v) if v == f64::INFINITY => Knob::Clamped(max),
         Ok(_) => Knob::Bad("is not a finite number"),
         Err(_) => Knob::Bad("is not a number"),
     }
@@ -199,6 +206,50 @@ pub fn usize_var_where(
         &format!("must be {requirement}; falling back to the built-in default"),
     );
     None
+}
+
+/// A comma-separated list knob (the diagnostics sweeps: `arms` lists
+/// like `FERAL_NEMIN_LIST=1,4,8`), parsed token-by-token under the same
+/// policy as [`usize_var`].
+///
+/// The failure this exists to prevent is narrower than #176 but worse:
+/// a locally-parsed list drops its unusable tokens through `filter_map`
+/// and hands the caller a *shorter* list, so a sweep written
+/// `0,1e3,1e6` silently runs with one arm and reports "no difference"
+/// from an experiment that never had a second arm. Refused tokens warn
+/// individually, and a list with nothing usable left returns `None` so
+/// the caller's own default list is used rather than an empty sweep.
+fn unsigned_list_raw(name: &str, max: u128) -> Option<Vec<u128>> {
+    let raw = std::env::var(name).ok()?;
+    let mut out = Vec::new();
+    for token in raw.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(v) = report(name, token, parse_unsigned(token, max)) {
+            out.push(v);
+        }
+    }
+    if out.is_empty() {
+        warn_once(
+            name,
+            &raw,
+            "has no usable values; falling back to the built-in default list",
+        );
+        return None;
+    }
+    Some(out)
+}
+
+/// [`unsigned_list_raw`] for the `u128`-typed sweep knobs.
+pub fn u128_list_var(name: &str) -> Option<Vec<u128>> {
+    unsigned_list_raw(name, u128::MAX)
+}
+
+/// [`unsigned_list_raw`] for the `usize`-typed sweep knobs.
+pub fn usize_list_var(name: &str) -> Option<Vec<usize>> {
+    unsigned_list_raw(name, usize::MAX as u128).map(|v| v.into_iter().map(|x| x as usize).collect())
 }
 
 /// `None` when the knob is unset, or when it is set to something that is
@@ -268,6 +319,22 @@ mod tests {
         );
     }
 
+    /// The hole the first version of this module left: `1e30` clamped
+    /// but `1e400` did not, because it parses to `+inf` and fell into
+    /// the non-finite arm. An operator escalating past `1e30` to be
+    /// *extra* sure of "never" would have landed back on the default —
+    /// more parallelism, not less. Intent inverted, which is exactly
+    /// what the clamp policy exists to prevent.
+    #[test]
+    fn past_f64_range_clamps_like_any_other_magnitude() {
+        assert_eq!(parse_unsigned("1e400", U64), Knob::Clamped(U64));
+        assert_eq!(parse_unsigned("inf", U64), Knob::Clamped(U64));
+        assert_eq!(parse_unsigned("infinity", U64), Knob::Clamped(U64));
+        assert_eq!(parse_unsigned("1e400", 255), Knob::Clamped(255));
+        // The sign still matters: `-inf` is not a count of work.
+        assert!(matches!(parse_unsigned("-inf", U64), Knob::Bad(_)));
+    }
+
     #[test]
     fn unusable_values_are_refused_not_defaulted_silently() {
         assert!(matches!(parse_unsigned("", U64), Knob::Bad(_)));
@@ -278,7 +345,9 @@ mod tests {
         assert!(matches!(parse_unsigned("-1", U64), Knob::Bad(_)));
         assert!(matches!(parse_unsigned("-1e6", U64), Knob::Bad(_)));
         assert!(matches!(parse_unsigned("nan", U64), Knob::Bad(_)));
-        assert!(matches!(parse_unsigned("inf", U64), Knob::Bad(_)));
+        // `-inf` has no "as large as possible" reading; `+inf` does and
+        // clamps instead (see `past_f64_range_clamps_like_any_other_magnitude`).
+        assert!(matches!(parse_unsigned("-inf", U64), Knob::Bad(_)));
     }
 
     #[test]
@@ -303,12 +372,29 @@ mod tests {
         assert_eq!(parse_unsigned("255", 255), Knob::Ok(255));
     }
 
+    /// A list knob's tokens go through the same policy as a scalar
+    /// one — the point of routing them here rather than through a local
+    /// `filter_map(|t| t.parse().ok())`, which drops `1e3` and silently
+    /// shortens the sweep.
+    #[test]
+    fn list_tokens_use_the_same_policy_as_scalar_knobs() {
+        for token in ["0", "1e3", " 1e6 ", "2.5"] {
+            assert!(
+                matches!(parse_unsigned(token.trim(), U64), Knob::Ok(_)),
+                "list token {token:?} must be usable"
+            );
+        }
+        assert_eq!(parse_unsigned("1e3", U64), Knob::Ok(1000));
+    }
+
     #[test]
     fn float_knobs_take_the_usual_pivot_threshold_spellings() {
         assert_eq!(parse_float("1e-8"), Knob::Ok(1e-8));
         assert_eq!(parse_float("0.001"), Knob::Ok(0.001));
         assert_eq!(parse_float("-0.5"), Knob::Ok(-0.5));
         assert!(matches!(parse_float("nan"), Knob::Bad(_)));
+        // Unlike the counting knobs, a float knob is a threshold or a
+        // ratio: `inf` has no usable reading and stays refused.
         assert!(matches!(parse_float("inf"), Knob::Bad(_)));
         assert!(matches!(parse_float("1e-"), Knob::Bad(_)));
         assert!(matches!(parse_float(""), Knob::Bad(_)));

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,316 @@
+//! One parse policy for the numeric `FERAL_*` tuning knobs (issue #176).
+//!
+//! Every numeric knob used to be read as
+//!
+//! ```ignore
+//! std::env::var(NAME).ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(DEFAULT)
+//! ```
+//!
+//! which drops the parse error on the floor: `FERAL_PAR_TASK_MIN_FLOPS=1e18`
+//! is not a `u64` literal, so the knob was *silently* replaced by its
+//! built-in default. The path the operator believed they had switched off
+//! stayed on, and the timing they took from that run looked valid.
+//! Issue #176 caught two such measurements.
+//!
+//! The policy here, applied by every numeric knob in the tree:
+//!
+//! - **Scientific notation parses.** The defaults are written `1e6` /
+//!   `1e8` in the docs and in pounce's option help, so `1e18` must mean
+//!   `1_000_000_000_000_000_000` on an integer knob. Plain integers keep
+//!   parsing exactly — the integer parse is tried *first*, so
+//!   `18446744073709551615` survives as `u64::MAX` instead of rounding
+//!   through `f64`.
+//! - **A set-but-unusable value warns on stderr** in the same shape the
+//!   `FERAL_SCALING` vocabulary check already uses (`capi.rs`), and only
+//!   then falls back to the caller's default. The knob's intent is still
+//!   lost, but the run no longer *looks* like the knob took effect.
+//! - **Warned once per (name, value)**: knobs like
+//!   [`crate::dense::factor`]'s intra-front area gate are read once per
+//!   front, so an unconditional `eprintln!` would flood stderr.
+//! - **An above-range magnitude clamps rather than falls back.**
+//!   `FERAL_CB_THRESH=1e30` means "switch this path off"; clamping to
+//!   `u64::MAX` honours that, whereas falling back to the default would
+//!   reproduce exactly the bug being fixed. The clamp is announced.
+//!
+//! Boolean and enum-valued knobs (`FERAL_PARALLEL`, `FERAL_PACKED_SIMD`,
+//! ...) match a literal vocabulary rather than parsing a number and are
+//! not routed through here.
+//!
+//! Rationale and the full knob inventory:
+//! `dev/research/env-knob-parsing-2026-08-19.md`.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+/// The outcome of parsing one raw value, before any reporting. Split
+/// from the env read so the policy is unit-testable without mutating
+/// process-global state (the same split `bench.rs` uses for the
+/// `FERAL_SCALING` / `FERAL_ORDERING` vocabularies).
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Knob<T> {
+    /// Usable as given.
+    Ok(T),
+    /// Usable, but the magnitude exceeded what the knob's type holds and
+    /// was clamped to the value carried here.
+    Clamped(T),
+    /// Unusable. The string says why, for the stderr warning.
+    Bad(&'static str),
+}
+
+/// Print `warning: NAME="RAW" MSG` to stderr the first time this exact
+/// `(name, raw)` pair is rejected. Later reads of the same bad value are
+/// silent — the knobs are read per factorization, per solve, or per
+/// front.
+fn warn_once(name: &str, raw: &str, msg: &str) {
+    static SEEN: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
+    let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+    let first = match seen.lock() {
+        Ok(mut set) => set.insert((name.to_string(), raw.to_string())),
+        // Poisoned: a warning that repeats beats a warning that vanishes.
+        Err(_) => true,
+    };
+    if first {
+        eprintln!("warning: {name}=\"{raw}\" {msg}");
+    }
+}
+
+/// Turn a parse outcome into an `Option`, warning on anything the caller
+/// would otherwise never hear about.
+fn report<T>(name: &str, raw: &str, parsed: Knob<T>) -> Option<T> {
+    match parsed {
+        Knob::Ok(v) => Some(v),
+        Knob::Clamped(v) => {
+            warn_once(
+                name,
+                raw,
+                "is larger than this knob can hold; clamped to its maximum",
+            );
+            Some(v)
+        }
+        Knob::Bad(why) => {
+            warn_once(
+                name,
+                raw,
+                &format!("{why}; falling back to the built-in default"),
+            );
+            None
+        }
+    }
+}
+
+/// Parse a non-negative integer knob, accepting both plain integer and
+/// float/scientific spellings. `max` is the largest value the target
+/// type holds.
+///
+/// Integer-first is load-bearing: `u64::MAX as f64` rounds up to 2^64,
+/// so routing `18446744073709551615` through `f64` would report a clamp
+/// on a value that is exactly representable.
+///
+/// Fractional input rounds half-away-from-zero rather than truncating:
+/// truncation would turn `FERAL_PAR_MIN_SEEDS=0.9` into 0 ("always
+/// parallel"), the opposite of what the value asks for.
+fn parse_unsigned(raw: &str, max: u128) -> Knob<u128> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Knob::Bad("is empty");
+    }
+    if let Ok(v) = s.parse::<u128>() {
+        return if v > max {
+            Knob::Clamped(max)
+        } else {
+            Knob::Ok(v)
+        };
+    }
+    match s.parse::<f64>() {
+        Ok(v) if v.is_finite() && v >= 0.0 => {
+            let rounded = v.round();
+            // `max as f64` rounds *up* for u64/usize, so `>=` (not `>`)
+            // keeps a value that lands on 2^64 out of the `as` cast.
+            if rounded >= max as f64 {
+                Knob::Clamped(max)
+            } else {
+                Knob::Ok(rounded as u128)
+            }
+        }
+        Ok(v) if v.is_finite() => Knob::Bad("is negative, and this knob counts work"),
+        Ok(_) => Knob::Bad("is not a finite number"),
+        Err(_) => Knob::Bad("is not a number"),
+    }
+}
+
+/// Parse a finite floating-point knob. Scientific notation is native to
+/// `f64::from_str`; the added policy is that `nan` and `inf` are refused
+/// rather than propagated into a pivot threshold.
+fn parse_float(raw: &str) -> Knob<f64> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Knob::Bad("is empty");
+    }
+    match s.parse::<f64>() {
+        Ok(v) if v.is_finite() => Knob::Ok(v),
+        Ok(_) => Knob::Bad("is not a finite number"),
+        Err(_) => Knob::Bad("is not a number"),
+    }
+}
+
+/// Read and parse an unsigned knob, keeping the raw text for any
+/// follow-up warning from a caller-side validity check.
+fn unsigned_var_raw(name: &str, max: u128) -> Option<(String, u128)> {
+    let raw = std::env::var(name).ok()?;
+    let v = report(name, &raw, parse_unsigned(&raw, max))?;
+    Some((raw, v))
+}
+
+/// Read and parse a floating-point knob, keeping the raw text.
+fn float_var_raw(name: &str) -> Option<(String, f64)> {
+    let raw = std::env::var(name).ok()?;
+    let v = report(name, &raw, parse_float(&raw))?;
+    Some((raw, v))
+}
+
+/// `None` when the knob is unset, or when it is set to something this
+/// module refused (after warning) — so the call site's own default
+/// expression stays in one place.
+pub fn u64_var(name: &str) -> Option<u64> {
+    unsigned_var_raw(name, u64::MAX as u128).map(|(_, v)| v as u64)
+}
+
+/// [`u64_var`], for the `usize`-typed knobs.
+pub fn usize_var(name: &str) -> Option<usize> {
+    unsigned_var_raw(name, usize::MAX as u128).map(|(_, v)| v as usize)
+}
+
+/// [`usize_var`] with a caller-side validity check. `requirement`
+/// completes the sentence "must be ..." in the warning, so an
+/// out-of-range value is as loud as an unparseable one.
+pub fn usize_var_where(
+    name: &str,
+    requirement: &str,
+    accept: impl Fn(usize) -> bool,
+) -> Option<usize> {
+    let (raw, v) = unsigned_var_raw(name, usize::MAX as u128)?;
+    let v = v as usize;
+    if accept(v) {
+        return Some(v);
+    }
+    warn_once(
+        name,
+        &raw,
+        &format!("must be {requirement}; falling back to the built-in default"),
+    );
+    None
+}
+
+/// `None` when the knob is unset, or when it is set to something that is
+/// not a finite number (after warning).
+pub fn f64_var(name: &str) -> Option<f64> {
+    float_var_raw(name).map(|(_, v)| v)
+}
+
+/// [`f64_var`] with a caller-side validity check; see
+/// [`usize_var_where`] for `requirement`.
+pub fn f64_var_where(name: &str, requirement: &str, accept: impl Fn(f64) -> bool) -> Option<f64> {
+    let (raw, v) = float_var_raw(name)?;
+    if accept(v) {
+        return Some(v);
+    }
+    warn_once(
+        name,
+        &raw,
+        &format!("must be {requirement}; falling back to the built-in default"),
+    );
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const U64: u128 = u64::MAX as u128;
+
+    /// The reporter's case, verbatim from issue #176: this is the value
+    /// that used to vanish into the default.
+    #[test]
+    fn scientific_notation_parses_on_an_integer_knob() {
+        assert_eq!(
+            parse_unsigned("1e18", U64),
+            Knob::Ok(1_000_000_000_000_000_000)
+        );
+    }
+
+    /// The two spellings of the documented default must agree — the docs
+    /// write `1e6`, the code writes `1_000_000`.
+    #[test]
+    fn integer_and_scientific_spellings_agree() {
+        assert_eq!(parse_unsigned("1e6", U64), Knob::Ok(1_000_000));
+        assert_eq!(parse_unsigned("1000000", U64), Knob::Ok(1_000_000));
+        assert_eq!(parse_unsigned("1.0e6", U64), Knob::Ok(1_000_000));
+    }
+
+    /// `u64::MAX as f64` is 2^64, so a float round-trip would report a
+    /// clamp here. The integer parse has to be tried first.
+    #[test]
+    fn u64_max_survives_exactly() {
+        assert_eq!(parse_unsigned("18446744073709551615", U64), Knob::Ok(U64));
+    }
+
+    #[test]
+    fn above_range_clamps_rather_than_falling_back() {
+        assert_eq!(parse_unsigned("1e30", U64), Knob::Clamped(U64));
+        assert_eq!(
+            parse_unsigned("18446744073709551616", U64),
+            Knob::Clamped(U64)
+        );
+        // Exactly 2^64: representable as f64, one past the type.
+        assert_eq!(
+            parse_unsigned("1.8446744073709552e19", U64),
+            Knob::Clamped(U64)
+        );
+    }
+
+    #[test]
+    fn unusable_values_are_refused_not_defaulted_silently() {
+        assert!(matches!(parse_unsigned("", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("   ", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("abc", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("1e", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("1e18x", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("-1", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("-1e6", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("nan", U64), Knob::Bad(_)));
+        assert!(matches!(parse_unsigned("inf", U64), Knob::Bad(_)));
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(parse_unsigned("  42  ", U64), Knob::Ok(42));
+        assert_eq!(parse_float(" 1e-8 "), Knob::Ok(1e-8));
+    }
+
+    /// Half-away-from-zero, so a fractional seed count cannot round down
+    /// into "no gate at all".
+    #[test]
+    fn fractional_input_rounds_rather_than_truncating() {
+        assert_eq!(parse_unsigned("0.9", U64), Knob::Ok(1));
+        assert_eq!(parse_unsigned("2.5", U64), Knob::Ok(3));
+        assert_eq!(parse_unsigned("2.4", U64), Knob::Ok(2));
+        assert_eq!(parse_unsigned("0.4", U64), Knob::Ok(0));
+    }
+
+    #[test]
+    fn small_type_max_clamps_at_its_own_bound() {
+        assert_eq!(parse_unsigned("300", 255), Knob::Clamped(255));
+        assert_eq!(parse_unsigned("255", 255), Knob::Ok(255));
+    }
+
+    #[test]
+    fn float_knobs_take_the_usual_pivot_threshold_spellings() {
+        assert_eq!(parse_float("1e-8"), Knob::Ok(1e-8));
+        assert_eq!(parse_float("0.001"), Knob::Ok(0.001));
+        assert_eq!(parse_float("-0.5"), Knob::Ok(-0.5));
+        assert!(matches!(parse_float("nan"), Knob::Bad(_)));
+        assert!(matches!(parse_float("inf"), Knob::Bad(_)));
+        assert!(matches!(parse_float("1e-"), Knob::Bad(_)));
+        assert!(matches!(parse_float(""), Knob::Bad(_)));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod capi;
 pub mod dense;
+pub mod env;
 pub mod error;
 pub mod inertia;
 pub mod io;

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -3418,20 +3418,22 @@ pub const PAR_MIN_SEEDS: usize = 2;
 /// factorization (not per panel, unlike the dense-kernel knobs), so
 /// caching buys nothing and would prevent in-process calibration and
 /// the parity sweep in `tests/task_plan_parity.rs`.
+///
+/// Public so a caller (and `tests/env_knob_parsing.rs`) can ask what
+/// value this process actually resolved the knob to — the question
+/// issue #176 could not answer from outside.
 #[inline]
-fn par_min_seeds() -> usize {
-    std::env::var("FERAL_PAR_MIN_SEEDS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(PAR_MIN_SEEDS)
+pub fn par_min_seeds() -> usize {
+    crate::env::usize_var("FERAL_PAR_MIN_SEEDS").unwrap_or(PAR_MIN_SEEDS)
 }
 
+/// The resolved `FERAL_PAR_TASK_MIN_FLOPS` cutoff: the env value when
+/// it is set and usable, [`PAR_TASK_MIN_FLOPS`] otherwise. Public for
+/// the same reason as [`par_min_seeds`] — an operator who sets the knob
+/// needs a way to confirm it took (issue #176).
 #[inline]
-fn par_task_min_flops() -> u64 {
-    std::env::var("FERAL_PAR_TASK_MIN_FLOPS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(PAR_TASK_MIN_FLOPS)
+pub fn par_task_min_flops() -> u64 {
+    crate::env::u64_var("FERAL_PAR_TASK_MIN_FLOPS").unwrap_or(PAR_TASK_MIN_FLOPS)
 }
 
 /// Task partition of the supernode tree (issue #148): one rayon task

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -785,9 +785,10 @@ impl CbThreshold {
         match self {
             CbThreshold::FromWorkers => {
                 let num_threads = rayon::current_num_threads().max(1);
-                std::env::var("FERAL_CB_THRESH")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
+                // Parsed through `crate::env` so `1e18` means 1e18 and a
+                // typo warns instead of silently restoring the default
+                // (issue #176).
+                crate::env::u64_var("FERAL_CB_THRESH")
                     .unwrap_or_else(|| (total / (num_threads as u64 * 16)).max(1))
             }
             CbThreshold::Reference => (total / CB_REFERENCE_FANOUT).max(1),

--- a/tests/env_knob_parsing.rs
+++ b/tests/env_knob_parsing.rs
@@ -1,0 +1,150 @@
+//! Issue #176: a numeric `FERAL_*` knob must never be silently replaced
+//! by its built-in default.
+//!
+//! The reported case, verbatim:
+//!
+//!     $ FERAL_PAR_TASK_MIN_FLOPS=1e18 pounce NARX_CFy.nl --no-sol max_iter=1
+//!     task_plan: n_snodes=45736 n_tasks=21 seeds=11 cutoff=1000000 min_seeds=2
+//!
+//! `cutoff=1000000` is `PAR_TASK_MIN_FLOPS`, the default — the `1e18`
+//! failed `parse::<u64>()` and was thrown away by `.ok()`. Two perf
+//! measurements were taken from runs whose knobs had never taken effect.
+//!
+//! Lives in its own integration-test binary because the first test sets
+//! process-global env vars: it cannot race tests in the same process.
+
+use feral::numeric::factorize::{par_min_seeds, par_task_min_flops, PAR_TASK_MIN_FLOPS};
+
+/// One test, one process: every env mutation in this binary happens here,
+/// in order, so nothing observes a half-set environment.
+#[test]
+fn numeric_knobs_take_scientific_notation_and_never_default_silently() {
+    // --- The issue's case: `1e18` on the flop-count knob.
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1e18") };
+    assert_eq!(
+        par_task_min_flops(),
+        1_000_000_000_000_000_000,
+        "FERAL_PAR_TASK_MIN_FLOPS=1e18 must mean 1e18, not the default"
+    );
+
+    // --- The two spellings of the same number must agree.
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1000000000000000000") };
+    assert_eq!(par_task_min_flops(), 1_000_000_000_000_000_000);
+
+    // --- Plain integers keep working exactly (no f64 round-trip).
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "18446744073709551615") };
+    assert_eq!(par_task_min_flops(), u64::MAX);
+
+    // --- A magnitude past u64 clamps to "off", it does not fall back to
+    // the default: the operator asked for a cutoff nothing can reach.
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1e30") };
+    assert_eq!(par_task_min_flops(), u64::MAX);
+
+    // --- A genuinely unusable value falls back (loudly — the warning
+    // goes to stderr, which is the part this test cannot assert) rather
+    // than being interpreted as something else.
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1e18x") };
+    assert_eq!(par_task_min_flops(), PAR_TASK_MIN_FLOPS);
+
+    unsafe { std::env::remove_var("FERAL_PAR_TASK_MIN_FLOPS") };
+    assert_eq!(par_task_min_flops(), PAR_TASK_MIN_FLOPS);
+
+    // --- Fractional input rounds instead of truncating: 0.9 seeds must
+    // not become "0" (= always parallel), the opposite of the request.
+    unsafe { std::env::set_var("FERAL_PAR_MIN_SEEDS", "0.9") };
+    assert_eq!(par_min_seeds(), 1);
+    unsafe { std::env::set_var("FERAL_PAR_MIN_SEEDS", "4") };
+    assert_eq!(par_min_seeds(), 4);
+    unsafe { std::env::remove_var("FERAL_PAR_MIN_SEEDS") };
+
+    // --- The other knob named in the issue, through the shared reader
+    // it now goes through (`CbThreshold::resolve` is private).
+    unsafe { std::env::set_var("FERAL_CB_THRESH", "1e18") };
+    assert_eq!(
+        feral::env::u64_var("FERAL_CB_THRESH"),
+        Some(1_000_000_000_000_000_000)
+    );
+    unsafe { std::env::set_var("FERAL_CB_THRESH", "wat") };
+    assert_eq!(feral::env::u64_var("FERAL_CB_THRESH"), None);
+    unsafe { std::env::remove_var("FERAL_CB_THRESH") };
+    assert_eq!(feral::env::u64_var("FERAL_CB_THRESH"), None);
+
+    // --- Float knobs: the pivot-threshold spellings, and the validity
+    // check that used to swallow an out-of-range value in silence.
+    unsafe { std::env::set_var("FERAL_PIVTOL", "1e-8") };
+    assert_eq!(
+        feral::env::f64_var_where("FERAL_PIVTOL", ">= 0", |v| v >= 0.0),
+        Some(1e-8)
+    );
+    unsafe { std::env::set_var("FERAL_PIVTOL", "-1") };
+    assert_eq!(
+        feral::env::f64_var_where("FERAL_PIVTOL", ">= 0", |v| v >= 0.0),
+        None
+    );
+    unsafe { std::env::set_var("FERAL_PIVTOL", "nan") };
+    assert_eq!(
+        feral::env::f64_var_where("FERAL_PIVTOL", ">= 0", |v| v >= 0.0),
+        None
+    );
+    unsafe { std::env::remove_var("FERAL_PIVTOL") };
+}
+
+/// Source scan: no `FERAL_*` env read may parse its own value again.
+///
+/// The bug in #176 was not one call site but one *shape*, copied to
+/// sixteen places. `feral::env` is now the single place that decides
+/// what a numeric knob accepts and what happens to a value it cannot
+/// use; this test fails if a new knob reintroduces the local
+/// `.parse().ok()` that discards the error.
+#[test]
+fn no_feral_env_read_parses_its_own_value() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    collect_rs(&root.join("src"), &mut files);
+    collect_rs(&root.join("crates"), &mut files);
+
+    let mut offenders = Vec::new();
+    for path in files {
+        // The one file allowed to parse: the shared policy itself.
+        if path.ends_with("src/env.rs") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (start, _) in text.match_indices("env::var(\"FERAL_") {
+            // Window = the rest of that statement, capped so a `;`-less
+            // construct cannot swallow the whole file.
+            let rest = &text[start..];
+            let end = rest.find(';').unwrap_or(rest.len()).min(400);
+            let window = &rest[..end];
+            // Comma-separated *list* knobs (`FERAL_NEMIN_LIST`,
+            // `FERAL_MERGE_BUDGET_LIST`, both diagnostics-only) parse
+            // per token after a split; they are not single-value knobs
+            // and have no `feral::env` shape to use.
+            if window.contains(".parse") && !window.contains(".split(") {
+                let line = text[..start].matches('\n').count() + 1;
+                offenders.push(format!("{}:{}", path.display(), line));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these FERAL_* env reads parse locally instead of going through \
+         feral::env, which is how issue #176 happened: {offenders:?}"
+    );
+}
+
+fn collect_rs(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}

--- a/tests/env_knob_parsing.rs
+++ b/tests/env_knob_parsing.rs
@@ -10,13 +10,24 @@
 //! failed `parse::<u64>()` and was thrown away by `.ok()`. Two perf
 //! measurements were taken from runs whose knobs had never taken effect.
 //!
-//! Lives in its own integration-test binary because the first test sets
-//! process-global env vars: it cannot race tests in the same process.
+//! This binary holds exactly one `#[test]`, on purpose. libtest runs the
+//! tests in a binary on concurrent threads, and `std::env::set_var` is
+//! undefined behaviour if any other thread reads the environment while
+//! it runs — including a `getenv` from inside std or the harness. One
+//! test means there is no other thread to race. The source-scan half of
+//! this issue's coverage is in `env_knob_scan.rs` for that reason.
 
 use feral::numeric::factorize::{par_min_seeds, par_task_min_flops, PAR_TASK_MIN_FLOPS};
 
 /// One test, one process: every env mutation in this binary happens here,
 /// in order, so nothing observes a half-set environment.
+///
+/// SAFETY (every `set_var`/`remove_var` below): `std::env::set_var` is
+/// sound only when no other thread touches the environment
+/// concurrently. This is the only `#[test]` in this integration binary
+/// (see the module comment), so libtest has no second test thread to
+/// run against it, and the code under test reads the environment on
+/// this thread.
 #[test]
 fn numeric_knobs_take_scientific_notation_and_never_default_silently() {
     // --- The issue's case: `1e18` on the flop-count knob.
@@ -38,6 +49,12 @@ fn numeric_knobs_take_scientific_notation_and_never_default_silently() {
     // --- A magnitude past u64 clamps to "off", it does not fall back to
     // the default: the operator asked for a cutoff nothing can reach.
     unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1e30") };
+    assert_eq!(par_task_min_flops(), u64::MAX);
+
+    // --- Past f64 range too: `1e400` parses to +inf, and an operator
+    // who escalates past `1e30` to be extra sure must not land back on
+    // the default (which would be more parallel, not less).
+    unsafe { std::env::set_var("FERAL_PAR_TASK_MIN_FLOPS", "1e400") };
     assert_eq!(par_task_min_flops(), u64::MAX);
 
     // --- A genuinely unusable value falls back (loudly — the warning
@@ -87,64 +104,4 @@ fn numeric_knobs_take_scientific_notation_and_never_default_silently() {
         None
     );
     unsafe { std::env::remove_var("FERAL_PIVTOL") };
-}
-
-/// Source scan: no `FERAL_*` env read may parse its own value again.
-///
-/// The bug in #176 was not one call site but one *shape*, copied to
-/// sixteen places. `feral::env` is now the single place that decides
-/// what a numeric knob accepts and what happens to a value it cannot
-/// use; this test fails if a new knob reintroduces the local
-/// `.parse().ok()` that discards the error.
-#[test]
-fn no_feral_env_read_parses_its_own_value() {
-    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut files = Vec::new();
-    collect_rs(&root.join("src"), &mut files);
-    collect_rs(&root.join("crates"), &mut files);
-
-    let mut offenders = Vec::new();
-    for path in files {
-        // The one file allowed to parse: the shared policy itself.
-        if path.ends_with("src/env.rs") {
-            continue;
-        }
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        for (start, _) in text.match_indices("env::var(\"FERAL_") {
-            // Window = the rest of that statement, capped so a `;`-less
-            // construct cannot swallow the whole file.
-            let rest = &text[start..];
-            let end = rest.find(';').unwrap_or(rest.len()).min(400);
-            let window = &rest[..end];
-            // Comma-separated *list* knobs (`FERAL_NEMIN_LIST`,
-            // `FERAL_MERGE_BUDGET_LIST`, both diagnostics-only) parse
-            // per token after a split; they are not single-value knobs
-            // and have no `feral::env` shape to use.
-            if window.contains(".parse") && !window.contains(".split(") {
-                let line = text[..start].matches('\n').count() + 1;
-                offenders.push(format!("{}:{}", path.display(), line));
-            }
-        }
-    }
-    assert!(
-        offenders.is_empty(),
-        "these FERAL_* env reads parse locally instead of going through \
-         feral::env, which is how issue #176 happened: {offenders:?}"
-    );
-}
-
-fn collect_rs(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_rs(&path, out);
-        } else if path.extension().is_some_and(|e| e == "rs") {
-            out.push(path);
-        }
-    }
 }

--- a/tests/env_knob_scan.rs
+++ b/tests/env_knob_scan.rs
@@ -1,0 +1,81 @@
+//! Issue #176 guard: no env read outside `src/env.rs` may parse its own
+//! value.
+//!
+//! The bug in #176 was not one call site but one *shape*, copied to
+//! sixteen places: `env::var(NAME).ok().and_then(|v| v.parse().ok())`
+//! throws the parse error away, so a value the parser cannot use is
+//! replaced by the built-in default without a word. `feral::env` is now
+//! the single place that decides what a knob accepts and what happens
+//! to a value it cannot use.
+//!
+//! This is a source scan, not a behavioural test, so it lives apart from
+//! `env_knob_parsing.rs` — that binary mutates process-global env vars
+//! and must not share a process with anything else.
+
+/// The scan matches `env::var(` with **any** argument, not just a
+/// literal `"FERAL_…"`. The four sneakiest sites #176 touched read
+/// `env::var(key)` through a local `fn env_usize(key: &str, …)` helper,
+/// so a literal-name scan would have missed exactly the cases that are
+/// easiest to reintroduce.
+#[test]
+fn no_env_read_parses_its_own_value() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    collect_rs(&root.join("src"), &mut files);
+    collect_rs(&root.join("crates"), &mut files);
+    assert!(
+        files.len() > 50,
+        "source scan found only {} files — the walk is broken, not the tree clean",
+        files.len()
+    );
+
+    let mut offenders = Vec::new();
+    for path in files {
+        // The one file allowed to parse: the shared policy itself.
+        if path.ends_with("src/env.rs") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (start, _) in text.match_indices("env::var(") {
+            // Window = the rest of that statement, capped so a `;`-less
+            // construct cannot swallow the whole file. The cap is walked
+            // back to a char boundary: this tree's comments are full of
+            // multibyte characters (`×`, `‖`, `≥`), and slicing a byte
+            // offset inside one panics.
+            let rest = &text[start..];
+            let hard = rest.find(';').unwrap_or(rest.len()).min(400);
+            let end = rest
+                .char_indices()
+                .map(|(i, _)| i)
+                .take_while(|&i| i <= hard)
+                .last()
+                .unwrap_or(0);
+            let window = &rest[..end];
+            if window.contains(".parse") {
+                let line = text[..start].matches('\n').count() + 1;
+                offenders.push(format!("{}:{}", path.display(), line));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these env reads parse locally instead of going through \
+         feral::env, which is how issue #176 happened: {offenders:?}"
+    );
+}
+
+fn collect_rs(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix issue #176: numeric `FERAL_*` environment knobs were silently falling back to their built-in defaults when given unparseable values (e.g., `FERAL_PAR_TASK_MIN_FLOPS=1e18`), with no warning. This caused measurements taken with knobs "set" to actually measure the default behavior, leading to incorrect performance attributions.

## Changes

- **New module `src/env.rs`** (`feral::env`): Centralized parse policy for all numeric environment knobs
  - `u64_var()`, `usize_var()`, `f64_var()` — read and parse numeric knobs, returning `Option<T>`
  - `_where()` variants for knobs with validity constraints (e.g., `>= 0`)
  - Each returns `None` for both unset and set-but-unusable values, so call sites keep their own defaults
  - Accepts scientific notation (`1e6`, `1e18`) on integer knobs to match documented defaults
  - Integer parse attempted before float parse to preserve exact values like `u64::MAX`
  - Above-range magnitudes clamp to type maximum rather than fall back (e.g., `1e30` → `u64::MAX`)
  - Fractional input rounds half-away-from-zero, not truncates
  - Refused values warn once per `(name, value)` on stderr, then fall back

- **Converted 18 call sites** across library and diagnostics:
  - `src/numeric/solve.rs`: `FERAL_CB_THRESH`
  - `src/numeric/factorize.rs`: `FERAL_PAR_TASK_MIN_FLOPS`, `FERAL_PAR_MIN_SEEDS` (made `pub` for observability)
  - `src/dense/factor.rs`: `FERAL_INTRAFRONT_MIN_AREA`, `FERAL_PACKED_SIMD_MIN_WORK`
  - `src/capi.rs`: `FERAL_PIVTOL`, `FERAL_STATIC_PIVOT`, `FERAL_AUTO_CB_BETA`
  - `src/bin/bench.rs`: `FERAL_DENSE_MAX`, `FERAL_SPARSE_MAX`
  - `src/bin/probe_ft_eta.rs`: `FERAL_PIVTOL`
  - Four diagnostics binaries: replaced local `env_usize`/`env_f64` copies with shared module

- **Tests**:
  - 9 unit tests in `src/env.rs` covering scientific notation, clamping, rounding, edge cases
  - `tests/env_knob_parsing.rs`: integration test with process-env mutation; source scan that fails if any `FERAL_*` read re-introduces local `.parse()` (caught 2 missed sites)
  - All 437 existing tests pass; no tolerance changes

- **Documentation**:
  - Research note: `dev/research/env-knob-parsing-2026-08-19.md` (inventory of all 18 sites, design rationale)
  - Session checkpoint: `dev/sessions/2026-08-19-03.md`
  - `CHANGELOG.md`: user-visible fix entry
  - `README.md`: numeric knob table with `1e6` notation note
  - `dev/decisions.md`: decision record

## Evidence

Reporter's probe with the fix:
```
$ FERAL_DEBUG_TASK_PLAN=1 FERAL_PAR_TASK_MIN_FLOPS=1e18 cargo test --release --test parallel_parity
task_plan: n_snodes=501 seeds=1 cutoff=1000000000000000000 min_seeds=2 -> sequential
```

Cutoff is now the value that was set (previously `1000000`, the default). Rejected values warn:
```
warning: FERAL_PAR_TASK_MIN_FLOPS="1e18x" is not a number

https://claude.ai/code/session_01RebHxrJFG5qxJf1i4w1po3