### PR TITLE
docs: session checkpoint 2026-08-19-05

### DIFF
--- a/dev/context.md
+++ b/dev/context.md
@@ -1,334 +1,70 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-19T19:56:19Z
+Generated: 2026-08-20T02:05:49Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-03.md
+File: dev/sessions/2026-08-19-04.md
 ```
-# Session 2026-08-19-03
+# Session 2026-08-19-04
 
 ## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
 
-Reported first, per the hard rule in CLAUDE.md. `cargo run --bin bench
---release` in this container found only the 8 synthetic matrices — the
-external corpus and the MUMPS/SPRAL oracle timings are not mounted — so
-both Phase 2.8.1 exit partitions report `N/A`, exactly as in
-2026-08-19-02. **No comparison against 2026-08-15-02's 1.61 / 2.00 /
-1.67 / 1.67 is possible from this run.** The numbers were not measured;
-I am not claiming they held.
+Reported first, per the hard rule in CLAUDE.md — and for the same reason
+as 2026-08-19-02: `cargo run --bin bench --release` in this container
+finds only the 8 synthetic matrices. The external corpus and the
+MUMPS/SPRAL oracle timings are absent, so both Phase 2.8.1 exit
+partitions report `N/A` and **no comparison against 2026-08-15-02's
+1.61 / 2.00 / 1.67 / 1.67 is possible from this run**. I am not claiming
+those numbers held; they were not measured.
 
-This is also the wrong benchmark for this change: nothing in it touches
-factor or solve arithmetic. What the run does confirm is that the change
-is inert where it should be — inertia 2/2 vs MUMPS, residual 2/2, worst
-residual 1.26e-16 (`densecol_kkt_300_0000`), byte-for-byte the same
-figures 2026-08-19-02 reported.
+What the run does confirm, identical to last session: inertia 2/2 vs
+MUMPS, residual 2/2, worst residual 1.26e-16.
+
+It is also the wrong benchmark for this change, which touches solve
+*scheduling* and not the factor path. The measurements that matter are
+in "Benchmark Results" below.
 
 ## Goal
 
-Fix issue #176 — `FERAL_CB_THRESH` and `FERAL_PAR_TASK_MIN_FLOPS`
-silently ignore unparseable values (e.g. `1e18`) instead of erroring.
+Fix issue #175 — the tree-parallel solve added for #131 Gap A is a net
+15% loss on the wide-sparse Mittelmann KKT `NARX_CFy`, and
+`CbTaskPlan::worthwhile` has no per-call-overhead term.
 
 ## Accomplished
 
-### The bug is one shape, copied eighteen times
+### The report is real, and it is purely a scheduling bug
 
-Every numeric `FERAL_*` knob in the tree was read as
+The reporter serialized the tree-parallel solve with `FERAL_CB_THRESH`
+and recovered 7.35 s of 49.41 s (15%) plus ~3.0M involuntary context
+switches, on 14 cores over 100 IPM iterations. Two things follow that
+the issue does not state:
 
-    std::env::var(NAME).ok().and_then(|v| v.parse().ok()).unwrap_or(DEFAULT)
+1. `FERAL_CB_THRESH` does not choose the solve *core* — since #177 that
+   is `cb_core_profitable`, which reads neither the worker count nor the
+   environment. A huge threshold collapses the plan to one task, so the
+   **same** CB core runs serially. The whole 7.35 s is scheduling
+   overhead, and fixing it cannot move a bit of any solve.
+2. Rows 3 and 4 of the reporter's table are within noise, so the CB core
+   running serially already matches switching parallelism off entirely
+   on this problem. Nothing in the report argues for changing which core
+   runs.
 
-`"1e18".parse::<u64>()` is `Err(InvalidDigit)`, `.ok()` discards it, and
-`unwrap_or` puts the default back. The knob is set; the process behaves
-as if it were unset; nothing is printed. The reporter's evidence:
+### Mechanism: the overhead is per front, not per task
 
-    $ FERAL_PAR_TASK_MIN_FLOPS=1e18 pounce NARX_CFy.nl --no-sol max_iter=1
-    task_plan: n_snodes=45736 n_tasks=21 seeds=11 cutoff=1000000 min_seeds=2
-
-`cutoff=1000000` is `PAR_TASK_MIN_FLOPS`, the built-in default. Two perf
-attributions in the sibling issue were taken from runs like this.
-
-The sweep the issue asked for found the same shape at 18 sites (the
-inventory is in `dev/research/env-knob-parsing-2026-08-19.md`), four of
-them behind local `env_usize`/`env_f64` copies in `feral-diagnostics`.
-
-### One parse policy, in one module
-
-New `src/env.rs` (`feral::env`), `u64_var` / `usize_var` / `f64_var` plus
-`_where` variants carrying a validity check. Each returns `Option<T>`,
-so every call site keeps its own default expression — including
+`cb_run_parallel` takes the shared `contribs` mutex inside its per-front
+loop — once per child drained, once to store the front's own block. That
+cost scales with the supernode count; `MIN_TOTAL_COST` is a floor on
+*total* work. `NARX_CFy` has 45,736 supernodes and a Lagrangian Hessian
 ```
 
 ## Git Status
 ```
-2b84177 docs: document the numeric FERAL_* knobs and their parse policy (#176)
-12e3330 fix(knobs): route every numeric FERAL_* read through feral::env (#176)
-647202a feat(env): one parse policy for the numeric FERAL_* knobs (#176)
-45429f1 docs: research note and plan for the FERAL_* knob parse policy (#176)
-ffb7599 Merge pull request #180 from jkitchin/claude/quirky-bardeen-c3ynyz
+2fbf9b7 Merge pull request #186 from jkitchin/release/0.17.0
+5082eff release: 0.17.0
+a91082b Merge pull request #185 from jkitchin/fix/pre-release-0.17.0
+d758cd8 docs(journal): session 2026-08-19-05 pre-release review entries
+8b97b21 docs: correct pre-release claims across CHANGELOG, README and rustdoc
 ```
 
 ## Test Status
-```
-test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
-test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
-test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::test_symbolic_factorize_basic ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
-test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
-test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
-
-test result: ok. 437 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.93s
-
-```
-
-## Benchmark
-```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-03.md)
-
-
-8 matrices benchmarked
-
-KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000, 0 parse-skipped)
-  Inertia match: 1/1 (100.0%)
-  Residual pass: 1/1 (100.0%)
-  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
-
---- Sparse solver validation ---
-Sparse solver: 2/2 total
-  Inertia match vs MUMPS: 2/2 (100.0%)
-  Residual pass: 2/2 (100.0%)
-  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
-
---- Dense perf vs oracles: no matrices have oracle timings ---
---- Sparse perf vs oracles: no matrices have oracle timings ---
-
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)          0        -     <= 2.0      N/A
-medium (<500)                 0        -     <= 3.0      N/A
-
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)          0        -     <= 2.0      N/A
-medium (<500)                 0        -     <= 3.0      N/A
-
-```
-
-## Recent Decisions
-   `feral_min_par_flops` help. The notation the docs teach must work.
-   The integer parse is tried first, so `18446744073709551615` stays
-   `u64::MAX` rather than round-tripping through 2^64.
-2. **A refused value warns on stderr, once per `(name, value)`, then
-   falls back.** Not an error: these knobs are read from inside a
-   factorization whose `Result` is reserved for *numerical* failure, and
-   turning an environment typo into a `FeralError` would hand pounce a
-   numeric-looking failure for an environment problem. The warn-and-fall-
-   back shape has precedent here — `FERAL_SCALING` has warned on an
-   unrecognized value since the X5 follow-up.
-3. **An above-range magnitude clamps to the type maximum** instead of
-   falling back. `FERAL_CB_THRESH=1e30` means "no subtree can reach this
-   cutoff"; falling back to the default there would be the reported bug
-   again, with the operator's intent inverted rather than merely lost.
-4. **Fractional input rounds half away from zero.** Truncation would
-   make `FERAL_PAR_MIN_SEEDS=0.9` mean 0 — "always parallel" — the
-   opposite of what the value asks for.
-
-Boolean and enum knobs are out of scope: they match a literal vocabulary
-rather than parsing a number.
-
-A source-scan test (`tests/env_knob_parsing.rs`) fails the build if a new
-`FERAL_*` read parses its own value locally, because the defect was one
-shape copied to eighteen sites, not one site. Two diagnostics-only
-comma-list knobs are exempted by name in that scan.
-
-Consequence for the public API: `numeric::factorize::par_task_min_flops`
-and `par_min_seeds` are `pub`, so a caller can confirm what value the
-process resolved a knob to. #176 could not be diagnosed from outside the
-process without that.
-
-## Recent Tried-and-Rejected
-
-**Rejected on measurement.** The predicate runs on every refined solve,
-including the ones it rejects, and `CbTaskPlan::build` allocates three
-`Vec<Vec<usize>>` of length `n_nodes` (`build_children`, `owned`,
-`tr_children`). Cost of the verdict alone, versus the shared-vector
-baseline it was supposed to preserve:
-
-    chain_400     1.29x
-    chain_2000    1.27x
-    chain_20000   1.24x
-
-That is the same 1.24-1.29x the design existed to avoid — the predicate
-cost as much as the core it was declining. Replaced by a flat
-`O(n_nodes)` computation (four `Vec`s of scalars, subtree costs folded
-into parents using the postorder guarantee, no child lists), which
-brings the rejected trees back to 1.00-1.03x.
-
-The cost of that replacement is a second implementation of one gate.
-`cb_core_profitable_matches_the_plan_gate` pins the two together across
-six fixtures landing on both sides of the gate.
-
-## Source Files
-```
-src/bin/bench.rs
-src/bin/perf_probe.rs
-src/bin/probe_ft_eta.rs
-src/bin/probe_lu_phases.rs
-src/bin/probe_panel_frag.rs
-src/capi.rs
-src/dense/block_ldlt32.rs
-src/dense/equilibrate.rs
-src/dense/factor.rs
-src/dense/matrix.rs
-src/dense/mod.rs
-src/dense/rook.rs
-src/dense/schur_kernel.rs
-src/dense/solve.rs
-src/env.rs
-src/error.rs
-src/inertia.rs
-src/io/mod.rs
-src/io/mtx.rs
-src/io/sidecar.rs
-src/lib.rs
-src/lu/condition.rs
-src/lu/dense_factor.rs
-src/lu/dense_matrix.rs
-src/lu/dense_solve.rs
-src/lu/dense_update.rs
-src/lu/markowitz.rs
-src/lu/mod.rs
-src/lu/scaling.rs
-src/lu/sparse_factor.rs
-src/lu/sparse_hyper.rs
-src/lu/sparse_matrix.rs
-src/lu/sparse_solve.rs
-src/lu/sparse_symbolic.rs
-src/lu/sparse_triangular.rs
-src/lu/sparse_update.rs
-src/numeric/condition.rs
-src/numeric/factorize.rs
-src/numeric/mod.rs
-src/numeric/solve.rs
-src/numeric/solver.rs
-src/ordering/amd.rs
-src/ordering/elimination_tree.rs
-src/ordering/mod.rs
-src/ordering/postorder.rs
-src/ordering/schur.rs
-src/scaling/hungarian.rs
-src/scaling/infnorm.rs
-src/scaling/mc64.rs
-src/scaling/mod.rs
-src/scaling/value_bound.rs
-src/sparse/csc.rs
-src/sparse/mod.rs
-src/symbolic/column_counts.rs
-src/symbolic/ldlt_compress.rs
-src/symbolic/mod.rs
-src/symbolic/profiler.rs
-src/symbolic/small_leaf.rs
-src/symbolic/supernode.rs
-```
-
-## Test Files
-```
-tests/amf_corpus_oracle.rs
-tests/auto_strategy.rs
-tests/blocked_ldlt.rs
-tests/build_row_indices_trailing_invariant.rs
-tests/cb_core_choice_ignores_env.rs
-tests/cb_solve_parity.rs
-tests/column_renumbering.rs
-tests/column_renumbering_parity.rs
-tests/d4_solve_2x2_gate.rs
-tests/d6_contrib_uninit.rs
-tests/d7_block32_dispatch_pooled.rs
-tests/delayed_pivoting.rs
-tests/dense_fast_path.rs
-tests/dense_ldlt.rs
-tests/env_knob_parsing.rs
-tests/factor_scratch_parity.rs
-tests/factor_workspace_parity.rs
-tests/factors_ld_export.rs
-tests/fine_grained_delay.rs
-tests/fma_opt_in_roundtrip.rs
-tests/golden_bits.rs
-tests/growth_flag.rs
-tests/issue102_intrafront_deadlock.rs
-tests/issue102_ordering_escalation.rs
-tests/issue107_external_ordering.rs
-tests/issue112_bg_update.rs
-tests/issue127_pipeline_split.rs
-tests/issue128_supernode_nrow.rs
-tests/issue178_refine_cap.rs
-tests/issue178_solve_into.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
-tests/issue91_preprocess_misfire.rs
-tests/issue99_fma_front_gate.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
-tests/kkt_hardening.rs
-tests/kkt_matrices.rs
-tests/large_matrix_smoke.rs
-tests/ldlt_compress.rs
-tests/lu_adversarial_inputs.rs
-tests/lu_default_ordering.rs
-tests/lu_dense.rs
-tests/lu_dense_bump.rs
-tests/lu_dense_update_bg.rs
-tests/lu_ft_widebump.rs
-tests/lu_hyper_sparse.rs
-tests/lu_markowitz.rs
-tests/lu_real_bases.rs
-tests/lu_scaling.rs
-tests/lu_sparse.rs
-tests/lu_sparse_rhs.rs
-tests/lu_update_alloc_probe.rs
-tests/lu_update_casctanks.rs
-tests/maxfromm_parity.rs
-tests/mc64_end_to_end.rs
-tests/mc64_scaling.rs
-tests/multi_rhs.rs
-tests/n2_static_pivot_scaling.rs
-tests/n3_parallel_profiler.rs
-tests/n4_mc64_retry_latch.rs
-tests/parallel_parity.rs
-tests/parity.rs
-tests/pivot_rejection.rs
-tests/pounce_interface.rs
-tests/profiler_smoke.rs
-tests/property_tests.rs
-tests/refined_solve_core_stability.rs
-tests/rook_rescue.rs
-tests/rook_rescue_kkt.rs
-tests/small_leaf_parity.rs
-tests/solver_with_ordering.rs
-tests/sparse_postorder.rs
-tests/sparse_refined.rs
-tests/sqd_fast_path.rs
-tests/static_assembly_maps.rs
-tests/stress_tests.rs
-tests/symbolic_profiler.rs
-tests/task_plan_parity.rs
-tests/threshold_consistency.rs
-tests/tiny_fast_path.rs
 ```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -6960,3 +6960,69 @@ Evidence: `src/env.rs` (`past_f64_range_clamps_like_any_other_magnitude`);
 `tests/env_knob_scan.rs` (fails with 21 offenders before the conversions);
 `tests/env_knob_parsing.rs` (`1e400` -> `u64::MAX`);
 `dev/research/env-knob-parsing-2026-08-19.md` addendum.
+
+## 2026-08-19 — `solve_sparse_refined_parallel` maps to `Auto`, not `ContribBlock` (pre-release review of #177)
+
+Issue #177 established that which core runs must be a function of the
+factor alone (see the entry above). Applying that to
+`solve_sparse_refined_parallel` was done by mapping it to
+`SolveCore::ContribBlock { parallel: true }`. That is the wrong mapping,
+and the pre-release review of the six PRs merged since v0.16.0 caught it
+before the 0.17.0 tag.
+
+**What the function did through v0.16.0.** It built a CB workspace and
+used it only when the gate accepted the factor:
+
+```rust
+let mut cb_ws: Option<CbSolveWorkspace> = if parallel_cb && n > 0 {
+    let cb = CbSolveWorkspace::for_factors(factors);
+    cb.worthwhile().then_some(cb)
+} else { None };
+```
+
+On a rejected factor it ran the shared-vector core. `ContribBlock` has no
+gate — `solve_sparse_refined_core` maps it to `use_cb = true`
+unconditionally — so the rewrite changed the reassociation this public
+function returns on every factor the gate used to reject, and made it the
+slower of the two. PR #180's own rejected-alternative table measures that
+design at 1.86x on poisson_40 (refined solve, 659 µs -> 1228 µs): the
+review had already priced this arrangement and rejected it, and it
+shipped to `main` anyway because nothing pinned the entry point's core.
+
+**The decision.** Map it to `SolveCore::Auto { parallel: true }`.
+
+The tempting alternative — restore the v0.16.0 gate — is not available.
+`worthwhile()` reads `rayon::current_num_threads()` and
+`FERAL_CB_THRESH`, which is exactly the host-dependence #177 exists to
+remove; restoring it would undo the release's headline contract to fix a
+regression the contract's own implementation introduced. `Auto` keeps the
+fallback and derives it from `cb_core_profitable`, the shape half of the
+gate, which reads the factor and nothing else.
+
+**What this costs, stated plainly.** `Auto` restores the *fallback* but
+not v0.16.0's *bits*. The old predicate was `worthwhile()` (threads +
+env); the new one is `cb_core_profitable` (shape only). On a host where
+those disagree about a factor — which is the entire point of #177 — the
+function returns the other core's reassociation than 0.16.0 did. That is
+unavoidable if #177's contract holds, so 0.17.0 is a last-bits-change
+release for three public entry points (`Solver::solve_refined`,
+`solve_many_refined`, `solve_sparse_refined_parallel`), not a purely
+additive one. The CHANGELOG says so under its own heading rather than
+leaving it to be discovered; issue #16 documents how a last-bit solve
+change amplifies along an IPM trajectory.
+
+**Consequence for the API surface.** `solve_sparse_refined_parallel` is
+now an exact alias of `solve_sparse_refined_auto(.., true)`. Its name
+predates the separation of *which core* (numerical) from *how it
+executes* (scheduling), so it reads as a core selector and is not one.
+Kept as the pre-#177 name with a doc comment that says what it actually
+is and points new code at `_auto`; not deprecated in this release, since
+the fix already moves its bits and a deprecation warning on top would be
+two changes to absorb at once.
+
+Evidence: `tests/issue177_parallel_entry_point_core.rs`, four tests. The
+oracle is v0.16.0's shipped behaviour reached through
+`solve_sparse_refined`, which is unchanged and golden-pinned — external
+to the session that wrote the fix. Non-vacuity is asserted rather than
+assumed: on chain_400 the two cores must differ bit-for-bit or the test
+fails saying so, so a regression to `ContribBlock` cannot pass silently.

--- a/dev/journal/2026-08-19-05.org
+++ b/dev/journal/2026-08-19-05.org
@@ -324,3 +324,60 @@ to stop. Its finding was correct and useful — the parity suite never
 reaches =cb_run_parallel= — but review agents must run with
 =isolation: "worktree"= when they intend mutation testing, or be told up
 front that the tree is shared and read-only to them.
+
+* 00:40 :release:0.17.0:
+PR #185 merged (a91082b) with all checks green. Cut 0.17.0 on top:
+CHANGELOG =[Unreleased]= -> =## [0.17.0] - 2026-08-19=,
+=scripts/release-checklist.sh bump 0.17.0= moved all six version sites,
+=check= exits 0 (six agree, no ordering crate stale — all six still
+0.2.1, unchanged since v0.16.0). PR #186 merged (2fbf9b7). Tag v0.17.0
+pushed.
+
+=cargo publish --dry-run -p feral= exit 0:
+
+: Packaged 83 files, 2.4MiB (697.5KiB compressed)
+: Verifying feral v0.17.0
+: warning: aborting upload due to dry run
+
+Stopped short of =gh release create=. It is the one irreversible step —
+=release.yml= publishes 7 crates to crates.io (permanent, only
+=cargo yank=) and =python-wheels.yml= publishes feral_solver-0.17.0 to
+PyPI (that version's filenames can never be re-uploaded). Held for
+explicit human go-ahead because 0.17.0 moves the bits of three public
+entry points (=Solver::solve_refined=, =solve_many_refined=,
+=solve_sparse_refined_parallel=) rather than only adding API, and that
+is worth a human deciding on before it is permanent.
+
+* 00:45 :bench:session-end:
+Session-end benchmark, run on the 0.17.0 tree. No regression; both exit
+partitions PASS.
+
+: --- Dense Phase 2.8.1 exit partition ---
+: small-frontal (<200)  147982  p90 1.58  <= 2.0  PASS
+: medium (<500)         152145  p90 2.00  <= 3.0  PASS
+: --- Sparse Phase 2.8.1 exit partition ---
+: small-frontal (<200)  153455  p90 1.58  <= 2.0  PASS
+: medium (<500)         153560  p90 1.58  <= 3.0  PASS
+: factor/MUMPS  geomean 0.45  solve/MUMPS  geomean 0.08
+: factor/SSIDS  geomean 0.04  solve/SSIDS  geomean 0.95
+
+Small-frontal p90 read 1.60/1.61 on the run earlier this session and
+1.58 now. Not claiming an improvement — nothing in these PRs touches a
+factor hot path, so this is run-to-run noise on this container, and per
+=dev/decisions.md= (2026-08-09) medians collected in different processes
+at different times are not comparable anyway.
+
+* 00:48 :process:pre-commit:tooling:
+Two commits were killed by a foreground timeout mid-hook and both times
+left the working tree stripped. Cause: pre-commit stashes unstaged
+changes to =~/.cache/pre-commit/patch*= before running its three cargo
+invocations, and restores them only on exit. A kill skips the restore.
+
+Compounding it: the hook clippy-checks the *staged* state, which differs
+from the working tree whenever a commit is partial, so cargo rebuilds
+from cold — ~9 minutes — and then rebuilds again when the tree is
+restored. Four partial commits is ~35 minutes of hook time.
+
+Recovery is =git apply ~/.cache/pre-commit/patch<newest>=; verify with
+=grep '^diff --git'= first. Fix going forward: run commits with
+=run_in_background: true= so no timeout can kill them.

--- a/dev/sessions/2026-08-19-05.md
+++ b/dev/sessions/2026-08-19-05.md
@@ -1,0 +1,231 @@
+# Session 2026-08-19-05
+
+## Goal
+
+Close out issue #153 item 2, review the six PRs merged since v0.16.0 for
+mistakes before shipping, and cut release 0.17.0 (which unblocks
+pounce#710's second blocker).
+
+## Benchmark Results
+
+No regression. Both exit partitions PASS, and the small-frontal p90
+improved slightly against the run earlier in this session (1.60/1.61 ->
+1.58); the change is within run-to-run noise on this container and is not
+claimed as an improvement.
+
+```
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.58     <= 2.0     PASS
+medium (<500)            153560     1.58     <= 3.0     PASS
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.45       0.32       1.58       3.45      10.58
+solve/MUMPS        153560       0.08       0.08       0.15       0.79       2.71
+factor/SSIDS       154500       0.04       0.03       0.33       1.02       2.30
+solve/SSIDS        154500       0.95       1.00       2.50       9.00      35.25
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+```
+
+## Accomplished
+
+### Issue #153 item 2 — both hypotheses falsified (PR #184, merged)
+
+Rescoped #153 to item 2 and measured rather than assumed. Both standing
+hypotheses for the dtoc1nd dense-front gap — a packed-SIMD work gate, and
+`block_size` — were falsified by measurement. Research note written; two
+diagnostic probes landed.
+
+### Pre-release review of six PRs (PR #185, merged)
+
+Reviewed #174, #179, #180, #181, #182, #183 with agents, then verified
+every reported finding by hand against git before acting on it. One
+behavioural regression, one guard-test gap, and a set of unsupported
+documentation claims.
+
+**Blocker: `solve_sparse_refined_parallel` silently changed its
+arithmetic.** #177 mapped it to `SolveCore::ContribBlock { parallel:
+true }`, which has no gate, where v0.16.0 fell back to the shared-vector
+core whenever `worthwhile()` rejected the factor. So the function
+returned a different reassociation *and* took the slower core on every
+rejected factor — the arrangement PR #180's own rejected-alternative
+table measures at 1.86x on poisson_40 (659 -> 1228 µs). Meanwhile the
+CHANGELOG asserted the function was unchanged. Fixed by mapping to
+`SolveCore::Auto { parallel: true }`; see `dev/decisions.md` for why
+restoring the old gate was not available. Pinned by
+`tests/issue177_parallel_entry_point_core.rs` (4 tests), whose oracle is
+v0.16.0's shipped behaviour via the unchanged, golden-pinned
+`solve_sparse_refined`, and which asserts non-vacuity rather than
+assuming it.
+
+#177 had also left the function undocumented: its doc had been moved onto
+`solve_sparse_refined_cb`, where it stacked with that function's own doc
+and asserted two things — a per-solve `worthwhile` fallback, and use by
+`Solver::solve_refined` — that the paragraph six lines below denies.
+Removed the stale block; wrote the function a real doc comment.
+
+**Two env knobs slipped past the #176 scan.** `SIZES`
+(`bench_intrafront.rs`) and `STATIC_PIVOTS`
+(`probe_static_pivot_inertia.rs`) both bind `env::var` to a local and
+parse in a *later* statement, which the statement-scoped scan cannot see.
+`STATIC_PIVOTS` was the worse of the two: `.parse().unwrap_or(0.0)` maps
+an unreadable token to `0.0`, which the next line turns into `None` —
+static pivoting off. A typo did not fall back to the default list, it
+silently ran a different experiment arm. Both converted; added
+`env::f64_list_var` (the float twin of `usize_list_var`) for the second.
+
+The scan itself was passing on a margin, not a rule. Its window was
+`min(next ';', 400)`, and `Solver::pool_num_threads`
+(`src/numeric/solver.rs:506`) reads `RAYON_NUM_THREADS` as a function
+tail expression — no `;` for 1708 bytes — while the `.parse` in the
+*separate* `pool_num_threads_from` helper sits at +485:
+
+```
+line 506: first ';' at +1708, '.parse' at +485, hard=min(1708,400)=400
+```
+
+It passed only because 400 < 485. Trimming ~86 characters of doc comment
+would have failed CI on a file nobody touched. Added a blank-line
+terminator, a real statement boundary under rustfmt that can only shrink
+windows, so it cannot introduce a new offender. The module doc now states
+the guard is statement-scoped and names what it cannot see.
+
+**Documentation asserting things the code does not do.**
+`DEFAULT_REFINE_MAX_STEPS` attributed 10 to "MUMPS's `ICNTL(10)` default"
+in two places; MUMPS defaults `ICNTL(10)` to **0**
+(`ref/mumps/src/dini_defaults.F:363-367`), as
+`external_benchmarks/comparison/REPORT.md:19` already said. README still
+described `FERAL_CB_THRESH` as selecting the solve *core* (schedule-only
+since #177) and never mentioned `RefineOptions` at all — the release's
+headline feature. `tests/cb_solve_parity.rs` claimed its n = 9216 fixture
+"exercises the actual tree-parallel task path"; measured total cost is
+351,544 against `MIN_TOTAL_COST = 1,000,000`, so both arms run
+`cb_run_serial` and the file pins no parallel behaviour (that claim is
+genuinely covered by `refined_solve_core_stability.rs` on poisson_160,
+total 1,090,303, at 1/2/3/4/8 workers). `scripts/release-checklist.sh`
+step 8 verified the crates.io publish with a User-Agent-less curl, which
+crates.io rejects silently — a successful publish would have read back as
+"never published". Plus a broken intra-doc link and a hardcoded
+"10 + 1 initial = 11" that stopped being constant when #183 made the cap
+an option.
+
+CHANGELOG gained an explicit **this release can change your numbers**
+note covering `Solver::solve_refined`, `solve_many_refined` and
+`solve_sparse_refined_parallel`, including for Python callers, who
+otherwise got #177's bit change with none of the Rust-side explanation.
+
+Evidence: 924 passed, 0 failed, 23 ignored (`cargo test --release`);
+`cargo clippy --all-targets -- -D warnings` clean; `cargo clippy -p
+feral-diagnostics --all-targets -- -D warnings` exit 0; CI green on #185.
+
+### Also closed
+
+- PRs #181 and #182 reviewed, polished and merged (`7c6a422`, `61d2996`).
+- pounce#710: code half done (PR #183, `ba124a8`); the remaining blocker
+  is the crates.io release, which 0.17.0 clears.
+- Issues #175 and #176 closed. They had stayed open because the PR titles
+  used `(issue #175)` and `(#176)`, which link but are not GitHub closing
+  keywords.
+
+### Release 0.17.0 (PR #186, merged; tagged, NOT published)
+
+All six version-bearing locations bumped via
+`scripts/release-checklist.sh bump 0.17.0`; CHANGELOG `[Unreleased]` ->
+`## [0.17.0] - 2026-08-19`. `check` exits 0 — six agree, no ordering
+crate stale (all six remain at 0.2.1, unchanged since v0.16.0), CHANGELOG
+has a `[0.17.0]` section. `cargo publish --dry-run -p feral` exit 0,
+packaged 83 files / 697.5 KiB compressed. Tag `v0.17.0` pushed.
+
+**`gh release create` deliberately not run.** It is the irreversible
+trigger — `release.yml` publishes 7 crates to crates.io (permanent, only
+`cargo yank`) and `python-wheels.yml` publishes `feral_solver-0.17.0` to
+PyPI (that version's filenames can never be re-uploaded). Held for
+explicit human go-ahead, since this release moves the bits of three
+public entry points rather than only adding API.
+
+## Decisions Made
+
+- `solve_sparse_refined_parallel` maps to `SolveCore::Auto`, not
+  `ContribBlock`. Restoring the v0.16.0 gate was not available:
+  `worthwhile()` reads `rayon::current_num_threads()` and
+  `FERAL_CB_THRESH`, exactly the host-dependence #177 exists to remove.
+  `Auto` restores the fallback but not v0.16.0's bits, which is
+  unavoidable if #177's contract holds — so 0.17.0 is a last-bits-change
+  release, stated as such in the CHANGELOG. Appended to
+  `dev/decisions.md` with the full reasoning.
+- `RefineOptions` is deliberately **not** `#[non_exhaustive]` —
+  maintainer's call, on the grounds that the codebase uses that attribute
+  nowhere and consistency beats the marginal future-proofing.
+
+## Abandoned Approaches
+
+Nothing abandoned this session. (Issue #153's two falsified hypotheses
+were recorded in PR #184's research note during that part of the session,
+not here.)
+
+## Known Not Fixed
+
+All NIT-level, none release-blocking:
+
+- `SolveCore` is exported but appears in no public signature — the public
+  entry points still take `parallel: bool`.
+- `tests/env_knob_scan.rs` has no `target/` exclusion in its recursive
+  walk.
+- Three argument checks are ordered differently across `solve_many_into`,
+  `solve_many_refined_into` and `solve_sparse_many_refined_into`.
+- `unreachable!()` at `solve.rs:2499` and `:2589` (pre-existing).
+- `_cb` has no `_into` form while `_auto` and `_parallel` do.
+- README knob table omits `FERAL_NEMIN_LIST` and
+  `FERAL_MERGE_BUDGET_LIST`.
+- Three of PR #183's six tests are structurally tautological on their
+  `nrhs = 2` arm (they compare one-line delegations). The three with real
+  signal are `the_default_run_refines_past_one_step_on_both_arms`,
+  `cap_zero_on_the_solver_equals_solve_many_bit_for_bit` and
+  `each_extra_allowed_step_is_actually_taken`.
+- `dev/sessions/2026-08-19-04.md` says "433 lib" tests; the actual count
+  is 443.
+- The Python bindings expose none of the new refinement API. Now called
+  out in the CHANGELOG rather than left silent.
+
+## Process Note
+
+A review agent mutated a tracked file in the shared working tree: it
+inserted `panic!("PARALLEL PATH REACHED")` into `cb_run_parallel` at
+`src/numeric/solve.rs:671` to test whether the parity suite reaches that
+path. Caught on `git status`, restored with `git checkout --`, and the
+agent told to stop. Its *finding* was correct and useful — the parity
+suite never reaches `cb_run_parallel` — but mutation-testing agents must
+run with `isolation: "worktree"` or be told up front that the tree is
+shared and read-only to them.
+
+Second process note: the pre-commit hook stashes unstaged changes before
+running three cargo invocations, so a commit made from a partially-staged
+tree rebuilds from cold (~9 min) and, if the command is killed by a
+timeout mid-hook, leaves the working tree stripped. Recovered twice from
+`~/.cache/pre-commit/patch*`. Run commits with `run_in_background` rather
+than a foreground timeout.
+
+## Next Session Should
+
+1. **Publish 0.17.0** if the human approves — `gh release create v0.17.0
+   --title "feral v0.17.0" --notes-file <notes> --verify-tag`. Then
+   verify with the User-Agent-carrying curl in `release-checklist.sh`
+   step 8, and close out pounce#710's second blocker.
+2. Decide what `SolveCore` is for. It is exported, documented, and
+   reachable from no public signature. Either take it in the public entry
+   points (replacing `parallel: bool`, which conflates core choice with
+   scheduling) or stop exporting it.
+3. Consider deprecating `solve_sparse_refined_parallel` in 0.18.0. It is
+   now an exact alias of `solve_sparse_refined_auto(.., true)` and its
+   name reads as a core selector, which it is not. Held out of 0.17.0 so
+   callers absorb the bit change without a deprecation warning on top.
+4. Give `_cb` an `_into` form, for symmetry with `_auto`/`_parallel`.
+5. Add a `target/` exclusion to `env_knob_scan.rs`'s walk before it ever
+   runs on a tree with vendored sources in it.


### PR DESCRIPTION
Session-end protocol for 2026-08-19-05: checkpoint, refreshed `dev/context.md`,
a `decisions.md` entry, and the remaining journal entries. `dev/` only — no
source changed.

## Benchmark: no regression

Reported at the top of the checkpoint per protocol. Both exit partitions PASS.

```
--- Dense Phase 2.8.1 exit partition ---
small-frontal (<200)  147982  p90 1.58  <= 2.0  PASS
medium (<500)         152145  p90 2.00  <= 3.0  PASS
--- Sparse Phase 2.8.1 exit partition ---
small-frontal (<200)  153455  p90 1.58  <= 2.0  PASS
medium (<500)         153560  p90 1.58  <= 3.0  PASS
factor/MUMPS geomean 0.45 · solve/MUMPS 0.08
factor/SSIDS geomean 0.04 · solve/SSIDS 0.95
```

Small-frontal p90 read 1.60/1.61 on the run earlier in the session and 1.58
here. Not claimed as an improvement: nothing in these PRs touches a factor hot
path, and per `dev/decisions.md` (2026-08-09) medians collected in different
processes at different times are not comparable.

## decisions.md

One architectural entry: `solve_sparse_refined_parallel` maps to
`SolveCore::Auto`, not `ContribBlock`. Restoring the v0.16.0 gate was not an
option — `worthwhile()` reads `rayon::current_num_threads()` and
`FERAL_CB_THRESH`, precisely the host-dependence #177 exists to remove.

The entry states the cost plainly rather than burying it: `Auto` restores the
*fallback* but not v0.16.0's *bits*, because the old predicate was
`worthwhile()` (threads + env) and the new one is `cb_core_profitable` (shape
only), and on a host where those disagree the function returns the other
core's reassociation. That is unavoidable if #177's contract holds, which
makes 0.17.0 a last-bits-change release for three public entry points rather
than a purely additive one.

## Also recorded

- Nine NIT-level findings knowingly left unfixed, each named, so the next
  session inherits the list rather than rediscovering it.
- Two process findings. A review agent mutated a tracked file in the shared
  working tree (inserted a `panic!` into `cb_run_parallel` to test parity-suite
  non-vacuity) — its finding was correct and useful, but mutation-testing
  agents need `isolation: "worktree"` or an explicit read-only instruction.
  And the pre-commit hook stashes unstaged changes before three cargo
  invocations, so a foreground timeout mid-hook strips the working tree;
  recovered twice from `~/.cache/pre-commit/patch*`, and the fix is to run
  commits with `run_in_background`.
- Next-session priorities, led by publishing 0.17.0 (tagged, deliberately not
  released) and deciding what `SolveCore` is for — it is exported, documented,
  and reachable from no public signature.

`tried-and-rejected.md` is unchanged: nothing was abandoned this session.

Evidence: CI on the most recent code commit (a91082b, PR #185) was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAxgLjVsYe4oB2XRURmKG
