### PR TITLE
ci: measure coverage with cargo-llvm-cov and report it to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,109 @@
+name: Coverage
+
+# Scoped to `main` on both triggers so a PR from a branch in this repo
+# produces ONE coverage run, not the two that `on: [push, pull_request]`
+# gives ci.yml. Codecov keys its comparison off a single head commit;
+# duplicate uploads for the same SHA are merged, but the second run is
+# pure cost.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage:
+    name: llvm-cov -> Codecov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: coverage
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: run tests under instrumentation
+        # `--workspace --exclude feral-diagnostics`: diagnostics is a
+        # publish = false crate of ~144 one-off probe binaries (issue #71).
+        # It is a measurement tool, not shipped code, and its coverage
+        # number would be both meaningless and large enough to swamp the
+        # signal from src/.
+        #
+        # Note this runs MORE tests than ci.yml does. `cargo test` at the
+        # workspace root resolves to the `feral` package alone, so the six
+        # ordering crates' 258 tests have never run in CI; `--workspace`
+        # picks them up. That is deliberate — see the coverage note in
+        # dev/decisions.md.
+        #
+        # `-- --nocapture` + tee mirrors ci.yml so fixture-gated "SKIP:"
+        # lines survive libtest's stderr swallowing and can be surfaced
+        # below. `shell: bash` turns on pipefail so the tee cannot mask a
+        # test failure.
+        #
+        # `--skip dirichlet120_parallel_factor_does_not_deadlock`: that
+        # test asserts a parallel dense-front factor of dirichlet120
+        # finishes inside a hard 120 s wall clock (issue #102 guard). Under
+        # llvm-cov the build is unoptimized AND carries per-region counters,
+        # and the factor blows the budget:
+        #
+        #   test result: FAILED. 0 passed; 1 failed; finished in 123.25s
+        #
+        # while the same test passes under both `cargo test` and
+        # `cargo test --release`. That is instrumentation overhead, not a
+        # deadlock regression, so measuring it here would give a permanently
+        # red coverage job that reads like issue #102 came back. The test is
+        # NOT weakened: ci.yml's `check` job still runs it at 120 s on every
+        # push and PR, so the guard keeps its teeth. Coverage simply does not
+        # measure that one path. It is the only test in the tree with a
+        # wall-clock assertion (large_matrix_smoke and rook_rescue_kkt time
+        # themselves but assert nothing about it), so no other test needs
+        # this treatment.
+        shell: bash
+        run: >-
+          cargo llvm-cov --workspace --exclude feral-diagnostics
+          --lcov --output-path lcov.info
+          -- --nocapture --skip dirichlet120_parallel_factor_does_not_deadlock
+          2>&1 | tee /tmp/coverage-test.log
+
+      - name: surface fixture-gated skips
+        # A coverage percentage is only readable if you know what did not
+        # run. Fixture-gated tests SKIP-and-pass when their (gitignored)
+        # fixtures are absent, so every path they guard reads as uncovered
+        # on CI while being covered locally. Same reasoning as the
+        # identical step in ci.yml — without this the number silently
+        # understates and nobody knows by how much.
+        if: always()
+        run: |
+          {
+            echo "### Fixture-gated tests skipped (fixtures absent on CI)"
+            echo ""
+            echo "Paths these guard read as UNCOVERED in this report."
+            echo ""
+            grep "SKIP:" /tmp/coverage-test.log | sort -u \
+              || echo "none — all fixture-gated tests ran"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: upload to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: rust-stable
+          # Fail loudly on a broken upload. A silently-missing upload
+          # leaves Codecov comparing against a stale baseline, which is
+          # worse than a red check because it looks like a real coverage
+          # change.
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![FERAL banner](https://raw.githubusercontent.com/jkitchin/feral/main/assets/feral-banner.png)
 
 [![CI](https://github.com/jkitchin/feral/actions/workflows/ci.yml/badge.svg)](https://github.com/jkitchin/feral/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jkitchin/feral/branch/main/graph/badge.svg)](https://codecov.io/gh/jkitchin/feral)
 [![crates.io](https://img.shields.io/crates/v/feral.svg)](https://crates.io/crates/feral)
 [![PyPI](https://img.shields.io/pypi/v/feral-solver.svg)](https://pypi.org/project/feral-solver/)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20162687-blue.svg)](https://doi.org/10.5281/zenodo.20162687)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,68 @@
+# Codecov configuration for feral.
+#
+# Validate after editing:
+#   curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+#
+# Coverage here is a MEASUREMENT, not a gate. Both status checks are
+# informational, so Codecov comments the numbers on a PR and never turns
+# a check red. This matches how ci.yml already treats its other
+# measurements (the x86 FMA probe is continue-on-error; the
+# fixture-skip step is summary-only) and keeps the blocking set to
+# things that are actually invariants: fmt, clippy, the test suite, the
+# stress gate, and the amd-cleanroom check.
+#
+# Read the number with the fixture caveat in mind. Fixture-gated tests
+# SKIP-and-pass when their (gitignored) fixtures are absent, so on CI
+# every path they guard reads as uncovered. The coverage job prints the
+# skip list to the run summary; consult it before treating a low number
+# in those modules as a real gap.
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Paths excluded from the report. These are not "untested code we are
+# ignoring" -- they are code that is not the library, or code whose
+# coverage number carries no information.
+ignore:
+  # publish = false. ~144 one-off probe binaries (issue #71). A
+  # measurement tool, not shipped code; its size would swamp src/.
+  - "crates/feral-diagnostics/**"
+  # Test and measurement code measures itself at ~100% by construction.
+  - "tests/**"
+  - "benches/**"
+  - "examples/**"
+  - "src/bin/**"
+  - "**/tests/**"
+  # Vendored reference sources (MUMPS, SPRAL, Ipopt, faer) read for
+  # clean-room comparison. Never compiled into feral.
+  - "ref/**"
+  # Harnesses, corpora and oracle data.
+  - "external_benchmarks/**"
+  - "data/**"
+  - "scripts/**"
+  # PyO3 binding shim; exercised by the wheel tests in
+  # python-wheels.yml, which do not feed this report.
+  - "python/**"
+  # Prose.
+  - "dev/**"
+  - "manuscript/**"
+  - "book/**"
+  - ".crucible/**"

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7026,3 +7026,73 @@ oracle is v0.16.0's shipped behaviour reached through
 to the session that wrote the fix. Non-vacuity is asserted rather than
 assumed: on chain_400 the two cores must differ bit-for-bit or the test
 fails saying so, so a regression to `ContribBlock` cannot pass silently.
+
+## 2026-08-20 — Coverage is measured, not gated (Codecov)
+
+**The decision.** Add a `Coverage` workflow that runs the test suite
+under `cargo llvm-cov` and uploads lcov to Codecov, with three
+deliberate choices: the status checks are informational, the scope is
+`--workspace --exclude feral-diagnostics`, and the coverage job skips one
+test that ci.yml still runs.
+
+**Informational, never blocking.** Both the project and patch statuses
+carry `informational: true`, so Codecov comments a number on a PR and
+never turns a check red. Coverage is a measurement whose denominator
+moves for reasons that have nothing to do with a change's quality — add
+a module of `Display` impls and the percentage drops. The blocking set
+stays what it already was, and each of those is an invariant rather than
+a proxy: fmt, clippy, the test suite, the stress gate, the amd-cleanroom
+check. This also matches how ci.yml already treats its other
+measurements (the x86 FMA probe is `continue-on-error`; the fixture-skip
+step is summary-only).
+
+**Scope: the workspace minus diagnostics.** `feral-diagnostics` is
+`publish = false` — roughly 144 one-off probe binaries (issue #71). It is
+a measurement tool, not shipped code, and it is large enough that its
+number would swamp the signal from `src/`. Everything else in the
+workspace is in, including the six ordering crates.
+
+That last part is a change in what CI runs, not only in what it
+measures. `Cargo.toml` declares a root package and no `default-members`,
+so a bare `cargo test` at the workspace root resolves to the `feral`
+package alone; every `cargo test` invocation in ci.yml is either bare or
+`-p feral-diagnostics`. The consequence, verified by reading the
+manifest and the workflow rather than assumed: the ordering crates' 258
+tests — `feral-ordering-core` 69, `feral-metis` 59, `feral-kahip` 63,
+`feral-scotch` 45, `feral-amd` 12, `feral-amf` 10 — have never run in
+CI. `--workspace` runs them for the first time here.
+
+**One test is skipped under instrumentation, and why that is not a
+loosened tolerance.** `dirichlet120_parallel_factor_does_not_deadlock`
+asserts that a parallel dense-front factor of dirichlet120 completes
+inside a hard 120 s wall clock; it is the issue #102 re-entrant-deadlock
+guard. Under `cargo llvm-cov` the build is unoptimized *and* carries
+per-region counters, and the factor misses the budget:
+
+    test dirichlet120_parallel_factor_does_not_deadlock ... FAILED
+    panicked at tests/issue102_intrafront_deadlock.rs:72:13:
+    issue #102 regression: ... did not finish in 120 s
+    test result: FAILED. 0 passed; 1 failed; finished in 123.25s
+    real 3m4.912s   user 11m14.718s
+
+The same test passes under `cargo test` and under `cargo test --release`
+in the same tree. So this is instrumentation overhead, and had the
+workflow shipped without the skip the coverage job would have been red
+from its first run in a way that reads like issue #102 came back.
+
+The alternative — raising the 120 s budget so it survives instrumentation
+— is loosening a tolerance, which needs human approval, and it would
+weaken the guard everywhere to accommodate one job. Skipping in the
+coverage job only leaves the assertion at 120 s in ci.yml's `check` job,
+which runs on every push and PR. The guard keeps its teeth; coverage
+just does not measure that path. An audit found no other test that needs
+the same treatment: `large_matrix_smoke` and `rook_rescue_kkt` time
+themselves but assert nothing about the elapsed time, so
+`issue102_intrafront_deadlock` is the tree's only wall-clock assertion.
+
+**How to read the number.** Fixture-gated tests SKIP-and-pass when their
+gitignored fixtures are absent, so on CI every path they guard reads as
+uncovered while being covered locally. The coverage job prints the skip
+list to the run summary — the same step ci.yml has — so a low number in
+those modules can be checked against it before being treated as a real
+gap.


### PR DESCRIPTION
Adds coverage measurement via `cargo-llvm-cov` + Codecov. This PR is
itself the first live test of the upload — `CODECOV_TOKEN` is set.

## What

- `.github/workflows/coverage.yml` — runs the suite under `cargo llvm-cov`, uploads `lcov.info`
- `codecov.yml` — report config, validated against `https://codecov.io/validate` ("Valid!")
- `README.md` — badge
- `dev/decisions.md` — the three judgement calls, recorded

## Three choices worth reviewing

**1. Informational, never blocking.** Both the project and patch statuses
carry `informational: true`. Codecov comments a number on a PR and never
turns a check red. Coverage is a measurement whose denominator moves for
reasons unrelated to a change's quality; the blocking set stays what it
was — fmt, clippy, the test suite, the stress gate, amd-cleanroom. This
matches how `ci.yml` already treats its measurements (the x86 FMA probe
is `continue-on-error`, the fixture-skip step is summary-only).

**2. Scope is `--workspace --exclude feral-diagnostics`.** Diagnostics is
`publish = false`, ~144 one-off probe binaries (#71); a measurement tool,
not shipped code, and big enough to swamp the signal from `src/`.

Note this runs **more tests than `ci.yml` does**. `Cargo.toml` declares a
root package and no `default-members`, so a bare `cargo test` at the
workspace root resolves to the `feral` package alone, and every
`cargo test` in `ci.yml` is either bare or `-p feral-diagnostics`. So the
six ordering crates' **258 tests have never run in CI** — `ordering-core`
69, `metis` 59, `kahip` 63, `scotch` 45, `amd` 12, `amf` 10. `--workspace`
runs them here for the first time. If any of them are red, this PR is
where that shows up.

**3. The coverage job skips one test.**
`dirichlet120_parallel_factor_does_not_deadlock` asserts a parallel
dense-front factor of dirichlet120 finishes inside a hard 120 s wall
clock (the #102 re-entrant-deadlock guard). A local baseline run of the
unskipped command:

```
test dirichlet120_parallel_factor_does_not_deadlock ... FAILED
panicked at tests/issue102_intrafront_deadlock.rs:72:13:
issue #102 regression: parallel dense-front factor of dirichlet120
did not finish in 120 s
test result: FAILED. 0 passed; 1 failed; finished in 123.25s
real 3m4.912s  user 11m14.718s
```

The same test passes under `cargo test` and `cargo test --release` in
this tree. So 123.25 s is llvm-cov's unoptimized-plus-per-region-counters
overhead, not a deadlock regression — and without the skip this job would
have been red from its first run, in a way that reads like #102 came
back.

The test is **not** weakened: `ci.yml`'s `check` job still asserts 120 s
on every push and PR, so the guard keeps its teeth; coverage just does
not measure that path. Raising the budget instead would be loosening a
tolerance, and it would blunt the guard everywhere to accommodate one
job. Audited the rest: `large_matrix_smoke` and `rook_rescue_kkt` time
themselves but assert nothing about elapsed time, so this is the tree's
only wall-clock assertion and nothing else needs the same treatment.

## Reading the number

Fixture-gated tests SKIP-and-pass when their gitignored fixtures are
absent, so on CI every path they guard reads as uncovered while being
covered locally. The job prints the skip list to the run summary (same
step `ci.yml` has) — check it before treating a low number in those
modules as a real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAxgLjVsYe4oB2XRURmKG
