### PR TITLE
release: 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to FERAL will be documented in this file.
 
-## [Unreleased]
+## [0.17.0] - 2026-08-19
 
 ### Fixed — the tree-parallel solve no longer runs on trees too thin to pay for it (issue #175)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "feral"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 description = "Sparse symmetric indefinite direct solver in pure Rust, with certified inertia counts."

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -110,7 +110,7 @@ version = "0.2.1"
 
 [[package]]
 name = "feral-python"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "feral",
  "numpy",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "feral-python"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 description = "Python bindings for feral — sparse symmetric indefinite direct solver."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feral-solver"
-version = "0.16.0"
+version = "0.17.0"
 description = "Sparse symmetric indefinite direct solver with certified inertia, in pure Rust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts 0.17.0. No source changes -- version strings, lockfiles and the CHANGELOG
section header only.

All six version-bearing locations move together
(`scripts/release-checklist.sh bump 0.17.0`):

| # | location | field |
|---|---|---|
| 1 | `Cargo.toml` | `[package] version` (feral) |
| 2 | `Cargo.lock` | feral entry |
| 3 | `python/Cargo.toml` | `[package] version` (feral-python) |
| 4 | `python/pyproject.toml` | `[project] version` (feral-solver) |
| 5 | `python/Cargo.lock` | feral-python entry |
| 6 | `python/Cargo.lock` | feral entry (path dep) |

The root crate and the Python bindings are separate cargo workspaces, so a
root-only cargo invocation never touches the Python lockfile -- the drift that
shipped v0.5.0's Python trio at 0.4.0 and had PyPI reject the upload.

The six fill-reducing ordering crates stay at 0.2.1: unchanged since v0.16.0,
confirmed by the checklist's staleness guard (release.yml treats "already on
crates.io" as success, so a crate whose code moved without a version bump would
be silently skipped at publish time).

## What is in 0.17.0

- **#178** — iterative refinement gains a configurable step cap
  (`RefineOptions`) and `_into` forms across the refined-solve family.
- **#177** — the solve core is chosen from the factor alone, not from the
  host's thread count and `FERAL_CB_THRESH`.
- **#175** — the tree-parallel solve gained a per-front overhead term, so it
  no longer runs on trees too thin to pay for it.
- **#176** — env knobs share one parse policy that warns instead of silently
  falling back to a default.
- **#134 item B** — the scaling router no longer routes on index order.
- **#185** — pre-release corrections: the `solve_sparse_refined_parallel` core
  routing regression, two env knobs that slipped past the #176 scan, and a set
  of CHANGELOG/README/rustdoc claims the code did not support.

## This is a last-bits-change release

`Solver::solve_refined`, `solve_many_refined` and
`solve_sparse_refined_parallel` can return a different reassociation than
0.16.0 on the same input, because #177 replaced a host-dependent core
predicate with a factor-only one and the two disagree on some factors. Issue
#16 documents how a last-bit solve change amplifies along an IPM trajectory,
so callers with pinned iteration counts need to re-baseline. Python callers get
the same change. The CHANGELOG says this under its own heading rather than
leaving it to be discovered.

## Verification

- `scripts/release-checklist.sh check` exits 0 — all six agree on 0.17.0, no
  ordering crate stale, CHANGELOG has a `[0.17.0]` section.
- `cargo publish --dry-run -p feral` — run before this PR.
- CI on the most recent *code* commit (a91082b, PR #185) was green: `check`
  and `stress-smoke` on both workflows plus linux-x86_64 wheel tests on python
  3.10 / 3.12 / 3.13. Full local suite on that tree: 924 passed, 0 failed, 23
  ignored.

Per CLAUDE.md, a commit that changes only version strings, lockfiles and docs
is exempt from re-running `cargo test` when CI on the most recent code commit
was green — the bar is "the code is tested", not "tests ran on this exact SHA".

## After merge

Tag `v0.17.0` and `gh release create`, which is the irreversible step: it fires
`release.yml` (publishes 7 crates to crates.io — permanent, only `cargo yank`)
and `python-wheels.yml` (feral_solver-0.17.0 wheels to PyPI — that version's
files can never be re-uploaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAxgLjVsYe4oB2XRURmKG
