### PR TITLE
fix: pre-release corrections for 0.17.0 (core routing, env scan, docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,16 @@ All notable changes to FERAL will be documented in this file.
   `env::usize_list_var`: a locally-parsed list drops its unusable tokens and
   hands the caller a *shorter* sweep, so `0,1e3,1e6` ran one arm and reported
   "no difference" from an experiment that never had a second arm. The policy
-  lives in one new module, `feral::env`; a source-scan test
+  lives in one new **public** module, `feral::env` (`usize_var`, `u64_var`,
+  `usize_var_where`, `f64_var`, `f64_var_where`, `usize_list_var`,
+  `u128_list_var`), so a caller that reads its own knobs can apply the same
+  rules; a source-scan test
   (`tests/env_knob_scan.rs`) fails the build if any env read in `src/` or
-  `crates/` parses its own value locally again — with no exemption but
-  `feral::env` itself.
+  `crates/` parses its own value in the same statement again — with no
+  exemption but `feral::env` itself. Reads that stash the raw string in a
+  local and parse it further down are outside that scan's reach; the two
+  live instances (`SIZES`, `STATIC_PIVOTS`) were found by review and
+  converted too.
 - **No default and no gate changed** — only what a knob accepts and what it
   reports when it refuses. `feral::numeric::factorize::par_task_min_flops()` and
   `par_min_seeds()` are now public so a caller can confirm what the process
@@ -86,9 +92,14 @@ All notable changes to FERAL will be documented in this file.
 - **No default changed.** The cap is an upper bound only: the `eps*sqrt(n)`
   relative-residual target, the 100x divergence guard, and the 2-strike plateau
   exit all keep priority, and the best-iterate contract holds under every `k`, so
-  no cap can return an answer worse than `solve_sparse`. `k = 0` equals
-  `solve_sparse` bit-for-bit — and costs the same, since the residual matvec is
-  skipped rather than computed and discarded.
+  no cap can return an answer worse than `solve_sparse`. `k = 0` skips the
+  residual matvec rather than computing and discarding it, so it costs what the
+  unrefined solve costs — and on the shared-vector entry points
+  (`solve_sparse_refined_opts`) it is `solve_sparse` bit-for-bit. On an entry
+  point that may route to the contribution-block core (`Solver`,
+  `solve_sparse_refined_auto*`, `solve_sparse_refined_cb*`) `k = 0` is that
+  core's unrefined solve, which is a different reassociation of the same
+  answer — compare against `Solver::solve`, not `solve_sparse`.
 - **In-place entry points.** `Solver::solve_into`, `solve_refined_into`,
   `solve_many_into`, `solve_many_refined_into`, plus free-function
   `solve_sparse_into`, `solve_sparse_refined_into`,
@@ -98,7 +109,12 @@ All notable changes to FERAL will be documented in this file.
   its allocating twin; a wrong-length `rhs` or `x_out` returns
   `DimensionMismatch` rather than panicking; `NoFactor` keeps precedence.
   Aliasing `rhs` with `x_out` is unrepresentable in safe Rust rather than
-  checked at runtime.
+  checked at runtime. The crate root re-exports the single-RHS free
+  functions (`feral::solve_sparse_into`, `feral::solve_sparse_refined_into`,
+  `feral::RefineOptions`, ...); the multi-RHS and `_parallel` forms
+  (`solve_sparse_many_refined`, `_opts`, `_into`, and
+  `solve_sparse_refined_parallel`, `_opts`, `_into`) live at their module path,
+  `feral::numeric::solve`.
 - The refined paths also lost an internal allocation: the caller's `x_out` is
   now the best-iterate storage, and the multi-RHS refiner runs its initial
   batched solve directly into it.
@@ -112,6 +128,9 @@ All notable changes to FERAL will be documented in this file.
   `rayon::current_num_threads()` and overridable by `FERAL_CB_THRESH`, plus a
   fall-back to the shared-vector core whenever `ThreadPoolBuilder::build()` had
   failed — and `use_parallel` itself defaults from `available_parallelism()`.
+  (At `nrhs >= 16`, `solve_many_refined` takes the batched panel kernel
+  instead — a third reassociation, host-independent like the other two, so the
+  contract holds; it is simply not one of the two named cores.)
 - **The bug.** The two cores use different (equally valid) floating-point
   reassociations: the shared-vector core folds each front's separator update
   into a global vector in flat postorder, the contribution-block core sums a
@@ -129,10 +148,32 @@ All notable changes to FERAL will be documented in this file.
   (1.00–1.03x). On a factor routed to the contribution-block core, a host that
   cannot spawn workers pays ~1.10x for the determinism (poisson_160, refined
   solve: 27.8 ms → 30.6 ms) while a 4-worker host gains 25% (20.8 ms).
+  Best-of-7 on a 4-worker container over synthetic Poisson grids and chains;
+  the Mittelmann corpus was not re-measured for this change, so treat the
+  ratios as characteristic of bushy grid-like factors rather than as a bound.
 - **New API.** `SolveCore`, `solve_sparse_refined_auto` (the factor-derived
   choice, what `Solver` uses) and `solve_sparse_refined_cb` (the explicit
-  contribution-block entry point, with an execution-strategy argument).
-  `solve_sparse_refined` and `solve_sparse_refined_parallel` are unchanged.
+  contribution-block entry point, with an execution-strategy argument), plus
+  their `_opts` and `_into` forms: `solve_sparse_refined_auto_opts`,
+  `solve_sparse_refined_auto_into`, `solve_sparse_refined_cb_opts`. All are
+  re-exported at the crate root.
+- **`solve_sparse_refined` is unchanged.** `solve_sparse_refined_parallel` keeps
+  the shared-vector fallback it has always had — it is now
+  `solve_sparse_refined_auto(.., parallel: true)` — but the *predicate* behind
+  that fallback changed with everything else here, from the host-dependent
+  `CbSolveWorkspace::worthwhile()` to `cb_core_profitable`. On a factor where
+  the two disagree it returns a different (equally valid) reassociation than
+  v0.16.0 did on that host. Pinned by
+  `tests/issue177_parallel_entry_point_core.rs`.
+- **This release can change your numbers.** `Solver::solve_refined`,
+  `Solver::solve_many_refined` and `solve_sparse_refined_parallel` return the
+  bits the *factor* selects, where v0.16.0 returned the bits the *host*
+  selected. Any host whose core count, pool availability or `FERAL_CB_THRESH`
+  put it on the other side of the old gate will see its refined solves move in
+  the last bits — and, per issue #16, an interior-point host can amplify that
+  into a different iterate trajectory. This is the fix, not a side effect, but
+  it is not a no-op: re-baseline before comparing 0.17.0 runs against 0.16.0
+  ones. Python callers of `Solver.solve_refined` get the same change.
 
 ### Fixed — scaling router no longer routes on index order (issue #134 item B)
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,26 @@ a wrong `A⁻¹`, the refinement guarantees the returned `x` is no worse
 than the unrefined solve, even when individual refinement steps would
 have amplified the error.
 
+The step budget is a per-call parameter. `RefineOptions::with_max_steps(k)`
+caps the *correction* steps at `k` (the initial solve always runs, so a call
+does at most `k + 1` substitution passes); `RefineOptions::default()` is the
+historical budget, `DEFAULT_REFINE_MAX_STEPS = 10`. It is a cap, not a target:
+the `ε·√n` residual test, the divergence guard, and the plateau exit all keep
+priority, and best-iterate holds under every `k`, so no cap returns an answer
+worse than the unrefined solve. `k = 0` *is* the unrefined solve, and costs the
+same — the residual matvec is skipped rather than computed and discarded. The
+caller that wants this is one running its own refinement loop over the same
+system, an interior-point method being the standard case: without a cap the two
+loops nest and one solve can cost `10 × 11 = 110` passes.
+
+Every entry point has an `_opts` form taking `RefineOptions` and an `_into`
+form writing into a caller-owned buffer instead of allocating —
+`Solver::solve_into`, `solve_refined_into`, `solve_many_into`,
+`solve_many_refined_into`, and the free functions `solve_sparse_into`,
+`solve_sparse_refined_into`, `solve_sparse_many_refined_into`. Each is
+bit-identical to its allocating twin; a wrong-length buffer returns
+`DimensionMismatch` rather than panicking.
+
 ## Python bindings
 
 The `feral-solver` package on PyPI provides Python bindings built with
@@ -314,7 +334,7 @@ on `feral_new()`:
 |-----------------------------|---------|-----------------------------------------------------------------|
 | `FERAL_PAR_TASK_MIN_FLOPS`  | `1e6`   | subtree flops at or above which a supernode becomes its own task |
 | `FERAL_PAR_MIN_SEEDS`       | `2`     | task-graph seeds below which the factorization runs sequentially |
-| `FERAL_CB_THRESH`           | derived | coarsening cutoff for the contribution-block solve core          |
+| `FERAL_CB_THRESH`           | derived | task-graph coarsening cutoff for the contribution-block solve *schedule* — since #177 it cannot change a result bit |
 | `FERAL_INTRAFRONT_MIN_AREA` | `32768` | front area below which intra-front parallelism is off            |
 | `FERAL_PACKED_SIMD_MIN_WORK`| `1024`  | Schur work below which the packed SIMD kernel is skipped         |
 | `FERAL_DENSE_MAX`           | `1000`  | `bench` only: dense-BK size gate                                 |

--- a/crates/feral-diagnostics/src/bin/bench_intrafront.rs
+++ b/crates/feral-diagnostics/src/bin/bench_intrafront.rs
@@ -123,12 +123,13 @@ fn main() {
 
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.is_empty() {
-        let sizes = std::env::var("SIZES").unwrap_or_else(|_| "1200,1600,2000".to_string());
-        for tok in sizes.split(',') {
-            if let Ok(n) = tok.trim().parse::<usize>() {
-                let a = dense_spd(n);
-                bench_one(&format!("dense_spd_{n}"), &a);
-            }
+        // Issue #176: a locally-parsed list drops the tokens it cannot
+        // read, so `SIZES=1200,1.6e3` would quietly bench one size and
+        // look like a two-point sweep.
+        let sizes = feral::env::usize_list_var("SIZES").unwrap_or_else(|| vec![1200, 1600, 2000]);
+        for n in sizes {
+            let a = dense_spd(n);
+            bench_one(&format!("dense_spd_{n}"), &a);
         }
     } else {
         for path in &args {

--- a/crates/feral-diagnostics/src/bin/probe_static_pivot_inertia.rs
+++ b/crates/feral-diagnostics/src/bin/probe_static_pivot_inertia.rs
@@ -97,18 +97,14 @@ fn main() {
     let stop_arg: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(18);
     let only: Option<usize> = feral::env::usize_var("ONLY");
 
-    let pivots_env =
-        std::env::var("STATIC_PIVOTS").unwrap_or_else(|_| "0,1e-12,1e-10,1e-8,1e-6".to_string());
-    let thresholds: Vec<Option<f64>> = pivots_env
-        .split(',')
-        .map(|s| {
-            let v: f64 = s.trim().parse().unwrap_or(0.0);
-            if v <= 0.0 {
-                None
-            } else {
-                Some(v)
-            }
-        })
+    // Issue #176: a token this could not parse used to become `0.0`,
+    // i.e. silently a *different experiment arm* (`None` = static
+    // pivoting off) rather than an error. `f64_list_var` warns and drops
+    // it instead, so the arm count in the output matches what ran.
+    let thresholds: Vec<Option<f64>> = feral::env::f64_list_var("STATIC_PIVOTS")
+        .unwrap_or_else(|| vec![0.0, 1e-12, 1e-10, 1e-8, 1e-6])
+        .into_iter()
+        .map(|v| if v <= 0.0 { None } else { Some(v) })
         .collect();
 
     let iter_range: Vec<usize> = if let Some(o) = only {

--- a/dev/journal/2026-08-19-05.org
+++ b/dev/journal/2026-08-19-05.org
@@ -1,0 +1,326 @@
+#+TITLE: Session 2026-08-19-05 journal
+#+DATE: 2026-08-19
+
+* 22:10 :issue-153:triage:rescope:
+Read #153 cold and checked each of its three items against `main` at
+0.16.0. Items 1 and 3 are closed by prior sessions; item 2 (dtoc1nd's
+dense-front gap) is the only live one.
+
+- Item 1 (warm-path scaling): KR warm-start falsified twice
+  (`dev/tried-and-rejected.md` 2026-08-15), MC64 cache-miss cost closed
+  with a mechanism (2026-08-15-02). Separately, 0.15.1 already shipped
+  the real "never warms" fix on the MC64 side — the value-bound gate's
+  condition 3 compared the current *minimum* scaled diagonal against the
+  baseline *mean*, so it rejected reuse on unmoved matrices. robot_1600:
+  scaling -39.8%, factor -14.3%. The issue's profiling table predates it.
+- Item 3 (nemin): rejected in the issue's own thread.
+- Sizing correction carried forward: only 2 of the 6 fixtures (clnlbeam,
+  steering_12800) actually run KR; dtoc1nd/rocket/marine steady-state on
+  MC64. So "scaling = 34% of rocket_12800" is MC64 cost, not the KR loop.
+
+Posted the rescoping comment and retitled the issue to item 2.
+
+* 22:35 :issue-153:tooling:profiler:
+Needed the front-size histogram weighted by *loop time* that the issue
+asked for. `profile_supernode_distribution` buckets by nrow but on a
+hardcoded matrix list with no phase split; `diag_factor_phases` splits
+phases but aggregates over all fronts. Neither can say which size class
+a phase's time sits in. Wrote
+`crates/feral-diagnostics/src/bin/probe_front_bucket_phases.rs`:
+argv-driven, sequential supernodal driver (per-supernode phase deltas
+come from process-global counters, so a parallel driver would interleave
+them), warm workspace, median of N runs, buckets matching
+`Profiler::report()` so the numbers are comparable with prior probes.
+
+* 18:05 :issue153:blocksize:bitparity:
+Wrote =crates/feral-diagnostics/src/bin/probe_panel_block_size.rs= — paired
+alternating sweep over =BunchKaufmanParams.block_size= ∈ {8,16,24,32,48,64},
+=min_us= per arm plus a sign test over pairs, and per arm an inertia,
+delayed-pivot count, and a hash of every =d_diag=/=d_subdiag=/=l= bit in
+storage order. Motivation: dtoc1nd's paying bucket is ncol≈62 against
+=block_size: 64=, so =bs = params.block_size.min(ncol)= (src/dense/factor.rs:2171)
+makes the whole front one BLAS-2 left-looking panel; panel is 56.5% of that
+bucket's time while every other fixture is panel 7-15% / schur 26-31%.
+
+First run on dtoc1nd_0010 (n=9685, 482 supernodes, ncol p90 = 63, ncol max = 63):
+
+: bs   min_us  vs_base  wins  inertia/delayed  digest             resid
+:  8    14357   0.865     1   5960/3725 d0     9cb93f568423e6c0   5.54e-6
+: 16    16896   1.018     0   5960/3725 d0     9cb93f568423e6c0   5.54e-6
+: 24    17703   1.067     1   5960/3725 d0     9cb93f568423e6c0   5.54e-6
+: 32    12075   0.728     3   5960/3725 d0     9cb93f568423e6c0   5.54e-6
+: 48    15285   0.921     2   5960/3725 d0     9cb93f568423e6c0   5.54e-6
+: 64    16597   1.000     1   5960/3725 d0     9cb93f568423e6c0   5.54e-6  <- default
+
+Two results, of very different quality.
+
+1. **=block_size= is bit-neutral here.** All six arms produce the same
+   inertia, the same zero delayed pivots, the same residual, and the *same
+   hash over every L and D bit*. So on this matrix the knob is pure
+   scheduling — it does not perturb the pivot sequence. That is a
+   load-independent result and it is the precondition for the lever being
+   shippable at all. Not yet generalized: needs the same check on fixtures
+   where pivots actually get delayed (dtoc1nd delays none).
+
+2. **The timings are junk.** =uptime= reports load average 14.54 with two
+   rustc processes at 620% and 172% CPU and a =pounce= release binary at
+   58% — other sessions are compiling in this working tree. bs=64 measures
+   16597 µs here against the ~6564 µs warm sequential minimum measured for
+   this same matrix earlier today, i.e. 2.5x inflated, and the per-pair
+   wins scatter across five of the six arms (1,0,1,3,2,1). Nothing about
+   the arm *ranking* survives that. Re-running with 40 pairs; the ordering
+   is not to be quoted until the machine is quiet.
+
+* 22:55 :pr-review:pr182:merge:
+Applied the PR #182 review nits (env parse policy, issue #176) and
+merged. The broadened =tests/env_knob_scan.rs= — matching =env::var(=
+with any argument and exempting only =src/env.rs= — turned up 21 live
+offenders across =src/bin/= and =crates/feral-diagnostics=. Converted
+all 21 rather than re-narrowing the guard, so the scan now has no
+exemptions. Merged as 61d2996.
+
+Consequence noticed while merging: PR #181 introduced
+=std::env::var("FERAL_CALIB_REPS").ok().and_then(|s| s.parse().ok())=
+in =src/numeric/solve.rs=, which is exactly the shape the new scan
+rejects. Not visible on either branch in isolation — only in the merge.
+Merge order therefore mattered: #182 first, then merge main into #181
+and convert the knob there.
+
+* 23:05 :pr-review:pr181:issue-177:
+The blocking #181 finding reproduced exactly as reported. Applying the
+leak — =cb_gate_shape(..) && cb_sync_amortized(total, n_nodes)= as the
+last line of =cb_core_profitable= — passed the whole suite before the
+fix. After adding =narx_proxy(24, 2000, 1)= to
+=cb_core_profitable_matches_the_plan_gate=:
+
+    assertion `left == right` failed: n=96001: flat predicate says
+    false, CbTaskPlan says true
+
+Added =saw_split= so the test fails if a future edit drops the only
+fixture where =shape_ok= and =worthwhile= disagree — otherwise the same
+hole reopens silently.
+
+Measured the calibration table's reachability rather than taking the
+reviewer's count on trust. Two of eight points are unreachable, and one
+of them is not the pair the review named:
+
+    fixture       nodes      total   per_front  shape_ok  worthwhile
+    poisson_96     1736     351544         202     false       false
+    poisson_160    4633    1090303         235      true        true
+    narx_w1       47228    1208092          25      true       false
+    narx_w2       33138     958763          28     false       false
+    narx_w3        6024    1840981         305      true        true
+    narx_w4       21595    1155171          53      true       false
+    narx_w6       15384    1150719          74      true        true
+    narx_w8       11880    1229411         103      true        true
+
+Both unreachable points (narx_w2, poisson_96) fail on MIN_TOTAL_COST =
+1e6, not on the per-front floor. The six reachable points are still
+monotone and still bracket the break-even between 53 and 74, so
+MIN_COST_PER_FRONT = 64 stands unchanged. Doc and research note both
+annotated. Merged as 7c6a422.
+
+* 23:20 :pounce-710:refinement:test-gap:
+pounce#710's acceptance item 3 — "verify the cap actually takes effect
+on the =nrhs = 2= path" — was a real gap, not a formality. Issue #178's
+tests cover the free functions =solve_sparse_many_refined_opts= at
+nrhs = 2/3/4/20, and cover =Solver= only at =RefineOptions::default()=.
+Nothing covered the combination pounce consumes: the stateful =Solver=,
+a non-default cap, and =nrhs = 2= (below BLAS3_REFINE_THRESHOLD = 16,
+so the per-column arm rather than the batched one).
+
+Wrote =tests/pounce710_refine_cap_nrhs2.rs= (6 tests, both arms).
+Non-vacuity checked by mutation: changing the narrow arm to
+=self.refine_into(.., RefineOptions::default())= — i.e. silently
+ignoring the caller's cap on exactly the path pounce uses — fails 4 of
+the 6. The two that still pass are the ones that should
+(=default_options_change_nothing_on_this_path= and the =_into= parity
+check), which is the expected signature of that defect.
+
+Reading the code, the cap does reach the narrow arm:
+=solve_many_refined_into= passes =opts= to =refine_into= per column
+(=src/numeric/solver.rs:1861=). So item 3 is confirmed working, and now
+pinned.
+
+* 23:30 :pounce-710:release:blocker:
+Checked crates.io with a User-Agent (serde sanity check first: 1.0.229
+returned). feral's published max is =0.16.0=, dated 2026-08-14 — before
+#179 merged. So =RefineOptions= is not in any published release, and
+pounce's =scripts/check-release-consistency.sh= rejects a git dep.
+pounce#710's second blocker is therefore still open and is a feral-side
+release action, not a code change. Unreleased has five entries
+(#134B, #175, #176, #177, #178); 0.17.0 is the right bump.
+
+* 23:20 :issue153:blocksize:falsified:
+Re-ran both #153 probes on a quieter machine (load 7.1-7.6 vs the 14.5
+of the first attempt) and the picture resolved.
+
+The =probe_front_bucket_phases= result is stable across runs:
+dtoc1nd_0010's cost is 148 fronts of mean shape ncol=62 nrow=88, 89% of
+loop time against 99% of flops, panel 53.5% / schur 19.5%. Every other
+#153 fixture is panel 6-15% / schur 17-30%. Cause is shape:
+=bs = block_size.min(ncol)= with block_size 64 makes a 62-column front
+*one* left-looking BLAS-2 panel.
+
+**Packed-SIMD gate hypothesis: falsified.** The gate is
+=n_elim*(nrow-col_start)*ncol= ≈ 3.4e5 against a 1024 threshold — cleared
+by 330x, so the SIMD path was never in question. Confirmed with
+=FERAL_PACKED_SIMD_MIN_WORK= (paying bucket avg_ns, median of 7):
+
+: min_work        avg_ns   panel%  schur%
+: 0                32910     54.9    17.9
+: 1024 (default)   32131     55.6    18.1
+: 1e12             37173     47.9    26.5
+
+min_work=0 changes nothing (nothing was being rejected); 1e12 costs
+15.7%. The kernel is engaged and paying.
+
+**block_size: mechanism confirmed, payoff 1.3%.** Added =FERAL_BUCKET_BS=
+so the phase shares can be read as a function of the lever. Panel falls
+54%->15% and schur rises 18%->57% as bs goes 64->8 — exactly the
+predicted conversion. But the paired sweep (60 pairs, single process)
+puts bs=48 only 1.3% ahead: min_us 9604 vs 9733, 43/60 wins. Real (43 vs
+an expected 15 under the null) and tiny. Converting three quarters of the
+panel share buys 1.3%, so the 53.5% is not recoverable time.
+
+Does not generalize: bs=48 and bs=64 are identical for ncol<=48, which is
+every other matrix sampled — ncol p90 is 1-19 across twelve corpus
+matrices, only dtoc1nd is at 63. nql180 0.990 (5/12 wins, tied), 
+qcqp1500-1c 0.994 (3/12). Not shipped.
+
+Two independent runs of the phase probe disagreed on which bs minimized
+avg_ns (64 in one, 48 in the other) — across-process medians are not
+trustworthy at a 1% effect size. The paired sweep is the measurement of
+record, per dev/decisions.md 2026-08-09. Recorded that explicitly in the
+research note so a future reader does not quote the phase-probe timings.
+
+Bit-neutrality now generalizes past dtoc1nd: identical digest across
+bs in {8,16,24,32,48,62,64} on nql180_0000 (4f588093d6bac8c7) and
+qcqp1500-1c_0000 (cfec17df1a4f8d38) too. All three report d0, so the
+claim is still untested where may_delay actually fires.
+
+* 23:22 :process:issues:
+#175 and #176 were still open after their PRs merged: PR #181's title
+said "(issue #175)" and #182's "(#176)", which link but are not closing
+keywords. Closed both with comments recording the fix and the merge
+commit. Worth remembering — the project's PR titles use the "(#N)"
+convention, which never auto-closes.
+
+* 23:50 :pr-review:pre-release:blocker:issue177:
+Five review agents over the six PRs merged since v0.16.0 (#174, #179,
+#180, #181, #182, #183 — the brief said five; the cross-cutting agent
+found #174 also has an [Unreleased] section). Two of them independently
+reported the same blocker, which I then confirmed against git rather
+than on their word.
+
+=solve_sparse_refined_parallel= silently changed its arithmetic. At
+v0.16.0 (=git show v0.16.0:src/numeric/solve.rs=):
+
+: let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
+:     let cb = CbSolveWorkspace::for_factors(factors);
+:     cb.worthwhile().then_some(cb)
+: } else { None };
+
+i.e. shared-vector core whenever the gate rejected the factor. #177's
+rewrite mapped it to =SolveCore::ContribBlock { parallel: true }=, and
+=solve_sparse_refined_core= turns that into =use_cb = true=
+unconditionally. So every rejected factor changed bits *and* got slower
+— #180's own rejected-alternative table measures that design at 1.86x on
+poisson_40 (659 -> 1228 µs). Meanwhile CHANGELOG.md:135 asserted
+"=solve_sparse_refined= and =solve_sparse_refined_parallel= are
+unchanged".
+
+Fix is =SolveCore::Auto { parallel: true }=, not a restoration of the old
+gate: =worthwhile()= reads =rayon::current_num_threads()= and
+=FERAL_CB_THRESH=, which is exactly the host-dependence #177 exists to
+remove. =Auto= keeps the fallback and derives it from
+=cb_core_profitable= (shape only). Side effect: =_parallel= is now an
+exact alias of =_auto(.., true)=, which is what it actually is; said so
+in its doc comment, which #177 had left empty by moving it onto
+=solve_sparse_refined_cb= (where it stacked with the new one and rustdoc
+rendered both, the top one asserting two things the bottom one denies).
+
+Pinned by =tests/issue177_parallel_entry_point_core.rs= (4 tests).
+Oracle is v0.16.0's shipped behaviour via =solve_sparse_refined=, which
+is unchanged and golden-pinned. Non-vacuity is asserted inside the test
+rather than assumed: on chain_400 the two cores must differ bit-for-bit
+or the test says so and fails.
+
+: test parallel_entry_point_keeps_the_shared_vector_core_on_a_rejected_factor ok
+: test parallel_entry_point_still_reaches_the_cb_core_on_a_profitable_factor  ok
+: test parallel_entry_point_equals_auto_with_parallelism_on                   ok
+: test opts_and_into_forms_make_the_same_core_choice                          ok
+
+Full suite after all fixes: 924 passed, 0 failed, 23 ignored
+(=cargo test --release=). clippy --all-targets -D warnings clean.
+
+* 23:52 :pr-review:env:scan-gap:
+The #182 CHANGELOG claimed =tests/env_knob_scan.rs= leaves "no exemption
+but =feral::env= itself". Two live offenders passed it:
+
+- =bench_intrafront.rs:126= =SIZES= — =env::var= into a local, then
+  =.parse::<usize>()= in a *later* statement (the =for= loop).
+- =probe_static_pivot_inertia.rs:100= =STATIC_PIVOTS= — same shape, and
+  worse: =.parse().unwrap_or(0.0)= turns an unreadable token into 0.0,
+  which the next line maps to =None= = static pivoting *off*. A typo
+  silently became a different experiment arm.
+
+The scan is statement-scoped, so it structurally cannot see the
+bind-then-parse-later shape. Converted both (added =env::f64_list_var=,
+the float twin of =usize_list_var=, for the second) and scoped the
+CHANGELOG claim to what the scan actually checks.
+
+Separately fixed a fragility the #182 agent found and I initially
+doubted: the window is =min(next ';', 400)=, and
+=Solver::pool_num_threads= (src/numeric/solver.rs:506) is a tail
+expression with no =;= for 1708 bytes, while the =.parse= in the
+*separate* =pool_num_threads_from= helper below sits at +485. The scan
+passed only because 400 < 485. Measured, not estimated:
+
+: line 506: first ';' at +1708, '.parse' at +485, hard=min(1708,400)=400
+
+Trimming ~86 characters of doc comment would have failed CI on a file
+nobody touched. Added a blank-line terminator to the window — statements
+do not span blank lines under rustfmt, so it can only shrink windows,
+never add offenders.
+
+* 23:54 :pr-review:docs:changelog:
+Remaining pre-release corrections, all doc/CHANGELOG:
+
+- =DEFAULT_REFINE_MAX_STEPS= doc claimed 10 is "MUMPS's =ICNTL(10)=
+  default". It is not: =ref/mumps/src/dini_defaults.F:363= says
+  =ICNTL(10)= defaults to 0 (no refinement), and
+  =external_benchmarks/comparison/REPORT.md:19= already said so. Two
+  sites corrected to attribute 10 to feral's own corpus.
+- =README.md:317= still described =FERAL_CB_THRESH= as selecting the
+  solve *core*; since #177 it is schedule-only.
+- =README.md= refinement section never mentioned =RefineOptions=, the
+  cap, or the =_into= family — the release's headline feature.
+- CHANGELOG: "k = 0 equals =solve_sparse= bit-for-bit" is true only on
+  the shared-vector entry points; on a CB-routed factor it is that
+  core's unrefined solve. Scoped.
+- CHANGELOG: added the missing new public items (=_auto_opts=,
+  =_auto_into=, =_cb_opts=, the seven =feral::env= functions) and an
+  explicit "this release can change your numbers" note, including for
+  Python callers, who get #177's bit change with none of the Rust-side
+  explanation.
+- =tests/cb_solve_parity.rs:217= claimed poisson_96 "clears the
+  =worthwhile= gate, so this exercises the actual tree-parallel task
+  path". It does not: total 351,544 vs MIN_TOTAL_COST 1,000,000, so both
+  arms run =cb_run_serial=. Pre-existing. The claim it was standing in
+  for is genuinely covered by =refined_solve_core_stability.rs= on
+  poisson_160 (total 1,090,303) at 1/2/3/4/8 workers; corrected the
+  comment to say which file pins what.
+- =scripts/release-checklist.sh= step 8 verified the publish with a
+  User-Agent-less =curl= to crates.io, which fails silently and reads as
+  "never published".
+
+* 23:56 :process:agents:worktree:
+A review agent mutated =src/numeric/solve.rs= in the live working tree
+(inserted =panic!("PARALLEL PATH REACHED")= into =cb_run_parallel= to
+test parity-suite non-vacuity) while I was about to edit the same file.
+Caught it on =git status=, restored with =git checkout --=, and told it
+to stop. Its finding was correct and useful — the parity suite never
+reaches =cb_run_parallel= — but review agents must run with
+=isolation: "worktree"= when they intend mutation testing, or be told up
+front that the tree is shared and read-only to them.

--- a/scripts/release-checklist.sh
+++ b/scripts/release-checklist.sh
@@ -259,8 +259,10 @@ Remaining manual steps (this script does NOT commit, tag, or release):
      feral_solver-$ver wheels and publishes to PyPI — that version's
      files can never be re-uploaded). Make sure $ver is final first.
 
-  8. Verify:
-       curl -s https://crates.io/api/v1/crates/feral | \\
+  8. Verify (crates.io rejects a request with no User-Agent, and does it
+     silently — without the header even 'serde' reads as unpublished):
+       curl -s -H 'User-Agent: feral-release (jkitchin@andrew.cmu.edu)' \\
+         https://crates.io/api/v1/crates/feral | \\
          python3 -c 'import sys,json;print(json.load(sys.stdin)["crate"]["max_version"])'
        curl -s https://pypi.org/pypi/feral-solver/json | \\
          python3 -c 'import sys,json;print(json.load(sys.stdin)["info"]["version"])'

--- a/src/env.rs
+++ b/src/env.rs
@@ -273,6 +273,36 @@ pub fn f64_var_where(name: &str, requirement: &str, accept: impl Fn(f64) -> bool
     None
 }
 
+/// Comma-separated sweep list of floats, e.g.
+/// `STATIC_PIVOTS=0,1e-12,1e-10`. The float twin of [`usize_list_var`],
+/// and it exists for the same reason: a locally-parsed list silently
+/// *drops* the tokens it cannot read, so a sweep reports "no difference"
+/// from an experiment that never ran the arms the operator asked for.
+/// Each unusable token warns and is skipped; an all-unusable list warns
+/// and yields `None` so the caller falls back to its own default list.
+pub fn f64_list_var(name: &str) -> Option<Vec<f64>> {
+    let raw = std::env::var(name).ok()?;
+    let mut out = Vec::new();
+    for token in raw.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(v) = report(name, token, parse_float(token)) {
+            out.push(v);
+        }
+    }
+    if out.is_empty() {
+        warn_once(
+            name,
+            &raw,
+            "has no usable values; falling back to the built-in default list",
+        );
+        return None;
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -848,7 +848,7 @@ enum CbThreshold {
     /// host, so it may drive **scheduling only** (issue #177).
     FromWorkers,
     /// A fixed [`CB_REFERENCE_FANOUT`]-way cut, identical on every host.
-    /// The basis for [`CbTaskPlan::core_profitable`].
+    /// The basis for [`cb_core_profitable`].
     Reference,
     /// Explicit, for the tests that sweep the threshold.
     #[cfg(test)]
@@ -1946,9 +1946,9 @@ fn gemm_scalar_block(
 
 /// Default cap on iterative-refinement **correction** steps: 10.
 ///
-/// MUMPS's `ICNTL(10)` default. Below this, some near-rank-deficient KKT
-/// matrices (CERI651C/ELS, HAHN1, MEYER3NE) bounce in and out of the
-/// machine-precision basin before settling — see
+/// Chosen from FERAL's own corpus, not inherited: below 10, some
+/// near-rank-deficient KKT matrices (CERI651C/ELS, HAHN1, MEYER3NE)
+/// bounce in and out of the machine-precision basin before settling — see
 /// `dev/journal/2026-04-18-06.org`. Issue #178 makes the cap settable
 /// per call but explicitly does **not** change this default.
 pub const DEFAULT_REFINE_MAX_STEPS: usize = 10;
@@ -2035,8 +2035,10 @@ impl RefineOptions {
 /// the returned `x` is no worse than the unrefined `solve_sparse()` output.
 ///
 /// Convergence test: stop when `||r||₂ / ||b||₂ < ε·√n` (we've reached
-/// machine precision) or after 10 steps. 10 is MUMPS's ICNTL(10)
-/// default; below that some near-rank-deficient KKT matrices
+/// machine precision) or after 10 steps. 10 comes from FERAL's corpus,
+/// not from MUMPS (whose `ICNTL(10)` default is `0` — no refinement at
+/// all; the comparison harness sets it to `2`): below 10 some
+/// near-rank-deficient KKT matrices
 /// (CERI651C/ELS, HAHN1, MEYER3NE) bounce in and out of the machine-
 /// precision basin before settling, and the best-iterate tracker below
 /// guarantees no regression from the extra steps.
@@ -2300,7 +2302,7 @@ pub fn solve_sparse_refined_parallel_into(
 ///
 /// Step 0 is the unrefined initial solve; subsequent steps are refinement
 /// iterations. The number of steps is bounded by the refinement cap
-/// (currently 10 + 1 initial = 11) and may exit early on convergence,
+/// (`RefineOptions::max_steps` + 1 initial) and may exit early on convergence,
 /// divergence, or plateau.
 #[derive(Debug, Clone, Copy)]
 pub struct RefinementStep {
@@ -2481,7 +2483,7 @@ fn solve_sparse_refined_core(
     };
 
     // Issue #131 Gap A: when the caller selects the contribution-block
-    // core, pool one CB workspace across the initial + up-to-10 correction
+    // core, pool one CB workspace across the initial + capped correction
     // solves (each reuses the plan + scratch). Otherwise use the
     // shared-vector `SolveWorkspace` path, bit-for-bit.
     //

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2103,14 +2103,6 @@ pub fn solve_sparse_refined_into(
     Ok(())
 }
 
-/// Iterative refinement using the tree-parallel contribution-block solve
-/// (issue #131 Gap A) for the initial and correction solves, pooling one
-/// `CbSolveWorkspace` across them. Falls back per-solve to the serial
-/// path when the factor's assembly tree is not `worthwhile` (path-like /
-/// small trees), so it never regresses those; on bushy trees it runs the
-/// substitutions across the rayon pool. The refined result is a valid
-/// solution equal to `solve_sparse_refined`'s up to floating-point
-/// reassociation. Used by `Solver::solve_refined` when parallelism is on.
 /// Iterative refinement through the contribution-block solve core (issue
 /// #131 Gap A) for the initial and correction solves, pooling one
 /// `CbSolveWorkspace` across them.
@@ -2225,6 +2217,35 @@ pub fn solve_sparse_refined_auto_into(
     Ok(())
 }
 
+/// Iterative refinement with tree-parallel execution requested, and the
+/// core chosen from the factor's structure — exactly
+/// [`solve_sparse_refined_auto`]`(.., parallel: true)`, which this
+/// forwards to.
+///
+/// # Relationship to the other entry points
+///
+/// This is the pre-#177 name. It predates the separation of *which core*
+/// (a numerical decision) from *how it executes* (a scheduling one), so
+/// its name says "parallel" while its behavior is "let the factor pick
+/// the core, and run it over the pool if that lands on the CB core".
+/// Prefer [`solve_sparse_refined_auto`] in new code, which says that
+/// outright, or [`solve_sparse_refined_cb`] when you want the
+/// contribution-block core regardless of what the factor's shape
+/// suggests.
+///
+/// # Why it is not the CB core unconditionally
+///
+/// Through v0.16.0 this function built a `CbSolveWorkspace` and used it
+/// only when `worthwhile()` held, falling back to the shared-vector core
+/// otherwise. Issue #177 removed that gate because it read
+/// `rayon::current_num_threads()` and `FERAL_CB_THRESH`, so the same
+/// factor solved with different arithmetic on different hosts.
+/// [`SolveCore::Auto`] is the host-independent replacement: it keeps the
+/// fallback (from the factor's shape alone) rather than dropping it.
+/// Routing this function to the CB core unconditionally instead would
+/// have cost 1.86x on the small path-like factors the gate exists to
+/// protect (poisson_40, refined solve: 659 µs → 1228 µs) — the
+/// alternative issue #177 measured and rejected.
 pub fn solve_sparse_refined_parallel(
     matrix: &CscMatrix,
     factors: &SparseFactors,
@@ -2248,7 +2269,7 @@ pub fn solve_sparse_refined_parallel_opts(
         rhs,
         &mut x,
         false,
-        SolveCore::ContribBlock { parallel: true },
+        SolveCore::Auto { parallel: true },
         opts,
     )?;
     Ok(x)
@@ -2268,7 +2289,7 @@ pub fn solve_sparse_refined_parallel_into(
         rhs,
         x_out,
         false,
-        SolveCore::ContribBlock { parallel: true },
+        SolveCore::Auto { parallel: true },
         opts,
     )?;
     Ok(())

--- a/tests/cb_solve_parity.rs
+++ b/tests/cb_solve_parity.rs
@@ -214,9 +214,15 @@ fn cb_parity_disjoint_tridiag() {
 
 #[test]
 fn cb_parity_poisson_2d_96x96_concurrent() {
-    // n = 9216: large + bushy enough to clear the `worthwhile` gate, so
-    // this exercises the actual tree-parallel task path (not the serial
-    // fallback) — the byte-identity check that matters most.
+    // n = 9216, the largest fixture here. Note what this does *not*
+    // reach: its total solve cost is 351,544 against
+    // `MIN_TOTAL_COST = 1_000_000`, so `worthwhile` is false and both
+    // sides of the parity check run `cb_run_serial`. The claim that
+    // `cb_run_parallel` is byte-identical to it is covered by
+    // `tests/refined_solve_core_stability.rs`, whose poisson_160 fixture
+    // (total 1,090,303) does clear the gate and is checked at 1/2/3/4/8
+    // workers. What this file pins is CB-core vs shared-vector-core
+    // agreement, which does not depend on the schedule.
     check(&poisson_2d_spd(96), "poisson_2d_96x96");
 }
 

--- a/tests/env_knob_scan.rs
+++ b/tests/env_knob_scan.rs
@@ -11,6 +11,16 @@
 //! This is a source scan, not a behavioural test, so it lives apart from
 //! `env_knob_parsing.rs` — that binary mutates process-global env vars
 //! and must not share a process with anything else.
+//!
+//! **Scope.** The guard is *statement*-scoped: it catches a parse in the
+//! same statement as the read, which is the shape #176 found sixteen
+//! copies of. It does not catch a read whose value is bound to a local
+//! and parsed further down — `SIZES` in `bench_intrafront.rs` and
+//! `STATIC_PIVOTS` in `probe_static_pivot_inertia.rs` were both live
+//! instances of that second shape, found by review rather than by this
+//! test and converted to `feral::env` alongside it. Widening the window
+//! to catch them generically would flag legitimate `argv` parsing, so
+//! the scan stays narrow and this note records what it cannot see.
 
 /// The scan matches `env::var(` with **any** argument, not just a
 /// literal `"FERAL_…"`. The four sneakiest sites #176 touched read
@@ -44,8 +54,25 @@ fn no_env_read_parses_its_own_value() {
             // back to a char boundary: this tree's comments are full of
             // multibyte characters (`×`, `‖`, `≥`), and slicing a byte
             // offset inside one panics.
+            //
+            // The window ends at whichever comes first: the statement's
+            // `;`, a blank line, or 400 bytes. The blank line matters —
+            // a read used as a function's *tail expression* has no `;`
+            // at all, so `find(';')` runs on into whatever follows and
+            // only the byte cap stops it. `Solver::pool_num_threads`
+            // (`src/numeric/solver.rs`) is exactly that: its next `;` is
+            // 1708 bytes away and the `.parse` inside the *separate*
+            // `pool_num_threads_from` helper below it sits at +485, so
+            // the scan passed only because 400 < 485 — an 85-byte
+            // margin that trimming a doc comment would have erased.
+            // Statements do not span blank lines under rustfmt, so
+            // cutting there is the real statement boundary.
             let rest = &text[start..];
-            let hard = rest.find(';').unwrap_or(rest.len()).min(400);
+            let hard = rest
+                .find(';')
+                .unwrap_or(rest.len())
+                .min(rest.find("\n\n").unwrap_or(rest.len()))
+                .min(400);
             let end = rest
                 .char_indices()
                 .map(|(i, _)| i)

--- a/tests/issue177_parallel_entry_point_core.rs
+++ b/tests/issue177_parallel_entry_point_core.rs
@@ -1,0 +1,226 @@
+//! `solve_sparse_refined_parallel` must keep the shared-vector fallback
+//! it had through v0.16.0.
+//!
+//! # What went wrong
+//!
+//! Issue #177 replaced the runtime core gate — `CbSolveWorkspace::
+//! worthwhile()`, derived from `rayon::current_num_threads()` and
+//! `FERAL_CB_THRESH` — with an explicit [`SolveCore`] argument, because
+//! the old gate made a factor's arithmetic a function of the host. In the
+//! rewrite, `solve_sparse_refined_parallel` was mapped to
+//! `SolveCore::ContribBlock { parallel: true }`, which runs the
+//! contribution-block core *unconditionally*. Through v0.16.0 it ran the
+//! CB core only when the gate accepted the factor and the shared-vector
+//! core otherwise:
+//!
+//! ```text
+//! // v0.16.0, src/numeric/solve.rs
+//! let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
+//!     let cb = CbSolveWorkspace::for_factors(factors);
+//!     cb.worthwhile().then_some(cb)
+//! } else { None };
+//! ```
+//!
+//! So the function silently changed its answer on every factor the gate
+//! used to reject — while the `[Unreleased]` CHANGELOG entry that
+//! introduced `SolveCore` asserted it was unchanged. It was also the
+//! slower of the two: routing rejected factors to the CB core cost 1.86x
+//! on poisson_40 (659 µs → 1228 µs), which is the alternative #177's own
+//! measurements rejected.
+//!
+//! # The oracle
+//!
+//! `solve_sparse_refined` — the shared-vector entry point, unchanged
+//! since v0.16.0 and pinned by `tests/golden_bits.rs`. On a factor the
+//! profitability predicate rejects, the parallel entry point must agree
+//! with it bit-for-bit, because that is what v0.16.0 returned. The
+//! oracle is therefore the released binary's behaviour, not a value
+//! computed here.
+//!
+//! # What is pinned
+//!
+//!  1. on a CB-rejected factor, `solve_sparse_refined_parallel` is
+//!     bit-identical to `solve_sparse_refined`;
+//!  2. that check is not vacuous — the CB core genuinely returns
+//!     different bits on the same factor, so a regression to
+//!     `ContribBlock` would fail (1);
+//!  3. on a CB-profitable factor the parallel entry point does reach the
+//!     CB core, so the fallback was restored rather than the CB core
+//!     disabled;
+//!  4. the `_opts` and `_into` forms make the same core choice as the
+//!     allocating one.
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams};
+use feral::numeric::solve::{
+    solve_sparse_refined, solve_sparse_refined_auto, solve_sparse_refined_cb,
+    solve_sparse_refined_parallel, solve_sparse_refined_parallel_into,
+    solve_sparse_refined_parallel_opts, RefineOptions,
+};
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        pivot_threshold: 0.0,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+/// Path-like and below the cost floor: `cb_core_profitable` rejects it,
+/// so v0.16.0's gate rejected it too, at every worker count.
+fn chain(n: usize) -> CscMatrix {
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    for i in 0..n {
+        rows.push(i);
+        cols.push(i);
+        vals.push(4.0);
+        if i + 1 < n {
+            rows.push(i + 1);
+            cols.push(i);
+            vals.push(-1.0);
+        }
+        if i + 2 < n {
+            rows.push(i + 2);
+            cols.push(i);
+            vals.push(-0.5);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("chain")
+}
+
+/// 2-D Poisson on a `k x k` grid: bushy nested dissection. At `k = 160`
+/// the tree clears the predicate and the CB core is chosen.
+fn poisson_2d_spd(k: usize) -> CscMatrix {
+    let n = k * k;
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    for j in 0..k {
+        for i in 0..k {
+            let p = j * k + i;
+            rows.push(p);
+            cols.push(p);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(p + 1);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(p + k);
+                cols.push(p);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("poisson_2d")
+}
+
+fn factor_of(m: &CscMatrix) -> feral::numeric::factorize::SparseFactors {
+    let sym = symbolic_factorize(m, &SupernodeParams::default()).expect("symbolic");
+    let (f, _) = factorize_multifrontal(m, &sym, &ldlt_params()).expect("numeric");
+    f
+}
+
+fn rhs_for(n: usize) -> Vec<f64> {
+    (0..n).map(|i| 1.0 + 0.37 * (i % 7) as f64).collect()
+}
+
+fn bit_diff(a: &[f64], b: &[f64]) -> usize {
+    (0..a.len())
+        .filter(|&i| a[i].to_bits() != b[i].to_bits())
+        .count()
+}
+
+fn assert_bit_eq(a: &[f64], b: &[f64], what: &str) {
+    let d = bit_diff(a, b);
+    assert_eq!(d, 0, "{what}: {d} of {} entries differ", a.len());
+}
+
+/// Contracts 1 and 2. The non-vacuity half runs first: if the two cores
+/// happened to agree on this matrix, contract 1 would hold no matter
+/// which core the parallel entry point ran, and the test would pin
+/// nothing.
+#[test]
+fn parallel_entry_point_keeps_the_shared_vector_core_on_a_rejected_factor() {
+    let m = chain(400);
+    let f = factor_of(&m);
+    let b = rhs_for(m.n);
+
+    let shared = solve_sparse_refined(&m, &f, &b).expect("shared-vector refine");
+    let cb = solve_sparse_refined_cb(&m, &f, &b, false).expect("cb refine");
+    assert!(
+        bit_diff(&shared, &cb) > 0,
+        "non-vacuity: the two cores agree bit-for-bit on chain_400, so this \
+         test cannot distinguish them — pick a fixture where they differ"
+    );
+
+    let parallel = solve_sparse_refined_parallel(&m, &f, &b).expect("parallel refine");
+    assert_bit_eq(
+        &shared,
+        &parallel,
+        "chain_400: solve_sparse_refined_parallel vs solve_sparse_refined (v0.16.0 behaviour)",
+    );
+}
+
+/// Contract 3: the fallback was restored, not bolted on by disabling the
+/// CB core outright.
+#[test]
+fn parallel_entry_point_still_reaches_the_cb_core_on_a_profitable_factor() {
+    let m = poisson_2d_spd(160);
+    let f = factor_of(&m);
+    let b = rhs_for(m.n);
+
+    let cb = solve_sparse_refined_cb(&m, &f, &b, true).expect("cb refine");
+    let parallel = solve_sparse_refined_parallel(&m, &f, &b).expect("parallel refine");
+    assert_bit_eq(
+        &cb,
+        &parallel,
+        "poisson_160: solve_sparse_refined_parallel vs the CB core",
+    );
+}
+
+/// The parallel entry point is `solve_sparse_refined_auto(.., true)` —
+/// which is what its documentation now says it is — on both sides of the
+/// predicate.
+#[test]
+fn parallel_entry_point_equals_auto_with_parallelism_on() {
+    for (m, label) in [
+        (chain(400), "chain_400"),
+        (poisson_2d_spd(40), "poisson_40"),
+        (poisson_2d_spd(160), "poisson_160"),
+    ] {
+        let f = factor_of(&m);
+        let b = rhs_for(m.n);
+        let auto = solve_sparse_refined_auto(&m, &f, &b, true).expect("auto refine");
+        let parallel = solve_sparse_refined_parallel(&m, &f, &b).expect("parallel refine");
+        assert_bit_eq(
+            &auto,
+            &parallel,
+            &format!("{label}: parallel vs auto(parallel = true)"),
+        );
+    }
+}
+
+/// Contract 4: the `_opts` and `_into` forms route to the same core. A
+/// fix applied to only the allocating entry point would leave the other
+/// two on the CB core.
+#[test]
+fn opts_and_into_forms_make_the_same_core_choice() {
+    for (m, label) in [
+        (chain(400), "chain_400"),
+        (poisson_2d_spd(160), "poisson_160"),
+    ] {
+        let f = factor_of(&m);
+        let b = rhs_for(m.n);
+        let base = solve_sparse_refined_parallel(&m, &f, &b).expect("parallel refine");
+
+        let via_opts = solve_sparse_refined_parallel_opts(&m, &f, &b, RefineOptions::default())
+            .expect("parallel refine opts");
+        assert_bit_eq(&base, &via_opts, &format!("{label}: _opts vs allocating"));
+
+        let mut x = vec![0.0; m.n];
+        solve_sparse_refined_parallel_into(&m, &f, &b, &mut x, RefineOptions::default())
+            .expect("parallel refine into");
+        assert_bit_eq(&base, &x, &format!("{label}: _into vs allocating"));
+    }
+}


### PR DESCRIPTION
Pre-release review of the six PRs merged since v0.16.0 (#174, #179, #180,
#181, #182, #183), before cutting 0.17.0. One behavioural regression, one
correctness gap in a guard test, and a set of documentation claims that the
code does not support.

## 1. `solve_sparse_refined_parallel` silently changed its arithmetic

Issue #177 replaced the runtime core gate (`CbSolveWorkspace::worthwhile()`,
which reads `rayon::current_num_threads()` and `FERAL_CB_THRESH`) with an
explicit `SolveCore` argument. In that rewrite `solve_sparse_refined_parallel`
was mapped to `SolveCore::ContribBlock { parallel: true }`, and
`solve_sparse_refined_core` turns that into `use_cb = true` with no gate.

Through v0.16.0 the same function ran the CB core only when the gate accepted
the factor:

```rust
let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
    let cb = CbSolveWorkspace::for_factors(factors);
    cb.worthwhile().then_some(cb)
} else { None };
```

So on every factor the gate used to reject, this public function returns a
different reassociation than 0.16.0 -- while the CHANGELOG entry that
introduced `SolveCore` asserted it was unchanged. It also picked the slower of
the two cores: PR #180's own rejected-alternative table measures routing
rejected factors to the CB core at 1.86x on poisson_40 (659 us -> 1228 us).

Fixed by mapping it to `SolveCore::Auto { parallel: true }` rather than
restoring the old gate -- `worthwhile()` is exactly the host-dependence #177
exists to remove, and `Auto` derives the same fallback from
`cb_core_profitable`, which reads the factor's shape alone. Both `_opts` and
`_into` forms are fixed, not just the allocating one.

Pinned by `tests/issue177_parallel_entry_point_core.rs` (4 tests). The oracle
is v0.16.0's shipped behaviour reached through `solve_sparse_refined`, which
is unchanged and golden-pinned. Non-vacuity is asserted rather than assumed:
on chain_400 the two cores must differ bit-for-bit or the test fails saying so.

#177 had also left the function undocumented, by moving its doc onto
`solve_sparse_refined_cb` where it stacked with that function's own doc and
asserted two things -- a per-solve `worthwhile` fallback, and use by
`Solver::solve_refined` -- that the paragraph six lines below denies. Removed
the stale block and wrote the function a real doc comment.

## 2. Two env knobs slipped past the #176 scan

`tests/env_knob_scan.rs` is meant to leave "no exemption but `feral::env`
itself". Two live knobs passed it:

| knob | file | shape |
|---|---|---|
| `SIZES` | `bench_intrafront.rs` | bind, then parse in a later statement |
| `STATIC_PIVOTS` | `probe_static_pivot_inertia.rs` | same, plus `.unwrap_or(0.0)` |

The scan is statement-scoped and structurally cannot see a read that binds to
a local and parses further down. `STATIC_PIVOTS` is the worse of the two: an
unreadable token becomes `0.0`, which the next line maps to `None` -- static
pivoting **off**. A typo did not fall back to the default list, it silently
ran a different experiment arm and reported the numbers as if it had not.

Both converted. `STATIC_PIVOTS` needs a float list, so this adds
`env::f64_list_var`, the float twin of `usize_list_var`, sharing the one
policy.

Separately the scan was passing on a margin rather than a rule. Its window was
`min(next ';', 400)`, and `Solver::pool_num_threads` reads `RAYON_NUM_THREADS`
as a function tail expression -- no `;` for 1708 bytes -- while the `.parse` in
the *separate* `pool_num_threads_from` helper below sits at +485:

```
line 506: first ';' at +1708, '.parse' at +485, hard=min(1708,400)=400
```

It passed only because 400 < 485. Deleting ~86 characters of doc comment would
have failed CI on a file nobody touched. Added a blank-line terminator, which
is a real statement boundary under rustfmt and can only shrink windows, so it
cannot introduce a new offender. The module doc now states the guard is
statement-scoped and names what it cannot see.

## 3. Documentation that asserts things the code does not do

- CHANGELOG: `solve_sparse_refined_parallel` "unchanged" -> what actually
  happened. Added an explicit **this release can change your numbers** note
  covering `Solver::solve_refined`, `solve_many_refined` and
  `solve_sparse_refined_parallel`, since issue #16 documents how a last-bit
  solve change amplifies along an IPM trajectory. Python callers get the same
  change and had no note at all.
- CHANGELOG: missing new public items (`_auto_opts`, `_auto_into`, `_cb_opts`,
  four of the seven `feral::env` functions); `k = 0 == solve_sparse`
  bit-for-bit scoped to the shared-vector entry points; performance bullet now
  states its conditions (best-of-7, 4-worker container, synthetic fixtures,
  Mittelmann not re-measured); `_into` forms located at
  `feral::numeric::solve`, not the crate root.
- README: `FERAL_CB_THRESH` still described as selecting the solve *core*;
  since #177 it is schedule-only. The refinement section never mentioned
  `RefineOptions` at all -- the release's headline feature.
- rustdoc: `DEFAULT_REFINE_MAX_STEPS` attributed 10 to "MUMPS's `ICNTL(10)`
  default" in two places. MUMPS defaults `ICNTL(10)` to **0**
  (`ref/mumps/src/dini_defaults.F:363-367`), as
  `external_benchmarks/comparison/REPORT.md:19` already said. Also a broken
  intra-doc link and a hardcoded "10 + 1 initial = 11" that stopped being a
  constant when #183 made the cap an option.
- `tests/cb_solve_parity.rs` claimed its n = 9216 fixture clears the
  `worthwhile` gate "so this exercises the actual tree-parallel task path".
  Measured total cost is 351,544 against `MIN_TOTAL_COST = 1,000,000`, so both
  arms run `cb_run_serial` and the file pins no parallel behaviour. That claim
  is genuinely covered by `refined_solve_core_stability.rs` on poisson_160
  (total 1,090,303) at 1/2/3/4/8 workers; comment corrected to say which file
  pins what.
- `scripts/release-checklist.sh` step 8 verified the crates.io publish with a
  User-Agent-less curl, which crates.io rejects silently -- a successful
  publish would have read back as "never published".

## Verification

- `cargo test --release`: **924 passed, 0 failed, 23 ignored**
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo clippy -p feral-diagnostics --all-targets -- -D warnings`: exit 0
- `cargo fmt --check`: clean
- Benchmark, run on `main` before these edits (none of them touch a hot path):
  Dense Phase 2.8.1 exit partition small-frontal p90 **1.60** (<= 2.0 PASS),
  medium **2.00** (<= 3.0 PASS); Sparse small-frontal **1.61** PASS, medium
  **1.61** PASS. Sparse geomean factor/MUMPS 0.45, solve/MUMPS 0.08,
  factor/SSIDS 0.04, solve/SSIDS 0.96. No regression against the previous
  session.

## Knowingly not fixed

All NIT-level, none release-blocking: `SolveCore` is exported but appears in
no public signature; `env_knob_scan.rs` has no `target/` exclusion in its walk;
three argument checks are ordered differently across the three `_many_*_into`
entry points; `_cb` has no `_into` form while `_auto`/`_parallel` do; the
README knob table omits `FERAL_NEMIN_LIST`/`FERAL_MERGE_BUDGET_LIST`; three of
PR #183's six tests are structurally tautological on their `nrhs = 2` arm; and
`dev/sessions/2026-08-19-04.md` says "433 lib" tests where the actual count is
443. Per the maintainer's call, `RefineOptions` is deliberately **not**
`#[non_exhaustive]` -- the codebase uses that attribute nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAxgLjVsYe4oB2XRURmKG
