### PR TITLE
tools(diagnostics): two probes for #153's dtoc1nd dense-front gap

### DIFF
--- a/crates/feral-diagnostics/src/bin/probe_front_bucket_phases.rs
+++ b/crates/feral-diagnostics/src/bin/probe_front_bucket_phases.rs
@@ -1,0 +1,287 @@
+//! probe_front_bucket_phases — front-size histogram weighted by **loop
+//! time**, with the phase breakdown computed inside each size bucket.
+//!
+//! Issue #153 item 2. The existing instruments answer half of this each:
+//! `profile_supernode_distribution` buckets loop time by `nrow` but on a
+//! hardcoded matrix list and with no phase split, and `diag_factor_phases`
+//! splits phases but aggregates over every front. Neither can say *which
+//! size class* a phase's time sits in, which is the question.
+//!
+//! What it found, and what that killed: dtoc1nd's cost is 148 fronts of
+//! mean shape `ncol = 62`, `nrow = 88` — 91% of loop time — and inside
+//! them the panel factor is 53% while every other #153 fixture is panel
+//! 6-15% / Schur 17-30%. The hypothesis this probe was written to test,
+//! that the regime falls below the packed-SIMD work gate
+//! (`PACKED_SIMD_MIN_WORK = 1024`, `src/dense/factor.rs`), is **false**:
+//! `n_elim · (nrow − col_start) · ncol ≈ 3.4e5` clears it by 330×, and
+//! `FERAL_PACKED_SIMD_MIN_WORK=0` changes nothing while `=1e12` costs
+//! 15.7%. See `dev/research/issue-153-dtoc1nd-dense-front-2026-08-19.md`.
+//!
+//! Method: sequential supernodal driver (the per-supernode phase deltas
+//! are read from process-global counters, so a parallel driver would
+//! interleave them), warm workspace, `N_REPS` runs, the run with median
+//! `loop_ns` reported. Buckets are the `Profiler::report()` ranges so the
+//! numbers are comparable with every prior probe: <=8, 9-16, 17-32,
+//! 33-64, 65-128, >128.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin probe_front_bucket_phases \
+//!       -- <a.mtx> [b.mtx ...]
+//!
+//! Env:
+//!   FERAL_BUCKET_REPS=5     repetitions per matrix (median run reported)
+//!   FERAL_BUCKET_BY=ncol    bucket by `ncol` instead of `nrow` (default nrow)
+//!   FERAL_BUCKET_BS=64      `BunchKaufmanParams::block_size` (default 64)
+//!
+//! Phase columns: `panel%`, `schur%` and `tail%` are the three parts
+//! of `dense%` — the left-looking BLAS-2 panel factor, the blocked
+//! BLAS-3 trailing update, and the scalar tail that finishes columns
+//! the panel could not eliminate. They are reported separately because
+//! `block_size` trades the first two against each other without
+//! changing the front's total work, so only the wall clock next to
+//! them says whether a trade paid.
+//!
+//! Note on totals: the phase counters are sampled per supernode, so
+//! `assembly + densefactor` is less than the bucket's wall by the
+//! per-node driver remainder. That gap is reported as `other%` rather
+//! than hidden — an optimization aimed at a named phase cannot pay for
+//! itself if the unnamed remainder is bigger than the phase.
+
+use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Arc, Mutex};
+
+use feral::dense::factor::PHASE_TIMING_ENABLED;
+use feral::numeric::factorize::{
+    factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, NumericParams, Profiler,
+    SupernodeTiming,
+};
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{read_mtx, BunchKaufmanParams, CscMatrix, ZeroPivotAction};
+
+const RANGES: &[(&str, usize, usize)] = &[
+    ("<=8", 0, 8),
+    ("9-16", 9, 16),
+    ("17-32", 17, 32),
+    ("33-64", 33, 64),
+    ("65-128", 65, 128),
+    (">128", 129, usize::MAX),
+];
+
+#[derive(Default, Clone)]
+struct Bucket {
+    count: usize,
+    ns: u64,
+    assembly_ns: u64,
+    densefactor_ns: u64,
+    panel_ns: u64,
+    schur_ns: u64,
+    scalartail_ns: u64,
+    /// Summed `ncol * nrow * nrow`, the per-front dense-cost proxy used
+    /// by `probe_front_concentration`. Reported next to measured time so
+    /// a bucket whose share of flops and share of time disagree is
+    /// visible rather than inferred.
+    flops: f64,
+    /// Summed `ncol` and `nrow`, for the bucket's mean front shape. A
+    /// nearly-square front spends its time in the panel; a wide-and-thin
+    /// one spends it in the trailing Schur update, so the shape is what
+    /// makes a phase share interpretable.
+    sum_ncol: usize,
+    sum_nrow: usize,
+}
+
+fn bucket_of(t: &SupernodeTiming, by_ncol: bool) -> usize {
+    let key = if by_ncol { t.ncol } else { t.nrow };
+    RANGES
+        .iter()
+        .position(|&(_, lo, hi)| key >= lo && key <= hi)
+        .unwrap_or(RANGES.len() - 1)
+}
+
+fn ldlt_params(profiler: Arc<Mutex<Profiler>>, block_size: usize) -> NumericParams {
+    NumericParams {
+        bk: BunchKaufmanParams {
+            on_zero_pivot: ZeroPivotAction::ForceAccept,
+            pivot_threshold: 0.01,
+            block_size,
+            ..BunchKaufmanParams::default()
+        },
+        profiler: Some(profiler),
+        ..NumericParams::default()
+    }
+}
+
+fn load_csc(path: &str) -> Option<CscMatrix> {
+    match read_mtx(Path::new(path)).and_then(|m| m.to_csc()) {
+        Ok(c) => Some(c),
+        Err(e) => {
+            eprintln!("{path}: load failed: {e}");
+            None
+        }
+    }
+}
+
+/// One run's per-supernode timings, or `None` if the factor failed.
+fn run_once(
+    csc: &CscMatrix,
+    sym: &feral::symbolic::SymbolicFactorization,
+    ws: &mut FactorWorkspace,
+    block_size: usize,
+) -> Option<Vec<SupernodeTiming>> {
+    let prof = Arc::new(Mutex::new(Profiler::new()));
+    let params = ldlt_params(Arc::clone(&prof), block_size);
+    if let Err(e) = factorize_multifrontal_supernodal_with_workspace(csc, sym, &params, ws) {
+        eprintln!("factor failed: {e}");
+        return None;
+    }
+    // Bind the lock result before the match so the temporary guard is
+    // dropped before `prof` is, rather than after it (E0597).
+    let timings = prof.lock().map(|p| p.timings().to_vec());
+    match timings {
+        Ok(t) => Some(t),
+        Err(_) => {
+            eprintln!("profiler mutex poisoned");
+            None
+        }
+    }
+}
+
+fn pct(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        100.0 * part as f64 / whole as f64
+    }
+}
+
+fn report(label: &str, timings: &[SupernodeTiming], by_ncol: bool, block_size: usize) {
+    let mut buckets = vec![Bucket::default(); RANGES.len()];
+    for t in timings {
+        let b = &mut buckets[bucket_of(t, by_ncol)];
+        b.count += 1;
+        b.ns += t.ns;
+        b.assembly_ns += t.assembly_ns;
+        b.densefactor_ns += t.densefactor_ns;
+        b.panel_ns += t.panelfactor_ns;
+        b.schur_ns += t.schur_ns;
+        b.scalartail_ns += t.scalartail_ns;
+        b.flops += t.ncol as f64 * t.nrow as f64 * t.nrow as f64;
+        b.sum_ncol += t.ncol;
+        b.sum_nrow += t.nrow;
+    }
+    let loop_ns: u64 = buckets.iter().map(|b| b.ns).sum();
+    let total_flops: f64 = buckets.iter().map(|b| b.flops).sum();
+
+    println!(
+        "=== {label} (fronts={}, loop={:.3} ms, bucketed by {}, bs={block_size}) ===",
+        timings.len(),
+        loop_ns as f64 / 1e6,
+        if by_ncol { "ncol" } else { "nrow" }
+    );
+    println!(
+        "{:>8}{:>9}{:>11}{:>9}{:>9}{:>11}{:>8}{:>8}{:>9}{:>9}{:>9}{:>9}{:>9}{:>9}",
+        "bucket",
+        "count",
+        "time_ms",
+        "time%",
+        "flop%",
+        "avg_ns",
+        "ncol",
+        "nrow",
+        "asm%",
+        "dense%",
+        "panel%",
+        "schur%",
+        "tail%",
+        "other%"
+    );
+    for (i, &(name, _, _)) in RANGES.iter().enumerate() {
+        let b = &buckets[i];
+        if b.count == 0 {
+            continue;
+        }
+        // `other` is the per-node driver remainder: the bucket's wall
+        // minus the two phases that partition it.
+        let named = b.assembly_ns.saturating_add(b.densefactor_ns);
+        let other = b.ns.saturating_sub(named);
+        println!(
+            "{:>8}{:>9}{:>11.3}{:>9.1}{:>9.1}{:>11.0}{:>8.0}{:>8.0}{:>9.1}{:>9.1}{:>9.1}{:>9.1}{:>9.1}{:>9.1}",
+            name,
+            b.count,
+            b.ns as f64 / 1e6,
+            pct(b.ns, loop_ns),
+            if total_flops > 0.0 {
+                100.0 * b.flops / total_flops
+            } else {
+                0.0
+            },
+            b.ns as f64 / b.count as f64,
+            b.sum_ncol as f64 / b.count as f64,
+            b.sum_nrow as f64 / b.count as f64,
+            pct(b.assembly_ns, b.ns),
+            pct(b.densefactor_ns, b.ns),
+            pct(b.panel_ns, b.ns),
+            pct(b.schur_ns, b.ns),
+            pct(b.scalartail_ns, b.ns),
+            pct(other, b.ns),
+        );
+    }
+    println!();
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: probe_front_bucket_phases <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    let reps: usize = feral::env::usize_var("FERAL_BUCKET_REPS")
+        .unwrap_or(5)
+        .max(1);
+    let by_ncol = matches!(std::env::var("FERAL_BUCKET_BY").as_deref(), Ok("ncol"));
+    // Panel width, so the phase shares can be read *as a function of*
+    // the lever. A `panel%` that does not move when `block_size` is
+    // cut from 64 to 8 says the phase attribution, not the panel
+    // kernel, is what needs explaining.
+    let block_size: usize = feral::env::usize_var("FERAL_BUCKET_BS")
+        .unwrap_or(BunchKaufmanParams::default().block_size)
+        .max(1);
+
+    PHASE_TIMING_ENABLED.store(true, Relaxed);
+
+    for path in &args {
+        let Some(csc) = load_csc(path) else { continue };
+        let sym = match symbolic_factorize(&csc, &SupernodeParams::default()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{path}: symbolic failed: {e}");
+                continue;
+            }
+        };
+        let mut ws = FactorWorkspace::default();
+        // Warm the workspace and the caches: the IPM host's steady state
+        // is a warm re-factor, and a cold first call would put its
+        // allocation cost in whichever bucket ran first.
+        if run_once(&csc, &sym, &mut ws, block_size).is_none() {
+            continue;
+        }
+
+        let mut runs: Vec<Vec<SupernodeTiming>> = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            if let Some(t) = run_once(&csc, &sym, &mut ws, block_size) {
+                runs.push(t);
+            }
+        }
+        if runs.is_empty() {
+            continue;
+        }
+        runs.sort_by_key(|r| r.iter().map(|t| t.ns).sum::<u64>());
+        let median = &runs[runs.len() / 2];
+
+        let label = Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(path);
+        report(label, median, by_ncol, block_size);
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_panel_block_size.rs
+++ b/crates/feral-diagnostics/src/bin/probe_panel_block_size.rs
@@ -1,0 +1,245 @@
+//! probe_panel_block_size — does the panel block size sit in the wrong
+//! place for wide-panel fronts?
+//!
+//! Issue #153 item 2. `probe_front_bucket_phases` localized dtoc1nd's
+//! cost to 148 fronts of mean shape `ncol = 62`, `nrow = 88`, and inside
+//! those the **panel factor** is 56% of the time while the trailing
+//! Schur update is 16%. Every other fixture in the #153 set is the other
+//! way round (panel 7-15%, Schur 26-31%), and the reason is shape:
+//! `lblt_panel_frontal` is left-looking, so a panel of `bs` columns
+//! costs ~`bs^2 * nrow / 2` in rank-1/rank-2 axpy traffic, while the
+//! blocked Schur update between panels is BLAS-3. `bs =
+//! params.block_size.min(ncol)` (`src/dense/factor.rs:2171`) and
+//! `block_size` defaults to 64, so a 62-column front runs as **one**
+//! panel and does all of its elimination in the BLAS-2 kernel.
+//!
+//! The hypothesis this probe tests: lowering `block_size` splits those
+//! fronts into several narrower panels and moves work from the BLAS-2
+//! panel into the BLAS-3 trailing update, which should be a net win once
+//! `ncol` is large enough for the quadratic term to matter.
+//!
+//! **Answered: the split moves, the clock does not.** `FERAL_BUCKET_BS`
+//! on `probe_front_bucket_phases` shows panel% falling 54 → 15 and
+//! schur% rising 18 → 57 as `bs` goes 64 → 8, exactly as predicted; this
+//! probe's 60-pair run then puts `bs = 48` ahead of the default by only
+//! **1.3%** (43/60 wins — real, but tiny), and finds nothing at all on
+//! the two other corpus matrices with fronts wider than 48. Kept as a
+//! re-runnable instrument, not as a shipped tuning.
+//! `dev/research/issue-153-dtoc1nd-dense-front-2026-08-19.md`,
+//! `dev/tried-and-rejected.md` 2026-08-19.
+//!
+//! Methodology follows `dev/decisions.md` 2026-08-09: **paired
+//! alternating** arms (every block size is timed once per pair, in
+//! order, so drift hits every arm equally), `min_us` per arm, and a sign
+//! test over the pairs. Do not compare medians collected at different
+//! times.
+//!
+//! `block_size` changes the pivot *blocking*, not the pivot sequence's
+//! definition — the panel path is documented bit-exact with the scalar
+//! path (`tests/blocked_ldlt.rs`). Whether that makes every arm
+//! byte-identical is exactly what this probe checks rather than assumes:
+//! each arm reports its inertia and its true relative residual, and the
+//! `L`/`D` digest so a silent numeric change cannot hide behind an
+//! unchanged inertia.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin probe_panel_block_size \
+//!       -- <a.mtx> [b.mtx ...]
+//!
+//! Env:
+//!   FERAL_BS_LIST=8,16,24,32,48,64   arms to sweep (default this list)
+//!   FERAL_BS_PAIRS=8                 paired repetitions (default 8)
+
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::time::Instant;
+
+use feral::numeric::factorize::{
+    factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, NumericParams,
+};
+use feral::symbolic::{symbolic_factorize, SupernodeParams, SymbolicFactorization};
+use feral::{read_mtx, BunchKaufmanParams, CscMatrix};
+
+fn params_at(bs: usize) -> NumericParams {
+    NumericParams {
+        bk: BunchKaufmanParams {
+            block_size: bs,
+            ..BunchKaufmanParams::default()
+        },
+        ..NumericParams::default()
+    }
+}
+
+/// Digest of the factor's numeric content: the raw bits of every `D`
+/// entry and every `L` value, in storage order, plus each node's
+/// `nelim`. Two arms that agree here produced byte-identical factors;
+/// two that differ produced a different pivot sequence, a different
+/// delayed-pivot count, or different rounding — all three of which
+/// matter and none of which an unchanged inertia would reveal.
+fn digest(csc: &CscMatrix, sym: &SymbolicFactorization, bs: usize) -> Option<(String, u64)> {
+    let mut ws = FactorWorkspace::default();
+    let params = params_at(bs);
+    let (factors, inertia) =
+        factorize_multifrontal_supernodal_with_workspace(csc, sym, &params, &mut ws).ok()?;
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    let mut delayed = 0usize;
+    for node in factors.node_factors.iter() {
+        node.nelim.hash(&mut h);
+        delayed += node.ncol - node.nelim;
+        let f = &node.frontal_factors;
+        for v in f.d_diag.iter().chain(f.d_subdiag.iter()).chain(f.l.iter()) {
+            v.to_bits().hash(&mut h);
+        }
+    }
+    Some((
+        format!(
+            "{}/{}/{}+d{delayed}",
+            inertia.positive, inertia.negative, inertia.zero
+        ),
+        h.finish(),
+    ))
+}
+
+/// True relative residual `||Ax-b||_inf / ||b||_inf` for one arm, from a
+/// single unrefined solve, so a numeric change shows up rather than
+/// being absorbed by iterative refinement.
+fn residual(csc: &CscMatrix, sym: &SymbolicFactorization, bs: usize) -> Option<f64> {
+    let mut ws = FactorWorkspace::default();
+    let params = params_at(bs);
+    let (factors, _) =
+        factorize_multifrontal_supernodal_with_workspace(csc, sym, &params, &mut ws).ok()?;
+    let b = vec![1.0f64; csc.n];
+    let x = feral::numeric::solve::solve_sparse(&factors, &b).ok()?;
+    let mut ax = vec![0.0f64; csc.n];
+    for j in 0..csc.n {
+        for k in csc.col_ptr[j]..csc.col_ptr[j + 1] {
+            let i = csc.row_idx[k];
+            let v = csc.values[k];
+            ax[i] += v * x[j];
+            if i != j {
+                ax[j] += v * x[i];
+            }
+        }
+    }
+    let num = (0..csc.n).fold(0.0f64, |m, i| m.max((ax[i] - b[i]).abs()));
+    let den = b
+        .iter()
+        .fold(0.0f64, |m, v| m.max(v.abs()))
+        .max(f64::MIN_POSITIVE);
+    Some(num / den)
+}
+
+fn time_one(
+    csc: &CscMatrix,
+    sym: &SymbolicFactorization,
+    bs: usize,
+    ws: &mut FactorWorkspace,
+) -> Option<u128> {
+    let params = params_at(bs);
+    let t = Instant::now();
+    factorize_multifrontal_supernodal_with_workspace(csc, sym, &params, ws).ok()?;
+    Some(t.elapsed().as_micros())
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: probe_panel_block_size <a.mtx> [b.mtx ...]");
+        std::process::exit(2);
+    }
+    let arms: Vec<usize> =
+        feral::env::usize_list_var("FERAL_BS_LIST").unwrap_or_else(|| vec![8, 16, 24, 32, 48, 64]);
+    let pairs: usize = feral::env::usize_var("FERAL_BS_PAIRS").unwrap_or(8).max(1);
+    let baseline = BunchKaufmanParams::default().block_size;
+
+    for path in &args {
+        let Ok(csc) = read_mtx(Path::new(path)).and_then(|m| m.to_csc()) else {
+            eprintln!("{path}: load failed");
+            continue;
+        };
+        let Ok(sym) = symbolic_factorize(&csc, &SupernodeParams::default()) else {
+            eprintln!("{path}: symbolic failed");
+            continue;
+        };
+        // Front-shape context: the lever is quadratic in the panel
+        // width, so the arm ranking is only interpretable next to how
+        // wide this matrix's paying fronts actually are.
+        let mut ncols: Vec<usize> = sym.supernodes.iter().map(|s| s.ncol).collect();
+        ncols.sort_unstable();
+        let ncol_max = ncols.last().copied().unwrap_or(0);
+        let ncol_p90 = ncols[(ncols.len().saturating_sub(1)) * 9 / 10];
+
+        let label = Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(path);
+        println!(
+            "=== {label} (n={}, snodes={}, ncol p90={}, ncol max={}) ===",
+            csc.n,
+            sym.supernodes.len(),
+            ncol_p90,
+            ncol_max
+        );
+
+        // Paired alternating timing: every arm runs once per pair, in
+        // list order, so machine drift is shared across arms.
+        let mut mins: Vec<u128> = vec![u128::MAX; arms.len()];
+        let mut wins: Vec<usize> = vec![0; arms.len()];
+        let mut ws = FactorWorkspace::default();
+        for (i, &bs) in arms.iter().enumerate() {
+            // Warm each arm's workspace once before the paired loop.
+            if time_one(&csc, &sym, bs, &mut ws).is_none() {
+                eprintln!("{label}: factor failed at block_size={bs}");
+                mins[i] = 0;
+            }
+        }
+        for _ in 0..pairs {
+            let mut pair: Vec<u128> = Vec::with_capacity(arms.len());
+            for &bs in &arms {
+                pair.push(time_one(&csc, &sym, bs, &mut ws).unwrap_or(u128::MAX));
+            }
+            if let Some(best) = pair
+                .iter()
+                .enumerate()
+                .min_by_key(|&(_, v)| *v)
+                .map(|(i, _)| i)
+            {
+                wins[best] += 1;
+            }
+            for (i, v) in pair.into_iter().enumerate() {
+                mins[i] = mins[i].min(v);
+            }
+        }
+
+        let base_idx = arms.iter().position(|&b| b == baseline);
+        let base_min = base_idx.map(|i| mins[i]).unwrap_or(0);
+
+        println!(
+            "{:>6}{:>10}{:>9}{:>8}{:>20}{:>20}{:>10}",
+            "bs", "min_us", "vs_base", "wins", "inertia/delayed", "digest", "resid"
+        );
+        for (i, &bs) in arms.iter().enumerate() {
+            let (inertia, dig) = digest(&csc, &sym, bs)
+                .map(|(a, b)| (a, format!("{b:016x}")))
+                .unwrap_or_else(|| ("failed".into(), "-".into()));
+            let res = residual(&csc, &sym, bs).unwrap_or(f64::NAN);
+            let ratio = if base_min > 0 && mins[i] > 0 {
+                mins[i] as f64 / base_min as f64
+            } else {
+                f64::NAN
+            };
+            println!(
+                "{:>6}{:>10}{:>9.3}{:>8}{:>20}{:>20}{:>10.2e}{}",
+                bs,
+                mins[i],
+                ratio,
+                wins[i],
+                inertia,
+                dig,
+                res,
+                if bs == baseline { "  <- default" } else { "" }
+            );
+        }
+        println!();
+    }
+}

--- a/dev/research/issue-153-dtoc1nd-dense-front-2026-08-19.md
+++ b/dev/research/issue-153-dtoc1nd-dense-front-2026-08-19.md
@@ -1,0 +1,176 @@
+# Issue #153 item 2 — where dtoc1nd's dense-front time actually goes
+
+Session 2026-08-19-05. Scope: the single surviving item of #153 after the
+2026-08-19 rescope (items 1 and 3 were closed by prior sessions; see the
+issue thread and `dev/journal/2026-08-19-05.org` 22:10).
+
+The question: dtoc1nd is the worst downstream case in the #148 follow-up
+table, and its time is not in scaling, ordering, or the sparse tail. Which
+*phase*, on which *size class* of front, and is any of it recoverable?
+
+## Instruments written for this
+
+Neither existing probe could answer the question.
+`profile_supernode_distribution` buckets loop time by `nrow` but on a
+hardcoded matrix list and with no phase split; `diag_factor_phases` splits
+phases but aggregates over every front. Neither can say *which size class*
+a phase's time sits in.
+
+- `crates/feral-diagnostics/src/bin/probe_front_bucket_phases.rs` — the
+  front-size histogram weighted by loop time, with the phase breakdown
+  computed inside each bucket, plus the bucket's mean `ncol`/`nrow` so the
+  phase shares are interpretable. Sequential driver (the per-supernode
+  deltas come from process-global counters, so a parallel driver would
+  interleave them), warm workspace, median of N runs. `FERAL_BUCKET_BS`
+  sets `BunchKaufmanParams::block_size`, so the phase shares can be read
+  *as a function of the lever*.
+- `crates/feral-diagnostics/src/bin/probe_panel_block_size.rs` — a paired
+  alternating sweep over `block_size` (`dev/decisions.md` 2026-08-09
+  methodology: every arm timed once per pair in order, `min_us` per arm,
+  sign test over pairs), reporting per arm the inertia, the delayed-pivot
+  count, a hash of every `d_diag`/`d_subdiag`/`l` bit in storage order,
+  and the true relative residual.
+
+## Finding 1 — the cost is 148 fronts, and it is 91% of the factor
+
+`dtoc1nd_0010` (n = 9685, 482 supernodes), bucketed by `nrow`,
+`FERAL_BUCKET_REPS=7`, default `block_size = 64`:
+
+    bucket   count  time_ms  time%  flop%   avg_ns  ncol  nrow   asm%  dense%  panel%  schur%  tail%
+     17-32     162    0.239    4.0    0.2     1476     1    26   36.8    54.6     0.0     0.0    0.0
+     33-64     172    0.397    6.7    1.0     2311     2    50   19.2    75.2    11.1     0.5    0.0
+    65-128     148    5.284   89.2   98.8    35701    62    88   14.4    84.9    53.5    19.5    0.0
+
+The paying bucket is 148 fronts of mean shape `ncol = 62`, `nrow = 88`.
+Time share and flop share agree (89% vs 99%), so this is not a bucket
+whose cost is out of line with its work — it simply *is* the work.
+
+Inside that bucket the split is anomalous against every other #153
+fixture. Same probe, same settings:
+
+    matrix                paying bucket   ncol  nrow   panel%  schur%
+    dtoc1nd_0010          65-128            62    88     53.5    19.5
+    clnlbeam_0001         17-32             17    19      6.4    23.9
+    dtoc2_0000            33-64             16    46     13.4    17.2
+    marine_1600_0010      33-64             17    47      7.5    27.3
+    rocket_12800_0001     17-32             17    22     14.5    25.9
+    steering_12800_0002   17-32             17    19     10.7    30.1
+
+Every other fixture is panel 6-15% / Schur 17-30%. dtoc1nd is the other
+way round, and the reason is shape: `bs = params.block_size.min(ncol)`
+(`src/dense/factor.rs:2171`) and `block_size` defaults to 64, so a
+62-column front runs as **one** panel and does all of its elimination in
+the left-looking BLAS-2 kernel with no inter-panel BLAS-3 update at all.
+dtoc1nd is the only fixture in the set with `ncol` in the 48-64 range —
+every other one has `ncol` ≈ 17.
+
+## Finding 2 — the packed-SIMD work gate is not involved
+
+The standing hypothesis (issue text, and the doc comment this probe was
+written under) was that dtoc1nd's front regime falls between the eager
+small-front path and the packed-SIMD work gate
+(`PACKED_SIMD_MIN_WORK = 1024`, `src/dense/factor.rs:3861`), so its
+trailing updates run on the scalar walk.
+
+**Falsified, structurally and by measurement.** The gate is
+`simd_work = n_elim · (nrow − col_start) · ncol`; on the paying front that
+is `62 · 88 · 62 ≈ 3.4e5`, which clears the 1024 threshold by 330×. So the
+SIMD path is already taken. Forcing the question with
+`FERAL_PACKED_SIMD_MIN_WORK` (median of 7, paying bucket avg_ns):
+
+    min_work        avg_ns   panel%  schur%   note
+    0                32910     54.9    17.9   SIMD always
+    1024 (default)   32131     55.6    18.1
+    1e12             37173     47.9    26.5   scalar always, +15.7%
+
+Lowering the gate to 0 changes nothing — nothing was being rejected.
+Raising it past every panel costs 15.7%, which confirms the SIMD kernel is
+both engaged and paying on exactly these fronts. There is no missed
+dispatch here to recover.
+
+## Finding 3 — `block_size` moves the split exactly as predicted, and buys ~1%
+
+If the 53.5% panel share is BLAS-2 work that ought to be BLAS-3, lowering
+`block_size` should convert it. It does, cleanly and monotonically —
+`FERAL_BUCKET_BS` sweep, median of 9, paying bucket:
+
+    bs    avg_ns   panel%   schur%   tail%
+     8     35016     14.7     57.2     2.3
+    16     33449     23.2     48.8     0.0
+    32     31367     36.0     36.3     0.0
+    48     30633     43.7     28.0     0.0
+    62     32199     53.4     18.4     0.3
+    64     32348     54.1     17.9     0.0
+
+The panel share falls 54% → 15% and the Schur share rises 18% → 57% as the
+panel narrows. The mechanism is confirmed. **The wall clock is not.**
+Across-process `avg_ns` from this sweep is not trustworthy at this effect
+size — an earlier run of the same sweep put the minimum at `bs = 64`, this
+one at `bs = 48`. The paired alternating sweep is the measurement of
+record (single process, arms interleaved, 60 pairs):
+
+    bs    min_us   vs_base   wins/60
+    16      9769     1.004         6
+    32      9673     0.994         9
+    48      9604     0.987        43
+    64      9733     1.000         2   <- default
+
+`bs = 48` does win: 43 of 60 pairs against an expected 15 under the null,
+which is not noise. But the effect is **1.3% of total factor time**, on a
+matrix whose paying bucket is 91% of that time. Converting three quarters
+of the panel share into BLAS-3 buys 1.3%. The 53.5% is not recoverable
+time; the two kernels cost very nearly the same per flop at this front
+shape.
+
+It also does not generalize. `bs = 48` and `bs = 64` are *identical* for
+any front with `ncol ≤ 48`, and that is every other fixture in the corpus
+sample — `ncol` p90 is 1-19 everywhere except dtoc1nd (63):
+
+    matrix           ncol p90   ncol max
+    dtoc1nd_0010           63         63
+    pinene_3200             19         29
+    marine_1600             19         51
+    nql180                  15         86
+    gasoil_3200             16         21
+    robot_1600              16         17
+    clnlbeam                16         16
+    dtoc2                    1         23
+    svanberg                 1         18
+    qcqp1500-1c              1        612
+    cont5_2_4_l              1        308
+
+On the two with any wide fronts at all, the paired sweep finds nothing:
+
+    nql180_0000       bs=48  0.990  5/12 wins (tied with bs=64)
+    qcqp1500-1c_0000  bs=48  0.994  3/12 wins
+
+So `block_size = 48` is a 1.3% win on one matrix and a no-op on the rest.
+That is below the bar for changing a global default. Not shipped; recorded
+in `dev/tried-and-rejected.md`.
+
+## Finding 4 — `block_size` is bit-neutral (worth keeping)
+
+Every arm of every sweep above produced the same inertia, the same zero
+delayed pivots, the same residual, and the **same hash over every `L` and
+`D` bit in storage order**:
+
+    dtoc1nd_0010    5960/3725/0  d0   9cb93f568423e6c0   resid 5.54e-6
+    nql180_0000   129601/130080/0 d0  4f588093d6bac8c7   resid 7.55e-7
+    qcqp1500-1c     1500/10508/0 d0   cfec17df1a4f8d38   resid 7.55e-7
+
+across `bs ∈ {8,16,24,32,48,62,64}`. On these matrices `block_size` is
+pure scheduling — it does not perturb the pivot sequence, so any future
+retuning of it is a performance-only change. Caveat: none of the three
+delays a pivot (`d0` throughout), so this is not yet established on a
+matrix where `may_delay` actually fires.
+
+## What is left
+
+The dtoc1nd gap is *not* a mis-set threshold. Three candidate levers are
+now eliminated: the packed-SIMD work gate (Finding 2), the panel/Schur
+split (Finding 3), and — from the rescope — scaling and `nemin` (issue
+thread). The remaining decomposition of the paying front is assembly 14.4%
+/ dense 84.9% with the dense part genuinely spent in kernels that are
+already SIMD and already near-optimally blocked. Any further win has to
+come from the kernel itself at `ncol ≈ 62`, `nrow ≈ 88`, or from producing
+fewer such fronts (ordering), not from a dispatch decision.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5639,3 +5639,73 @@ and its per-call workspace construction are `O(n)` work in *both* arms,
 which dilutes a per-front effect until it disappears. Replaced by an
 in-crate `#[ignore]`d test that times `CbSolveWorkspace::solve_into`
 against a pooled workspace: the exact call `worthwhile` decides.
+
+## 2026-08-19 — #153 item 2: two levers for dtoc1nd's dense-front gap
+
+Full measurement writeup: `dev/research/issue-153-dtoc1nd-dense-front-2026-08-19.md`.
+Both instruments are committed
+(`crates/feral-diagnostics/src/bin/probe_front_bucket_phases.rs`,
+`probe_panel_block_size.rs`) so either can be re-run.
+
+### Rejected: "dtoc1nd's fronts fall below the packed-SIMD work gate"
+
+The standing hypothesis in #153 and in the probe's own doc comment: dtoc1nd's
+33-64-column front regime sits between the eager small-front path and
+`PACKED_SIMD_MIN_WORK = 1024` (`src/dense/factor.rs:3861`), so its trailing
+updates run on the scalar tile walk.
+
+**Wrong.** The gate is `n_elim · (nrow − col_start) · ncol`; on dtoc1nd's paying
+front (`ncol = 62`, `nrow = 88`) that is ≈ 3.4e5, clearing the threshold by 330×.
+Confirmed with `FERAL_PACKED_SIMD_MIN_WORK` on `dtoc1nd_0010` (median of 7,
+paying-bucket avg_ns): `min_work = 0` gives 32910 ns — indistinguishable from the
+default's 32131, i.e. nothing was being rejected; `min_work = 1e12` (scalar
+always) gives 37173 ns, +15.7%, with schur% rising 18.1 → 26.5. The SIMD kernel
+is already engaged on exactly these fronts and already paying. There was no
+missed dispatch to recover.
+
+### Rejected: lowering `block_size` from 64 to 48
+
+`bs = params.block_size.min(ncol)` (`src/dense/factor.rs:2171`), so dtoc1nd's
+62-column front runs as one left-looking BLAS-2 panel with no inter-panel BLAS-3
+update — panel is 53.5% of the paying bucket's time while every other #153 fixture
+is panel 6-15% / Schur 17-30%. Lowering `block_size` should convert that panel
+work into BLAS-3.
+
+**It converts it, and the conversion does not pay.** `FERAL_BUCKET_BS` sweep on
+`dtoc1nd_0010`, paying bucket, median of 9 — the split moves monotonically and
+exactly as predicted:
+
+    bs      8     16     32     48     62     64
+    panel% 14.7   23.2   36.0   43.7   53.4   54.1
+    schur% 57.2   48.8   36.3   28.0   18.4   17.9
+
+The wall clock does not follow. Paired alternating sweep (60 pairs, single
+process, `min_us` per arm):
+
+    bs    min_us   vs_base   wins/60
+    16      9769     1.004         6
+    32      9673     0.994         9
+    48      9604     0.987        43
+    64      9733     1.000         2   <- default
+
+`bs = 48` does win the sign test (43/60 against an expected 15), but by **1.3% of
+total factor time** on a matrix whose paying bucket is 91% of that time. Moving
+three quarters of the panel share into BLAS-3 buys 1.3%: the two kernels cost
+nearly the same per flop at this front shape, so the 53.5% panel share is not
+recoverable time.
+
+It also does not generalize. `bs = 48` and `bs = 64` are identical for any front
+with `ncol ≤ 48`, and that is every other matrix sampled — `ncol` p90 is 1-19
+across clnlbeam, dtoc2, marine_1600, rocket, steering, gasoil_3200, pinene_3200,
+robot_1600, svanberg, nql180, qcqp1500-1c, cont5_2_4_l; only dtoc1nd is at 63. On
+the two with any wide fronts at all the paired sweep finds nothing: nql180 0.990
+(5/12 wins, tied with the default), qcqp1500-1c 0.994 (3/12). A 1.3% win on one
+corpus matrix and a no-op elsewhere is below the bar for changing a global default.
+
+**Kept from this attempt:** `block_size` is bit-neutral on all three matrices
+swept — identical inertia, zero delayed pivots, identical residual, and an
+identical hash over every `L`/`D` bit in storage order across
+`bs ∈ {8,16,24,32,48,62,64}` (`dtoc1nd_0010` 9cb93f568423e6c0, `nql180_0000`
+4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
+is a performance-only change. Not yet established on a matrix that actually
+delays a pivot — all three report `d0`.


### PR DESCRIPTION
Instruments and measurements for the single surviving item of #153 (dtoc1nd's
dense-front gap). **Diagnostics only — no production code changes.**

## Why new probes

`profile_supernode_distribution` buckets loop time by `nrow` but on a hardcoded
matrix list with no phase split; `diag_factor_phases` splits phases but aggregates
over every front. Neither can say *which size class* a phase's time sits in, which
is the whole question.

- **`probe_front_bucket_phases`** — front-size histogram weighted by loop time,
  phase breakdown computed inside each bucket, plus the bucket's mean `ncol`/`nrow`
  and a `tail%` column so `panel + schur + tail` account for all of `dense%`.
  `FERAL_BUCKET_BS` sets `block_size`, so phase shares can be read *as a function
  of the lever*.
- **`probe_panel_block_size`** — paired alternating sweep over `block_size`
  (`dev/decisions.md` 2026-08-09 methodology), reporting per arm the inertia, the
  delayed-pivot count, a hash of every `d_diag`/`d_subdiag`/`l` bit in storage
  order, and the true relative residual.

## What they found

**1. The cost is 148 fronts, 89% of loop time.** `dtoc1nd_0010`, bucketed by `nrow`:

| bucket | count | time% | flop% | avg_ns | ncol | nrow | asm% | panel% | schur% |
|---|---|---|---|---|---|---|---|---|---|
| 17-32 | 162 | 4.0 | 0.2 | 1476 | 1 | 26 | 36.8 | 0.0 | 0.0 |
| 33-64 | 172 | 6.7 | 1.0 | 2311 | 2 | 50 | 19.2 | 11.1 | 0.5 |
| 65-128 | 148 | 89.2 | 98.8 | 35701 | 62 | 88 | 14.4 | 53.5 | 19.5 |

Every other #153 fixture is panel 6-15% / Schur 17-30%. dtoc1nd is inverted, and
the cause is shape: `bs = block_size.min(ncol)` with `block_size = 64` makes a
62-column front **one** left-looking BLAS-2 panel with no inter-panel BLAS-3 update.

**2. The packed-SIMD work gate is not involved — hypothesis falsified.** The gate
is `n_elim · (nrow − col_start) · ncol` ≈ 3.4e5 against a 1024 threshold, cleared
330×. Measured with `FERAL_PACKED_SIMD_MIN_WORK` (paying bucket, median of 7):

| min_work | avg_ns | panel% | schur% |
|---|---|---|---|
| 0 (SIMD always) | 32910 | 54.9 | 17.9 |
| 1024 (default) | 32131 | 55.6 | 18.1 |
| 1e12 (scalar always) | 37173 | 47.9 | 26.5 |

Lowering the gate changes nothing — nothing was being rejected. Raising it costs
15.7%. There is no missed dispatch to recover.

**3. `block_size` moves the split exactly as predicted, and buys ~1%.**
`FERAL_BUCKET_BS` sweep, paying bucket, median of 9:

| bs | 8 | 16 | 32 | 48 | 62 | 64 |
|---|---|---|---|---|---|---|
| panel% | 14.7 | 23.2 | 36.0 | 43.7 | 53.4 | 54.1 |
| schur% | 57.2 | 48.8 | 36.3 | 28.0 | 18.4 | 17.9 |

Mechanism confirmed. Wall clock does not follow — paired alternating, 60 pairs:

| bs | min_us | vs_base | wins/60 |
|---|---|---|---|
| 16 | 9769 | 1.004 | 6 |
| 32 | 9673 | 0.994 | 9 |
| 48 | 9604 | **0.987** | 43 |
| 64 | 9733 | 1.000 | 2 |

`bs = 48` wins the sign test (43/60 vs an expected 15) but by **1.3% of total
factor time**. And it does not generalize: `48` and `64` are identical for any
front with `ncol ≤ 48`, which is every other matrix sampled (`ncol` p90 is 1-19
across twelve corpus matrices; only dtoc1nd is at 63). On the two with wide fronts
at all: nql180 0.990 (5/12 wins, tied with default), qcqp1500-1c 0.994 (3/12).
Below the bar for a global default change — **not shipped**, recorded in
`dev/tried-and-rejected.md` with the numbers.

**4. Kept: `block_size` is bit-neutral.** Identical inertia, zero delayed pivots,
identical residual, and an identical hash over every `L`/`D` bit across
`bs ∈ {8,16,24,32,48,62,64}` on all three matrices swept (`dtoc1nd_0010`
`9cb93f568423e6c0`, `nql180_0000` `4f588093d6bac8c7`, `qcqp1500-1c_0000`
`cfec17df1a4f8d38`). So future retuning is a performance-only change. Not yet
established on a matrix that actually delays a pivot — all three report `d0`.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, and
`cargo clippy -p feral-diagnostics --all-targets -- -D warnings` all clean. Both
binaries read their knobs through `feral::env` (#176), so `tests/env_knob_scan.rs`
passes.
