### PR TITLE
fix(solve): default refinement certifies componentwise accuracy (closes #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,25 @@ All notable changes to FERAL will be documented in this file.
     of `eps` says "as good as a backward-stable factorization would have
     returned," independent of `n` and of row scaling.
 - **What you get back.** The `*_refined_into` entry points now return a
-  `RefineOutcome { steps, relative_residual, stop }` instead of `()`, where
-  `stop` is `Converged | MaxSteps | Stagnated | Diverged`. All three values
-  are already computed by the loop, so reporting them costs nothing. The
-  full `RefinementDiagnostics` is deliberately *not* returned here: it
+  `RefineOutcome { steps, relative_residual, backward_error, stop }` instead
+  of `()`, where `stop` is `Converged | MaxSteps | Stagnated | Diverged`.
+  All four values are already computed by the loop, so reporting them costs
+  nothing.
+
+  `backward_error` is the achieved componentwise `omega` of the returned
+  iterate — the quantity the new default criterion certifies, so a host that
+  gets `Converged` back can log or threshold on the certificate without
+  paying a second `abs_symv` to recompute it. For a multi-RHS call it is the
+  worst column, matching `steps` and `relative_residual`.
+
+  **It is `NaN` when `omega` was not measured** — under `EpsSqrtN`,
+  `RelativeResidual`, and `max_steps = 0`, where the loop never forms it.
+  `NaN` here means *not measured* and is deliberately distinct from
+  `INFINITY`, which is a real measurement (a non-finite iterate). Test it
+  with `is_nan()` before comparing against a bound; `NaN < t` is `false`, so
+  a bare comparison reads "not measured" as failure.
+
+  The full `RefinementDiagnostics` is deliberately *not* returned here: it
   computes a Hager-Higham condition estimate costing 3-5 extra solves, which
   would multiply exactly the cost this change exists to cut. Ask for it
   explicitly via `solve_sparse_refined_with_diagnostics` when you want it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Added - iterative refinement can be told what "converged" means (issue #190)
+
+- **The problem.** The refinement loop's only convergence test was a hardwired
+  `||r||_2 < eps * sqrt(n) * ||b||_2`. That target is not reachable on large
+  ill-conditioned systems — at `n = 118,276`, `eps * sqrt(n) = 7.6e-14` — so
+  every call ran the full `max_steps` budget and paid for iterations that
+  bought the caller nothing. The only lever was `max_steps`, a step count with
+  no principled value: the right count is problem-dependent, so tuning it is
+  guessing.
+- **What changed.** `RefineOptions` gains a `stop: StopCriterion` field:
+  - `StopCriterion::EpsSqrtN` — the historical behavior, and still the
+    default. Bit-for-bit unchanged.
+  - `StopCriterion::RelativeResidual(t)` — stop once
+    `||r||_2 <= t * ||b||_2`.
+  - `StopCriterion::BackwardError(t)` — stop once the componentwise backward
+    error `max_i |r_i| / (|A| |x| + |b|)_i <= t` (Arioli-Demmel-Duff 1989;
+    the quantity MA57 reports in `RINFO(6..8)` and MUMPS in `RINFO(7..8)`).
+    This is the criterion with a principled stopping value: `t` on the order
+    of `eps` says "as good as a backward-stable factorization would have
+    returned," independent of `n` and of row scaling.
+- **What you get back.** The `*_refined_into` entry points now return a
+  `RefineOutcome { steps, relative_residual, stop }` instead of `()`, where
+  `stop` is `Converged | MaxSteps | Stagnated | Diverged`. All three values
+  are already computed by the loop, so reporting them costs nothing. The
+  full `RefinementDiagnostics` is deliberately *not* returned here: it
+  computes a Hager-Higham condition estimate costing 3-5 extra solves, which
+  would multiply exactly the cost this change exists to cut. Ask for it
+  explicitly via `solve_sparse_refined_with_diagnostics` when you want it.
+- **Migration.** `RefineOptions::default()` is unchanged and existing callers
+  compile unchanged — the new return value is not `#[must_use]`. Build a
+  criterion with `RefineOptions::with_target(t)`,
+  `RefineOptions::with_backward_error(t)`, or `.and_stop(...)` /
+  `.and_max_steps(...)` on an existing value.
+- **Note on scale.** `||r||_2 / ||b||_2` can look perfect while the solution
+  is not backward stable: on the worked badly-scaled 2x2 in the research
+  note it reads `1.0e-36` where the componentwise error is `5.0e-13`. Prefer
+  `BackwardError` unless you specifically want a normwise target.
+- **Oracle.** The backward-error formula is LAPACK `dgerfs`'s, including its
+  `safe1`/`safe2` underflow guard, with one documented deviation: a row whose
+  denominator is exactly zero contributes 0 rather than LAPACK's 1, because
+  such a row forces `r_i == 0` exactly. Expected values for the four unit
+  tests were computed independently in Python from the published formula
+  before any Rust was written.
+- See `dev/research/issue-190-refine-target.md` and
+  `dev/plans/issue-190-refine-target.md`.
+
+
 ### Changed - `needs_refinement` now measures growth against the pivot threshold, not a fixed 1e6
 
 - **What changed.** `Factors::needs_refinement` was set whenever any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Changed - `needs_refinement` now measures growth against the pivot threshold, not a fixed 1e6
+
+- **What changed.** `Factors::needs_refinement` was set whenever any
+  `|L_ij| > 1e6`. That is a statement about the *magnitude* of `L`, which is
+  a property of the caller's scaling, not about growth, which is a property
+  of the factorization. It now compares against `1/u`, the multiplier bound
+  that threshold partial pivoting with `pivot_threshold = u` actually
+  promises. With no threshold in force (`u = 0`) the factorization makes no
+  such promise and the old absolute `1e6` remains as the fallback.
+- **Why it is the right bound.** TPP accepts a candidate only within a factor
+  `u` of its column maximum, so `|L_ij| <= 1/u` is the contract. Exceeding it
+  means the pivoting did not deliver its own guarantee on this matrix, which
+  is exactly when plain forward/back substitution is untrustworthy. The bound
+  also moves with the threshold, so `Solver::increase_quality` walking `u`
+  from 1e-8 towards `pivtol_max = 0.5` tightens the signal as it tightens the
+  promise.
+- **Who is affected.** Callers reading `factors.needs_refinement` on
+  badly-scaled systems will see far fewer spurious `true`s. A genuine
+  violation still flags: at `u = 1e-8` a `max|L|` of 4.2e13 is five orders
+  past the promise and sets the flag as before.
+- Covered by four new cases in `growth_flag_tests`, including that the same
+  `L` is accepted at `u = 1e-8` and rejected at `u = 0.5`.
+
 ### Fixed - multi-RHS solve was up to 1.6x slower when `nrhs` was not a multiple of 8
 
 - **What changed.** The row-major multi-RHS work buffers (`y`, `w`) used a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to FERAL will be documented in this file.
 
+## [Unreleased]
+
+### Changed - the benchmark harness now times the solve core a host actually gets (issue #189)
+
+- **What changed.** `cargo run --bin bench` measured its sparse solve column
+  with `solve_sparse_refined`, which pins `SolveCore::SharedVector`. Every
+  host reaching FERAL through `Solver` gets `SolveCore::Auto`, which picks
+  between the shared-vector and contribution-block cores per factor. The
+  harness now calls `solve_sparse_refined_auto_into`, so the published number
+  describes the code path hosts run.
+- **Why it matters if you read the numbers.** On seven large KKT matrices,
+  `Auto` is 1.30x faster than `SharedVector` (geomean, n = 8k-181k), and the
+  old harness could not see any of it. On the ~154k-matrix regression corpus
+  the aggregate `solve/MUMPS` geomean and p50 are unchanged at 0.08, because
+  that corpus is almost entirely small matrices where `Auto` selects
+  `SharedVector` anyway.
+- **The harness stays serial** (`parallel = false`), so the solve column
+  remains a single-threaded measurement comparable with previous releases;
+  the schedule choice is bit-neutral and measures 0.98-1.01x, so nothing is
+  lost by holding it fixed.
+- **No library behaviour changes.** This is the benchmark binary only.
+
 ## [0.17.0] - 2026-08-19
 
 ### Fixed — the tree-parallel solve no longer runs on trees too thin to pay for it (issue #175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to FERAL will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - multi-RHS solve was up to 1.6x slower when `nrhs` was not a multiple of 8
+
+- **What changed.** The row-major multi-RHS work buffers (`y`, `w`) used a
+  leading dimension of exactly `nrhs`. When `nrhs` is not a multiple of 8,
+  every row of every supernode panel straddles cache lines, and the
+  misalignment compounds across the gather, the panel kernels, and the
+  scatter. The BLAS-3 path now pads the row stride up to a whole 8-column
+  tile, so every row starts on a 64-byte boundary. Separately, the panel
+  GEMM's `nrhs % 8` column tail ran an unblocked triple loop with no data
+  reuse; it now runs full-width register tiles with the unused lanes
+  zero-padded.
+- **Who is affected.** Anyone calling `solve_sparse_many`,
+  `solve_sparse_many_into`, or `solve_many_refined` with `nrhs >= 32` that is
+  not a multiple of 8 — 7 values in 8.
+- **Measured.** Geomean **1.36x** faster on the multi-RHS solve at
+  `nrhs = 33` across bcsstk38, r05_kkt and bratu3d (1.21x, 1.59x, 1.32x
+  anchored on `nrhs = 32`, whose code path is unchanged; raw times 1.22x,
+  1.22x, 1.32x). Before the fix, `nrhs = 31` cost **1.4-1.8x** `nrhs = 32` on
+  all seven large KKT matrices despite doing 3% less work; it is now ~1.0x.
+- **Results are bit-for-bit unchanged.** The padding columns carry a zero
+  right-hand side and are never read back, so every real column's arithmetic
+  and its order are untouched. Verified three ways: a new 800-shape
+  `to_bits()` equality test over every `nrhs % 8` and `m_dim % 4` residue; the
+  rank-1-vs-BLAS-3 difference unchanged at all 105 measured (matrix, `nrhs`)
+  points; and all 13 multi-RHS tests including the two
+  `assert_eq!(max_diff, 0.0)` band contracts. `BLAS3_NRHS_THRESHOLD` is
+  unchanged at 32.
+- See `dev/research/blas3-threshold-refit.md`.
+
 ### Changed - the benchmark harness now times the solve core a host actually gets (issue #189)
 
 - **What changed.** `cargo run --bin bench` measured its sparse solve column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,36 @@ All notable changes to FERAL will be documented in this file.
   computes a Hager-Higham condition estimate costing 3-5 extra solves, which
   would multiply exactly the cost this change exists to cut. Ask for it
   explicitly via `solve_sparse_refined_with_diagnostics` when you want it.
-- **Migration.** `RefineOptions::default()` is unchanged and existing callers
-  compile unchanged — the new return value is not `#[must_use]`. Build a
-  criterion with `RefineOptions::with_target(t)`,
+- **Migration — BREAKING. An earlier version of this entry said the opposite
+  and was wrong.** It claimed "existing callers compile unchanged — the new
+  return value is not `#[must_use]`." That is false, and a downstream build
+  (pounce) disproved it. `#[must_use]` governs only whether *discarding* a
+  value warns at statement position; it does nothing for the value's type.
+  Three `Solver` methods now return `Result<RefineOutcome, FeralError>` where
+  they returned `Result<(), FeralError>`:
+  - `Solver::solve_refined_into`
+  - `Solver::solve_many_refined_into`
+  - the parallel refined entry point reached from `solve_refined_into`
+
+  Any caller that uses the result in *expression* position — a `match` arm, a
+  tail expression in a function returning `Result<(), _>`, a `let () =`
+  binding — fails to compile with `E0308: mismatched types`. Reported
+  downstream as incompatible `match` arms at `pounce-feral/src/lib.rs:1257`.
+
+  The fix at a call site that does not want the outcome is `.map(|_| ())`:
+
+  ```rust
+  // before
+  self.solver.solve_refined_into(m, rhs, x_out, opts)
+  // after, when the outcome is not wanted
+  self.solver.solve_refined_into(m, rhs, x_out, opts).map(|_| ())
+  ```
+
+  Adding `stop` to `RefineOptions` *is* source-compatible for callers that
+  build options through `with_max_steps` / the constructors, so the return
+  type is the only break. Under 0.x semver this makes the next release
+  **0.18.0**, not 0.17.1.
+- **Building a criterion.** `RefineOptions::with_target(t)`,
   `RefineOptions::with_backward_error(t)`, or `.and_stop(...)` /
   `.and_max_steps(...)` on an existing value.
 - **Note on scale.** `||r||_2 / ||b||_2` can look perfect while the solution
@@ -133,6 +160,24 @@ All notable changes to FERAL will be documented in this file.
   **This is an accuracy-for-latency trade, not a free fix.** Callers that need
   the old latency profile and can accept the componentwise gap can pass
   `StopCriterion::EpsSqrtN` explicitly.
+- **On one real workload it is not a tail effect at all — it is the whole
+  run.** Measured downstream in pounce on `laptime` (58,014 variables, L-BFGS,
+  126,028-dimension KKT, 60 IPM iterations), one binary, arms differing only
+  in the `StopCriterion` handed to `RefineOptions`:
+
+  | stop criterion | overall | factor | back-solve | vs `EpsSqrtN` |
+  |---|---:|---:|---:|---:|
+  | `EpsSqrtN` (0.17.0's default) | 58.6 s | 9.27 s | 46.7 s | — |
+  | refinement off | 13.9 s | 5.85 s | 5.44 s | -76% |
+  | `RelativeResidual(1e-10)` | 22.8 s | 6.48 s | 13.77 s | -61% |
+  | **this default** | 69.4 s | 10.39 s | 56.4 s | **+18%** |
+
+  +18% overall and +21% on back-solve against 0.17.0, on every iteration —
+  not a p99 effect. A second model (`dirichlet120`, exact Hessian) is
+  factorization-dominated and does not discriminate: all four arms reach
+  `Optimal` in 56 iterations at the same objective. Anyone whose profile
+  resembles `laptime` should set `StopCriterion` explicitly rather than
+  inherit this default.
 - **Rejected on measurement.** A *pure* `BackwardError(sqrt(eps))` default was
   tried first: it fixes the componentwise gap but stops earlier than
   `EpsSqrtN` normwise, and `tests/parity.rs` caught it — `ROSZMAN1_0241` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ All notable changes to FERAL will be documented in this file.
 ### Added - iterative refinement can be told what "converged" means (issue #190)
 
 - **The problem.** The refinement loop's only convergence test was a hardwired
-  `||r||_2 < eps * sqrt(n) * ||b||_2`. That target is not reachable on large
-  ill-conditioned systems — at `n = 118,276`, `eps * sqrt(n) = 7.6e-14` — so
-  every call ran the full `max_steps` budget and paid for iterations that
-  bought the caller nothing. The only lever was `max_steps`, a step count with
-  no principled value: the right count is problem-dependent, so tuning it is
-  guessing.
+  `||r||_2 < eps * sqrt(n) * ||b||_2` — a *normwise* target. A normwise
+  residual is dominated by the rows where `|b_i|` is largest and says nothing
+  about the rows where it is smallest, so on a badly-scaled right-hand side
+  the loop can report success at a solution that is nowhere near backward
+  stable. Measured on `bratu3d` with entries spanning `1e-6..1e6`: the loop
+  stops immediately at `||r||_2/||b||_2 = 4.1e-16`, which looks perfect,
+  while the componentwise backward error is `9.0e-6`. Six of seven IPM-scale
+  KKT matrices show the same thing. The only lever was `max_steps`, a step
+  count with no principled value: the right count is problem-dependent, so
+  tuning it is guessing.
 - **What changed.** `RefineOptions` gains a `stop: StopCriterion` field:
   - `StopCriterion::EpsSqrtN` — the historical behavior, and still the
     default. Bit-for-bit unchanged.
@@ -41,6 +45,19 @@ All notable changes to FERAL will be documented in this file.
   is not backward stable: on the worked badly-scaled 2x2 in the research
   note it reads `1.0e-36` where the componentwise error is `5.0e-13`. Prefer
   `BackwardError` unless you specifically want a normwise target.
+- **What it costs, measured.** This is an accuracy feature, not a speed
+  feature. On seven matrices (n up to 180,900) with a badly-scaled RHS, one
+  `BackwardError` step takes the componentwise error from as bad as `9.5e-5`
+  down to `~3e-16`, and costs roughly one extra solve — about 2x the
+  refinement wall time, factor excluded. With a *well-scaled* RHS the default
+  already converges in 0-2 steps on all seven, so there is no wasted-iteration
+  saving to claim.
+- **The new criteria can also overrun.** A componentwise target below what
+  the factorization can deliver has the same failure mode as an unreachable
+  normwise one: `qap15_kkt` with a badly-scaled RHS and
+  `BackwardError(1e-14)` runs 8 steps, exits `Stagnated`, and lands at
+  `4.2e-11` — while `BackwardError(1e-10)` reaches `4.4e-11` in 3. Set `t`
+  near `eps` scaled to what you expect, and read `stop`.
 - **Oracle.** The backward-error formula is LAPACK `dgerfs`'s, including its
   `safe1`/`safe2` underflow guard, with one documented deviation: a row whose
   denominator is exactly zero contributes 0 rather than LAPACK's 1, because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to FERAL will be documented in this file.
   count with no principled value: the right count is problem-dependent, so
   tuning it is guessing.
 - **What changed.** `RefineOptions` gains a `stop: StopCriterion` field:
-  - `StopCriterion::EpsSqrtN` — the historical behavior, and still the
-    default. Bit-for-bit unchanged.
+  - `StopCriterion::EpsSqrtN` — the historical behavior. Bit-for-bit
+    unchanged, but no longer the default; see the entry below.
   - `StopCriterion::RelativeResidual(t)` — stop once
     `||r||_2 <= t * ||b||_2`.
   - `StopCriterion::BackwardError(t)` — stop once the componentwise backward
@@ -67,6 +67,71 @@ All notable changes to FERAL will be documented in this file.
 - See `dev/research/issue-190-refine-target.md` and
   `dev/plans/issue-190-refine-target.md`.
 
+
+### Changed - refinement's default stopping criterion now certifies componentwise accuracy (MA57/MUMPS parity)
+
+- **The defect.** `RefineOptions::default()` stopped on
+  `||r||_2 < eps * sqrt(n) * ||b||_2` alone. That test is normwise, so it is
+  dominated by the rows carrying the largest right-hand-side entries. On a RHS
+  whose entries span `1e-6..1e6` — the shape an interior-point method produces
+  near convergence, where the dual, primal and complementarity blocks differ by
+  many orders — it passes on the *raw* solve, and refinement never runs.
+  Measured against canonical MUMPS 5.8.2 on identical systems with identical
+  right-hand sides, FERAL returned:
+
+  | matrix | FERAL omega | MUMPS omega1 | FERAL steps |
+  |---|---:|---:|---:|
+  | `r05_kkt` | 9.520e-5 | 3.608e-16 | 0 |
+  | `bratu3d` | 8.953e-6 | 2.844e-16 | 0 |
+  | `cont-201` | 3.860e-7 | 2.728e-16 | 0 |
+
+  Nine to eleven orders behind the reference, reported as `Converged`, after
+  zero correction steps. MUMPS does not have this failure mode because its
+  `ICNTL(10)` loop stops on the componentwise backward error against
+  `CNTL(2)`, not on a norm ratio. In an IPM the small RHS blocks are the
+  complementarity residuals of near-active constraints — the rows that set the
+  step — so this was silently wrong exactly where it mattered, on
+  badly-scaled systems only.
+- **What changed.** `StopCriterion` gains `EpsSqrtNAndBackwardError(f64)`, and
+  it is the new `RefineOptions::default()` with
+  `DEFAULT_BACKWARD_ERROR_TARGET = sqrt(eps) = 1.4901161193847656e-8` —
+  MUMPS's `CNTL(2)` (`ref/mumps/src/dini_defaults.F:1094`). Refinement now
+  stops only when `||r||_2 < eps * sqrt(n) * ||b||_2` **and** `omega <=
+  sqrt(eps)`. Both are evaluated on the same best-iterate, so the returned `x`
+  satisfies both at once.
+- **It cannot regress an existing caller.** The new criterion is strictly
+  harder to satisfy than the old one, so the default can only refine *more*,
+  never less. No accuracy gate was loosened.
+- **What it costs, measured.** Seven matrices, n up to 180,900, both RHS
+  families. With a **well-scaled** RHS: identical to the old default on all
+  seven — same step counts, same residuals, no added work. With a
+  **badly-scaled** RHS: `r05_kkt`, `bratu3d` and `cont-201` each take one
+  extra correction step (5-14 ms) and their componentwise error drops to
+  `2.7e-16`, `3.2e-16` and `2.9e-16`, level with MUMPS. Worst-case step count
+  across all fourteen combinations is still 2, the bound `EpsSqrtN` already
+  had.
+- **Rejected on measurement.** A *pure* `BackwardError(sqrt(eps))` default was
+  tried first: it fixes the componentwise gap but stops earlier than
+  `EpsSqrtN` normwise, and `tests/parity.rs` caught it — `ROSZMAN1_0241` at
+  `4.805e-14` against a MUMPS-anchored gate of `2.077e-14`. `BackwardError(eps)`
+  — LAPACK `dgerfs`'s target — was also rejected: it is unreachable here,
+  stagnating or exhausting the step budget on five of seven under a
+  badly-scaled RHS.
+- **Not a fix for #190's cost complaint.** The conjunction keeps the
+  `EpsSqrtN` half, so a normwise target that a given problem cannot reach
+  still runs the step budget out. Hosts that know their own accuracy
+  requirement should say so via `RefineOptions::with_target(t)` or
+  `with_backward_error(t)`.
+- **Also ruled out this session, with evidence.** The gap was *not* the pivot
+  threshold and *not* `ZeroPivotAction::ForceAccept`. `ForceAccept` never
+  fires on this corpus (`inertia.zero == 0`, `n_tiny == 0` on all seven), and
+  FERAL's `pivot_threshold = 1e-8` already matches what Ipopt — the host
+  pounce ports — sets for MA27 and MA57 (`ma27_pivtol`, `ma57_pivtol`, both
+  `1e-8`; `mumps_pivtol` is `1e-6`). The standalone `CNTL(1) = 0.01` figure is
+  the library default Ipopt deliberately overrides downward. FERAL's inertia
+  matched MUMPS exactly on all seven matrices, including `qap15_kkt` at
+  `cond1 = 3.9e12`.
+- See `dev/research/issue-190-refine-target.md`, addendum 2026-08-21.
 
 ### Changed - `needs_refinement` now measures growth against the pivot threshold, not a fixed 1e6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,14 +102,37 @@ All notable changes to FERAL will be documented in this file.
 - **It cannot regress an existing caller.** The new criterion is strictly
   harder to satisfy than the old one, so the default can only refine *more*,
   never less. No accuracy gate was loosened.
-- **What it costs, measured.** Seven matrices, n up to 180,900, both RHS
-  families. With a **well-scaled** RHS: identical to the old default on all
-  seven — same step counts, same residuals, no added work. With a
+- **What it costs, measured on the seven-matrix set.** n up to 180,900, both
+  RHS families. With a **well-scaled** RHS: identical to the old default on
+  all seven — same step counts, same residuals, no added work. With a
   **badly-scaled** RHS: `r05_kkt`, `bratu3d` and `cont-201` each take one
   extra correction step (5-14 ms) and their componentwise error drops to
   `2.7e-16`, `3.2e-16` and `2.9e-16`, level with MUMPS. Worst-case step count
   across all fourteen combinations is still 2, the bound `EpsSqrtN` already
   had.
+- **What it costs on the full corpus: a real tail regression.** The
+  seven-matrix figures above understate it. A controlled A/B over the 154,588
+  benchmark matrices — same machine, same run, only `Default for
+  RefineOptions` changed — gives:
+
+  | ratio | `EpsSqrtN` | new default | delta |
+  |---|---:|---:|---:|
+  | solve/MUMPS geomean | 0.08 | 0.08 | none |
+  | solve/MUMPS p50 | 0.08 | 0.08 | none |
+  | solve/MUMPS p90 | 0.15 | 0.20 | **+33%** |
+  | solve/MUMPS p99 | 0.71 | 1.08 | **+52%** |
+  | solve/SSIDS geomean | 0.94 | 1.06 | **+13%** |
+  | solve/SSIDS p90 | 2.50 | 3.60 | **+44%** |
+  | solve/SSIDS p99 | 8.33 | 13.00 | **+56%** |
+
+  The median is untouched — the well-scaled majority never needed the extra
+  conjunct. The tail pays, because that is where the matrices sit whose
+  componentwise error was above `sqrt(eps)` and which now actually refine
+  (13 of 63 on the tracked parity corpus). Factor ratios are unchanged within
+  noise, confirming the effect is the refinement loop and not machine state.
+  **This is an accuracy-for-latency trade, not a free fix.** Callers that need
+  the old latency profile and can accept the componentwise gap can pass
+  `StopCriterion::EpsSqrtN` explicitly.
 - **Rejected on measurement.** A *pure* `BackwardError(sqrt(eps))` default was
   tried first: it fixes the componentwise gap but stops earlier than
   `EpsSqrtN` normwise, and `tests/parity.rs` caught it — `ROSZMAN1_0241` at

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,18 @@ crate-type = ["staticlib", "rlib"]
 # `cargo test --features lu-ft-invariant-check`.
 lu-ft-invariant-check = []
 
+# Opt-in in-process override for the multi-RHS BLAS-3 dispatch threshold, so a
+# probe can time both multi-RHS kernels at the *same* `nrhs` within one
+# process. Off by default and compiled out entirely: with the feature off the
+# dispatch reads the `BLAS3_NRHS_THRESHOLD` const directly, exactly as before.
+#
+# It exists because cross-process kernel comparison does not work on this
+# machine. A full sweep takes ~25 min, so two "alternating" runs are 25 min
+# apart, and the identical-code control drifted by up to 2x between them —
+# blocked measurement wearing a disguise. See
+# `dev/research/blas3-threshold-refit.md`.
+kernel-probe = []
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -162,13 +162,27 @@ The step budget is a per-call parameter. `RefineOptions::with_max_steps(k)`
 caps the *correction* steps at `k` (the initial solve always runs, so a call
 does at most `k + 1` substitution passes); `RefineOptions::default()` is the
 historical budget, `DEFAULT_REFINE_MAX_STEPS = 10`. It is a cap, not a target:
-the `ε·√n` residual test, the divergence guard, and the plateau exit all keep
+the convergence test, the divergence guard, and the plateau exit all keep
 priority, and best-iterate holds under every `k`, so no cap returns an answer
 worse than the unrefined solve. `k = 0` *is* the unrefined solve, and costs the
 same — the residual matvec is skipped rather than computed and discarded. The
 caller that wants this is one running its own refinement loop over the same
 system, an interior-point method being the standard case: without a cap the two
 loops nest and one solve can cost `10 × 11 = 110` passes.
+
+What counts as converged is a per-call parameter too. `RefineOptions::default()`
+keeps FERAL's historical `ε·√n` relative-residual test, but that target is
+unreachable on large ill-conditioned systems — at `n = 118 276` it is
+`7.6e-14` — so every call runs the full budget. `RefineOptions::with_target(t)`
+stops at `||r||₂ ≤ t·||b||₂`, and `RefineOptions::with_backward_error(t)` stops at
+the componentwise backward error `maxᵢ |rᵢ| / (|A||x| + |b|)ᵢ ≤ t`
+(Arioli–Demmel–Duff; the quantity MA57 reports in `RINFO(6..8)`). The
+componentwise form is the one with a principled stopping value — `t` of order
+`ε` means "as good as a backward-stable factorization would have returned",
+independent of `n` and of row scaling — and it costs one extra pass over `A`
+per step and no extra solves. The `*_refined_into` entry points return a
+`RefineOutcome { steps, relative_residual, stop }` so the caller can see which
+of `Converged`/`MaxSteps`/`Stagnated`/`Diverged` ended the loop.
 
 Every entry point has an `_opts` form taking `RefineOptions` and an `_into`
 form writing into a caller-owned buffer instead of allocating —

--- a/README.md
+++ b/README.md
@@ -171,9 +171,12 @@ system, an interior-point method being the standard case: without a cap the two
 loops nest and one solve can cost `10 × 11 = 110` passes.
 
 What counts as converged is a per-call parameter too. `RefineOptions::default()`
-keeps FERAL's historical `ε·√n` relative-residual test, but that target is
-unreachable on large ill-conditioned systems — at `n = 118 276` it is
-`7.6e-14` — so every call runs the full budget. `RefineOptions::with_target(t)`
+keeps FERAL's historical `ε·√n` relative-residual test, which is *normwise*
+and so is dominated by the rows where `|bᵢ|` is largest. On a badly-scaled
+right-hand side it can stop at what looks like a perfect solve while the
+solution is nowhere near backward stable — measured on `bratu3d` with `b`
+spanning `1e-6…1e6`, it converges immediately at `‖r‖₂/‖b‖₂ = 4.1e-16` with a
+componentwise backward error of `9.0e-6`. `RefineOptions::with_target(t)`
 stops at `||r||₂ ≤ t·||b||₂`, and `RefineOptions::with_backward_error(t)` stops at
 the componentwise backward error `maxᵢ |rᵢ| / (|A||x| + |b|)ᵢ ≤ t`
 (Arioli–Demmel–Duff; the quantity MA57 reports in `RINFO(6..8)`). The
@@ -183,6 +186,15 @@ independent of `n` and of row scaling — and it costs one extra pass over `A`
 per step and no extra solves. The `*_refined_into` entry points return a
 `RefineOutcome { steps, relative_residual, stop }` so the caller can see which
 of `Converged`/`MaxSteps`/`Stagnated`/`Diverged` ended the loop.
+
+This is an accuracy knob, not a speed knob. On seven matrices up to
+`n = 180 900` with a badly-scaled RHS, one `BackwardError` step takes the
+componentwise error from as bad as `9.5e-5` to `~3e-16` and costs about one
+extra solve; with a well-scaled RHS the default already converges in 0–2
+steps, so there are no wasted iterations to reclaim. Note also that a
+componentwise target below what the factorization can deliver overruns just
+as an unreachable normwise one does — on `qap15_kkt`, `1e-14` runs 8 steps to
+`Stagnated` at `4.2e-11` where `1e-10` reaches `4.4e-11` in 3. Read `stop`.
 
 Every entry point has an `_opts` form taking `RefineOptions` and an `_into`
 form writing into a caller-owned buffer instead of allocating —

--- a/crates/feral-diagnostics/Cargo.toml
+++ b/crates/feral-diagnostics/Cargo.toml
@@ -35,3 +35,16 @@ serde_json = "1"
 # Some probes call the SIMD Schur kernel / parallel driver directly.
 pulp = { version = "0.22.2", default-features = false, features = ["x86-v3"] }
 rayon = "1.10"
+
+[features]
+# Forwards to `feral/kernel-probe`, which exposes the in-process multi-RHS
+# dispatch override. Off by default; `probe_blas3_crossover` requires it, so
+# with the feature off Cargo skips that binary entirely (including under
+# `clippy --all-targets`).
+kernel-probe = ["feral/kernel-probe"]
+
+# `autobins = true` picks up every other probe; this one needs an explicit
+# stanza only to carry `required-features`.
+[[bin]]
+name = "probe_blas3_crossover"
+required-features = ["kernel-probe"]

--- a/crates/feral-diagnostics/src/bin/probe_batch_interleaved.rs
+++ b/crates/feral-diagnostics/src/bin/probe_batch_interleaved.rs
@@ -1,0 +1,123 @@
+//! Does the `solve_sparse_many` batching win survive interleaved measurement?
+//!
+//!   cargo run -p feral-diagnostics --bin probe_batch_interleaved --release [-- <name>...]
+//!
+//! `probe_largen_solve_levers` measured the batching lever in *blocks* —
+//! all repetitions of the looped path, then all repetitions of the batched
+//! path. `probe_solve_reconcile` showed that blocked measurement produced a
+//! 2.4x error on the contribution-block comparison, so every number taken
+//! that way is suspect until re-measured.
+//!
+//! This re-measures just the batching ratio with the two paths interleaved
+//! inside each repetition, so drift hits both equally. Batching is expected
+//! to survive — unlike the schedule comparison it was stable across runs —
+//! but "expected to survive" is what the other two claims looked like too.
+
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+const REPS: usize = 11;
+/// An L-BFGS host with `limited_memory_max_history = 6` presents 13.
+const NRHS: usize = 13;
+
+fn median(v: &[f64]) -> f64 {
+    let mut s = v.to_vec();
+    s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    s[s.len() / 2]
+}
+
+fn geomean(v: &[f64]) -> f64 {
+    if v.is_empty() {
+        return f64::NAN;
+    }
+    (v.iter().map(|x| x.ln()).sum::<f64>() / v.len() as f64).exp()
+}
+
+fn run(path: &Path) -> Option<f64> {
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let csc: CscMatrix = match read_mtx(path).and_then(|m| m.to_csc()) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: {e}");
+            return None;
+        }
+    };
+    let n = csc.n;
+    let mut solver = Solver::new();
+    match solver.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return None;
+        }
+    }
+
+    // Column-major n x NRHS block, each column a distinct well-scaled RHS.
+    let mut block = vec![0.0f64; n * NRHS];
+    for (j, col) in block.chunks_mut(n).enumerate() {
+        for (i, s) in col.iter_mut().enumerate() {
+            *s = 1.0 + ((i + j) % 7) as f64 / 8.0;
+        }
+    }
+
+    let mut looped_x = vec![0.0f64; n];
+    let mut batched_x = vec![0.0f64; n * NRHS];
+    let (mut t_loop, mut t_batch) = (Vec::new(), Vec::new());
+    for _ in 0..REPS {
+        let t = Instant::now();
+        for col in block.chunks(n) {
+            if let Err(e) = solver.solve_into(col, &mut looped_x) {
+                println!("SKIP {name}: looped: {e}");
+                return None;
+            }
+            std::hint::black_box(&looped_x);
+        }
+        t_loop.push(t.elapsed().as_secs_f64() * 1e6);
+
+        let t = Instant::now();
+        if let Err(e) = solver.solve_many_into(&block, NRHS, &mut batched_x) {
+            println!("SKIP {name}: batched: {e}");
+            return None;
+        }
+        std::hint::black_box(&batched_x);
+        t_batch.push(t.elapsed().as_secs_f64() * 1e6);
+    }
+    let (l, b) = (median(&t_loop), median(&t_batch));
+    println!(
+        "{name:<20} n={n:<8} looped {l:10.0}  batched {b:10.0} us   speedup {:.2}x",
+        l / b
+    );
+    Some(l / b)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "bcsstk38".into(),
+            "r05_kkt".into(),
+            "bratu3d".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+        ]
+    } else {
+        args
+    };
+    println!("batching re-check, interleaved ({REPS} reps, nrhs={NRHS}, medians)\n");
+    let r: Vec<f64> = names
+        .iter()
+        .filter_map(|nm| run(&Path::new("tests/data/large").join(format!("{nm}.mtx"))))
+        .collect();
+    println!(
+        "\ngeomean {:.2}x   min {:.2}x",
+        geomean(&r),
+        r.iter().cloned().fold(f64::INFINITY, f64::min)
+    );
+}

--- a/crates/feral-diagnostics/src/bin/probe_bench_solve_noise.rs
+++ b/crates/feral-diagnostics/src/bin/probe_bench_solve_noise.rs
@@ -1,0 +1,220 @@
+//! Is the bench harness's large-n solve reading reproducible?
+//!
+//!   cargo run -p feral-diagnostics --bin probe_bench_solve_noise --release [-- <name>...]
+//!
+//! `src/bin/bench.rs:1677-1684` times one solve, once:
+//!
+//! ```ignore
+//! let t1 = Instant::now();
+//! let x = solve_refined(&matrix, &factors, &rhs)?;
+//! let solve_us = t1.elapsed().as_micros();
+//! ```
+//!
+//! and only replicates it when the MUMPS oracle says the *factor* took
+//! under 200 us (`should_resample`, `:1042`) — a small-matrix denoise.
+//! Large matrices, the ones feral#189 wants to gate, get a single sample.
+//!
+//! This measures what that single sample is worth. For each matrix it
+//! repeats the bench's exact solve call `REPS` times and reports the
+//! spread, then reports what three candidate reductions (min, median,
+//! median-of-5-medians) would have yielded. The question it answers is
+//! Step 1 of `dev/plans/large-n-solve-gate.md`: how noisy is the reading,
+//! and which reduction makes it gateable.
+//!
+//! Deliberately uses `solve_sparse_refined` — the same serial
+//! shared-vector entry the bench reaches (`src/numeric/solve.rs:2077`
+//! passes `SolveCore::SharedVector`) — so this characterises the harness
+//! as it exists, not as it might be.
+
+use feral::numeric::solve::{solve_sparse_refined, RefineOptions};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+/// Enough repeats to see a tail without turning this into a corpus run.
+const REPS: usize = 15;
+/// Group size for the "median of medians" reduction, matching
+/// `RESAMPLE_COLD_REPS` in the bench.
+const GROUP: usize = 5;
+
+fn pct(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((sorted.len() as f64 * p).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: read_mtx: {e}");
+            return;
+        }
+    };
+    let csc: CscMatrix = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+
+    let mut solver = Solver::new();
+    match solver.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return;
+        }
+    }
+    let factors = match solver.factors() {
+        Some(f) => f,
+        None => {
+            println!("SKIP {name}: no factors");
+            return;
+        }
+    };
+
+    // Well-scaled deterministic RHS with a known O(1) solution, so the
+    // refinement loop does a representative amount of work rather than
+    // converging instantly on a trivial vector.
+    let mut rhs = vec![0.0f64; n];
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = 1.0 + (i % 7) as f64 / 8.0;
+    }
+    csc.symv(&v, &mut rhs);
+
+    let mut samples: Vec<f64> = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        match solve_sparse_refined(&csc, factors, &rhs) {
+            Ok(x) => {
+                std::hint::black_box(&x);
+            }
+            Err(e) => {
+                println!("SKIP {name}: solve: {e}");
+                return;
+            }
+        }
+        samples.push(t.elapsed().as_secs_f64() * 1e6);
+    }
+
+    let raw = samples.clone();
+    let mut sorted = samples;
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let lo = sorted[0];
+    let hi = sorted[sorted.len() - 1];
+    let med = pct(&sorted, 0.50);
+
+    // What each candidate reduction would report, and how much the
+    // *reported value* still moves between independent groups of GROUP.
+    let mut group_meds: Vec<f64> = Vec::new();
+    let mut group_mins: Vec<f64> = Vec::new();
+    for g in raw.chunks(GROUP) {
+        let mut s = g.to_vec();
+        s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        group_meds.push(s[s.len() / 2]);
+        group_mins.push(s[0]);
+    }
+    let spread = |v: &[f64]| -> f64 {
+        let mn = v.iter().cloned().fold(f64::INFINITY, f64::min);
+        let mx = v.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        if mn > 0.0 {
+            mx / mn
+        } else {
+            f64::NAN
+        }
+    };
+
+    println!(
+        "{name:<20} n={n:<8} serial   {lo:9.0}..{hi:9.0} us  med {med:9.0}  \
+         spread {:.2}x | med-of-{GROUP} {:.2}x | min-of-{GROUP} {:.2}x",
+        hi / lo,
+        spread(&group_meds),
+        spread(&group_mins),
+    );
+
+    // Same measurement, same reps, on the PARALLEL schedule. The earlier
+    // levers probe saw up to 2.20x drift on this path across runs, while
+    // the serial numbers above are tight -- but those were different
+    // probes on different days. Measuring both here, back to back, is the
+    // only way to attribute the noise to the schedule rather than to the
+    // machine or the method.
+    let mut psolver = Solver::new().with_parallel(true);
+    match psolver.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("{:<20} parallel: factor {other:?}", "");
+            return;
+        }
+    }
+    let opts = RefineOptions::default();
+    let mut px = vec![0.0f64; n];
+    let mut psamples: Vec<f64> = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        if let Err(e) = psolver.solve_refined_into(&csc, &rhs, &mut px, opts) {
+            println!("{:<20} parallel: solve: {e}", "");
+            return;
+        }
+        std::hint::black_box(&px);
+        psamples.push(t.elapsed().as_secs_f64() * 1e6);
+    }
+    let praw = psamples.clone();
+    let mut psorted = psamples;
+    psorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let (plo, phi) = (psorted[0], psorted[psorted.len() - 1]);
+    let pmed = pct(&psorted, 0.50);
+    let mut pgm: Vec<f64> = Vec::new();
+    let mut pgn: Vec<f64> = Vec::new();
+    for g in praw.chunks(GROUP) {
+        let mut s = g.to_vec();
+        s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        pgm.push(s[s.len() / 2]);
+        pgn.push(s[0]);
+    }
+    println!(
+        "{:<20} {:<10} parallel {plo:9.0}..{phi:9.0} us  med {pmed:9.0}  \
+         spread {:.2}x | med-of-{GROUP} {:.2}x | min-of-{GROUP} {:.2}x   (par/ser med {:.2}x)",
+        "",
+        "",
+        phi / plo,
+        spread(&pgm),
+        spread(&pgn),
+        med / pmed,
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "bcsstk38".into(),
+            "r05_kkt".into(),
+            "bratu3d".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+        ]
+    } else {
+        args
+    };
+    println!(
+        "bench single-shot solve reproducibility ({REPS} reps, serial shared-vector, 1 RHS)\n"
+    );
+    for nm in &names {
+        run(&Path::new("tests/data/large").join(format!("{nm}.mtx")));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_blas3_crossover.rs
+++ b/crates/feral-diagnostics/src/bin/probe_blas3_crossover.rs
@@ -1,0 +1,190 @@
+//! Where is the multi-RHS BLAS-3 crossover, actually?
+//!
+//!   cargo run -p feral-diagnostics --features kernel-probe \
+//!     --bin probe_blas3_crossover --release [-- <name>...]
+//!
+//! `BLAS3_NRHS_THRESHOLD = 32` (`src/numeric/solve.rs:17`) has never been
+//! measured. Its doc comment cites "the `k ~ 16` crossover from
+//! `dev/research/multi-rhs.md` D3", but D3 is a design note written before
+//! the kernels existed and simply asserts that BLAS-3 shapes pay off above
+//! `k ~ 16`. `issue-57-blas3-panel.md:121` then picks 32 as "a conservative
+//! crossover" relative to that assertion, and measures only
+//! `nrhs` in {31, 32, 37, 64, 256}, on 2-D Laplacians. The band 2..31 —
+//! where callers live — has no measurement behind it, and neither does any
+//! KKT matrix.
+//!
+//! ## Method
+//!
+//! For each matrix and `nrhs`, both kernels are timed at the **same `nrhs`,
+//! interleaved within each repetition**, in one process, via the
+//! `kernel-probe` threshold override.
+//!
+//! This replaces a two-binary design that failed. Building stock (threshold
+//! 32) and patched (threshold 2) binaries and alternating the runs sounds
+//! interleaved but is not: a full sweep takes ~25 minutes, so "adjacent"
+//! runs are 25 minutes apart. Two controls caught it — the looped
+//! single-RHS path (byte-identical in both builds) drifted by up to 2.0x,
+//! and the `nrhs >= 32` rows, where both builds run the *same* kernel and
+//! the ratio must be exactly 1.00, read 0.86-0.90. That is the same blocked
+//! measurement error that produced two retractions on 2026-08-20, one level
+//! down. Discarded rather than reported.
+//!
+//! ## Accuracy
+//!
+//! The two kernels reassociate differently, so they do not agree bit-for-bit.
+//! `tests/multi_rhs.rs:227,256` assert `max_diff == 0.0` between batched-
+//! refined and per-column-refined at `nrhs` 24 and 20 — a contract that holds
+//! only because `solve_sparse_many` stays on the rank-1 kernels below 32, and
+//! that pounce's Schur path consumes
+//! (`../pounce/crates/pounce-feral/src/schur.rs:303`). So this probe also
+//! reports `max |rank1 - blas3|` per `nrhs`: the size of what a threshold cut
+//! would actually trade away.
+
+use feral::numeric::solve::{set_blas3_nrhs_threshold, solve_sparse_many_into, SolveManyWorkspace};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+/// Odd, so the median is a measured sample rather than an average.
+const REPS: usize = 9;
+
+/// Dense around the two candidate crossovers (the asserted 16, the shipped
+/// 32). 2 is the IPM predictor-corrector width; 48 is past the shipped
+/// threshold, where BLAS-3 is already known to win.
+const NRHS_SWEEP: &[usize] = &[2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 31, 32, 33, 40, 48];
+
+/// `nrhs >= this` is false for any real `nrhs`, forcing the rank-1 kernel.
+/// (`usize::MAX` itself is the sentinel for "no override".)
+const FORCE_RANK1: usize = usize::MAX - 1;
+/// `nrhs >= 0` is always true, forcing the BLAS-3 kernel.
+const FORCE_BLAS3: usize = 0;
+
+fn median(v: &[f64]) -> f64 {
+    let mut s = v.to_vec();
+    s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    s[s.len() / 2]
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: read_mtx: {e}");
+            return;
+        }
+    };
+    let csc: CscMatrix = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+
+    let mut solver = Solver::new();
+    match solver.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return;
+        }
+    }
+    let Some(factors) = solver.factors() else {
+        println!("SKIP {name}: no factors");
+        return;
+    };
+
+    for &nrhs in NRHS_SWEEP {
+        // Deterministic, well-scaled RHS block; column `c` is a shifted ramp
+        // so no two columns are identical.
+        let mut rhs = vec![0.0f64; n * nrhs];
+        for c in 0..nrhs {
+            for i in 0..n {
+                rhs[c * n + i] = 1.0 + ((i + 3 * c) % 7) as f64 / 8.0;
+            }
+        }
+
+        // Every buffer is allocated once, outside every timed region. A
+        // per-replicate allocation inside a timed solve is what caused the
+        // bench regression on 2026-08-20.
+        let mut x_r = vec![0.0f64; n * nrhs];
+        let mut x_b = vec![0.0f64; n * nrhs];
+        let mut ws = SolveManyWorkspace::for_factors(factors, nrhs);
+
+        let mut t_r = Vec::with_capacity(REPS);
+        let mut t_b = Vec::with_capacity(REPS);
+
+        // Warm both paths so neither pays the first-touch cost alone.
+        set_blas3_nrhs_threshold(FORCE_RANK1);
+        let _ = solve_sparse_many_into(factors, &rhs, nrhs, &mut x_r, &mut ws);
+        set_blas3_nrhs_threshold(FORCE_BLAS3);
+        let _ = solve_sparse_many_into(factors, &rhs, nrhs, &mut x_b, &mut ws);
+
+        for _ in 0..REPS {
+            set_blas3_nrhs_threshold(FORCE_RANK1);
+            let t = Instant::now();
+            if solve_sparse_many_into(factors, &rhs, nrhs, &mut x_r, &mut ws).is_err() {
+                println!("SKIP {name}: rank1 nrhs={nrhs} failed");
+                return;
+            }
+            t_r.push(t.elapsed().as_secs_f64() * 1e6);
+
+            set_blas3_nrhs_threshold(FORCE_BLAS3);
+            let t = Instant::now();
+            if solve_sparse_many_into(factors, &rhs, nrhs, &mut x_b, &mut ws).is_err() {
+                println!("SKIP {name}: blas3 nrhs={nrhs} failed");
+                return;
+            }
+            t_b.push(t.elapsed().as_secs_f64() * 1e6);
+        }
+
+        // How far apart the two kernels' answers are, absolute and relative
+        // to the solution scale. This is what a threshold cut trades away.
+        let mut max_abs = 0.0f64;
+        let mut max_x = 0.0f64;
+        for i in 0..n * nrhs {
+            max_abs = max_abs.max((x_r[i] - x_b[i]).abs());
+            max_x = max_x.max(x_r[i].abs());
+        }
+        let rel = if max_x > 0.0 { max_abs / max_x } else { 0.0 };
+
+        let r = median(&t_r);
+        let b = median(&t_b);
+        println!(
+            "DATA {name} {nrhs} {r:.1} {b:.1} {:.4} {max_abs:.3e} {rel:.3e}",
+            r / b
+        );
+    }
+    // Leave the process on the shipped dispatch.
+    set_blas3_nrhs_threshold(usize::MAX);
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "bcsstk38".into(),
+            "r05_kkt".into(),
+            "bratu3d".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+        ]
+    } else {
+        args
+    };
+    println!("# both kernels timed at the same nrhs, interleaved, one process");
+    println!(
+        "# DATA <name> <nrhs> <rank1_us> <blas3_us> <rank1/blas3> <max_abs_diff> <max_rel_diff>"
+    );
+    for nm in &names {
+        run(&Path::new("tests/data/large").join(format!("{nm}.mtx")));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_forceaccept_residual.rs
+++ b/crates/feral-diagnostics/src/bin/probe_forceaccept_residual.rs
@@ -1,0 +1,172 @@
+//! Is the unrefined residual actually caused by `ZeroPivotAction::ForceAccept`?
+//!
+//!   cargo run -p feral-diagnostics --bin probe_forceaccept_residual --release [-- <name>...]
+//!
+//! Issue #190 asserts that POUNCE cannot use `max_steps = 0` because
+//! "`ZeroPivotAction::ForceAccept` is the default, so feral's raw solve can
+//! leave a non-trivial residual against the very system it factorized."
+//! That is a claim about *mechanism*, and it has a testable consequence:
+//! a matrix whose unrefined solve is inaccurate should show force-accepted
+//! pivots, and a matrix with none should solve cleanly without refinement.
+//!
+//! ForceAccept fires in exactly one place (`try_reject_1x1_frontal`, the
+//! `may_delay == false` arm): a pivot that failed the column-relative
+//! threshold, that rook rescue could not turn into a 2x2, and that has no
+//! parent supernode left to be delayed into. It zeroes the L column and
+//! counts a zero eigenvalue -- so `inertia.zero > 0` is its fingerprint.
+//! `n_tiny` counts the *other* perturbation family (static-pivot floor /
+//! PerturbToEps), which is off by default and should read 0 throughout.
+//!
+//! So: print the fingerprint next to the unrefined error. If large
+//! unrefined error shows up with `zero = 0` and `n_tiny = 0`, ForceAccept
+//! is not the mechanism and the workaround in #190 is aimed at the wrong
+//! target.
+
+use feral::numeric::solve::RefineOptions;
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+
+fn residual_and_omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> (f64, f64) {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let rn = r.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let bn = b.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let rel = if bn > 0.0 { rn / bn } else { rn };
+
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut omega = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > omega {
+            omega = v;
+        }
+    }
+    (rel, omega)
+}
+
+fn build_rhs_easy(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = 1.0 + (i % 7) as f64 / 8.0;
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn build_rhs_hard(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        let mag = 10f64.powi(((i % 13) as i32) - 6);
+        *s = if i % 2 == 0 { mag } else { -mag };
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: {e}");
+            return;
+        }
+    };
+    let csc = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+    let mut solver = Solver::new();
+    let status = solver.factor(&csc, None);
+    match &status {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return;
+        }
+    }
+    let (zero, n_tiny, min_piv, needs_ref) = match solver.factors() {
+        Some(f) => (
+            solver.inertia().map(|i| i.zero).unwrap_or(usize::MAX),
+            f.n_tiny(),
+            f.min_pivot_magnitude().unwrap_or(f64::NAN),
+            f.needs_refinement,
+        ),
+        None => {
+            println!("SKIP {name}: no factors");
+            return;
+        }
+    };
+
+    // `max_steps = 0` is the unrefined solve: the raw forward/back
+    // substitution against the factor, which is what MA57/MUMPS hand back.
+    let unref = RefineOptions::default().and_max_steps(0);
+    let mut x = vec![0.0f64; n];
+    let mut out = Vec::new();
+    for (tag, b) in [
+        ("easy", build_rhs_easy(&csc)),
+        ("hard", build_rhs_hard(&csc)),
+    ] {
+        if solver.solve_refined_into(&csc, &b, &mut x, unref).is_err() {
+            out.push(format!("{tag}: solve error"));
+            continue;
+        }
+        let (rel, om) = residual_and_omega(&csc, &x, &b);
+        out.push(format!("{tag} rel={rel:.3e} omega={om:.3e}"));
+    }
+
+    println!(
+        "{name:<18} n={n:<7} zero={zero:<5} n_tiny={n_tiny:<4} \
+         min|piv|={min_piv:.3e} needs_ref={needs_ref:<5} | {}",
+        out.join("  |  ")
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "r05_kkt".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+            "bratu3d".into(),
+            "bcsstk38".into(),
+        ]
+    } else {
+        args
+    };
+    println!("unrefined (max_steps=0) error vs ForceAccept fingerprint");
+    println!(
+        "zero = force-accepted zero pivots (inertia.zero); n_tiny = static/PerturbToEps events"
+    );
+    for nm in names {
+        let p = format!("tests/data/large/{nm}.mtx");
+        run(Path::new(&p));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_largen_solve_levers.rs
+++ b/crates/feral-diagnostics/src/bin/probe_largen_solve_levers.rs
@@ -1,0 +1,314 @@
+//! Quantify the two solve-phase levers claimed in feral#131 and #189 on
+//! IPM-scale KKT matrices.
+//!
+//!   cargo run -p feral-diagnostics --bin probe_largen_solve_levers --release [-- <name>...]
+//!
+//! For each matrix it factors once, then times four ways of producing the
+//! same `NRHS` solutions:
+//!
+//!   A  serial   `solve_sparse`     x NRHS   (what a host at feral_refine=no gets today)
+//!   B  cb-ser   `solve_sparse_cb(false)` x NRHS
+//!   C  cb-par   `solve_sparse_cb(true)`  x NRHS   (#131: the unreachable core)
+//!   D  many     `solve_sparse_many(NRHS)` x 1     (batching: shares traversal)
+//!
+//! then sweeps `nrhs` through the BLAS-3 crossover (`BLAS3_NRHS_THRESHOLD
+//! = 32`) reporting per-RHS cost of `many` against looped single, which is
+//! the measurement #189 says was never taken above n = 1e4.
+//!
+//! Every path is reported with its own relative residual: the CB core and
+//! the shared-vector core are different reassociations (#177), so parity
+//! is a residual question, not a bit question.
+
+use feral::numeric::solve::{
+    solve_sparse, solve_sparse_cb, solve_sparse_many, solve_sparse_refined_auto_into, RefineOptions,
+};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+/// L-BFGS with `limited_memory_max_history = 6` presents this many
+/// columns per low-rank block, which is the case pounce#698 hits.
+const NRHS: usize = 13;
+/// Best-of-`REPS`: these are wall-clock timings on a shared machine, and
+/// the minimum is the least noisy estimator of the achievable cost.
+const REPS: usize = 5;
+const SWEEP: [usize; 10] = [1, 2, 4, 8, 13, 16, 24, 32, 48, 64];
+
+fn rel_residual(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let num = ax
+        .iter()
+        .zip(b)
+        .map(|(p, q)| (p - q).abs())
+        .fold(0.0f64, f64::max);
+    let den = b.iter().map(|v| v.abs()).fold(0.0f64, f64::max).max(1.0);
+    num / den
+}
+
+/// Deterministic, well-scaled RHS block: column `c` is `A * v_c` with
+/// `v_c[i] = 1 + ((i + c) % 7) as f64 / 8.0`, so each column has a known
+/// O(1) solution and no two columns are collinear.
+fn build_rhs_block(a: &CscMatrix, nrhs: usize) -> Vec<f64> {
+    let n = a.n;
+    let mut rhs = vec![0.0f64; n * nrhs];
+    let mut v = vec![0.0f64; n];
+    for c in 0..nrhs {
+        for (i, slot) in v.iter_mut().enumerate() {
+            *slot = 1.0 + ((i + c) % 7) as f64 / 8.0;
+        }
+        a.symv(&v, &mut rhs[c * n..(c + 1) * n]);
+    }
+    rhs
+}
+
+/// Best-of-REPS wall time, in seconds, for one closure.
+fn best_of(mut f: impl FnMut()) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..REPS {
+        let t = Instant::now();
+        f();
+        let s = t.elapsed().as_secs_f64();
+        if s < best {
+            best = s;
+        }
+    }
+    best
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: {e}");
+            return;
+        }
+    };
+    let csc = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+    let nnz = csc.row_idx.len();
+
+    let mut solver = Solver::new();
+    let t = Instant::now();
+    let status = solver.factor(&csc, None);
+    let factor_s = t.elapsed().as_secs_f64();
+    match &status {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return;
+        }
+    }
+    let factors = match solver.factors() {
+        Some(f) => f,
+        None => {
+            println!("SKIP {name}: no factors");
+            return;
+        }
+    };
+
+    println!();
+    println!("=== {name}  n={n}  nnz={nnz}  factor={factor_s:.3}s ===");
+
+    // Which core does `SolveCore::Auto` — the mode `Solver` uses — pick for
+    // this factor? `cb_core_profitable` is private, but the two cores are
+    // different reassociations, so the *bits* identify the choice: run the
+    // refined entry point with `max_steps = 0` (one bare core apply, no
+    // correction) and bit-compare against each explicit core.
+    {
+        let probe_rhs = {
+            let mut v = vec![0.0f64; n];
+            let mut u = vec![0.0f64; n];
+            for (i, s) in u.iter_mut().enumerate() {
+                *s = 1.0 + (i % 7) as f64 / 8.0;
+            }
+            csc.symv(&u, &mut v);
+            v
+        };
+        let mut x_auto = vec![0.0f64; n];
+        let verdict = match solve_sparse_refined_auto_into(
+            &csc,
+            factors,
+            &probe_rhs,
+            &mut x_auto,
+            false,
+            RefineOptions::with_max_steps(0),
+        ) {
+            Err(e) => format!("error: {e:?}"),
+            Ok(()) => {
+                let sv = solve_sparse(factors, &probe_rhs).expect("sv probe");
+                let cb = solve_sparse_cb(factors, &probe_rhs, false).expect("cb probe");
+                let m_sv = sv
+                    .iter()
+                    .zip(&x_auto)
+                    .all(|(a, b)| a.to_bits() == b.to_bits());
+                let m_cb = cb
+                    .iter()
+                    .zip(&x_auto)
+                    .all(|(a, b)| a.to_bits() == b.to_bits());
+                match (m_sv, m_cb) {
+                    (true, false) => "SharedVector".to_string(),
+                    (false, true) => "ContribBlock".to_string(),
+                    (true, true) => "ambiguous (cores agree bitwise)".to_string(),
+                    (false, false) => "neither (unexpected)".to_string(),
+                }
+            }
+        };
+        println!("SolveCore::Auto picks: {verdict}");
+    }
+
+    // End-to-end, through the API a host actually calls. `solve_refined` is
+    // the ONLY `Solver` entry that installs the pool (`solver.rs:1719`), so
+    // `with_parallel(true/false)` isolates the *schedule* — both sides run
+    // whichever core `Auto` picked above, so the arithmetic is unchanged and
+    // this is a pure parallel-vs-serial comparison of the shipped path.
+    {
+        let probe_rhs = {
+            let mut v = vec![0.0f64; n];
+            let mut u = vec![0.0f64; n];
+            for (i, s) in u.iter_mut().enumerate() {
+                *s = 1.0 + (i % 7) as f64 / 8.0;
+            }
+            csc.symv(&u, &mut v);
+            v
+        };
+        let opts = RefineOptions::with_max_steps(1);
+        let timed = |par: bool| -> Option<f64> {
+            let mut sv = Solver::new().with_parallel(par);
+            match sv.factor(&csc, None) {
+                FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+                _ => return None,
+            }
+            let mut x = vec![0.0f64; n];
+            Some(best_of(|| {
+                let _ = sv.solve_refined_into(&csc, &probe_rhs, &mut x, opts);
+                std::hint::black_box(&x);
+            }))
+        };
+        match (timed(false), timed(true)) {
+            (Some(ser), Some(par)) => println!(
+                "E solve_refined(1 step) x1   serial {:8.2} ms   parallel {:8.2} ms   {:.2}x",
+                ser * 1e3,
+                par * 1e3,
+                ser / par
+            ),
+            _ => println!("E solve_refined: factor failed"),
+        }
+    }
+
+    let rhs = build_rhs_block(&csc, NRHS);
+    let col = |c: usize| &rhs[c * n..(c + 1) * n];
+
+    // Correctness first: a fast wrong path is not a lever.
+    let res_a = (0..NRHS)
+        .map(|c| rel_residual(&csc, &solve_sparse(factors, col(c)).expect("A"), col(c)))
+        .fold(0.0f64, f64::max);
+    let res_c = (0..NRHS)
+        .map(|c| {
+            rel_residual(
+                &csc,
+                &solve_sparse_cb(factors, col(c), true).expect("C"),
+                col(c),
+            )
+        })
+        .fold(0.0f64, f64::max);
+    let many = solve_sparse_many(factors, &rhs, NRHS).expect("D");
+    let res_d = (0..NRHS)
+        .map(|c| rel_residual(&csc, &many[c * n..(c + 1) * n], col(c)))
+        .fold(0.0f64, f64::max);
+
+    let a = best_of(|| {
+        for c in 0..NRHS {
+            std::hint::black_box(solve_sparse(factors, col(c)).expect("A"));
+        }
+    });
+    let b = best_of(|| {
+        for c in 0..NRHS {
+            std::hint::black_box(solve_sparse_cb(factors, col(c), false).expect("B"));
+        }
+    });
+    let cpar = best_of(|| {
+        for c in 0..NRHS {
+            std::hint::black_box(solve_sparse_cb(factors, col(c), true).expect("C"));
+        }
+    });
+    let d = best_of(|| {
+        std::hint::black_box(solve_sparse_many(factors, &rhs, NRHS).expect("D"));
+    });
+
+    println!(
+        "{:<28} {:>12} {:>10} {:>12}",
+        "path (nrhs=13)", "wall(ms)", "vs A", "rel.resid"
+    );
+    let row = |label: &str, s: f64, res: Option<f64>| {
+        let r = match res {
+            Some(v) => format!("{v:.2e}"),
+            None => "-".to_string(),
+        };
+        println!("{:<28} {:>12.2} {:>10.2} {:>12}", label, s * 1e3, a / s, r);
+    };
+    row("A serial solve_sparse x13", a, Some(res_a));
+    row("B cb serial x13", b, None);
+    row("C cb PARALLEL x13  (#131)", cpar, Some(res_c));
+    row("D solve_sparse_many(13)", d, Some(res_d));
+
+    // BLAS-3 crossover sweep: per-RHS cost, batched vs looped.
+    println!();
+    println!(
+        "{:>6} {:>14} {:>14} {:>10}   (BLAS3 threshold = 32)",
+        "nrhs", "looped us/rhs", "many us/rhs", "speedup"
+    );
+    for &k in SWEEP.iter() {
+        let blk = build_rhs_block(&csc, k);
+        let looped = best_of(|| {
+            for c in 0..k {
+                std::hint::black_box(solve_sparse(factors, &blk[c * n..(c + 1) * n]).expect("s"));
+            }
+        });
+        let batched = best_of(|| {
+            std::hint::black_box(solve_sparse_many(factors, &blk, k).expect("m"));
+        });
+        println!(
+            "{:>6} {:>14.1} {:>14.1} {:>10.2}",
+            k,
+            looped * 1e6 / k as f64,
+            batched * 1e6 / k as f64,
+            looped / batched
+        );
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "r05_kkt".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+        ]
+    } else {
+        args
+    };
+    println!(
+        "rayon threads = {}  |  best-of-{} wall clock",
+        rayon::current_num_threads(),
+        REPS
+    );
+    for nm in names {
+        let p = format!("tests/data/large/{nm}.mtx");
+        run(Path::new(&p));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_largen_solve_levers.rs
+++ b/crates/feral-diagnostics/src/bin/probe_largen_solve_levers.rs
@@ -147,7 +147,7 @@ fn run(path: &Path) {
             RefineOptions::with_max_steps(0),
         ) {
             Err(e) => format!("error: {e:?}"),
-            Ok(()) => {
+            Ok(_) => {
                 let sv = solve_sparse(factors, &probe_rhs).expect("sv probe");
                 let cb = solve_sparse_cb(factors, &probe_rhs, false).expect("cb probe");
                 let m_sv = sv

--- a/crates/feral-diagnostics/src/bin/probe_omega_parity_corpus.rs
+++ b/crates/feral-diagnostics/src/bin/probe_omega_parity_corpus.rs
@@ -1,0 +1,151 @@
+//! Does the badly-scaled-RHS componentwise defect reproduce on the
+//! *tracked* parity corpus? (The large fixtures are gitignored, so a CI
+//! regression test has to live on these.)
+//!
+//!   cargo run -p feral-diagnostics --bin probe_omega_parity_corpus --release
+
+use feral::numeric::solve::{RefineOptions, StopCriterion};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+
+fn omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut om = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > om {
+            om = v;
+        }
+    }
+    om
+}
+
+fn hard_rhs(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let v: Vec<f64> = (0..n)
+        .map(|i| {
+            let mag = 10f64.powi(((i % 13) as i32) - 6);
+            if i % 2 == 0 {
+                mag
+            } else {
+                -mag
+            }
+        })
+        .collect();
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn main() {
+    let root = Path::new("tests/data/parity");
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(fams) = std::fs::read_dir(root) {
+        for fam in fams.flatten() {
+            if let Ok(files) = std::fs::read_dir(fam.path()) {
+                for f in files.flatten() {
+                    let p = f.path();
+                    if p.extension().map(|e| e == "mtx").unwrap_or(false) {
+                        paths.push(p);
+                    }
+                }
+            }
+        }
+    }
+    for p in [
+        Path::new("tests/data/large/sawpath_kkt.mtx"),
+        Path::new("tests/data/large/twirism1_kkt.mtx"),
+    ] {
+        if p.exists() {
+            paths.push(p.to_path_buf());
+        }
+    }
+    paths.sort();
+    let target = f64::EPSILON.sqrt();
+    println!(
+        "{:28} {:>7} {:>11} {:>4} {:>11} {:>4} {:>11}",
+        "matrix", "n", "eps_om", "it", "def_om", "it", "unref_om"
+    );
+    let mut worst: Vec<(f64, String)> = Vec::new();
+    for p in &paths {
+        let Ok(mtx) = read_mtx(p) else { continue };
+        let Ok(csc) = mtx.to_csc() else { continue };
+        let n = csc.n;
+        let b = hard_rhs(&csc);
+        let mut s = Solver::new();
+        if !matches!(
+            s.factor(&csc, None),
+            FactorStatus::Success | FactorStatus::WrongInertia { .. }
+        ) {
+            continue;
+        }
+        let name = p
+            .file_stem()
+            .map(|x| x.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let mut xe = vec![0.0f64; n];
+        let Ok(oe) = s.solve_refined_into(
+            &csc,
+            &b,
+            &mut xe,
+            RefineOptions::default().and_stop(StopCriterion::EpsSqrtN),
+        ) else {
+            continue;
+        };
+        let om_e = omega(&csc, &xe, &b);
+
+        let mut xd = vec![0.0f64; n];
+        let Ok(od) = s.solve_refined_into(&csc, &b, &mut xd, RefineOptions::default()) else {
+            continue;
+        };
+        let om_d = omega(&csc, &xd, &b);
+
+        let mut xu = vec![0.0f64; n];
+        let Ok(_) =
+            s.solve_refined_into(&csc, &b, &mut xu, RefineOptions::default().and_max_steps(0))
+        else {
+            continue;
+        };
+        let om_u = omega(&csc, &xu, &b);
+
+        let flag = if om_e > target && om_d <= target {
+            "  <== FIXED"
+        } else if om_d > target {
+            "  !! still bad"
+        } else {
+            ""
+        };
+        println!(
+            "{name:28} {n:>7} {om_e:>11.3e} {:>4} {om_d:>11.3e} {:>4} {om_u:>11.3e}{flag}",
+            oe.steps, od.steps
+        );
+        if om_e > target {
+            worst.push((om_e / target, name));
+        }
+    }
+    worst.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    println!(
+        "\nEpsSqrtN leaves omega > sqrt(eps) on {} of {} matrices",
+        worst.len(),
+        paths.len()
+    );
+    for (r, n) in worst.iter().take(12) {
+        println!("  {n:28} omega/sqrt(eps) = {r:.3e}");
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_pivot_threshold_residual.rs
+++ b/crates/feral-diagnostics/src/bin/probe_pivot_threshold_residual.rs
@@ -1,0 +1,171 @@
+//! Does raising the pivot threshold fix the unrefined residual?
+//!
+//!   cargo run -p feral-diagnostics --bin probe_pivot_threshold_residual --release [-- <name>...]
+//!
+//! `probe_forceaccept_residual` established that `ZeroPivotAction::ForceAccept`
+//! never fires on these matrices (`inertia.zero == 0`, `n_tiny == 0`), so the
+//! residual issue #190 attributes to it comes from somewhere else. The
+//! remaining suspect is the pivot threshold itself: feral's multifrontal
+//! default is `pivot_threshold = 1e-8` (`numeric/factorize.rs:645`), where
+//! MA57's `CNTL(1)` and MUMPS's `CNTL(1)` both default to `0.01` -- six
+//! orders of magnitude tighter. A loose threshold accepts pivots that are
+//! small relative to their column, and threshold partial pivoting then only
+//! promises `|L_ij| <= 1/u`, i.e. multipliers up to 1e8.
+//!
+//! This probe sweeps `u` and reports what it costs and what it buys: the
+//! unrefined (`max_steps = 0`) relative residual and componentwise backward
+//! error, against factor wall time, `nnz(L)`, and how many pivots got
+//! delayed up the tree as a result.
+//!
+//! If the residual falls as `u` rises, the "unrefined solve is untrustworthy"
+//! problem is a *tuning* problem with a real fix, not something a caller has
+//! to work around with a refinement knob.
+
+use feral::numeric::factorize::NumericParams;
+use feral::numeric::solve::RefineOptions;
+use feral::symbolic::supernode::SupernodeParams;
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+const REPS: usize = 3;
+
+fn residual_and_omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> (f64, f64) {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let rn = r.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let bn = b.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let rel = if bn > 0.0 { rn / bn } else { rn };
+
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut omega = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > omega {
+            omega = v;
+        }
+    }
+    (rel, omega)
+}
+
+fn build_rhs_easy(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = 1.0 + (i % 7) as f64 / 8.0;
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: {e}");
+            return;
+        }
+    };
+    let csc = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+    let b = build_rhs_easy(&csc);
+    println!();
+    println!("=== {name}  n={n}  nnz={} ===", csc.nnz());
+    println!(
+        "{:>10}  {:>9}  {:>10}  {:>11}  {:>10}  {:>5}  {:>6}  {:>7}",
+        "u", "factor(s)", "nnzL", "min|piv|", "unref rel", "zero", "n_tiny", "omega"
+    );
+
+    // 1e-8 is feral's shipped multifrontal default; 0.01 is MA57's and
+    // MUMPS's CNTL(1); 0.5 is `pivtol_max`, the MA27-style ceiling that
+    // `Solver::increase_quality` walks toward.
+    for u in [1e-8f64, 1e-6, 1e-4, 1e-2, 1e-1, 0.5] {
+        let mut np = NumericParams::default();
+        np.bk.pivot_threshold = u;
+        let mut best = f64::INFINITY;
+        let mut solver = Solver::with_params(np.clone(), SupernodeParams::default());
+        for _ in 0..REPS {
+            let mut s = Solver::with_params(np.clone(), SupernodeParams::default());
+            let t = Instant::now();
+            let st = s.factor(&csc, None);
+            let el = t.elapsed().as_secs_f64();
+            if !matches!(
+                st,
+                FactorStatus::Success | FactorStatus::WrongInertia { .. }
+            ) {
+                println!("{u:>10.1e}  factor {st:?}");
+                return;
+            }
+            if el < best {
+                best = el;
+            }
+            solver = s;
+        }
+        let (nnzl, min_piv, n_tiny) = match solver.factors() {
+            Some(f) => (
+                f.factor_nnz(),
+                f.min_pivot_magnitude().unwrap_or(f64::NAN),
+                f.n_tiny(),
+            ),
+            None => {
+                println!("{u:>10.1e}  no factors");
+                continue;
+            }
+        };
+        let zero = solver.inertia().map(|i| i.zero).unwrap_or(usize::MAX);
+        let mut x = vec![0.0f64; n];
+        let unref = RefineOptions::default().and_max_steps(0);
+        if solver.solve_refined_into(&csc, &b, &mut x, unref).is_err() {
+            println!("{u:>10.1e}  solve error");
+            continue;
+        }
+        let (rel, om) = residual_and_omega(&csc, &x, &b);
+        println!(
+            "{u:>10.1e}  {best:>9.3}  {nnzl:>10}  {min_piv:>11.3e}  {rel:>10.3e}  \
+             {zero:>5}  {n_tiny:>6}  {om:>7.3e}"
+        );
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "qap15_kkt".into(),
+            "cont5_late_kkt".into(),
+            "r05_kkt".into(),
+            "cont-201".into(),
+        ]
+    } else {
+        args
+    };
+    println!("best-of-{REPS} factor wall; unrefined = max_steps 0, well-scaled RHS");
+    for nm in names {
+        let p = format!("tests/data/large/{nm}.mtx");
+        run(Path::new(&p));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_refine_stop_criterion.rs
+++ b/crates/feral-diagnostics/src/bin/probe_refine_stop_criterion.rs
@@ -1,0 +1,228 @@
+//! Measure what issue #190's stopping criteria buy on IPM-scale KKT
+//! matrices.
+//!
+//!   cargo run -p feral-diagnostics --bin probe_refine_stop_criterion --release [-- <name>...]
+//!
+//! #190's claim is that the hardwired `eps*sqrt(n)` target is unreachable
+//! at IPM scale, so every refined solve runs the full `max_steps` budget
+//! and pays for corrections the caller did not need. This probe tests that
+//! claim directly: for each matrix it factors once, then runs the same
+//! solve under several `StopCriterion` settings, reporting steps taken,
+//! which exit fired, wall time, and the *quality actually delivered*
+//! (relative residual and componentwise backward error `omega`).
+//!
+//! The comparison that matters is not "fewer steps" — that is trivially
+//! true of any early exit — but "fewer steps at equivalent backward
+//! quality". So every row carries its own omega, and the default row is
+//! the reference.
+//!
+//! Everything goes through `Solver::solve_refined_into`, the entry point a
+//! host actually calls, so the numbers are the ones pounce would see.
+
+use feral::numeric::solve::{RefineOptions, RefineStop};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver, DEFAULT_REFINE_MAX_STEPS};
+use std::path::Path;
+use std::time::Instant;
+
+/// Best-of-`REPS` wall clock: these are timings on a shared machine and
+/// the minimum is the least noisy estimator of the achievable cost.
+const REPS: usize = 5;
+
+fn residual_and_omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> (f64, f64) {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let rn = r.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let bn = b.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let rel = if bn > 0.0 { rn / bn } else { rn };
+
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut omega = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > omega {
+            omega = v;
+        }
+    }
+    (rel, omega)
+}
+
+/// Deterministic well-scaled RHS with a known O(1) solution. This is the
+/// benign case: every entry of `b` is the same order of magnitude.
+fn build_rhs_easy(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = 1.0 + (i % 7) as f64 / 8.0;
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+/// Badly-scaled RHS: entries span twelve orders of magnitude and
+/// alternate sign. This is the case the componentwise criterion exists
+/// for -- `||r||_2/||b||_2` is dominated by the few large rows and says
+/// nothing about the small ones, while `omega` weighs every row against
+/// its own magnitude.
+fn build_rhs_hard(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        let mag = 10f64.powi(((i % 13) as i32) - 6);
+        *s = if i % 2 == 0 { mag } else { -mag };
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: {e}");
+            return;
+        }
+    };
+    let csc = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return;
+        }
+    };
+    let n = csc.n;
+    let mut solver = Solver::new();
+    let t = Instant::now();
+    let status = solver.factor(&csc, None);
+    let factor_s = t.elapsed().as_secs_f64();
+    match &status {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return;
+        }
+    }
+    if solver.factors().is_none() {
+        println!("SKIP {name}: no factors");
+        return;
+    }
+    let eps_sqrt_n = f64::EPSILON * (n as f64).sqrt();
+    println!();
+    println!(
+        "=== {name}  n={n}  nnz={}  factor={factor_s:.3}s  eps*sqrt(n)={eps_sqrt_n:.3e} ===",
+        csc.row_idx.len()
+    );
+    for (rhs_kind, b) in [
+        ("easy (uniform scale)", build_rhs_easy(&csc)),
+        ("hard (1e-6..1e6, alternating sign)", build_rhs_hard(&csc)),
+    ] {
+        println!("-- RHS: {rhs_kind}");
+        println!(
+            "{:<28} {:>5} {:>10} {:>10} {:>11} {:>11} {:>7}",
+            "criterion", "steps", "stop", "wall(s)", "rel", "omega", "vs def"
+        );
+        let cases: Vec<(String, RefineOptions)> = vec![
+            (
+                format!("EpsSqrtN (default, k={DEFAULT_REFINE_MAX_STEPS})"),
+                RefineOptions::default(),
+            ),
+            (
+                "BackwardError(1e-14)".into(),
+                RefineOptions::with_backward_error(1e-14),
+            ),
+            (
+                "BackwardError(1e-12)".into(),
+                RefineOptions::with_backward_error(1e-12),
+            ),
+            (
+                "BackwardError(1e-10)".into(),
+                RefineOptions::with_backward_error(1e-10),
+            ),
+            (
+                "RelativeResidual(1e-12)".into(),
+                RefineOptions::with_target(1e-12),
+            ),
+            (
+                "max_steps=0 (unrefined)".into(),
+                RefineOptions::with_max_steps(0),
+            ),
+        ];
+
+        let mut baseline = f64::NAN;
+        for (label, opts) in cases {
+            let mut x = vec![0.0f64; n];
+            let mut outcome = None;
+            let mut best = f64::INFINITY;
+            for _ in 0..REPS {
+                let t = Instant::now();
+                let o = match solver.solve_refined_into(&csc, &b, &mut x, opts) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        println!("{label:<28} error: {e:?}");
+                        break;
+                    }
+                };
+                let s = t.elapsed().as_secs_f64();
+                if s < best {
+                    best = s;
+                }
+                outcome = Some(o);
+            }
+            let Some(o) = outcome else { continue };
+            let (rel, omega) = residual_and_omega(&csc, &x, &b);
+            if baseline.is_nan() {
+                baseline = best;
+            }
+            let stop = match o.stop {
+                RefineStop::Converged => "Converged",
+                RefineStop::MaxSteps => "MaxSteps",
+                RefineStop::Stagnated => "Stagnated",
+                RefineStop::Diverged => "Diverged",
+            };
+            println!(
+                "{label:<28} {:>5} {stop:>10} {best:>10.4} {rel:>11.3e} {omega:>11.3e} {:>6.2}x",
+                o.steps,
+                baseline / best
+            );
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "r05_kkt".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+            "bratu3d".into(),
+        ]
+    } else {
+        args
+    };
+    println!("best-of-{REPS} wall clock");
+    for nm in names {
+        let p = format!("tests/data/large/{nm}.mtx");
+        run(Path::new(&p));
+    }
+}

--- a/crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs
+++ b/crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs
@@ -1,0 +1,260 @@
+//! Which of the three differences between the bench's solve and the
+//! shipped solve actually moves the number?
+//!
+//!   cargo run -p feral-diagnostics --bin probe_solve_reconcile --release [-- <name>...]
+//!
+//! Two earlier probes disagreed about whether feral#131's parallel solve
+//! core is worth anything, and the disagreement turned out to be a
+//! measurement artifact: they were not comparing the same two things.
+//!
+//!   * `probe_largen_solve_levers` compared `Solver::with_parallel(true)`
+//!     against `Solver::with_parallel(false)` at `max_steps = 1`. Both
+//!     sides run `SolveCore::Auto`, so that is a pure *schedule*
+//!     comparison. It reported geomean 0.92 (parallel slower).
+//!
+//!   * `probe_bench_solve_noise` compared `Solver::with_parallel(true)`
+//!     against the free `solve_sparse_refined` at `max_steps = 10`. The
+//!     free function hardcodes `SolveCore::SharedVector`
+//!     (`src/numeric/solve.rs:2077`) while `Solver` runs `Auto` — which
+//!     picks `ContribBlock` on six of these seven matrices. So that ratio
+//!     folds the *core* change in with the schedule change, at a
+//!     different refinement depth. It reported geomean 1.21 (parallel
+//!     faster).
+//!
+//! Neither number was wrong; they answer different questions. This probe
+//! measures all three configurations interleaved in one process, at both
+//! refinement depths, so core / schedule / depth can be attributed
+//! separately:
+//!
+//!   sv  `solve_sparse_refined_opts`      SharedVector, serial  <- the bench
+//!   au  `Solver` (serial)                Auto,         serial
+//!   ap  `Solver::with_parallel(true)`    Auto,         parallel <- hosts
+//!
+//! and reports three ratios (>1 means the second config is faster):
+//!
+//!   core     sv/au   what `Auto` picking ContribBlock buys, serially
+//!   sched    au/ap   what feral#131's parallel schedule buys
+//!   shipped  sv/ap   what a host gets over what the bench measures
+//!
+//! Configurations are interleaved within each repetition rather than run
+//! in blocks, so machine drift and thermal state hit all three equally.
+
+use feral::numeric::solve::{
+    solve_sparse_refined_opts, solve_sparse_refined_with_diagnostics_opts, RefineOptions,
+};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+/// Odd, so the median is a measured sample rather than an average.
+const REPS: usize = 11;
+
+fn median(v: &[f64]) -> f64 {
+    let mut s = v.to_vec();
+    s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    s[s.len() / 2]
+}
+
+fn geomean(v: &[f64]) -> f64 {
+    if v.is_empty() {
+        return f64::NAN;
+    }
+    (v.iter().map(|x| x.ln()).sum::<f64>() / v.len() as f64).exp()
+}
+
+struct Row {
+    name: String,
+    steps: usize,
+    /// `[depth1, depth10]` medians in microseconds for sv / au / ap.
+    sv: [f64; 2],
+    au: [f64; 2],
+    ap: [f64; 2],
+}
+
+fn run(path: &Path) -> Option<Row> {
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let mtx = match read_mtx(path) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("SKIP {name}: read_mtx: {e}");
+            return None;
+        }
+    };
+    let csc: CscMatrix = match mtx.to_csc() {
+        Ok(c) => c,
+        Err(e) => {
+            println!("SKIP {name}: to_csc: {e}");
+            return None;
+        }
+    };
+    let n = csc.n;
+
+    let mut ser = Solver::new();
+    match ser.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: factor {other:?}");
+            return None;
+        }
+    }
+    let mut par = Solver::new().with_parallel(true);
+    match par.factor(&csc, None) {
+        FactorStatus::Success | FactorStatus::WrongInertia { .. } => {}
+        other => {
+            println!("SKIP {name}: parallel factor {other:?}");
+            return None;
+        }
+    }
+    // `tests/parallel_parity.rs` contracts the two factors to be bit-equal,
+    // so `ser` and `par` differ only in whether a pool is installed.
+    let factors = ser.factors()?;
+
+    // Well-scaled deterministic RHS with a known O(1) solution, so the
+    // refinement loop does a representative amount of work rather than
+    // converging on the first iterate.
+    let mut rhs = vec![0.0f64; n];
+    let mut v = vec![0.0f64; n];
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = 1.0 + (i % 7) as f64 / 8.0;
+    }
+    csc.symv(&v, &mut rhs);
+
+    // How many corrections the default depth actually runs. If this is 1
+    // then "depth 1" and "depth 10" are the same call and the two probes
+    // could not have differed on depth alone.
+    let deep = RefineOptions::default();
+    let steps = match solve_sparse_refined_with_diagnostics_opts(&csc, factors, &rhs, deep) {
+        Ok((_, d)) => d.steps.len().saturating_sub(1),
+        Err(e) => {
+            println!("SKIP {name}: diagnostics: {e}");
+            return None;
+        }
+    };
+
+    let depths = [RefineOptions::with_max_steps(1), deep];
+    let mut sv = [0.0f64; 2];
+    let mut au = [0.0f64; 2];
+    let mut ap = [0.0f64; 2];
+
+    for (d, opts) in depths.iter().enumerate() {
+        let (mut t_sv, mut t_au, mut t_ap) = (Vec::new(), Vec::new(), Vec::new());
+        let mut x = vec![0.0f64; n];
+        for _ in 0..REPS {
+            let t = Instant::now();
+            match solve_sparse_refined_opts(&csc, factors, &rhs, *opts) {
+                Ok(y) => {
+                    std::hint::black_box(&y);
+                }
+                Err(e) => {
+                    println!("SKIP {name}: sv solve: {e}");
+                    return None;
+                }
+            }
+            t_sv.push(t.elapsed().as_secs_f64() * 1e6);
+
+            let t = Instant::now();
+            if let Err(e) = ser.solve_refined_into(&csc, &rhs, &mut x, *opts) {
+                println!("SKIP {name}: au solve: {e}");
+                return None;
+            }
+            std::hint::black_box(&x);
+            t_au.push(t.elapsed().as_secs_f64() * 1e6);
+
+            let t = Instant::now();
+            if let Err(e) = par.solve_refined_into(&csc, &rhs, &mut x, *opts) {
+                println!("SKIP {name}: ap solve: {e}");
+                return None;
+            }
+            std::hint::black_box(&x);
+            t_ap.push(t.elapsed().as_secs_f64() * 1e6);
+        }
+        sv[d] = median(&t_sv);
+        au[d] = median(&t_au);
+        ap[d] = median(&t_ap);
+    }
+
+    for (d, tag) in ["steps=1", "default"].iter().enumerate() {
+        println!(
+            "{name:<20} n={n:<8} {tag:<8} sv {:9.0}  au {:9.0}  ap {:9.0} us   \
+             core {:.2}x  sched {:.2}x  shipped {:.2}x",
+            sv[d],
+            au[d],
+            ap[d],
+            sv[d] / au[d],
+            au[d] / ap[d],
+            sv[d] / ap[d],
+        );
+    }
+    println!(
+        "{:<20} corrections actually run at default depth: {steps}",
+        ""
+    );
+
+    Some(Row {
+        name,
+        steps,
+        sv,
+        au,
+        ap,
+    })
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "bcsstk38".into(),
+            "r05_kkt".into(),
+            "bratu3d".into(),
+            "qap15_kkt".into(),
+            "dirichlet120_kkt".into(),
+            "cont-201".into(),
+            "cont5_late_kkt".into(),
+        ]
+    } else {
+        args
+    };
+    println!(
+        "core / schedule / depth attribution ({REPS} reps, interleaved, 1 RHS)\n\
+         sv = SharedVector serial (the bench)   au = Auto serial   ap = Auto parallel (hosts)\n\
+         ratios > 1 mean the second config is faster\n"
+    );
+    let rows: Vec<Row> = names
+        .iter()
+        .filter_map(|nm| run(&Path::new("tests/data/large").join(format!("{nm}.mtx"))))
+        .collect();
+
+    println!(
+        "\n{:<20} {:>8}  {:>6}  {:>6}  {:>7}",
+        "geomean", "depth", "core", "sched", "shipped"
+    );
+    for (d, tag) in ["steps=1", "default"].iter().enumerate() {
+        let core: Vec<f64> = rows.iter().map(|r| r.sv[d] / r.au[d]).collect();
+        let sched: Vec<f64> = rows.iter().map(|r| r.au[d] / r.ap[d]).collect();
+        let ship: Vec<f64> = rows.iter().map(|r| r.sv[d] / r.ap[d]).collect();
+        println!(
+            "{:<20} {tag:>8}  {:>5.2}x  {:>5.2}x  {:>6.2}x",
+            "",
+            geomean(&core),
+            geomean(&sched),
+            geomean(&ship)
+        );
+    }
+    let deep: Vec<String> = rows
+        .iter()
+        .filter(|r| r.steps > 1)
+        .map(|r| format!("{}({})", r.name, r.steps))
+        .collect();
+    println!(
+        "\nmatrices where default depth runs more than one correction: {}",
+        if deep.is_empty() {
+            "none".to_string()
+        } else {
+            deep.join(" ")
+        }
+    );
+}

--- a/crates/feral-diagnostics/src/bin/probe_vs_mumps_residual.rs
+++ b/crates/feral-diagnostics/src/bin/probe_vs_mumps_residual.rs
@@ -1,0 +1,232 @@
+//! Head-to-head against the canonical MUMPS 5.8.2 oracle on identical systems.
+//!
+//!   cargo run -p feral-diagnostics --bin probe_vs_mumps_residual --release [-- <name>...]
+//!
+//! `probe_pivot_threshold_residual` showed that on `qap15_kkt` feral's
+//! unrefined relative residual sits at ~3e-6 and does not move as the pivot
+//! threshold is swept from 1e-8 to 0.5. That ruled the pivot threshold out as
+//! the cause but left open whether ~3e-6 is simply what the matrix admits.
+//!
+//! The MUMPS oracle (`external_benchmarks/mumps_oracle`, CNTL(1)=0.01,
+//! ICNTL(10)=2 refinement steps) answers that: on the same matrix with the
+//! same RHS it reports relative residual 3.61e-15 and omega1 2.57e-14.
+//!
+//! **That is not a nine-order gap, and an earlier version of this comment was
+//! wrong to call it one.** It compares feral *unrefined* against MUMPS *with*
+//! its refinement enabled. Refined, feral matches or beats MUMPS on all seven
+//! large matrices under this RHS, and the inertia agrees exactly on all seven.
+//! What this probe went on to find is a different defect, visible only under
+//! `HARD_RHS=1`: see the addendum in `dev/research/issue-190-refine-target.md`.
+//!
+//! Environment knobs, both used to produce the tables in that addendum:
+//!
+//! - `HARD_RHS=1` -- build `b = A*v` from `v[i] = +/-10^((i%13)-6)` instead of
+//!   the well-scaled default, i.e. a RHS spanning twelve orders of magnitude,
+//!   the shape an interior-point method produces near convergence. This is the
+//!   regime where the old normwise-only default stopped at step 0 with a
+//!   componentwise error up to 9.5e-5.
+//! - `OMEGA_EPS=1` -- make the probe's omega-only criterion column target
+//!   `f64::EPSILON` (LAPACK `dgerfs`) rather than `sqrt(eps)` (MUMPS
+//!   `CNTL(2)`). Measured and rejected as a default: it stagnates or exhausts
+//!   the step budget on five of the seven large matrices under `HARD_RHS=1`.
+//!
+//! Default RHS is `b = A * v`, `v[i] = 1 + (i % 7) / 8`, byte-identical to the
+//! vector `mkrhs.py` fed the Fortran oracle.
+
+use feral::numeric::solve::{RefineOptions, StopCriterion};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::Path;
+use std::time::Instant;
+
+fn residual_and_omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> (f64, f64) {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let rn = r.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let bn = b.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let rel = if bn > 0.0 { rn / bn } else { rn };
+
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut omega = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > omega {
+            omega = v;
+        }
+    }
+    (rel, omega)
+}
+
+/// `sqrt(eps)` is MUMPS's `CNTL(2)` (`ref/mumps/src/dini_defaults.F:1094`);
+/// `eps` is LAPACK `dgerfs`'s componentwise target. `OMEGA_EPS=1` selects it.
+fn omega_target() -> f64 {
+    if std::env::var("OMEGA_EPS").is_ok() {
+        f64::EPSILON
+    } else {
+        f64::EPSILON.sqrt()
+    }
+}
+
+fn build_rhs_easy(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let mut v = vec![0.0f64; n];
+    let hard = std::env::var("HARD_RHS").is_ok();
+    for (i, s) in v.iter_mut().enumerate() {
+        *s = if hard {
+            let mag = 10f64.powi(((i % 13) as i32) - 6);
+            if i % 2 == 0 {
+                mag
+            } else {
+                -mag
+            }
+        } else {
+            1.0 + (i % 7) as f64 / 8.0
+        };
+    }
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn run(path: &Path) {
+    let name = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let Ok(mtx) = read_mtx(path) else {
+        println!("SKIP {name}: read_mtx");
+        return;
+    };
+    let Ok(csc) = mtx.to_csc() else {
+        println!("SKIP {name}: to_csc");
+        return;
+    };
+    let n = csc.n;
+    let b = build_rhs_easy(&csc);
+
+    let mut s = Solver::new();
+    let t = Instant::now();
+    let st = s.factor(&csc, None);
+    let fac = t.elapsed().as_secs_f64();
+    if !matches!(
+        st,
+        FactorStatus::Success | FactorStatus::WrongInertia { .. }
+    ) {
+        println!("{name:18} factor {st:?}");
+        return;
+    }
+    let (nnzl, min_piv, n_tiny) = match s.factors() {
+        Some(f) => (
+            f.factor_nnz(),
+            f.min_pivot_magnitude().unwrap_or(f64::NAN),
+            f.n_tiny(),
+        ),
+        None => {
+            println!("{name:18} no factors");
+            return;
+        }
+    };
+    let inertia = s.inertia();
+    let (p, ng, z) = match inertia {
+        Some(i) => (i.positive, i.negative, i.zero),
+        None => (usize::MAX, usize::MAX, usize::MAX),
+    };
+
+    let mut xu = vec![0.0f64; n];
+    if s.solve_refined_into(&csc, &b, &mut xu, RefineOptions::default().and_max_steps(0))
+        .is_err()
+    {
+        println!("{name:18} unrefined solve error");
+        return;
+    }
+    let (rel_u, om_u) = residual_and_omega(&csc, &xu, &b);
+
+    let mut xr = vec![0.0f64; n];
+    let t = Instant::now();
+    let out = s.solve_refined_into(&csc, &b, &mut xr, RefineOptions::default());
+    let solve = t.elapsed().as_secs_f64();
+    let (steps, stop) = match &out {
+        Ok(o) => (o.steps, format!("{:?}", o.stop)),
+        Err(_) => {
+            println!("{name:18} refined solve error");
+            return;
+        }
+    };
+    let (rel_r, om_r) = residual_and_omega(&csc, &xr, &b);
+
+    // MUMPS refines to omega <= CNTL(2) = sqrt(eps) (`ref/mumps/src/
+    // dini_defaults.F:1094`). This is the same ladder with feral's
+    // componentwise criterion selected instead of the normwise default.
+    let mut xw = vec![0.0f64; n];
+    let t = Instant::now();
+    let outw = s.solve_refined_into(
+        &csc,
+        &b,
+        &mut xw,
+        RefineOptions::default().and_stop(StopCriterion::BackwardError(omega_target())),
+    );
+    let solve_w = t.elapsed().as_secs_f64();
+    let (steps_w, stop_w) = match &outw {
+        Ok(o) => (o.steps, format!("{:?}", o.stop)),
+        Err(_) => {
+            println!("{name:18} omega-stop solve error");
+            return;
+        }
+    };
+    let (rel_w, om_w) = residual_and_omega(&csc, &xw, &b);
+
+    println!(
+        "{name:18} {n:>7} {fac:>8.3} {solve:>8.3} {nnzl:>10} {min_piv:>10.2e} {n_tiny:>6} \
+         {p}/{ng}/{z:<6} {rel_u:>10.3e} {om_u:>10.3e} {steps:>3} {rel_r:>10.3e} {om_r:>10.3e}  {steps_w:>3} {rel_w:>10.3e} {om_w:>10.3e} {solve_w:>7.3}  {stop}/{stop_w}"
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let names: Vec<String> = if args.is_empty() {
+        vec![
+            "qap15_kkt".into(),
+            "cont5_late_kkt".into(),
+            "r05_kkt".into(),
+            "cont-201".into(),
+            "bratu3d".into(),
+            "dirichlet120_kkt".into(),
+            "bcsstk38".into(),
+        ]
+    } else {
+        args
+    };
+    println!("feral defaults (Solver::new), RHS b = A*v, v[i] = 1 + (i%7)/8");
+    println!(
+        "{:18} {:>7} {:>8} {:>8} {:>10} {:>10} {:>6} {:>14} {:>10} {:>10} {:>3} {:>10} {:>10}  stop",
+        "matrix",
+        "n",
+        "fac(s)",
+        "sol(s)",
+        "nnzL",
+        "min|piv|",
+        "n_tiny",
+        "inertia p/n/z",
+        "unref rel",
+        "unref om",
+        "it",
+        "ref rel",
+        "ref om"
+    );
+    for nm in names {
+        let p = format!("tests/data/large/{nm}.mtx");
+        run(Path::new(&p));
+    }
+}

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,84 +1,84 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T13:59:26Z
+Generated: 2026-08-20T16:15:53Z
 
 ## Latest Session
-File: dev/sessions/2026-08-20-01.md
+File: dev/sessions/2026-08-20-02.md
 ```
-# Session 2026-08-20-01
+# Session 2026-08-20-02
 
 ## Unfavorable comparison, reported first (per CLAUDE.md)
 
-**A bench run in this session FAILED the Phase 2.8.1 sparse exit gate**:
-sparse small-frontal factor p90 **2.03 vs target ≤ 2.0**, against a
-baseline of 1.58 from session 2026-08-19-05. It was caused by a change
-made in this session and is now fixed; two confirming runs report 1.54
-and 1.61, both PASS. The full arc is in **Regression** below, including
-the hypothesis I published in the journal that the control run refuted.
+The session-end bench is at or slightly above the top of the previously
+observed band on the factor partitions:
 
-**Two conclusions I had posted publicly in the previous session were
-wrong and have been retracted**, both from the same methodological
-error. See **Corrections** below.
+| bucket | baseline 08-19-05 | 08-20-01 runs | this run |
+|---|---:|---:|---:|
+| sparse small-frontal p90 | 1.58 | 1.54 / 1.61 | **1.65** |
+| sparse medium p90 | 1.58 | 1.54 / 1.61 | **1.65** |
+| dense small-frontal p90 | 1.58 | 1.59 / 1.64 | **1.66** |
+| dense medium p90 | 2.00 | 1.96 / 1.98 | **2.04** |
+
+All four still PASS their targets, and `solve/MUMPS` geomean and p50 held at
+0.08 exactly. But this is the worst of the four runs recorded across the two
+sessions, and it is +4.4% on the sparse buckets against the 08-19-05 baseline.
+
+**This session's change cannot mechanically account for it.** The bench times
+factorization and a *single-RHS* solve; the change is confined to
+`solve_sparse_core_many_into` and the panel GEMM reached only from
+`fwd_blas3`/`back_blas3`, which the multi-RHS path alone calls. The
+single-RHS core (`solve_sparse_core_into`) and the whole factorization are
+untouched.
+
+The likely cause is machine state — the box had been under sustained compile
+and benchmark load for hours before this run. That is a hypothesis, not a
+result: I did not run a control on stashed code to test it, as was done on
+08-20-01 to refute a similar attribution. **Next session should re-run the
+bench cold before reading anything into these numbers.**
 
 ## Goal
 
-Continue the prioritized list from issue #189 / #131:
+Answer issue #189 item 4: is `BLAS3_NRHS_THRESHOLD = 32` costing pounce
+anything? Under the standing bar for this work — rigorous, thoroughly
+correct, and a real performance gain, or it does not ship.
 
-1. (pounce-side, filed at pounce#698 — no feral work)
-2. **#189 items 1–3, the large-n solve gate** ← this session
-3. #189 item 4, `BLAS3_NRHS_THRESHOLD` — blocked on (1)
-4. #131 — rescope, do not implement `solve_auto`
+## Accomplished
 
-Before starting (2), settle a contradiction: two probes from the previous
-session disagreed about whether the solve measurement was reproducible at
-all. They were separate probes on separate runs, so nothing could be
-concluded from the pair.
+### The threshold is fine. There was a defect underneath it.
 
-## Corrections — blocked measurement produced two wrong published claims
+`BLAS3_NRHS_THRESHOLD` is unchanged at 32. What the investigation found
+instead: the row-major multi-RHS work buffers used a leading dimension of
+exactly `nrhs`, so any `nrhs` that is not a multiple of 8 makes every row of
+every supernode panel straddle a cache line, compounding across the gather,
+the kernels and the scatter.
 
-The previous session's probes timed configuration A to completion, then
-configuration B. That lets machine drift between the two blocks appear as
-an effect of the configuration. Re-measuring with A and B **interleaved
-inside each repetition** removed it. On the strength of the blocked
-numbers I had posted:
-
-- **"The measurement is not reproducible"**, with a spread table showing
-  1.44×–2.20× movement on the same matrix. **Retracted.** The
-  irreproducibility was my method, not the solver.
-- **"`cb_core_profitable` looks mis-calibrated"**, specifically that it
-  approves `ContribBlock` on `r05_kkt` where the approved configuration
-  runs at 0.67×. **Retracted.** Interleaved, `r05_kkt` runs at **1.65×
-  faster** — a 2.4× error on the same machine with the same binary. The
-  gate is correct on **7 of 7** matrices.
-
-Retractions posted:
-- feral#131 — https://github.com/jkitchin/feral/issues/131#issuecomment-5356330763
-- feral#189 — https://github.com/jkitchin/feral/issues/189#issuecomment-5356336437
-
+Evidence, all within a single process so no cross-process drift can reach it.
+`t(31)/t(32)` — `nrhs = 31` is 3% *less* work, so a healthy kernel gives
+~0.97:
 ```
 
 ## Git Status
 ```
+a0b4d64 perf(solve): align the multi-RHS row stride to a cache line
+c34475e docs: session checkpoint 2026-08-20-01 (measurement corrections, #189 Step 1)
 c09da70 bench: time the solve core hosts actually run (#189 item 1)
 2ba437d probe: separate core, schedule, and depth in the solve measurement (#131, #189)
 0ac4fb1 probe: measure the solve-phase levers claimed in #131 and #189
-9b9e882 Merge pull request #188 from jkitchin/ci/codecov-coverage
-1292984 ci: measure coverage with cargo-llvm-cov and report it to Codecov
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
+test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
@@ -86,114 +86,88 @@ test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.71s
+test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 3.44s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-01.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-02.md)
 
-
-Three full corpus runs plus the 08-19-05 baseline:
-
-| bucket | baseline 08-19-05 | control (unmodified) | run 2 | run 3 |
-|---|---:|---:|---:|---:|
-| sparse small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
-| sparse medium p90 (≤3.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
-| dense small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.59 PASS | 1.64 PASS |
-| dense medium p90 (≤3.0) | 2.00 PASS | 2.00 PASS | 1.96 PASS | 1.98 PASS |
-
-The two post-change runs **bracket** the baseline (1.54, 1.61 vs 1.58).
-The honest reading is that the change is indistinguishable from baseline
-on the factor partition — which is correct, since it touches only the
-solve. **The 1.54 is not claimed as an improvement.** Run-to-run spread
-on this machine is ~±2.5%; that is now recorded in the plan as the floor
-below which a bench claim is noise.
-
-Run 3, full sparse aggregate:
-
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
 
 ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.44       0.30       1.61       3.27       9.71
-solve/MUMPS        153560       0.08       0.08       0.16       0.88       3.12
-factor/SSIDS       154500       0.04       0.03       0.32       0.96       2.26
-solve/SSIDS        154500       0.96       1.00       2.83      10.25      43.00
+factor/MUMPS       153560       0.46       0.33       1.65       4.13      71.94
+solve/MUMPS        153560       0.08       0.08       0.16       0.88      25.59
+factor/SSIDS       154500       0.04       0.03       0.34       1.11      23.34
+solve/SSIDS        154500       0.96       1.00       2.83      10.25     583.65
 nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
 nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.64     <= 2.0     PASS
-medium (<500)            152145     1.98     <= 3.0     PASS
+small-frontal (<200)     147982     1.66     <= 2.0     PASS
+medium (<500)            152145     2.04     <= 3.0     PASS
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.61     <= 2.0     PASS
-medium (<500)            153560     1.61     <= 3.0     PASS
-
-Note on the `factor/MUMPS` **max** column: it reads 9.71 here, 68.79 on
-the FAIL run, and the worst-offender list changes identity between runs
-(CRESC100/MUONSINE ↔ ACOPR14/KIRBY2). That tail is resample-loop noise on
-sub-millisecond matrices. **The max is not a stable statistic in this
-harness and should not be quoted as a result.**
+small-frontal (<200)     153455     1.65     <= 2.0     PASS
+medium (<500)            153560     1.65     <= 3.0     PASS
 
 ```
 
 ## Recent Decisions
-The mechanism is that `resample_or_fallback` (`src/bin/bench.rs:1060`)
-runs factor **and** solve interleaved inside one closure,
-`RESAMPLE_COLD_REPS = 5` times, and reduces `factor_us` by **min** across
-those replicates. Whatever the solve does to cache and allocator state is
-the state the next replicate's factor is measured in. And
-`should_resample` (`:1042`) fires on `mumps_timing.factor_us < 200` — the
-same small matrices the `small-frontal (<200)` bucket gates.
+**Decision:** the panel path allocates and indexes at
+`padded_ldw(nrhs) = nrhs.div_ceil(NR) * NR`, i.e. a multiple of 64 bytes.
+The rank-1 path keeps the raw `nrhs` stride — it is row-major but not
+tiled, and it carries the bit-identity band contract that
+`tests/multi_rhs.rs:227,256` assert and pounce's `schur.rs:303` consumes.
 
-The change had allocated its solve buffer inside the closure: an n-double
-alloc-and-zero per replicate at n < 1000. Hoisting it to one allocation
-per matrix, reused across replicates, restored the partition to 1.54 PASS
-(dense 1.59 / 1.96 PASS) and dropped the worst sparse factor ratio from
-68.79 to 9.29.
+The padding is paid for in flops: the kernels solve `padded_ldw(nrhs)`
+columns, of which up to 7 are zero padding. That is 21% extra arithmetic at
+`nrhs = 33`, 7% at 100, under 1% at 1000 — and it is still a net 1.36×
+geomean win in the shipped regime (`nrhs >= 32`, not a multiple of 8),
+because the alignment is worth more than the wasted lanes. After the fix
+`t(33)/t(32) ≈ 1.21`, which is exactly `40/33`: the residual is entirely
+the padding columns, with no misalignment left.
 
-**The coupling itself is left in place, deliberately.** It is
-pre-existing: any solve-side change can perturb the small-matrix factor
-reading through it. Fixing it means giving factor and solve separate
-timing passes, which changes every small-matrix number in the corpus and
-needs its own commit with its own before/after — not a drive-by inside a
-different change. Recorded as a Step 1 item in
-`dev/plans/large-n-solve-gate.md`.
+**Alternative not taken:** pad the *allocation* for alignment but iterate
+only the `nrhs` live columns, masking the final tile. `gemm_tile` already
+takes a `live` argument, so the kernel side is ready. It recovers roughly
+the remaining 18% at `nrhs = 33`. It is not part of this decision because
+it requires distinguishing stride from live width through five kernels, and
+that belongs in its own commit with its own before/after.
 
-*Spread, added after a third confirming run:* the sparse small-frontal
-p90 reads 1.54 and 1.61 on the two post-fix runs against a 1.58 baseline
-— the change is indistinguishable from baseline on the factor partition,
-which is the correct outcome for a solve-only change. The 1.54 above is a
-single draw, not an improvement. Run-to-run spread on this machine is
-~±2.5%; the `factor/MUMPS` **max** column is not stable at all (9.71 here,
-68.79 on the failing run, with the offender list changing identity) and
-should not be quoted as a result.
+**Bit-neutral**, verified three independent ways: an 800-shape `to_bits()`
+test against a scalar left-fold reference (`gemm_tail_tests`); the probe's
+`max |rank1 - blas3|` column unchanged at all 105 measured (matrix, `nrhs`)
+points; and all 13 `tests/multi_rhs.rs` green including both
+`assert_eq!(max_diff, 0.0)` band contracts. No tolerance was touched.
+
+`BLAS3_NRHS_THRESHOLD` stays at 32 — the crossover constant was the
+suspect, but the defect was underneath it, and the threshold is load-bearing
+for the bit-identity contract.
 
 ## Recent Tried-and-Rejected
-total factor time** on a matrix whose paying bucket is 91% of that time. Moving
-three quarters of the panel share into BLAS-3 buys 1.3%: the two kernels cost
-nearly the same per flop at this front shape, so the 53.5% panel share is not
-recoverable time.
+**Why.** A full sweep is ~25 minutes, so two "adjacent" runs are 25 minutes
+apart. That is blocked measurement with an interleaved label on it — the same
+error behind the two claim retractions earlier the same day, one level up the
+stack. Cross-process A/B of a few-millisecond kernel does not work on this
+machine at this cadence.
 
-It also does not generalize. `bs = 48` and `bs = 64` are identical for any front
-with `ncol ≤ 48`, and that is every other matrix sampled — `ncol` p90 is 1-19
-across clnlbeam, dtoc2, marine_1600, rocket, steering, gasoil_3200, pinene_3200,
-robot_1600, svanberg, nql180, qcqp1500-1c, cont5_2_4_l; only dtoc1nd is at 63. On
-the two with any wide fronts at all the paired sweep finds nothing: nql180 0.990
-(5/12 wins, tied with the default), qcqp1500-1c 0.994 (3/12). A 1.3% win on one
-corpus matrix and a no-op elsewhere is below the bar for changing a global default.
+The remaining runs were killed (`pkill -f probe_blas3_crossover`, 0 left) and
+no number from the paired dataset was reported as a result.
 
-**Kept from this attempt:** `block_size` is bit-neutral on all three matrices
-swept — identical inertia, zero delayed pivots, identical residual, and an
-identical hash over every `L`/`D` bit in storage order across
-`bs ∈ {8,16,24,32,48,62,64}` (`dtoc1nd_0010` 9cb93f568423e6c0, `nql180_0000`
-4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
-is a performance-only change. Not yet established on a matrix that actually
-delays a pivot — all three report `d0`.
+**Replaced by** an in-process design: the `kernel-probe` feature (off by
+default, compiled out entirely) exposes
+`set_blas3_nrhs_threshold`, so one process can time rank-1 and BLAS-3 at the
+*same* `nrhs`, alternating within each repetition — microseconds apart instead
+of 25 minutes. See `dev/research/blas3-threshold-refit.md`.
+
+**Kept from this attempt:** the single-build, single-process runs are valid,
+because looped-vs-batched was measured within one process. Two findings survive
+and are recorded in the research note: the 31→32 dispatch discontinuity (3% more
+work, batched time *drops* 1.36–1.77×), and that at `nrhs ∈ {2, 4}` batching is
+**21–27% slower** than looping single-RHS solves.
 
 ## Source Files
 ```
@@ -348,5 +322,8 @@ tests/sparse_refined.rs
 tests/sqd_fast_path.rs
 tests/static_assembly_maps.rs
 tests/stress_tests.rs
-
-(truncated from      355 lines to 350 line budget)
+tests/symbolic_profiler.rs
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
+```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,70 +1,352 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T02:05:49Z
+Generated: 2026-08-20T13:59:26Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-04.md
+File: dev/sessions/2026-08-20-01.md
 ```
-# Session 2026-08-19-04
+# Session 2026-08-20-01
 
-## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
+## Unfavorable comparison, reported first (per CLAUDE.md)
 
-Reported first, per the hard rule in CLAUDE.md — and for the same reason
-as 2026-08-19-02: `cargo run --bin bench --release` in this container
-finds only the 8 synthetic matrices. The external corpus and the
-MUMPS/SPRAL oracle timings are absent, so both Phase 2.8.1 exit
-partitions report `N/A` and **no comparison against 2026-08-15-02's
-1.61 / 2.00 / 1.67 / 1.67 is possible from this run**. I am not claiming
-those numbers held; they were not measured.
+**A bench run in this session FAILED the Phase 2.8.1 sparse exit gate**:
+sparse small-frontal factor p90 **2.03 vs target ≤ 2.0**, against a
+baseline of 1.58 from session 2026-08-19-05. It was caused by a change
+made in this session and is now fixed; two confirming runs report 1.54
+and 1.61, both PASS. The full arc is in **Regression** below, including
+the hypothesis I published in the journal that the control run refuted.
 
-What the run does confirm, identical to last session: inertia 2/2 vs
-MUMPS, residual 2/2, worst residual 1.26e-16.
-
-It is also the wrong benchmark for this change, which touches solve
-*scheduling* and not the factor path. The measurements that matter are
-in "Benchmark Results" below.
+**Two conclusions I had posted publicly in the previous session were
+wrong and have been retracted**, both from the same methodological
+error. See **Corrections** below.
 
 ## Goal
 
-Fix issue #175 — the tree-parallel solve added for #131 Gap A is a net
-15% loss on the wide-sparse Mittelmann KKT `NARX_CFy`, and
-`CbTaskPlan::worthwhile` has no per-call-overhead term.
+Continue the prioritized list from issue #189 / #131:
 
-## Accomplished
+1. (pounce-side, filed at pounce#698 — no feral work)
+2. **#189 items 1–3, the large-n solve gate** ← this session
+3. #189 item 4, `BLAS3_NRHS_THRESHOLD` — blocked on (1)
+4. #131 — rescope, do not implement `solve_auto`
 
-### The report is real, and it is purely a scheduling bug
+Before starting (2), settle a contradiction: two probes from the previous
+session disagreed about whether the solve measurement was reproducible at
+all. They were separate probes on separate runs, so nothing could be
+concluded from the pair.
 
-The reporter serialized the tree-parallel solve with `FERAL_CB_THRESH`
-and recovered 7.35 s of 49.41 s (15%) plus ~3.0M involuntary context
-switches, on 14 cores over 100 IPM iterations. Two things follow that
-the issue does not state:
+## Corrections — blocked measurement produced two wrong published claims
 
-1. `FERAL_CB_THRESH` does not choose the solve *core* — since #177 that
-   is `cb_core_profitable`, which reads neither the worker count nor the
-   environment. A huge threshold collapses the plan to one task, so the
-   **same** CB core runs serially. The whole 7.35 s is scheduling
-   overhead, and fixing it cannot move a bit of any solve.
-2. Rows 3 and 4 of the reporter's table are within noise, so the CB core
-   running serially already matches switching parallelism off entirely
-   on this problem. Nothing in the report argues for changing which core
-   runs.
+The previous session's probes timed configuration A to completion, then
+configuration B. That lets machine drift between the two blocks appear as
+an effect of the configuration. Re-measuring with A and B **interleaved
+inside each repetition** removed it. On the strength of the blocked
+numbers I had posted:
 
-### Mechanism: the overhead is per front, not per task
+- **"The measurement is not reproducible"**, with a spread table showing
+  1.44×–2.20× movement on the same matrix. **Retracted.** The
+  irreproducibility was my method, not the solver.
+- **"`cb_core_profitable` looks mis-calibrated"**, specifically that it
+  approves `ContribBlock` on `r05_kkt` where the approved configuration
+  runs at 0.67×. **Retracted.** Interleaved, `r05_kkt` runs at **1.65×
+  faster** — a 2.4× error on the same machine with the same binary. The
+  gate is correct on **7 of 7** matrices.
 
-`cb_run_parallel` takes the shared `contribs` mutex inside its per-front
-loop — once per child drained, once to store the front's own block. That
-cost scales with the supernode count; `MIN_TOTAL_COST` is a floor on
-*total* work. `NARX_CFy` has 45,736 supernodes and a Lagrangian Hessian
+Retractions posted:
+- feral#131 — https://github.com/jkitchin/feral/issues/131#issuecomment-5356330763
+- feral#189 — https://github.com/jkitchin/feral/issues/189#issuecomment-5356336437
+
 ```
 
 ## Git Status
 ```
-2fbf9b7 Merge pull request #186 from jkitchin/release/0.17.0
-5082eff release: 0.17.0
-a91082b Merge pull request #185 from jkitchin/fix/pre-release-0.17.0
-d758cd8 docs(journal): session 2026-08-19-05 pre-release review entries
-8b97b21 docs: correct pre-release claims across CHANGELOG, README and rustdoc
+c09da70 bench: time the solve core hosts actually run (#189 item 1)
+2ba437d probe: separate core, schedule, and depth in the solve measurement (#131, #189)
+0ac4fb1 probe: measure the solve-phase levers claimed in #131 and #189
+9b9e882 Merge pull request #188 from jkitchin/ci/codecov-coverage
+1292984 ci: measure coverage with cargo-llvm-cov and report it to Codecov
 ```
 
 ## Test Status
 ```
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
+test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
+test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
+
+test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.71s
+
+```
+
+## Benchmark
+```
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-01.md)
+
+
+Three full corpus runs plus the 08-19-05 baseline:
+
+| bucket | baseline 08-19-05 | control (unmodified) | run 2 | run 3 |
+|---|---:|---:|---:|---:|
+| sparse small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
+| sparse medium p90 (≤3.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
+| dense small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.59 PASS | 1.64 PASS |
+| dense medium p90 (≤3.0) | 2.00 PASS | 2.00 PASS | 1.96 PASS | 1.98 PASS |
+
+The two post-change runs **bracket** the baseline (1.54, 1.61 vs 1.58).
+The honest reading is that the change is indistinguishable from baseline
+on the factor partition — which is correct, since it touches only the
+solve. **The 1.54 is not claimed as an improvement.** Run-to-run spread
+on this machine is ~±2.5%; that is now recorded in the plan as the floor
+below which a bench claim is noise.
+
+Run 3, full sparse aggregate:
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.61       3.27       9.71
+solve/MUMPS        153560       0.08       0.08       0.16       0.88       3.12
+factor/SSIDS       154500       0.04       0.03       0.32       0.96       2.26
+solve/SSIDS        154500       0.96       1.00       2.83      10.25      43.00
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.64     <= 2.0     PASS
+medium (<500)            152145     1.98     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.61     <= 2.0     PASS
+medium (<500)            153560     1.61     <= 3.0     PASS
+
+Note on the `factor/MUMPS` **max** column: it reads 9.71 here, 68.79 on
+the FAIL run, and the worst-offender list changes identity between runs
+(CRESC100/MUONSINE ↔ ACOPR14/KIRBY2). That tail is resample-loop noise on
+sub-millisecond matrices. **The max is not a stable statistic in this
+harness and should not be quoted as a result.**
+
+```
+
+## Recent Decisions
+The mechanism is that `resample_or_fallback` (`src/bin/bench.rs:1060`)
+runs factor **and** solve interleaved inside one closure,
+`RESAMPLE_COLD_REPS = 5` times, and reduces `factor_us` by **min** across
+those replicates. Whatever the solve does to cache and allocator state is
+the state the next replicate's factor is measured in. And
+`should_resample` (`:1042`) fires on `mumps_timing.factor_us < 200` — the
+same small matrices the `small-frontal (<200)` bucket gates.
+
+The change had allocated its solve buffer inside the closure: an n-double
+alloc-and-zero per replicate at n < 1000. Hoisting it to one allocation
+per matrix, reused across replicates, restored the partition to 1.54 PASS
+(dense 1.59 / 1.96 PASS) and dropped the worst sparse factor ratio from
+68.79 to 9.29.
+
+**The coupling itself is left in place, deliberately.** It is
+pre-existing: any solve-side change can perturb the small-matrix factor
+reading through it. Fixing it means giving factor and solve separate
+timing passes, which changes every small-matrix number in the corpus and
+needs its own commit with its own before/after — not a drive-by inside a
+different change. Recorded as a Step 1 item in
+`dev/plans/large-n-solve-gate.md`.
+
+*Spread, added after a third confirming run:* the sparse small-frontal
+p90 reads 1.54 and 1.61 on the two post-fix runs against a 1.58 baseline
+— the change is indistinguishable from baseline on the factor partition,
+which is the correct outcome for a solve-only change. The 1.54 above is a
+single draw, not an improvement. Run-to-run spread on this machine is
+~±2.5%; the `factor/MUMPS` **max** column is not stable at all (9.71 here,
+68.79 on the failing run, with the offender list changing identity) and
+should not be quoted as a result.
+
+## Recent Tried-and-Rejected
+total factor time** on a matrix whose paying bucket is 91% of that time. Moving
+three quarters of the panel share into BLAS-3 buys 1.3%: the two kernels cost
+nearly the same per flop at this front shape, so the 53.5% panel share is not
+recoverable time.
+
+It also does not generalize. `bs = 48` and `bs = 64` are identical for any front
+with `ncol ≤ 48`, and that is every other matrix sampled — `ncol` p90 is 1-19
+across clnlbeam, dtoc2, marine_1600, rocket, steering, gasoil_3200, pinene_3200,
+robot_1600, svanberg, nql180, qcqp1500-1c, cont5_2_4_l; only dtoc1nd is at 63. On
+the two with any wide fronts at all the paired sweep finds nothing: nql180 0.990
+(5/12 wins, tied with the default), qcqp1500-1c 0.994 (3/12). A 1.3% win on one
+corpus matrix and a no-op elsewhere is below the bar for changing a global default.
+
+**Kept from this attempt:** `block_size` is bit-neutral on all three matrices
+swept — identical inertia, zero delayed pivots, identical residual, and an
+identical hash over every `L`/`D` bit in storage order across
+`bs ∈ {8,16,24,32,48,62,64}` (`dtoc1nd_0010` 9cb93f568423e6c0, `nql180_0000`
+4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
+is a performance-only change. Not yet established on a matrix that actually
+delays a pivot — all three report `d0`.
+
+## Source Files
+```
+src/bin/bench.rs
+src/bin/perf_probe.rs
+src/bin/probe_ft_eta.rs
+src/bin/probe_lu_phases.rs
+src/bin/probe_panel_frag.rs
+src/capi.rs
+src/dense/block_ldlt32.rs
+src/dense/equilibrate.rs
+src/dense/factor.rs
+src/dense/matrix.rs
+src/dense/mod.rs
+src/dense/rook.rs
+src/dense/schur_kernel.rs
+src/dense/solve.rs
+src/env.rs
+src/error.rs
+src/inertia.rs
+src/io/mod.rs
+src/io/mtx.rs
+src/io/sidecar.rs
+src/lib.rs
+src/lu/condition.rs
+src/lu/dense_factor.rs
+src/lu/dense_matrix.rs
+src/lu/dense_solve.rs
+src/lu/dense_update.rs
+src/lu/markowitz.rs
+src/lu/mod.rs
+src/lu/scaling.rs
+src/lu/sparse_factor.rs
+src/lu/sparse_hyper.rs
+src/lu/sparse_matrix.rs
+src/lu/sparse_solve.rs
+src/lu/sparse_symbolic.rs
+src/lu/sparse_triangular.rs
+src/lu/sparse_update.rs
+src/numeric/condition.rs
+src/numeric/factorize.rs
+src/numeric/mod.rs
+src/numeric/solve.rs
+src/numeric/solver.rs
+src/ordering/amd.rs
+src/ordering/elimination_tree.rs
+src/ordering/mod.rs
+src/ordering/postorder.rs
+src/ordering/schur.rs
+src/scaling/hungarian.rs
+src/scaling/infnorm.rs
+src/scaling/mc64.rs
+src/scaling/mod.rs
+src/scaling/value_bound.rs
+src/sparse/csc.rs
+src/sparse/mod.rs
+src/symbolic/column_counts.rs
+src/symbolic/ldlt_compress.rs
+src/symbolic/mod.rs
+src/symbolic/profiler.rs
+src/symbolic/small_leaf.rs
+src/symbolic/supernode.rs
+```
+
+## Test Files
+```
+tests/amf_corpus_oracle.rs
+tests/auto_strategy.rs
+tests/blocked_ldlt.rs
+tests/build_row_indices_trailing_invariant.rs
+tests/cb_core_choice_ignores_env.rs
+tests/cb_solve_parity.rs
+tests/column_renumbering_parity.rs
+tests/column_renumbering.rs
+tests/d4_solve_2x2_gate.rs
+tests/d6_contrib_uninit.rs
+tests/d7_block32_dispatch_pooled.rs
+tests/delayed_pivoting.rs
+tests/dense_fast_path.rs
+tests/dense_ldlt.rs
+tests/env_knob_parsing.rs
+tests/env_knob_scan.rs
+tests/factor_scratch_parity.rs
+tests/factor_workspace_parity.rs
+tests/factors_ld_export.rs
+tests/fine_grained_delay.rs
+tests/fma_opt_in_roundtrip.rs
+tests/golden_bits.rs
+tests/growth_flag.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
+tests/issue127_pipeline_split.rs
+tests/issue128_supernode_nrow.rs
+tests/issue177_parallel_entry_point_core.rs
+tests/issue178_refine_cap.rs
+tests/issue178_solve_into.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
+tests/kkt_hardening.rs
+tests/kkt_matrices.rs
+tests/large_matrix_smoke.rs
+tests/ldlt_compress.rs
+tests/lu_adversarial_inputs.rs
+tests/lu_default_ordering.rs
+tests/lu_dense_bump.rs
+tests/lu_dense_update_bg.rs
+tests/lu_dense.rs
+tests/lu_ft_widebump.rs
+tests/lu_hyper_sparse.rs
+tests/lu_markowitz.rs
+tests/lu_real_bases.rs
+tests/lu_scaling.rs
+tests/lu_sparse_rhs.rs
+tests/lu_sparse.rs
+tests/lu_update_alloc_probe.rs
+tests/lu_update_casctanks.rs
+tests/maxfromm_parity.rs
+tests/mc64_end_to_end.rs
+tests/mc64_scaling.rs
+tests/multi_rhs.rs
+tests/n2_static_pivot_scaling.rs
+tests/n3_parallel_profiler.rs
+tests/n4_mc64_retry_latch.rs
+tests/parallel_parity.rs
+tests/parity.rs
+tests/pivot_rejection.rs
+tests/pounce_interface.rs
+tests/pounce710_refine_cap_nrhs2.rs
+tests/profiler_smoke.rs
+tests/property_tests.rs
+tests/refined_solve_core_stability.rs
+tests/rook_rescue_kkt.rs
+tests/rook_rescue.rs
+tests/small_leaf_parity.rs
+tests/solver_with_ordering.rs
+tests/sparse_postorder.rs
+tests/sparse_refined.rs
+tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
+tests/stress_tests.rs
+
+(truncated from      355 lines to 350 line budget)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,352 +1,70 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-21T03:54:19Z
+Generated: 2026-08-21T15:45:10Z
 
 ## Latest Session
-File: dev/sessions/2026-08-20-03.md
+File: dev/sessions/2026-08-21-01.md
 ```
-# Session 2026-08-20-03
+# Session 2026-08-21-01
 
 ## Unfavorable result, reported first (per CLAUDE.md)
 
-**Issue #190's stated premise does not reproduce on this corpus, and the
-feature built for it is not a performance gain.**
+**The solve tail regressed 33–56%, this session's change caused it, and a
+controlled A/B proves that rather than leaving it as a hypothesis.**
 
-#190 argues the hardwired `ε·√n` convergence target is unreachable on large
-ill-conditioned systems, so every refined solve runs the full 10-step budget
-and pays for iterations that buy nothing. Measured (`probe_refine_stop_criterion`,
-best-of-5 wall, seven matrices, well-scaled RHS):
+`src/bin/bench.rs:1985` times the sparse solve with `RefineOptions::default()`,
+so the new stopping criterion sits directly in the measured path. I ran the
+bench with the shipped default, then reverted `Default for RefineOptions` to
+`EpsSqrtN`, rebuilt, and re-ran on the same quiet machine:
 
-| matrix | n | default steps | stop | ω |
-|---|---:|---:|---|---:|
-| r05_kkt | 14,842 | 0 | Converged | 4.546e-13 |
-| qap15_kkt | 50,880 | 2 | Converged | 2.690e-16 |
-| dirichlet120_kkt | 54,363 | 0 | Converged | 1.679e-14 |
-| cont-201 | 80,595 | 0 | Converged | 8.720e-14 |
-| cont5_late_kkt | 180,900 | 1 | Converged | 1.711e-16 |
-| bratu3d | 27,792 | 0 | Converged | 2.467e-15 |
-| bcsstk38 | 8,032 | 0 | Converged | 1.324e-15 |
+| ratio | control (`EpsSqrtN`) | shipped default | delta |
+|---|---:|---:|---:|
+| factor/MUMPS p90 | 1.54 | 1.56 | +1.3% (noise) |
+| solve/MUMPS geomean | 0.08 | 0.08 | none |
+| solve/MUMPS p50 | 0.08 | 0.08 | none |
+| solve/MUMPS p90 | 0.15 | **0.20** | **+33%** |
+| solve/MUMPS p99 | 0.71 | **1.08** | **+52%** |
+| solve/SSIDS geomean | 0.94 | **1.06** | **+13%** |
+| solve/SSIDS p90 | 2.50 | **3.60** | **+44%** |
+| solve/SSIDS p99 | 8.33 | **13.00** | **+56%** |
 
-Zero to two steps, never at the cap. There is no wasted-iteration saving to
-claim, and the feature must not be described as one.
+**The shape is what the design predicts.** Geomean and p50 are identical to
+three decimals — the well-scaled majority never needed the extra conjunct
+and does not pay for it. The tail pays, because that is where the matrices
+live whose componentwise error was above `√ε` and which now actually refine.
+On the tracked parity corpus that is 13 of 63 (21%), the right order to move
+a p90.
 
-Stated in the other direction so the limit is on the record: the `n = 118,276`
-system #190 cites is a pounce *runtime* KKT and is not in the local corpus
-(largest local matrix is `c-big`, `n = 345,241`, not in this set). The premise
-is **untested at its own scale**, not refuted at it.
+Factor is unchanged within noise, as it must be — the change is confined to
+the refinement loop's stopping test. That also validates the control: machine
+state would have moved factor too, and did not. **Unlike 2026-08-20-02,
+nothing here is attributed to machine state.**
 
-The measured *cost* of the new criteria is ~2x on the refinement wall
-(0.39x–0.61x "vs def"), roughly one extra solve, factor excluded. The only
-speedups measured are the caller deliberately buying less accuracy: qap15 easy
-at `BackwardError(1e-10)` is 1.45x by stopping at ω 8.755e-12 instead of
-2.690e-16; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
-(ω 8.038e-10 vs the default's 1.229e-10).
-
-Against the standing bar for this thread — "rigorous, thoroughly correct, and
-result in performance gains, or we will not include it in a release" — #190
-clears the first two and **fails the third**. Ship-or-not is a human call; see
-"Next Session Should".
+**Against the standing bar** ("rigorous, thoroughly correct, and result in
+performance gains, or we will not include it in a release"): this is a
+measured performance *cost*, not a gain. It buys MA57/MUMPS componentwise
+parity on systems where feral returned ω up to 9.5e-5 and reported
+`Converged`. Whether that trade ships is the human's call. The alternative is
+to keep `EpsSqrtN` as the default and make the conjunction opt-in — which
+costs pounce the fix it asked for.
 
 ## Goal
 
-Act on issue #190: the `ε·√n` refinement target is a hardwired constant with
-no principled value; let the caller say what "converged" means.
+Human instruction: *"we need to fix the deficiency gap with ma57/mumps if
+there is one because this is causing an issue on a class of problems in
+pounce. surprisingly, it works well for the vast majority of problems."*
 
 ## Accomplished
-
-### `StopCriterion`: the caller says what converged means (`f547bc5`)
 ```
 
 ## Git Status
 ```
+f5bc004 docs(dense): drop unverifiable pounce provenance from the growth-flag docs
+396bfa3 fix(solve): default refinement now certifies componentwise accuracy
+001a7db diag: four probes that locate the MA57/MUMPS deficiency gap
+963884c docs: session checkpoint 2026-08-20-03 (#190 measured; premise refuted)
 65f488c docs(refine): correct #190's premise against the corpus measurement
-f547bc5 feat(refine): let the caller say what "converged" means (issue #190)
-849caea fix(dense): flag L-growth against the pivot threshold's own promise
-7de1a93 docs: cold bench resolves the drift; masked-tile follow-up rejected as slower
-2637964 docs: state which pounce call sites the padded stride actually reaches
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
-test symbolic::tests::test_symbolic_factorize_basic ... ok
-test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
-test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
-test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
-test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
-
-test result: ok. 456 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.66s
-
-```
-
-## Benchmark
-```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-03.md)
-
-
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
-
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.44       0.30       1.56       3.25       9.20
-solve/MUMPS        153560       0.08       0.08       0.15       0.73       2.60
-factor/SSIDS       154500       0.04       0.03       0.32       0.94       1.96
-solve/SSIDS        154500       0.94       1.00       2.50       8.67      29.00
-nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
-nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
-
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
-
---- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.56     <= 2.0     PASS
-medium (<500)            153560     1.56     <= 3.0     PASS
-
-Quiet machine, nothing else running. This is the best of the recent runs and
-sits at the bottom of the observed band — better than 08-20-02's hot run on
-every bucket and level with its cold re-run:
-
-| bucket | 08-19-05 baseline | 08-20-02 hot | 08-20-02 cold | this run |
-|---|---:|---:|---:|---:|
-| sparse small-frontal p90 | 1.58 | 1.65 | 1.54 | **1.56** |
-| sparse medium p90 | 1.58 | 1.65 | 1.54 | **1.56** |
-| dense small-frontal p90 | 1.58 | 1.66 | 1.59 | **1.58** |
-| dense medium p90 | 2.00 | 2.04 | 1.97 | **2.00** |
-
-All four PASS. `solve/MUMPS` geomean 0.08 and p50 0.08 unchanged. The
-machine-state signature the previous session identified is visible again in
-the right direction: `factor/MUMPS` max is **9.20** here against 71.94 on the
-hot run, and `factor/SSIDS` p99 is 0.94 against 1.11.
-
-Neither of this session's commits should touch the bench path — the bench
-times factorization and a single-RHS solve, `849caea` changes only which
-matrices set an advisory `needs_refinement` flag (read by nobody in the bench),
-and `f547bc5` adds a criterion whose default is bit-for-bit the old behavior.
-The numbers are consistent with that.
-
-```
-
-## Recent Decisions
-`n = 118,276` system #190 cites is a pounce runtime KKT and is not in the
-local corpus (largest local is `c-big`, `n = 345,241`, not in this set), so
-the premise is untested at its own scale rather than refuted at it.
-
-**What the measurement did establish is a correctness gap.** With a RHS
-whose entries span `1e-6..1e6`, the default declares `Converged` at normwise
-`rel` of `1e-14..1e-17` while the componentwise backward error is up to
-eleven orders worse: r05_kkt `9.5e-5`, bratu3d `9.0e-6`, cont-201 `3.9e-7`,
-dirichlet120_kkt `4.3e-10`, bcsstk38 `1.1e-10`, qap15_kkt `1.2e-10`. One
-`BackwardError` step lands all of them at `~3e-16`. The default cannot see
-this by construction: `||r||_2/||b||_2` is dominated by the rows where
-`|b_i| ~ 1e6`.
-
-**Cost.** ~2x on the refinement wall time (0.39x–0.61x "vs def"), factor
-excluded — roughly one extra solve. The only measured speedups are the
-caller deliberately buying less accuracy: qap15 easy at
-`BackwardError(1e-10)` is 1.45x by stopping at omega `8.8e-12` instead of
-`2.7e-16`; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
-(omega `8.0e-10` vs the default's `1.2e-10`).
-
-**Decision.** The feature stays, documented as an accuracy/observability
-knob with the measured cost stated, not as a speedup. `CHANGELOG.md`,
-`README.md` and the `solve_sparse_refined` doc comment were corrected —
-all three had asserted the unreachable-target premise as fact.
-
-**Documented caveat, new.** An unreachable *componentwise* target has the
-identical failure mode the old constant had. qap15_kkt with a badly-scaled
-RHS and `BackwardError(1e-14)` runs 8 steps, exits `Stagnated` at omega
-`4.2e-11`, and costs 0.32x for nothing; `BackwardError(1e-10)` reaches
-`4.4e-11` in 3 steps. The knob does not remove the need to read `stop`.
-
-## Recent Tried-and-Rejected
-**Why, as far as the measurement shows.** Pre-mask, cost was a pure function
-of `padded_ldw(nrhs)`, confirmed three ways: `t(36) ~ t(40)` on all seven
-matrices (7059 vs 7111 us on bcsstk38; 104460 vs 104470 on dirichlet120),
-`t(47) ~ t(48)` on all seven, and `t(33)/t(32) = 1.225` against `40/33 =
-1.212` predicted. Post-mask, cost tracks neither model — 1.490 at `nrhs = 33`
-is worse than the 1.250 pad model *and* far worse than the 1.031 work model.
-
-Mechanism is inference, not measurement: iterating a non-multiple-of-8 column
-count appears to cost more than the arithmetic it saves, presumably because
-the fixed-width `NR = 8` tile is what lets the loops compile to whole
-vector operations, and a variable-length `live` tail reintroduces exactly the
-per-row irregularity the padding was added to remove. **The pad columns are
-not waste — they are what keeps every loop a whole number of 8-wide
-operations.** 8 extra multiply-adds on aligned lanes beat 7 skipped ones
-behind a mask.
-
-**Consequence.** `a0b4d64`'s padded stride stands as the final form. The
-`40/33` residual is not recoverable this way and should not be described as
-"available headroom" in future notes. Reverted in full; no code from this
-attempt was kept.
-
-## Source Files
-```
-src/bin/bench.rs
-src/bin/perf_probe.rs
-src/bin/probe_ft_eta.rs
-src/bin/probe_lu_phases.rs
-src/bin/probe_panel_frag.rs
-src/capi.rs
-src/dense/block_ldlt32.rs
-src/dense/equilibrate.rs
-src/dense/factor.rs
-src/dense/matrix.rs
-src/dense/mod.rs
-src/dense/rook.rs
-src/dense/schur_kernel.rs
-src/dense/solve.rs
-src/env.rs
-src/error.rs
-src/inertia.rs
-src/io/mod.rs
-src/io/mtx.rs
-src/io/sidecar.rs
-src/lib.rs
-src/lu/condition.rs
-src/lu/dense_factor.rs
-src/lu/dense_matrix.rs
-src/lu/dense_solve.rs
-src/lu/dense_update.rs
-src/lu/markowitz.rs
-src/lu/mod.rs
-src/lu/scaling.rs
-src/lu/sparse_factor.rs
-src/lu/sparse_hyper.rs
-src/lu/sparse_matrix.rs
-src/lu/sparse_solve.rs
-src/lu/sparse_symbolic.rs
-src/lu/sparse_triangular.rs
-src/lu/sparse_update.rs
-src/numeric/condition.rs
-src/numeric/factorize.rs
-src/numeric/mod.rs
-src/numeric/solve.rs
-src/numeric/solver.rs
-src/ordering/amd.rs
-src/ordering/elimination_tree.rs
-src/ordering/mod.rs
-src/ordering/postorder.rs
-src/ordering/schur.rs
-src/scaling/hungarian.rs
-src/scaling/infnorm.rs
-src/scaling/mc64.rs
-src/scaling/mod.rs
-src/scaling/value_bound.rs
-src/sparse/csc.rs
-src/sparse/mod.rs
-src/symbolic/column_counts.rs
-src/symbolic/ldlt_compress.rs
-src/symbolic/mod.rs
-src/symbolic/profiler.rs
-src/symbolic/small_leaf.rs
-src/symbolic/supernode.rs
-```
-
-## Test Files
-```
-tests/amf_corpus_oracle.rs
-tests/auto_strategy.rs
-tests/blocked_ldlt.rs
-tests/build_row_indices_trailing_invariant.rs
-tests/cb_core_choice_ignores_env.rs
-tests/cb_solve_parity.rs
-tests/column_renumbering_parity.rs
-tests/column_renumbering.rs
-tests/d4_solve_2x2_gate.rs
-tests/d6_contrib_uninit.rs
-tests/d7_block32_dispatch_pooled.rs
-tests/delayed_pivoting.rs
-tests/dense_fast_path.rs
-tests/dense_ldlt.rs
-tests/env_knob_parsing.rs
-tests/env_knob_scan.rs
-tests/factor_scratch_parity.rs
-tests/factor_workspace_parity.rs
-tests/factors_ld_export.rs
-tests/fine_grained_delay.rs
-tests/fma_opt_in_roundtrip.rs
-tests/golden_bits.rs
-tests/growth_flag.rs
-tests/issue_15_cascade_arm_gate.rs
-tests/issue_17_robot_1600_cascade_off.rs
-tests/issue_18_narx_cfy_cascade_off.rs
-tests/issue_2_kkt_ls_init.rs
-tests/issue_38_static_pivot.rs
-tests/issue_46_saddle_kkt_cascade.rs
-tests/issue_55_delay_budget.rs
-tests/issue_55_n_tiny_counter.rs
-tests/issue102_intrafront_deadlock.rs
-tests/issue102_ordering_escalation.rs
-tests/issue107_external_ordering.rs
-tests/issue112_bg_update.rs
-tests/issue127_pipeline_split.rs
-tests/issue128_supernode_nrow.rs
-tests/issue177_parallel_entry_point_core.rs
-tests/issue178_refine_cap.rs
-tests/issue178_solve_into.rs
-tests/issue190_refine_target.rs
-tests/issue52_stats.rs
-tests/issue64_arrow_ordering.rs
-tests/issue65_mc64_fallback.rs
-tests/issue67_thin_ordering.rs
-tests/issue91_preprocess_misfire.rs
-tests/issue99_fma_front_gate.rs
-tests/kkt_hardening.rs
-tests/kkt_matrices.rs
-tests/large_matrix_smoke.rs
-tests/ldlt_compress.rs
-tests/lu_adversarial_inputs.rs
-tests/lu_default_ordering.rs
-tests/lu_dense_bump.rs
-tests/lu_dense_update_bg.rs
-tests/lu_dense.rs
-tests/lu_ft_widebump.rs
-tests/lu_hyper_sparse.rs
-tests/lu_markowitz.rs
-tests/lu_real_bases.rs
-tests/lu_scaling.rs
-tests/lu_sparse_rhs.rs
-tests/lu_sparse.rs
-tests/lu_update_alloc_probe.rs
-tests/lu_update_casctanks.rs
-tests/maxfromm_parity.rs
-tests/mc64_end_to_end.rs
-tests/mc64_scaling.rs
-tests/multi_rhs.rs
-tests/n2_static_pivot_scaling.rs
-tests/n3_parallel_profiler.rs
-tests/n4_mc64_retry_latch.rs
-tests/parallel_parity.rs
-tests/parity.rs
-tests/pivot_rejection.rs
-tests/pounce_interface.rs
-tests/pounce710_refine_cap_nrhs2.rs
-tests/profiler_smoke.rs
-tests/property_tests.rs
-tests/refined_solve_core_stability.rs
-tests/rook_rescue_kkt.rs
-tests/rook_rescue.rs
-tests/small_leaf_parity.rs
-tests/solver_with_ordering.rs
-tests/sparse_postorder.rs
-tests/sparse_refined.rs
-tests/sqd_fast_path.rs
-tests/static_assembly_maps.rs
-tests/stress_tests.rs
-tests/symbolic_profiler.rs
-
-(truncated from      354 lines to 350 line budget)

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T17:16:31Z
+Generated: 2026-08-20T17:40:42Z
 
 ## Latest Session
 File: dev/sessions/2026-08-20-02.md
@@ -33,8 +33,16 @@ untouched.
 The likely cause is machine state — the box had been under sustained compile
 and benchmark load for hours before this run. That is a hypothesis, not a
 result: I did not run a control on stashed code to test it, as was done on
-08-20-01 to refute a similar attribution. **Next session should re-run the
-bench cold before reading anything into these numbers.**
+08-20-01 to refute a similar attribution.
+
+> **RESOLVED, same day.** The cold re-run (built cold, 180 s settle, machine
+> quiet) put all four buckets at the *bottom* of the band: sparse
+> small-frontal **1.54**, sparse medium **1.54**, dense small-frontal
+> **1.59**, dense medium **1.97**. Two independent machine-state signatures
+> confirm the hot run rather than the change: `factor/MUMPS` max fell
+> **71.94 -> 9.10** and the worst-offender list changed identity entirely
+> (GAUSS2/CRESC100 cold vs HAIFAM/HAHN1 hot); `factor/SSIDS` p99 fell
+> 1.11 -> 0.95. `a0b4d64` did not regress the factor path.
 
 ## Goal
 
@@ -47,23 +55,15 @@ correct, and a real performance gain, or it does not ship.
 ### The threshold is fine. There was a defect underneath it.
 
 `BLAS3_NRHS_THRESHOLD` is unchanged at 32. What the investigation found
-instead: the row-major multi-RHS work buffers used a leading dimension of
-exactly `nrhs`, so any `nrhs` that is not a multiple of 8 makes every row of
-every supernode panel straddle a cache line, compounding across the gather,
-the kernels and the scatter.
-
-Evidence, all within a single process so no cross-process drift can reach it.
-`t(31)/t(32)` — `nrhs = 31` is 3% *less* work, so a healthy kernel gives
-~0.97:
 ```
 
 ## Git Status
 ```
+2637964 docs: state which pounce call sites the padded stride actually reaches
 ffb5862 docs: session checkpoint 2026-08-20-02 (multi-RHS stride alignment)
 a0b4d64 perf(solve): align the multi-RHS row stride to a cache line
 c34475e docs: session checkpoint 2026-08-20-01 (measurement corrections, #189 Step 1)
 c09da70 bench: time the solve core hosts actually run (#189 item 1)
-2ba437d probe: separate core, schedule, and depth in the solve measurement (#131, #189)
 ```
 
 ## Test Status
@@ -74,11 +74,11 @@ test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
 test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
@@ -86,7 +86,7 @@ test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.67s
+test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.65s
 
 ```
 
@@ -148,26 +148,26 @@ multi-RHS solve at `nrhs >= 32` and not a multiple of 8. It is not a pounce
 end-to-end number and must not be quoted as one.
 
 ## Recent Tried-and-Rejected
-**Why.** A full sweep is ~25 minutes, so two "adjacent" runs are 25 minutes
-apart. That is blocked measurement with an interleaved label on it — the same
-error behind the two claim retractions earlier the same day, one level up the
-stack. Cross-process A/B of a few-millisecond kernel does not work on this
-machine at this cadence.
+**Why, as far as the measurement shows.** Pre-mask, cost was a pure function
+of `padded_ldw(nrhs)`, confirmed three ways: `t(36) ~ t(40)` on all seven
+matrices (7059 vs 7111 us on bcsstk38; 104460 vs 104470 on dirichlet120),
+`t(47) ~ t(48)` on all seven, and `t(33)/t(32) = 1.225` against `40/33 =
+1.212` predicted. Post-mask, cost tracks neither model — 1.490 at `nrhs = 33`
+is worse than the 1.250 pad model *and* far worse than the 1.031 work model.
 
-The remaining runs were killed (`pkill -f probe_blas3_crossover`, 0 left) and
-no number from the paired dataset was reported as a result.
+Mechanism is inference, not measurement: iterating a non-multiple-of-8 column
+count appears to cost more than the arithmetic it saves, presumably because
+the fixed-width `NR = 8` tile is what lets the loops compile to whole
+vector operations, and a variable-length `live` tail reintroduces exactly the
+per-row irregularity the padding was added to remove. **The pad columns are
+not waste — they are what keeps every loop a whole number of 8-wide
+operations.** 8 extra multiply-adds on aligned lanes beat 7 skipped ones
+behind a mask.
 
-**Replaced by** an in-process design: the `kernel-probe` feature (off by
-default, compiled out entirely) exposes
-`set_blas3_nrhs_threshold`, so one process can time rank-1 and BLAS-3 at the
-*same* `nrhs`, alternating within each repetition — microseconds apart instead
-of 25 minutes. See `dev/research/blas3-threshold-refit.md`.
-
-**Kept from this attempt:** the single-build, single-process runs are valid,
-because looped-vs-batched was measured within one process. Two findings survive
-and are recorded in the research note: the 31→32 dispatch discontinuity (3% more
-work, batched time *drops* 1.36–1.77×), and that at `nrhs ∈ {2, 4}` batching is
-**21–27% slower** than looping single-RHS solves.
+**Consequence.** `a0b4d64`'s padded stride stands as the final form. The
+`40/33` residual is not recoverable this way and should not be described as
+"available headroom" in future notes. Reverted in full; no code from this
+attempt was kept.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,84 +1,84 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T17:40:42Z
+Generated: 2026-08-21T03:54:19Z
 
 ## Latest Session
-File: dev/sessions/2026-08-20-02.md
+File: dev/sessions/2026-08-20-03.md
 ```
-# Session 2026-08-20-02
+# Session 2026-08-20-03
 
-## Unfavorable comparison, reported first (per CLAUDE.md)
+## Unfavorable result, reported first (per CLAUDE.md)
 
-The session-end bench is at or slightly above the top of the previously
-observed band on the factor partitions:
+**Issue #190's stated premise does not reproduce on this corpus, and the
+feature built for it is not a performance gain.**
 
-| bucket | baseline 08-19-05 | 08-20-01 runs | this run |
-|---|---:|---:|---:|
-| sparse small-frontal p90 | 1.58 | 1.54 / 1.61 | **1.65** |
-| sparse medium p90 | 1.58 | 1.54 / 1.61 | **1.65** |
-| dense small-frontal p90 | 1.58 | 1.59 / 1.64 | **1.66** |
-| dense medium p90 | 2.00 | 1.96 / 1.98 | **2.04** |
+#190 argues the hardwired `ε·√n` convergence target is unreachable on large
+ill-conditioned systems, so every refined solve runs the full 10-step budget
+and pays for iterations that buy nothing. Measured (`probe_refine_stop_criterion`,
+best-of-5 wall, seven matrices, well-scaled RHS):
 
-All four still PASS their targets, and `solve/MUMPS` geomean and p50 held at
-0.08 exactly. But this is the worst of the four runs recorded across the two
-sessions, and it is +4.4% on the sparse buckets against the 08-19-05 baseline.
+| matrix | n | default steps | stop | ω |
+|---|---:|---:|---|---:|
+| r05_kkt | 14,842 | 0 | Converged | 4.546e-13 |
+| qap15_kkt | 50,880 | 2 | Converged | 2.690e-16 |
+| dirichlet120_kkt | 54,363 | 0 | Converged | 1.679e-14 |
+| cont-201 | 80,595 | 0 | Converged | 8.720e-14 |
+| cont5_late_kkt | 180,900 | 1 | Converged | 1.711e-16 |
+| bratu3d | 27,792 | 0 | Converged | 2.467e-15 |
+| bcsstk38 | 8,032 | 0 | Converged | 1.324e-15 |
 
-**This session's change cannot mechanically account for it.** The bench times
-factorization and a *single-RHS* solve; the change is confined to
-`solve_sparse_core_many_into` and the panel GEMM reached only from
-`fwd_blas3`/`back_blas3`, which the multi-RHS path alone calls. The
-single-RHS core (`solve_sparse_core_into`) and the whole factorization are
-untouched.
+Zero to two steps, never at the cap. There is no wasted-iteration saving to
+claim, and the feature must not be described as one.
 
-The likely cause is machine state — the box had been under sustained compile
-and benchmark load for hours before this run. That is a hypothesis, not a
-result: I did not run a control on stashed code to test it, as was done on
-08-20-01 to refute a similar attribution.
+Stated in the other direction so the limit is on the record: the `n = 118,276`
+system #190 cites is a pounce *runtime* KKT and is not in the local corpus
+(largest local matrix is `c-big`, `n = 345,241`, not in this set). The premise
+is **untested at its own scale**, not refuted at it.
 
-> **RESOLVED, same day.** The cold re-run (built cold, 180 s settle, machine
-> quiet) put all four buckets at the *bottom* of the band: sparse
-> small-frontal **1.54**, sparse medium **1.54**, dense small-frontal
-> **1.59**, dense medium **1.97**. Two independent machine-state signatures
-> confirm the hot run rather than the change: `factor/MUMPS` max fell
-> **71.94 -> 9.10** and the worst-offender list changed identity entirely
-> (GAUSS2/CRESC100 cold vs HAIFAM/HAHN1 hot); `factor/SSIDS` p99 fell
-> 1.11 -> 0.95. `a0b4d64` did not regress the factor path.
+The measured *cost* of the new criteria is ~2x on the refinement wall
+(0.39x–0.61x "vs def"), roughly one extra solve, factor excluded. The only
+speedups measured are the caller deliberately buying less accuracy: qap15 easy
+at `BackwardError(1e-10)` is 1.45x by stopping at ω 8.755e-12 instead of
+2.690e-16; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
+(ω 8.038e-10 vs the default's 1.229e-10).
+
+Against the standing bar for this thread — "rigorous, thoroughly correct, and
+result in performance gains, or we will not include it in a release" — #190
+clears the first two and **fails the third**. Ship-or-not is a human call; see
+"Next Session Should".
 
 ## Goal
 
-Answer issue #189 item 4: is `BLAS3_NRHS_THRESHOLD = 32` costing pounce
-anything? Under the standing bar for this work — rigorous, thoroughly
-correct, and a real performance gain, or it does not ship.
+Act on issue #190: the `ε·√n` refinement target is a hardwired constant with
+no principled value; let the caller say what "converged" means.
 
 ## Accomplished
 
-### The threshold is fine. There was a defect underneath it.
-
-`BLAS3_NRHS_THRESHOLD` is unchanged at 32. What the investigation found
+### `StopCriterion`: the caller says what converged means (`f547bc5`)
 ```
 
 ## Git Status
 ```
+65f488c docs(refine): correct #190's premise against the corpus measurement
+f547bc5 feat(refine): let the caller say what "converged" means (issue #190)
+849caea fix(dense): flag L-growth against the pivot threshold's own promise
+7de1a93 docs: cold bench resolves the drift; masked-tile follow-up rejected as slower
 2637964 docs: state which pounce call sites the padded stride actually reaches
-ffb5862 docs: session checkpoint 2026-08-20-02 (multi-RHS stride alignment)
-a0b4d64 perf(solve): align the multi-RHS row stride to a cache line
-c34475e docs: session checkpoint 2026-08-20-01 (measurement corrections, #189 Step 1)
-c09da70 bench: time the solve core hosts actually run (#189 item 1)
 ```
 
 ## Test Status
 ```
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
@@ -86,66 +86,90 @@ test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.65s
+test result: ok. 456 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.66s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-02.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-20-03.md)
 
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
 
 ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.46       0.33       1.65       4.13      71.94
-solve/MUMPS        153560       0.08       0.08       0.16       0.88      25.59
-factor/SSIDS       154500       0.04       0.03       0.34       1.11      23.34
-solve/SSIDS        154500       0.96       1.00       2.83      10.25     583.65
+factor/MUMPS       153560       0.44       0.30       1.56       3.25       9.20
+solve/MUMPS        153560       0.08       0.08       0.15       0.73       2.60
+factor/SSIDS       154500       0.04       0.03       0.32       0.94       1.96
+solve/SSIDS        154500       0.94       1.00       2.50       8.67      29.00
 nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
 nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.66     <= 2.0     PASS
-medium (<500)            152145     2.04     <= 3.0     PASS
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.65     <= 2.0     PASS
-medium (<500)            153560     1.65     <= 3.0     PASS
+small-frontal (<200)     153455     1.56     <= 2.0     PASS
+medium (<500)            153560     1.56     <= 3.0     PASS
+
+Quiet machine, nothing else running. This is the best of the recent runs and
+sits at the bottom of the observed band — better than 08-20-02's hot run on
+every bucket and level with its cold re-run:
+
+| bucket | 08-19-05 baseline | 08-20-02 hot | 08-20-02 cold | this run |
+|---|---:|---:|---:|---:|
+| sparse small-frontal p90 | 1.58 | 1.65 | 1.54 | **1.56** |
+| sparse medium p90 | 1.58 | 1.65 | 1.54 | **1.56** |
+| dense small-frontal p90 | 1.58 | 1.66 | 1.59 | **1.58** |
+| dense medium p90 | 2.00 | 2.04 | 1.97 | **2.00** |
+
+All four PASS. `solve/MUMPS` geomean 0.08 and p50 0.08 unchanged. The
+machine-state signature the previous session identified is visible again in
+the right direction: `factor/MUMPS` max is **9.20** here against 71.94 on the
+hot run, and `factor/SSIDS` p99 is 0.94 against 1.11.
+
+Neither of this session's commits should touch the bench path — the bench
+times factorization and a single-RHS solve, `849caea` changes only which
+matrices set an advisory `needs_refinement` flag (read by nobody in the bench),
+and `f547bc5` adds a criterion whose default is bit-for-bit the old behavior.
+The numbers are consistent with that.
 
 ```
 
 ## Recent Decisions
-Appended rather than editing the entry above, per the append-only rule. The
-preceding entry states the padded-stride decision correctly but says nothing
-about how much of a real host it reaches; a reader could take "1.36x on the
-multi-RHS solve" for "1.36x on pounce". It is much narrower than that.
+`n = 118,276` system #190 cites is a pounce runtime KKT and is not in the
+local corpus (largest local is `c-big`, `n = 345,241`, not in this set), so
+the premise is untested at its own scale rather than refuted at it.
 
-Prompted by pounce issue #698, comment 5359027510, which named a multi-RHS
-call site the 2026-08-20-02 checkpoint had not enumerated.
+**What the measurement did establish is a correctness gap.** With a RHS
+whose entries span `1e-6..1e6`, the default declares `Converged` at normwise
+`rel` of `1e-14..1e-17` while the componentwise backward error is up to
+eleven orders worse: r05_kkt `9.5e-5`, bratu3d `9.0e-6`, cont-201 `3.9e-7`,
+dirichlet120_kkt `4.3e-10`, bcsstk38 `1.1e-10`, qap15_kkt `1.2e-10`. One
+`BackwardError` step lands all of them at `~3e-16`. The default cannot see
+this by construction: `||r||_2/||b||_2` is dominated by the rows where
+`|b_i| ~ 1e6`.
 
-pounce has three multi-RHS-capable call sites. The padded stride reaches one:
+**Cost.** ~2x on the refinement wall time (0.39x–0.61x "vs def"), factor
+excluded — roughly one extra solve. The only measured speedups are the
+caller deliberately buying less accuracy: qap15 easy at
+`BackwardError(1e-10)` is 1.45x by stopping at omega `8.8e-12` instead of
+`2.7e-16`; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
+(omega `8.0e-10` vs the default's `1.2e-10`).
 
-| pounce call site | nrhs | reached? |
-|---|---|---|
-| `std_aug_system_solver.rs:497,625` (IPM) | 1, hardcoded | no |
-| `pounce-feral/src/lib.rs:1004,1006` (batched backsolve) | 6 | no — below the threshold |
-| `pounce-feral/src/schur.rs:303,304` | `n_s` | yes, when `n_s >= 32` |
+**Decision.** The feature stays, documented as an accuracy/observability
+knob with the measured cost stated, not as a speedup. `CHANGELOG.md`,
+`README.md` and the `solve_sparse_refined` doc comment were corrected —
+all three had asserted the unreachable-target premise as fact.
 
-The batched backsolve's width is `limited_memory_max_history`, which defaults
-to 6 (`alg_builder.rs:1037`, `:1508`). Below `BLAS3_NRHS_THRESHOLD = 32`, so
-it takes the rank-1 kernel, which the change does not touch. That dispatch is
-already correct — measured rank1/blas3 at `nrhs = 6` is 0.68-0.86 across all
-seven probe matrices, i.e. rank-1 wins — so there is no unclaimed gain there
-and no argument for lowering the threshold to capture it.
-
-The Schur path is the one that benefits, and it can be wide:
-`schur_aug_system_solver.rs:36` sets `DEFAULT_MAX_SCHUR_FRAC = 0.5`, so `n_s`
-reaches half the KKT dimension before the backend refuses the partition.
-
-**Consequence for release decisions:** the 1.36x figure is a property of the
-multi-RHS solve at `nrhs >= 32` and not a multiple of 8. It is not a pounce
-end-to-end number and must not be quoted as one.
+**Documented caveat, new.** An unreachable *componentwise* target has the
+identical failure mode the old constant had. qap15_kkt with a badly-scaled
+RHS and `BackwardError(1e-14)` runs 8 steps, exits `Stagnated` at omega
+`4.2e-11`, and costs 0.32x for nothing; `BackwardError(1e-10)` reaches
+`4.4e-11` in 3 steps. The knob does not remove the need to read `stop`.
 
 ## Recent Tried-and-Rejected
 **Why, as far as the measurement shows.** Pre-mask, cost was a pure function
@@ -274,6 +298,7 @@ tests/issue128_supernode_nrow.rs
 tests/issue177_parallel_entry_point_core.rs
 tests/issue178_refine_cap.rs
 tests/issue178_solve_into.rs
+tests/issue190_refine_target.rs
 tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs
@@ -323,7 +348,5 @@ tests/sqd_fast_path.rs
 tests/static_assembly_maps.rs
 tests/stress_tests.rs
 tests/symbolic_profiler.rs
-tests/task_plan_parity.rs
-tests/threshold_consistency.rs
-tests/tiny_fast_path.rs
-```
+
+(truncated from      354 lines to 350 line budget)

--- a/dev/context.md
+++ b/dev/context.md
@@ -68,3 +68,274 @@ f5bc004 docs(dense): drop unverifiable pounce provenance from the growth-flag do
 
 ## Test Status
 ```
+test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
+test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
+test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
+
+test result: ok. 456 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.68s
+
+```
+
+## Benchmark
+```
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-21-01.md)
+
+
+Inertia gate: **154531/154590 (100.0%) match vs MUMPS** — holds.
+
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.56       3.45      11.05
+solve/MUMPS        153560       0.08       0.08       0.20       1.08       4.56
+factor/SSIDS       154500       0.04       0.03       0.32       1.02       2.49
+solve/SSIDS        154500       1.06       1.00       3.60      13.00      52.33
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.56     <= 2.0     PASS
+medium (<500)            153560     1.56     <= 3.0     PASS
+
+All four partitions PASS and sit at the bottom of the observed band against
+the 08-19-05 baseline of 1.58/1.58/1.58/2.00. `factor/MUMPS` max fell
+71.94 → 11.05, the machine-quietness signature. The solve regression is
+covered at the top of this file.
+
+Suite: **956 passed, 0 failed, 113 suites.** `cargo clippy -- -D warnings` and
+`cargo clippy -p feral-diagnostics --all-targets -- -D warnings` both clean.
+
+```
+
+## Recent Decisions
+tolerance or residual gate. `EpsSqrtN` remains available and bit-for-bit
+unchanged for callers that want the historical behavior.
+
+**Cost, measured — and it is not free.** On the seven large matrices:
+well-scaled RHS identical to the old default (same steps, same iterates);
+badly-scaled RHS one extra step (5–14 ms) on the three worst, which then sit
+level with MUMPS at ~3e-16.
+
+That understates the corpus-wide cost. A controlled A/B over the 154,588
+benchmark matrices — same machine, only `Default for RefineOptions` changed —
+shows the median untouched and the tail paying: solve/MUMPS p90 0.15 → 0.20
+(+33%), p99 0.71 → 1.08 (+52%); solve/SSIDS geomean 0.94 → 1.06 (+13%), p90
+2.50 → 3.60 (+44%), p99 8.33 → 13.00 (+56%). Factor is unchanged within noise,
+which confirms the effect is the refinement loop rather than machine state.
+
+So this decision trades tail latency for componentwise correctness. It is
+recorded as such, not as a free improvement. Callers needing the old latency
+profile can pass `StopCriterion::EpsSqrtN` explicitly and accept the gap.
+
+**Rejected alternatives** (both in `dev/tried-and-rejected.md` with their
+failing cases): `BackwardError(√ε)` alone, which fails `tests/parity.rs` on
+ROSZMAN1_0241 because ω ≤ √ε can hold while the normwise residual is looser
+than the old rule delivered; and `BackwardError(f64::EPSILON)`, LAPACK
+`dgerfs`'s target, which stagnates or exhausts the step budget on five of
+seven large matrices under the badly-scaled RHS.
+
+**Regression coverage.** `tests/issue190_componentwise_default.rs`. The
+defect reproduces on the tracked parity corpus — `EpsSqrtN` leaves ω above
+√ε on 13 of 63 matrices, worst DEGENLPB_0046 at 359×√ε — and the new default
+drives all 63 to ω ≤ √ε.
+
+## Recent Tried-and-Rejected
+`StopCriterion::EpsSqrtNAndBackwardError(√ε)`, which is strictly harder to
+satisfy than the old default and therefore cannot regress any caller.
+ROSZMAN1_0241 and the rest of `tests/parity.rs` pass unchanged under it.
+
+## 2026-08-21 — `BackwardError(f64::EPSILON)` as the componentwise target
+
+**Tried.** Using `f64::EPSILON` — LAPACK `dgerfs`'s componentwise target —
+rather than `√ε` for `DEFAULT_BACKWARD_ERROR_TARGET`. Measured with
+`OMEGA_EPS=1 HARD_RHS=1 probe_vs_mumps_residual`.
+
+**Failed on cost.** Under the badly-scaled RHS it stagnates or exhausts the
+step budget on **five of the seven** large matrices, taking up to 10
+correction steps, while `√ε` converges on the same systems in at most one.
+That is precisely the wasted-budget pathology issue #190 complained about,
+reintroduced from the other direction.
+
+**Disposition.** Rejected. `√ε` is what MUMPS itself targets
+(`ref/mumps/src/dini_defaults.F:1094`), so matching it is both the cheaper
+and the better-justified choice. Recorded in the doc comment on
+`DEFAULT_BACKWARD_ERROR_TARGET` so it is not retried.
+
+## Source Files
+```
+src/bin/bench.rs
+src/bin/perf_probe.rs
+src/bin/probe_ft_eta.rs
+src/bin/probe_lu_phases.rs
+src/bin/probe_panel_frag.rs
+src/capi.rs
+src/dense/block_ldlt32.rs
+src/dense/equilibrate.rs
+src/dense/factor.rs
+src/dense/matrix.rs
+src/dense/mod.rs
+src/dense/rook.rs
+src/dense/schur_kernel.rs
+src/dense/solve.rs
+src/env.rs
+src/error.rs
+src/inertia.rs
+src/io/mod.rs
+src/io/mtx.rs
+src/io/sidecar.rs
+src/lib.rs
+src/lu/condition.rs
+src/lu/dense_factor.rs
+src/lu/dense_matrix.rs
+src/lu/dense_solve.rs
+src/lu/dense_update.rs
+src/lu/markowitz.rs
+src/lu/mod.rs
+src/lu/scaling.rs
+src/lu/sparse_factor.rs
+src/lu/sparse_hyper.rs
+src/lu/sparse_matrix.rs
+src/lu/sparse_solve.rs
+src/lu/sparse_symbolic.rs
+src/lu/sparse_triangular.rs
+src/lu/sparse_update.rs
+src/numeric/condition.rs
+src/numeric/factorize.rs
+src/numeric/mod.rs
+src/numeric/solve.rs
+src/numeric/solver.rs
+src/ordering/amd.rs
+src/ordering/elimination_tree.rs
+src/ordering/mod.rs
+src/ordering/postorder.rs
+src/ordering/schur.rs
+src/scaling/hungarian.rs
+src/scaling/infnorm.rs
+src/scaling/mc64.rs
+src/scaling/mod.rs
+src/scaling/value_bound.rs
+src/sparse/csc.rs
+src/sparse/mod.rs
+src/symbolic/column_counts.rs
+src/symbolic/ldlt_compress.rs
+src/symbolic/mod.rs
+src/symbolic/profiler.rs
+src/symbolic/small_leaf.rs
+src/symbolic/supernode.rs
+```
+
+## Test Files
+```
+tests/amf_corpus_oracle.rs
+tests/auto_strategy.rs
+tests/blocked_ldlt.rs
+tests/build_row_indices_trailing_invariant.rs
+tests/cb_core_choice_ignores_env.rs
+tests/cb_solve_parity.rs
+tests/column_renumbering_parity.rs
+tests/column_renumbering.rs
+tests/d4_solve_2x2_gate.rs
+tests/d6_contrib_uninit.rs
+tests/d7_block32_dispatch_pooled.rs
+tests/delayed_pivoting.rs
+tests/dense_fast_path.rs
+tests/dense_ldlt.rs
+tests/env_knob_parsing.rs
+tests/env_knob_scan.rs
+tests/factor_scratch_parity.rs
+tests/factor_workspace_parity.rs
+tests/factors_ld_export.rs
+tests/fine_grained_delay.rs
+tests/fma_opt_in_roundtrip.rs
+tests/golden_bits.rs
+tests/growth_flag.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
+tests/issue127_pipeline_split.rs
+tests/issue128_supernode_nrow.rs
+tests/issue177_parallel_entry_point_core.rs
+tests/issue178_refine_cap.rs
+tests/issue178_solve_into.rs
+tests/issue190_componentwise_default.rs
+tests/issue190_refine_target.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
+tests/kkt_hardening.rs
+tests/kkt_matrices.rs
+tests/large_matrix_smoke.rs
+tests/ldlt_compress.rs
+tests/lu_adversarial_inputs.rs
+tests/lu_default_ordering.rs
+tests/lu_dense_bump.rs
+tests/lu_dense_update_bg.rs
+tests/lu_dense.rs
+tests/lu_ft_widebump.rs
+tests/lu_hyper_sparse.rs
+tests/lu_markowitz.rs
+tests/lu_real_bases.rs
+tests/lu_scaling.rs
+tests/lu_sparse_rhs.rs
+tests/lu_sparse.rs
+tests/lu_update_alloc_probe.rs
+tests/lu_update_casctanks.rs
+tests/maxfromm_parity.rs
+tests/mc64_end_to_end.rs
+tests/mc64_scaling.rs
+tests/multi_rhs.rs
+tests/n2_static_pivot_scaling.rs
+tests/n3_parallel_profiler.rs
+tests/n4_mc64_retry_latch.rs
+tests/parallel_parity.rs
+tests/parity.rs
+tests/pivot_rejection.rs
+tests/pounce_interface.rs
+tests/pounce710_refine_cap_nrhs2.rs
+tests/profiler_smoke.rs
+tests/property_tests.rs
+tests/refined_solve_core_stability.rs
+tests/rook_rescue_kkt.rs
+tests/rook_rescue.rs
+tests/small_leaf_parity.rs
+tests/solver_with_ordering.rs
+tests/sparse_postorder.rs
+tests/sparse_refined.rs
+tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
+tests/stress_tests.rs
+tests/symbolic_profiler.rs
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
+```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T16:15:53Z
+Generated: 2026-08-20T17:16:31Z
 
 ## Latest Session
 File: dev/sessions/2026-08-20-02.md
@@ -59,26 +59,26 @@ Evidence, all within a single process so no cross-process drift can reach it.
 
 ## Git Status
 ```
+ffb5862 docs: session checkpoint 2026-08-20-02 (multi-RHS stride alignment)
 a0b4d64 perf(solve): align the multi-RHS row stride to a cache line
 c34475e docs: session checkpoint 2026-08-20-01 (measurement corrections, #189 Step 1)
 c09da70 bench: time the solve core hosts actually run (#189 item 1)
 2ba437d probe: separate core, schedule, and depth in the solve measurement (#131, #189)
-0ac4fb1 probe: measure the solve-phase levers claimed in #131 and #189
 ```
 
 ## Test Status
 ```
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
 test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
-test symbolic::tests::choose_adaptive_rules ... ok
 test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test symbolic::tests::choose_adaptive_rules ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
@@ -86,7 +86,7 @@ test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 3.44s
+test result: ok. 445 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.67s
 
 ```
 
@@ -116,36 +116,36 @@ medium (<500)            153560     1.65     <= 3.0     PASS
 ```
 
 ## Recent Decisions
-**Decision:** the panel path allocates and indexes at
-`padded_ldw(nrhs) = nrhs.div_ceil(NR) * NR`, i.e. a multiple of 64 bytes.
-The rank-1 path keeps the raw `nrhs` stride — it is row-major but not
-tiled, and it carries the bit-identity band contract that
-`tests/multi_rhs.rs:227,256` assert and pounce's `schur.rs:303` consumes.
+Appended rather than editing the entry above, per the append-only rule. The
+preceding entry states the padded-stride decision correctly but says nothing
+about how much of a real host it reaches; a reader could take "1.36x on the
+multi-RHS solve" for "1.36x on pounce". It is much narrower than that.
 
-The padding is paid for in flops: the kernels solve `padded_ldw(nrhs)`
-columns, of which up to 7 are zero padding. That is 21% extra arithmetic at
-`nrhs = 33`, 7% at 100, under 1% at 1000 — and it is still a net 1.36×
-geomean win in the shipped regime (`nrhs >= 32`, not a multiple of 8),
-because the alignment is worth more than the wasted lanes. After the fix
-`t(33)/t(32) ≈ 1.21`, which is exactly `40/33`: the residual is entirely
-the padding columns, with no misalignment left.
+Prompted by pounce issue #698, comment 5359027510, which named a multi-RHS
+call site the 2026-08-20-02 checkpoint had not enumerated.
 
-**Alternative not taken:** pad the *allocation* for alignment but iterate
-only the `nrhs` live columns, masking the final tile. `gemm_tile` already
-takes a `live` argument, so the kernel side is ready. It recovers roughly
-the remaining 18% at `nrhs = 33`. It is not part of this decision because
-it requires distinguishing stride from live width through five kernels, and
-that belongs in its own commit with its own before/after.
+pounce has three multi-RHS-capable call sites. The padded stride reaches one:
 
-**Bit-neutral**, verified three independent ways: an 800-shape `to_bits()`
-test against a scalar left-fold reference (`gemm_tail_tests`); the probe's
-`max |rank1 - blas3|` column unchanged at all 105 measured (matrix, `nrhs`)
-points; and all 13 `tests/multi_rhs.rs` green including both
-`assert_eq!(max_diff, 0.0)` band contracts. No tolerance was touched.
+| pounce call site | nrhs | reached? |
+|---|---|---|
+| `std_aug_system_solver.rs:497,625` (IPM) | 1, hardcoded | no |
+| `pounce-feral/src/lib.rs:1004,1006` (batched backsolve) | 6 | no — below the threshold |
+| `pounce-feral/src/schur.rs:303,304` | `n_s` | yes, when `n_s >= 32` |
 
-`BLAS3_NRHS_THRESHOLD` stays at 32 — the crossover constant was the
-suspect, but the defect was underneath it, and the threshold is load-bearing
-for the bit-identity contract.
+The batched backsolve's width is `limited_memory_max_history`, which defaults
+to 6 (`alg_builder.rs:1037`, `:1508`). Below `BLAS3_NRHS_THRESHOLD = 32`, so
+it takes the rank-1 kernel, which the change does not touch. That dispatch is
+already correct — measured rank1/blas3 at `nrhs = 6` is 0.68-0.86 across all
+seven probe matrices, i.e. rank-1 wins — so there is no unclaimed gain there
+and no argument for lowering the threshold to capture it.
+
+The Schur path is the one that benefits, and it can be wide:
+`schur_aug_system_solver.rs:36` sets `DEFAULT_MAX_SCHUR_FRAC = 0.5`, so `n_s`
+reaches half the KKT dimension before the backend refuses the partition.
+
+**Consequence for release decisions:** the 1.36x figure is a property of the
+multi-RHS solve at `nrhs >= 32` and not a multiple of 8. It is not a pounce
+end-to-end number and must not be quoted as one.
 
 ## Recent Tried-and-Rejected
 **Why.** A full sweep is ~25 minutes, so two "adjacent" runs are 25 minutes

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7218,3 +7218,36 @@ points; and all 13 `tests/multi_rhs.rs` green including both
 `BLAS3_NRHS_THRESHOLD` stays at 32 — the crossover constant was the
 suspect, but the defect was underneath it, and the threshold is load-bearing
 for the bit-identity contract.
+
+## 2026-08-20 — Scope correction: which pounce call sites the padded stride reaches
+
+Appended rather than editing the entry above, per the append-only rule. The
+preceding entry states the padded-stride decision correctly but says nothing
+about how much of a real host it reaches; a reader could take "1.36x on the
+multi-RHS solve" for "1.36x on pounce". It is much narrower than that.
+
+Prompted by pounce issue #698, comment 5359027510, which named a multi-RHS
+call site the 2026-08-20-02 checkpoint had not enumerated.
+
+pounce has three multi-RHS-capable call sites. The padded stride reaches one:
+
+| pounce call site | nrhs | reached? |
+|---|---|---|
+| `std_aug_system_solver.rs:497,625` (IPM) | 1, hardcoded | no |
+| `pounce-feral/src/lib.rs:1004,1006` (batched backsolve) | 6 | no — below the threshold |
+| `pounce-feral/src/schur.rs:303,304` | `n_s` | yes, when `n_s >= 32` |
+
+The batched backsolve's width is `limited_memory_max_history`, which defaults
+to 6 (`alg_builder.rs:1037`, `:1508`). Below `BLAS3_NRHS_THRESHOLD = 32`, so
+it takes the rank-1 kernel, which the change does not touch. That dispatch is
+already correct — measured rank1/blas3 at `nrhs = 6` is 0.68-0.86 across all
+seven probe matrices, i.e. rank-1 wins — so there is no unclaimed gain there
+and no argument for lowering the threshold to capture it.
+
+The Schur path is the one that benefits, and it can be wide:
+`schur_aug_system_solver.rs:36` sets `DEFAULT_MAX_SCHUR_FRAC = 0.5`, so `n_s`
+reaches half the KKT dimension before the backend refuses the partition.
+
+**Consequence for release decisions:** the 1.36x figure is a property of the
+multi-RHS solve at `nrhs >= 32` and not a multiple of 8. It is not a pounce
+end-to-end number and must not be quoted as one.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7177,3 +7177,44 @@ single draw, not an improvement. Run-to-run spread on this machine is
 ~±2.5%; the `factor/MUMPS` **max** column is not stable at all (9.71 here,
 68.79 on the failing run, with the offender list changing identity) and
 should not be quoted as a result.
+
+## 2026-08-20 — The multi-RHS panel path pads its row stride to a cache line
+
+The row-major multi-RHS work buffers (`y`, `w`, `acc` in
+`SolveManyWorkspace`) used a leading dimension of exactly `nrhs`. On the
+BLAS-3 panel path that makes every row of every supernode panel straddle a
+cache line whenever `nrhs % 8 != 0`, and the cost compounds across the
+gather, both kernels, and the scatter. Measured within a single process, so
+immune to cross-process drift: `t(31)/t(32)` read 1.41–1.80 across seven
+large KKTs when it should read ~0.97 (`nrhs = 31` is 3% *less* work).
+
+**Decision:** the panel path allocates and indexes at
+`padded_ldw(nrhs) = nrhs.div_ceil(NR) * NR`, i.e. a multiple of 64 bytes.
+The rank-1 path keeps the raw `nrhs` stride — it is row-major but not
+tiled, and it carries the bit-identity band contract that
+`tests/multi_rhs.rs:227,256` assert and pounce's `schur.rs:303` consumes.
+
+The padding is paid for in flops: the kernels solve `padded_ldw(nrhs)`
+columns, of which up to 7 are zero padding. That is 21% extra arithmetic at
+`nrhs = 33`, 7% at 100, under 1% at 1000 — and it is still a net 1.36×
+geomean win in the shipped regime (`nrhs >= 32`, not a multiple of 8),
+because the alignment is worth more than the wasted lanes. After the fix
+`t(33)/t(32) ≈ 1.21`, which is exactly `40/33`: the residual is entirely
+the padding columns, with no misalignment left.
+
+**Alternative not taken:** pad the *allocation* for alignment but iterate
+only the `nrhs` live columns, masking the final tile. `gemm_tile` already
+takes a `live` argument, so the kernel side is ready. It recovers roughly
+the remaining 18% at `nrhs = 33`. It is not part of this decision because
+it requires distinguishing stride from live width through five kernels, and
+that belongs in its own commit with its own before/after.
+
+**Bit-neutral**, verified three independent ways: an 800-shape `to_bits()`
+test against a scalar left-fold reference (`gemm_tail_tests`); the probe's
+`max |rank1 - blas3|` column unchanged at all 105 measured (matrix, `nrhs`)
+points; and all 13 `tests/multi_rhs.rs` green including both
+`assert_eq!(max_diff, 0.0)` band contracts. No tolerance was touched.
+
+`BLAS3_NRHS_THRESHOLD` stays at 32 — the crossover constant was the
+suspect, but the defect was underneath it, and the threshold is load-bearing
+for the bit-identity contract.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7342,3 +7342,72 @@ identical failure mode the old constant had. qap15_kkt with a badly-scaled
 RHS and `BackwardError(1e-14)` runs 8 steps, exits `Stagnated` at omega
 `4.2e-11`, and costs 0.32x for nothing; `BackwardError(1e-10)` reaches
 `4.4e-11` in 3 steps. The knob does not remove the need to read `stop`.
+
+## 2026-08-21 — refinement's default stopping criterion is now conjunctive
+
+**Context.** Ipopt/pounce reported a class of problems where feral's solve
+was materially worse than the MA57/MUMPS ports it replaces, while the vast
+majority of problems were fine. Four candidate causes were measured and
+ruled out: ForceAccept (`inertia.zero == 0`, `n_tiny == 0` on all seven
+large matrices), the pivot threshold (Ipopt sets `ma27_pivtol = 1e-8`,
+`ma57_pivtol = 1e-8`, `mumps_pivtol = 1e-6` — *below* the library defaults;
+feral's 1e-8 already matches), the escalation ladder
+(`pounce-feral/src/lib.rs:1368` does wire `increase_quality`), and the
+inertia itself (exact agreement with canonical MUMPS 5.8.2 on all seven,
+including `qap15_kkt` at `cond1 = 3.9e12`).
+
+**The cause is the stopping criterion.** `RefineOptions::default()` stopped
+on `EpsSqrtN`, `‖r‖₂ < ε·√n·‖b‖₂`, which is normwise and therefore dominated
+by the rows carrying the largest right-hand-side entries. MUMPS's `ICNTL(10)`
+refinement stops on the Arioli–Demmel–Duff *componentwise* backward error
+against `CNTL(2) = √ε` (`ref/mumps/src/dini_defaults.F:1094`). On a RHS
+spanning twelve orders — the shape an IPM produces near convergence, where
+the dual, primal and complementarity blocks differ by many orders — the two
+diverge by up to eleven orders and feral declared `Converged` without
+refining once:
+
+| matrix | feral ω, old default | MUMPS ω1 |
+|---|---:|---:|
+| `r05_kkt` | 9.520e-5 (0 steps) | 3.608e-16 |
+| `bratu3d` | 8.953e-6 (0 steps) | 2.844e-16 |
+| `cont-201` | 3.860e-7 (0 steps) | 2.728e-16 |
+
+**Decision.** The default is now
+`StopCriterion::EpsSqrtNAndBackwardError(DEFAULT_BACKWARD_ERROR_TARGET)`
+with the target set to `√ε` — MUMPS's `CNTL(2)`, the same number for the
+same purpose — so a default-configured `solve_refined` certifies at least
+what a default-configured MUMPS does.
+
+It is the **conjunction**, deliberately. Requiring both tests is strictly
+harder to satisfy than the old default, so no caller can receive a worse
+iterate than it did before, and the change ships without touching a single
+tolerance or residual gate. `EpsSqrtN` remains available and bit-for-bit
+unchanged for callers that want the historical behavior.
+
+**Cost, measured — and it is not free.** On the seven large matrices:
+well-scaled RHS identical to the old default (same steps, same iterates);
+badly-scaled RHS one extra step (5–14 ms) on the three worst, which then sit
+level with MUMPS at ~3e-16.
+
+That understates the corpus-wide cost. A controlled A/B over the 154,588
+benchmark matrices — same machine, only `Default for RefineOptions` changed —
+shows the median untouched and the tail paying: solve/MUMPS p90 0.15 → 0.20
+(+33%), p99 0.71 → 1.08 (+52%); solve/SSIDS geomean 0.94 → 1.06 (+13%), p90
+2.50 → 3.60 (+44%), p99 8.33 → 13.00 (+56%). Factor is unchanged within noise,
+which confirms the effect is the refinement loop rather than machine state.
+
+So this decision trades tail latency for componentwise correctness. It is
+recorded as such, not as a free improvement. Callers needing the old latency
+profile can pass `StopCriterion::EpsSqrtN` explicitly and accept the gap.
+
+**Rejected alternatives** (both in `dev/tried-and-rejected.md` with their
+failing cases): `BackwardError(√ε)` alone, which fails `tests/parity.rs` on
+ROSZMAN1_0241 because ω ≤ √ε can hold while the normwise residual is looser
+than the old rule delivered; and `BackwardError(f64::EPSILON)`, LAPACK
+`dgerfs`'s target, which stagnates or exhausts the step budget on five of
+seven large matrices under the badly-scaled RHS.
+
+**Regression coverage.** `tests/issue190_componentwise_default.rs`. The
+defect reproduces on the tracked parity corpus — `EpsSqrtN` leaves ω above
+√ε on 13 of 63 matrices, worst DEGENLPB_0046 at 359×√ε — and the new default
+drives all 63 to ω ≤ √ε.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7096,3 +7096,84 @@ uncovered while being covered locally. The coverage job prints the skip
 list to the run summary — the same step ci.yml has — so a low number in
 those modules can be checked against it before being treated as a real
 gap.
+
+## 2026-08-20 — The bench times the `Auto` core, serially (issue #189 item 1)
+
+`src/bin/bench.rs` timed the sparse KKT solve through the free
+`solve_sparse_refined`, which hardcodes `SolveCore::SharedVector`
+(`src/numeric/solve.rs:2077`). Every `Solver` entry point dispatches
+through `SolveCore::Auto` (`src/numeric/solver.rs:1690-1722`), and `Auto`
+selects `ContribBlock` on most of the KKT corpus above n ≈ 10⁴. The
+published solve column therefore described a configuration no host runs.
+
+Measured with `crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs`
+(11 reps, three configurations interleaved within each repetition,
+medians, one process), over seven matrices spanning n = 8,032 … 180,900:
+
+| ratio | `steps=1` | default depth |
+|---|---:|---:|
+| core, `SharedVector → Auto`, serial | **1.37×** | **1.30×** |
+| schedule, `Auto` serial → parallel | 1.01× | 0.98× |
+| bench → shipped | 1.38× | 1.27× |
+
+Up to 1.90× on `r05_kkt` and `cont5_late_kkt`.
+
+**Decision: time `solve_sparse_refined_auto_into(.., parallel = false, ..)`.**
+
+Two parts, both deliberate.
+
+*`Auto` rather than `SharedVector`* — the benchmark should measure the
+arithmetic hosts get. A gate built on the shared-vector core cannot see a
+regression in the `ContribBlock` traversal, which is the traversal the
+corpus's large matrices actually take.
+
+*Serial rather than pooled* — per #177 the pool changes only the
+schedule, never the arithmetic, and the same probe measures that schedule
+at geomean 1.01/0.98, i.e. nothing. Installing a pool would import
+thread-count variance into a CI-visible number in exchange for no
+measurable signal. `parallel = false` measures the host's core without
+the host's scheduler.
+
+The aggregate barely moves — `solve/MUMPS` geomean and p50 both stay at
+0.08 — because the corpus is ~154k matrices dominated by small ones where
+`Auto` picks `SharedVector` anyway. That is the expected outcome and was
+recorded in the journal before the run landed. The change makes the
+column describe the right core; it is not a speedup.
+
+### The regression this exposed, and why it is a harness defect
+
+The first run of the change failed the sparse small-frontal exit
+partition — p90 2.03 against a ≤ 2.0 target, from 1.58. A control run on
+stashed, unmodified code in the same session reproduced 1.58 PASS, so the
+cause was the change, not machine state.
+
+The mechanism is that `resample_or_fallback` (`src/bin/bench.rs:1060`)
+runs factor **and** solve interleaved inside one closure,
+`RESAMPLE_COLD_REPS = 5` times, and reduces `factor_us` by **min** across
+those replicates. Whatever the solve does to cache and allocator state is
+the state the next replicate's factor is measured in. And
+`should_resample` (`:1042`) fires on `mumps_timing.factor_us < 200` — the
+same small matrices the `small-frontal (<200)` bucket gates.
+
+The change had allocated its solve buffer inside the closure: an n-double
+alloc-and-zero per replicate at n < 1000. Hoisting it to one allocation
+per matrix, reused across replicates, restored the partition to 1.54 PASS
+(dense 1.59 / 1.96 PASS) and dropped the worst sparse factor ratio from
+68.79 to 9.29.
+
+**The coupling itself is left in place, deliberately.** It is
+pre-existing: any solve-side change can perturb the small-matrix factor
+reading through it. Fixing it means giving factor and solve separate
+timing passes, which changes every small-matrix number in the corpus and
+needs its own commit with its own before/after — not a drive-by inside a
+different change. Recorded as a Step 1 item in
+`dev/plans/large-n-solve-gate.md`.
+
+*Spread, added after a third confirming run:* the sparse small-frontal
+p90 reads 1.54 and 1.61 on the two post-fix runs against a 1.58 baseline
+— the change is indistinguishable from baseline on the factor partition,
+which is the correct outcome for a solve-only change. The 1.54 above is a
+single draw, not an improvement. Run-to-run spread on this machine is
+~±2.5%; the `factor/MUMPS` **max** column is not stable at all (9.71 here,
+68.79 on the failing run, with the offender list changing identity) and
+should not be quoted as a result.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7251,3 +7251,49 @@ reaches half the KKT dimension before the backend refuses the partition.
 **Consequence for release decisions:** the 1.36x figure is a property of the
 multi-RHS solve at `nrhs >= 32` and not a multiple of 8. It is not a pounce
 end-to-end number and must not be quoted as one.
+
+
+## 2026-08-20 — Refinement stopping criterion is a caller choice, not a constant (issue #190)
+
+`RefineOptions` carries a `StopCriterion` enum rather than a second numeric
+knob. Three variants: `EpsSqrtN` (the pre-#190 hardwired test, kept as the
+default so no existing caller changes behavior), `RelativeResidual(f64)`, and
+`BackwardError(f64)`.
+
+Why an enum and not "add a `target: Option<f64>` field": the two useful
+targets are not the same quantity and cannot share one number. `||r||/||b||`
+is normwise and blind to row scaling; the componentwise backward error is
+scale-aware per row. On the badly-scaled 2x2 in the research note they read
+`1.0e-36` and `5.0e-13` for the same solution. A single `f64` field would
+have forced a silent choice between them.
+
+`BackwardError` is the one with a principled stopping value. `eps`-order `t`
+means "as good as a backward-stable factorization would have returned",
+independent of `n`. `max_steps` has no such value, which is Finding 1 of the
+research note: the corpus sweep of step counts is non-monotone, so no
+constant is defensible.
+
+Cost: `BackwardError` needs `|A| |x|`, one extra pass over the matrix per
+iteration via the new `CscMatrix::abs_symv`. **Zero extra solves.** That is
+why it is affordable in the hot path and why `RefinementDiagnostics` is not:
+the latter's `kappa_1_est` is 3-5 extra solves (`solve.rs:2596`), multiplying
+the cost #190 exists to cut.
+
+Returned instead: `RefineOutcome { steps, relative_residual, stop }`, all
+three already computed by the loop. `RefineStop` is ordered
+`Converged < Stagnated < Diverged < MaxSteps` for the multi-RHS aggregate,
+which reports the max steps, the max relative residual, and the worst stop
+across columns.
+
+**Documented deviation from LAPACK `dgerfs`.** The guarded formula is
+adopted verbatim, `safe1 = (n+1) * MIN_POSITIVE` and `safe2 = safe1 / EPSILON`
+included, with one exception: a row whose denominator `(|A||x| + |b|)_i` is
+exactly zero contributes `0`, where LAPACK computes `safe1/safe1 = 1`. Proof
+that this is safe, not a loosened tolerance: `d_i == 0` forces every
+`|a_ij||x_j| = 0` and `|b_i| = 0`, hence `r_i == 0` exactly. Keeping LAPACK's
+`1` would make any `BackwardError` target unreachable on a system with a
+structurally empty row — reproducing the exact defect #190 reports.
+
+**What this does not fix.** `ZeroPivotAction::ForceAccept` is FERAL's default
+and leaves residual on near-singular pivots, so `max_steps = 0` remains
+unusable for pounce regardless of the stopping criterion. Out of scope here.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7297,3 +7297,48 @@ structurally empty row — reproducing the exact defect #190 reports.
 **What this does not fix.** `ZeroPivotAction::ForceAccept` is FERAL's default
 and leaves residual on near-singular pivots, so `max_steps = 0` remains
 unusable for pounce regardless of the stopping criterion. Out of scope here.
+
+## 2026-08-20 — #190 measured: it is an accuracy feature, not a performance one
+
+The entry above was written before the corpus measurement. Recording the
+result here because it changes what the feature is *for*, and because the
+standing bar on this thread is "rigorous, thoroughly correct, and a real
+performance gain, or it does not ship."
+
+**The premise in issue #190 did not reproduce.** #190 argues the `ε·√n`
+target is unreachable on large systems so "every call runs the full budget."
+Best-of-5 over seven matrices (`probe_refine_stop_criterion`, output in the
+2026-08-20-01 journal) with a well-scaled RHS: the default converges in
+**0–2 steps on every one** — r05_kkt 0, qap15_kkt 2, dirichlet120_kkt 0,
+cont-201 0, cont5_late_kkt 1, bratu3d 0, bcsstk38 0. There is no
+wasted-iteration saving to claim. Caveat in the other direction: the
+`n = 118,276` system #190 cites is a pounce runtime KKT and is not in the
+local corpus (largest local is `c-big`, `n = 345,241`, not in this set), so
+the premise is untested at its own scale rather than refuted at it.
+
+**What the measurement did establish is a correctness gap.** With a RHS
+whose entries span `1e-6..1e6`, the default declares `Converged` at normwise
+`rel` of `1e-14..1e-17` while the componentwise backward error is up to
+eleven orders worse: r05_kkt `9.5e-5`, bratu3d `9.0e-6`, cont-201 `3.9e-7`,
+dirichlet120_kkt `4.3e-10`, bcsstk38 `1.1e-10`, qap15_kkt `1.2e-10`. One
+`BackwardError` step lands all of them at `~3e-16`. The default cannot see
+this by construction: `||r||_2/||b||_2` is dominated by the rows where
+`|b_i| ~ 1e6`.
+
+**Cost.** ~2x on the refinement wall time (0.39x–0.61x "vs def"), factor
+excluded — roughly one extra solve. The only measured speedups are the
+caller deliberately buying less accuracy: qap15 easy at
+`BackwardError(1e-10)` is 1.45x by stopping at omega `8.8e-12` instead of
+`2.7e-16`; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
+(omega `8.0e-10` vs the default's `1.2e-10`).
+
+**Decision.** The feature stays, documented as an accuracy/observability
+knob with the measured cost stated, not as a speedup. `CHANGELOG.md`,
+`README.md` and the `solve_sparse_refined` doc comment were corrected —
+all three had asserted the unreachable-target premise as fact.
+
+**Documented caveat, new.** An unreachable *componentwise* target has the
+identical failure mode the old constant had. qap15_kkt with a badly-scaled
+RHS and `BackwardError(1e-14)` runs 8 steps, exits `Stagnated` at omega
+`4.2e-11`, and costs 0.32x for nothing; `BackwardError(1e-10)` reaches
+`4.4e-11` in 3 steps. The knob does not remove the need to read `stop`.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -544,3 +544,31 @@ anything into it.
 * 16:50 :checkpoint:
 Checkpoint written to dev/sessions/2026-08-20-02.md, leading with the
 unfavorable bench comparison per CLAUDE.md. context.md refreshed (329 lines).
+
+* 17:20 :scope:pounce:correction:
+Read pounce issue #698 comment 5359027510 (srikanth-gm). Its subject is a
+residual 946 KB copy-back in pounce's backsolve and a possible feral
+`solve_in_place`, which the reporter bounds themselves at ~95 us against a
+0.2162 s per-iteration back-solve — under their ~30% run-to-run noise. Agreed;
+no feral issue filed, belongs as a line item under #134 if anywhere.
+
+The useful part was incidental: the comment mentions "six times that under the
+column batching at limited_memory_max_history = 6", naming a third multi-RHS
+call site I had not enumerated. Confirmed in the pounce tree (e1173385):
+alg_builder.rs:1037 and :1508 both set limited_memory_max_history: 6, and
+pounce-feral/src/lib.rs:1004,1006 is the batched backsolve.
+
+6 < BLAS3_NRHS_THRESHOLD = 32, so that path takes rank-1 and a0b4d64 cannot
+reach it. Checked whether that is a missed opportunity: probe rank1/blas3 at
+nrhs=6 is 0.79/0.86/0.73/0.81/0.68/0.75/0.70 across the seven matrices —
+rank-1 is FASTER at that width, so the dispatch is already right and there is
+no case for lowering the threshold.
+
+Net: pounce has three multi-RHS sites (nrhs=1 IPM hardcoded, nrhs=6 batched
+backsolve, n_s Schur) and a0b4d64 reaches only the third, and only when
+n_s >= 32. Schur can be wide — schur_aug_system_solver.rs:36 sets
+DEFAULT_MAX_SCHUR_FRAC = 0.5 — but this is one path under one condition.
+The 1.36x is a solve-kernel number, NOT a pounce end-to-end number.
+
+Amended dev/sessions/2026-08-20-02.md in place (marked as a correction) and
+appended a new decisions.md entry rather than editing the prior one.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -521,3 +521,26 @@ Residual t(33)/t(32) ~ 1.21 after the fix is exactly 40/33 — the cost of the
 aligned stride but iterate only the live columns with a masked final tile
 (gemm_tile already takes `live`). Recovers ~18% more at nrhs=33; needs a
 stride-vs-live parameter through five kernels, so it is a separate change.
+
+* 16:40 :bench:checkpoint:caveat:
+Session-end bench after a0b4d64. All four Phase 2.8.1 buckets PASS, but the
+factor p90s are the worst of the four runs recorded across 08-20-01 and this
+session: sparse small-frontal and medium both 1.65 (baseline 1.58, prior runs
+1.54/1.61), dense small-frontal 1.66 (1.59/1.64), dense medium 2.04 (2.00,
+prior 1.96/1.98). solve/MUMPS geomean and p50 held at 0.08 exactly.
+
+a0b4d64 cannot mechanically explain this: the bench times factorization and a
+*single-RHS* solve, and the change is confined to solve_sparse_core_many_into
+plus the panel GEMM reached only from fwd_blas3/back_blas3. solve_sparse_core_into
+and the whole factorization are byte-identical.
+
+Most likely machine state — the box had been under sustained compile and probe
+load for hours. But that is a hypothesis, NOT a result: no control run on
+stashed code was done. A similarly plausible attribution was already refuted
+once this session (the tail-loop hypothesis), so this one is recorded as
+unverified and the next session must re-run the bench cold before reading
+anything into it.
+
+* 16:50 :checkpoint:
+Checkpoint written to dev/sessions/2026-08-20-02.md, leading with the
+unfavorable bench comparison per CLAUDE.md. context.md refreshed (329 lines).

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -572,3 +572,42 @@ The 1.36x is a solve-kernel number, NOT a pounce end-to-end number.
 
 Amended dev/sessions/2026-08-20-02.md in place (marked as a correction) and
 appended a new decisions.md entry rather than editing the prior one.
+
+* 18:30 :bench:cold:resolved:
+Cold bench re-run (built cold, 180s settle, machine quiet). All four Phase
+2.8.1 buckets returned to the BOTTOM of the observed band: sparse
+small-frontal 1.54, sparse medium 1.54, dense small-frontal 1.59, dense
+medium 1.97 — against the hot run's 1.65/1.65/1.66/2.04 and the 08-19-05
+baseline of 1.58/1.58/1.58/2.00.
+
+Two independent machine-state signatures confirm it was not a0b4d64:
+factor/MUMPS max fell 71.94 -> 9.10, and the worst-offender list changed
+identity entirely (GAUSS2/CRESC100 ~87 cold vs HAIFAM/HAHN1 ~72 hot).
+factor/SSIDS p99 also fell 1.11 -> 0.95.
+
+The 2026-08-20-02 checkpoint caveat is resolved: a0b4d64 did not regress the
+factor path, as the mechanical argument predicted but could not prove.
+
+* 19:15 :perf:rejected:masked-tile:
+Implemented the masked-tile follow-up (stride ld vs live nrhs through
+fwd_blas3/back_blas3/dsolve_node/gemm_panel_minus). Correct — 445 tests pass,
+clippy RC=0, bit-identity sweep extended to 1600 shapes over both stride
+regimes, plus a new pad-columns-untouched assertion that I mutation-checked
+(re-injecting the full-ld loop fails it: "pad column 1 written at row 0 for
+nrhs=1 ld=8"). rank1-vs-blas3 max abs diff unchanged at all 42 points.
+
+AND IT IS SLOWER. Anchored geomean over seven KKTs: 0.823x at nrhs=33,
+0.799x at 36, 0.797x at 47. Slower in raw us on every matrix too (1.11-1.34x
+worse at nrhs=33). Null controls (nrhs 32/40/48, where masking is a provable
+no-op — identical machine code) moved only 1.019x, so ~1.9% drift against a
+~20% effect. Decisive.
+
+Pre-mask, cost was a pure function of padded_ldw: t(36)~t(40) on all seven
+(bcsstk38 7059 vs 7111 us), t(47)~t(48) on all seven, t(33)/t(32)=1.225 vs
+40/33=1.212 predicted. Post-mask it tracks NEITHER the pad model (1.250) nor
+the work model (1.031) — it is 1.490, worse than both.
+
+Conclusion: the padding is not waste, it is what keeps every loop a whole
+number of 8-wide vector operations. My "18% available headroom" note from
+16:05 was WRONG and is retracted. Reverted in full; nothing kept. Recorded
+in tried-and-rejected.md.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -611,3 +611,149 @@ Conclusion: the padding is not waste, it is what keeps every loop a whole
 number of 8-wide vector operations. My "18% available headroom" note from
 16:05 was WRONG and is retracted. Reverted in full; nothing kept. Recorded
 in tried-and-rejected.md.
+
+* 20:10 :issue-190:refinement:verify:
+Read feral#190 in full and checked all five of its code claims against
+the tree at 7de1a93. All confirmed. The issue cites solve.rs:2574 and
+:2749; those predate a0b4d64 (+~250 lines), so located by content:
+threshold is at :2693 (single-RHS) and :2872 (multi-RHS), RefineOptions
+at :2118, the ForceAccept comment at :2146 (quoted verbatim in the
+issue), and both Solver::*_refined_into sites at solver.rs:1676 / :1824
+do discard diagnostics. Arithmetic checks too: eps*sqrt(118276) =
+7.636e-14, so the target really is out of reach on that KKT and the
+"always runs to the cap" mechanism follows.
+
+* 20:25 :issue-190:design:cost:
+Two design findings before writing anything.
+
+(1) Returning RefinementDiagnostics from the hot path would be a serious
+cost regression. solve.rs:2596 gates kappa_1_est on with_diagnostics,
+and kappa comes from estimate_inverse_norm_1 (Hager-Higham) which the
+struct's own doc puts at 3-5 extra solves per run. #190's benchmark
+already spends 48.962 s in back-solve at max_steps=10 -- routing the
+host's normal call through diagnostics multiplies exactly the cost the
+issue exists to cut. The issue allows "even just usize". Everything a
+host needs (steps taken, relative residual, which exit fired) is already
+computed in the loop and discarded, so a small Copy struct is free.
+
+(2) ||r||_2/||b||_2 is a weaker measure than #190's own stated goal.
+The issue says the host wants "what a stable LDL^T would have returned
+-- a backward-stable solve of the system it factorized". The direct
+measure of that is the componentwise backward error of Arioli-Demmel-Duff
+1989, omega = max_i |r_i| / (|A||x| + |b|)_i, which is what MA57
+(RINFO(6..8)) and MUMPS (RINFO(7..8)) actually report. It has a
+principled stopping point (omega <~ u = "the solve is honest", no guessed
+number) and it is scale-aware per row, which matters because #190's
+corpus includes a badly-scaled LP at data scale 1e11. Cost is one extra
+pass over A per step and ZERO extra solves -- unlike anything derived
+from kappa.
+
+Naive omega is fragile: a row whose denominator underflows gives a
+spuriously huge ratio that refinement cannot reduce, so the criterion
+would never fire -- the same failure mode #190 reports for eps*sqrt(n).
+Adopting LAPACK dgerfs' guarded form (safe1 = (n+1)*MIN_POSITIVE,
+safe2 = safe1/EPSILON) instead. Side benefit: a published formula is an
+external oracle, which CLAUDE.md requires when implementation and test
+would otherwise be written in the same session.
+
+Asked the user; they chose both criteria via a StopCriterion enum, and
+deferred the release-shape decision until #190 is measured. Research
+note at dev/research/issue-190-refine-target.md, plan at
+dev/plans/issue-190-refine-target.md.
+
+* 21:40 :issue-190:implement:
+Implemented the full #190 design. `CscMatrix::abs_symv` (4 tests),
+`backward_error` in solve.rs against the LAPACK dgerfs formula (4 oracle
+tests, expected values from an independent Python script written before the
+Rust), `StopCriterion`/`RefineOptions.stop`, `RefineOutcome`/`RefineStop`,
+wired through the single-RHS core, the batched multi-RHS path, and both
+`Solver` entry points. New integration suite `tests/issue190_refine_target.rs`
+(15 tests) including a bit-identity check that the default criterion
+reproduces pre-#190 behavior and that the batched path matches the
+per-column loop.
+
+Three compile errors surfaced and fixed along the way:
+- `probe_largen_solve_levers.rs:150` matched `Ok(())` against what is now
+  `Result<RefineOutcome, _>` (E0308) -> `Ok(_)`.
+- the new test used `Solver::factor(..).is_ok()`, but `factor` returns
+  `FactorStatus`, not `Result` (E0599).
+- `FactorStatus` derives only `Debug`, no `PartialEq`, so `assert_eq!` on it
+  does not compile either. Used `matches!` rather than widening the public
+  derive set for a test's convenience.
+
+Docs done: CHANGELOG `[Unreleased]` entry and a `dev/decisions.md` append
+recording why an enum rather than a numeric field, why `RefineOutcome` and
+not `RefinementDiagnostics` (kappa_1_est = 3-5 extra solves), and the
+documented `d_i == 0` deviation from dgerfs with its proof.
+
+* 22:05 :issue-190:test:measurement:
+First full run of `tests/issue190_refine_target.rs` failed 3 of 15. All three
+were my test constants, not the implementation: I had guessed target values
+instead of measuring what the fixture can reach.
+
+  a_backward_error_target_stops_early_too      berr 1e-8  -> MaxSteps
+  a_tighter_relative_target_costs_more_steps   rel  1e-10 -> MaxSteps
+  the_multi_rhs_path_honors_each_criterion     rel  1e-6  -> MaxSteps
+
+Wrote a throwaway probe (`tests/tmp_probe190.rs`, deleted after) to get the
+actual ladder for `full_budget_case()`, single RHS, per correction step:
+
+  k     1        2        3        4        5
+  rel 2.37e-3  7.74e-4  2.55e-4  8.38e-5  2.76e-5
+  ome 1.21e-3  4.85e-4  1.66e-4  5.53e-5  1.82e-5
+  k     6        7        8        9       10
+  rel 9.07e-6  2.99e-6  9.82e-7  3.23e-7  1.06e-7
+  ome 6.01e-6  1.98e-6  6.51e-7  2.14e-7  7.05e-8
+
+Contraction is 3.0x per step and the 10-step floor is rel 1.06e-7 /
+omega 7.05e-8. So 1e-10 and 1e-8 were below the floor; the loop was
+correctly reporting MaxSteps. Retargeted to 1e-4 (4 steps) and 1e-6
+(8 steps), both measured, and put the ladder in the module comment so the
+constants are not magic. 15/15 pass.
+
+** Unplanned finding: omega is far more uniform across columns than ||r||/||b||
+On the 20-column `many_rhs` fixture at the cap:
+
+  criterion  best column   worst column   spread
+  rel        1.06e-7       4.46e-6        42x
+  omega      2.86e-8       7.65e-8        2.7x
+
+The columns differ only by an additive offset in b, so ||b|| varies and the
+normwise ratio inherits that variation; the componentwise measure does not.
+Consequence at a fixed numeric target on the batched path:
+
+  t      rel steps        berr steps
+  1e-3   6  Converged     2  Converged
+  1e-4   8  Converged     4  Converged
+  1e-5  10  Converged     6  Converged
+  1e-6  10  MaxSteps      8  Converged
+  1e-7  10  MaxSteps     10  Converged
+
+A batched normwise target is hostage to its worst-scaled column: at 1e-5 it
+costs 10 steps where the componentwise target costs 6 for a solution of
+equivalent backward quality. This was not an argument I had for the design
+beforehand -- the research note justified omega on scale-awareness within a
+single system. It is a stronger argument on the multi-RHS path, which is
+exactly the path pounce's Schur solver uses.
+
+* 22:20 :needs-refinement:provenance:caveat:
+Found an uncommitted change to =src/dense/factor.rs= in the working tree
+while staging #190: =flag_growth_for_refinement= now compares =|L_ij|=
+against =1/pivot_threshold= (the multiplier bound TPP actually promises)
+instead of a fixed =1e6=, with the constant kept only as the =u = 0=
+fallback. Four new =growth_flag_tests= cases; suite green, clippy clean.
+
+The change stands on its own: =|L_ij| <= 1/u= is the contract of threshold
+partial pivoting, so it is the right thing to check the factor against, and
+unlike =1e6= it is scale-free and moves with =increase_quality=.
+
+**Provenance caveat, stated because it matters.** The doc comment cites a
+pounce measurement -- a 126028-order KKT where the old test fired on 91 of
+108 factorizations whose actual growth =max|L|/max|A|= was 8.7e-8, and where
+the largest =|L|= anywhere was 5.1e7 against a promised 1e8 -- and I cannot
+reproduce that measurement from anything in this session's record. Grepping
+the transcript finds those numbers only inside the diff itself, and there is
+no probe output, research note, or journal entry behind them. Committing it
+separately from #190 for exactly that reason: the mathematical argument is
+sound and self-contained, the cited numbers are not independently checkable
+here and should be re-derived before they are quoted anywhere else.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -401,3 +401,123 @@ changed identity (CRESC100/MUONSINE -> ACOPR14/KIRBY2). That tail is
 resample-loop noise on sub-millisecond matrices, not a real factor
 change; the max column is not a stable statistic here and should not be
 quoted as a result.
+
+* 14:05 :measurement:rejected:blas3:
+Discarded the entire two-build kernel comparison. Built stock (threshold 32)
+and patched (threshold 2) binaries of probe_blas3_crossover and ran them
+alternating, on the theory that alternation cancels drift. Two controls say
+otherwise. The looped single-RHS path is byte-identical in both builds and
+must read 1.00 across builds; it read 1.15, 1.58, 1.97, 2.10. And nrhs in
+{32,40,48}, where both builds dispatch to the same kernel so the ratio must be
+exactly 1.00, read 0.86-0.90 — a >=10% systematic bias with no code cause.
+A sweep takes ~25 min, so "adjacent" runs are 25 min apart: blocked
+measurement wearing an interleaved label. Same error as this morning's two
+retractions, one level down. Killed the remaining runs (pkill, 0 left) and
+reported no number from the paired dataset. Logged in tried-and-rejected.md.
+
+* 14:20 :method:blas3:
+Replaced it with an in-process design: new `kernel-probe` Cargo feature (off
+by default, compiled out entirely — with it off the dispatch reads the const
+directly as before) exposes set_blas3_nrhs_threshold. One process now times
+rank-1 and BLAS-3 at the *same* nrhs, alternating within each of 9 reps —
+microseconds apart, not 25 minutes. Both `cargo build --release` and
+`--features kernel-probe` compile clean.
+
+* 14:40 :finding:blas3:confirmed:
+The threshold was the wrong question. Timing both kernels at the same nrhs
+shows a sawtooth with period 8, not a crossover. bcsstk38 rank1/blas3:
+nrhs=8 2.12, 10 1.40, 12 1.06, 14 0.89, 16 1.60, 20 1.00, 24 1.36, 28 1.14,
+31 1.03, 32 1.31. BLAS-3 wins decisively at every multiple of NR=8 and decays
+as nrhs moves off one.
+
+Cause: gemm_scalar_block handled the nrhs%NR column tail with an unblocked
+triple loop — for every output element it re-walked all of A's row (stride
+col_stride) and B's column (stride nrhs), no reuse. Fitting blas3_us on the
+multiples of 8 and attributing the excess to tail columns puts a tail column
+at 1.6-5.1x a blocked column, consistent across all five matrices analysed.
+
+Cleanest evidence, needing no fit and no cross-process comparison: within a
+single run, t(31)/t(32) should be ~0.97 (31 is 3% less work). Measured:
+bcsstk38 1.61, r05_kkt 1.41, bratu3d 1.79, qap15_kkt 1.47, dirichlet120_kkt
+1.80, cont-201 1.47, cont5_late_kkt 1.64. All seven. nrhs=31 costs 1.4-1.8x
+nrhs=32.
+
+This is a defect, not a tuning parameter, and it is orthogonal to the
+threshold: it hits every nrhs>=32 caller whose nrhs is not a multiple of 8 —
+7 cases in 8, including pounce's Schur path where nrhs = n_s is problem data.
+
+* 14:55 :fix:blas3:bitneutral:
+Replaced gemm_scalar_block with gemm_tile<const R: usize>: runs the tails at
+full NR register width with unused lanes zero-padded. Padded lanes compute
+0.0 - a*0.0 == 0.0 every step and are never stored, so each stored element
+stays a left fold over increasing k. The MR x NR main loop is untouched —
+deliberately, to put zero risk on the path that already works.
+
+Bit-neutral, two independent checks:
+- New test panel_gemm_is_bit_identical_to_the_reference_on_every_tail_shape
+  asserts to_bits() equality against a scalar left-fold reference over 800
+  shapes (16 nrhs x 10 m_dim x 5 k_dim), covering every nrhs%8 and m_dim%4
+  residue. Passes.
+- The probe's max|rank1-blas3| column is unchanged at all 89 (matrix,nrhs)
+  points compared before vs after. rank-1 is untouched, so any change in the
+  BLAS-3 output would move it. Zero moved.
+
+Because it is bit-neutral it needs no threshold change, no tolerance change,
+and no sign-off on the assert_eq!(max_diff, 0.0) band contract.
+
+* 15:10 :measurement:selfinflicted:
+First after-fix probe run is contaminated and discarded: I ran
+`cargo test --release` (full release compile + 451 tests) while it was timing.
+Signature is unambiguous — matrices early in the sweep (bcsstk38, r05_kkt,
+qap15_kkt) show tail excess *worse* than before, matrices late in it
+(dirichlet120_kkt, cont-201) show it collapsed to ~0-1x. That is the compile
+finishing partway through, not a property of the kernel. Re-running with the
+machine quiet, and switching the headline metric to within-run t(31)/t(32),
+which needs no fit and no cross-process comparison.
+
+* 15:40 :finding:refuted:alignment:
+The tail hypothesis was wrong as the *cause*. Discriminating experiment:
+nrhs=33 has ONE tail column, nrhs=31 has SEVEN. If tail count drove cost they
+would differ sharply. bratu3d blas3: 31->72298, 32->46582, 33->74154,
+34->74043, 36->76060, 38->80859, 40->58760. 33 costs 1.59x 32 while doing 3%
+MORE work, and matches 31 to within 3%. Tail count does not predict cost.
+Stride does: 32 and 40 doubles are 256 and 320 bytes, whole cache lines;
+31/33/34/36/38 are not.
+
+Cause is cache-line alignment of the row-major leading dimension. y and w are
+row-major with ld = nrhs (issue #57), so a non-multiple-of-8 nrhs makes every
+panel row straddle cache lines, compounding across gather, kernels, scatter.
+
+Fix: padded_ldw(nrhs) = nrhs.div_ceil(8)*8 as the row stride on the panel
+path. Padding columns carry a zero RHS and are never read back, so every real
+column's arithmetic and order is untouched. Rank-1 path keeps the raw stride —
+it gains nothing and would only pay for the extra columns.
+
+The tail fix (gemm_tile) is kept: it moved t(31)/t(32) from 1.41-1.80 to
+1.39-1.51 on its own, is bit-neutral, and is a prerequisite for the follow-up
+below.
+
+* 16:05 :result:confirmed:alignment:
+Sawtooth eliminated. Within-run t(31)/t(32), which needs no cross-process
+comparison: 1.61->1.06, 1.41->0.73, 1.79->1.38, 1.47->0.88, 1.80->0.96,
+1.47->0.97, 1.64->1.00 across the seven KKTs. Anchored on nrhs=32, which is
+byte-identical code before and after (padded_ldw(32)==32), so uniform drift
+cancels.
+
+Bit-identical: max|rank1-blas3| unchanged at all 105 (matrix,nrhs) points;
+new 800-shape to_bits() test passes; all 13 tests/multi_rhs.rs pass including
+both assert_eq!(max_diff, 0.0) band contracts. Full suite green, clippy clean
+with --all-features.
+
+IMPORTANT scoping correction: the probe forces blas3 at every nrhs, but the
+library only dispatches to it at nrhs>=32. So the big ratios at nrhs 6-31 are
+diagnostic, not shipped gain — quoting the 1.83x geomean over those points as
+the headline would overstate by ~35%. Shipped regime is nrhs>=32 and not a
+multiple of 8. At nrhs=33, two independent framings agree: anchored 1.21/1.59/
+1.32x, raw absolute 1.22/1.22/1.32x. Geomean 1.36x.
+
+Residual t(33)/t(32) ~ 1.21 after the fix is exactly 40/33 — the cost of the
+7 padding columns, not leftover misalignment. Follow-up available: keep the
+aligned stride but iterate only the live columns with a masked final tile
+(gemm_tile already takes `live`). Recovers ~18% more at nrhs=33; needs a
+stride-vs-live parameter through five kernels, so it is a separate change.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -125,3 +125,105 @@ lands.
 median 2.39x, never below 1.70x, and stable across runs. This is the only
 robust lever measured today, and the work is pounce-side (already
 reported at pounce#698). feral already has the API.
+
+* 09:10 :perf:solve:measurement:artifact:
+Two probes disagreed about feral#131's parallel solve core and I nearly
+posted the second as a correction to the first. They were not measuring
+the same comparison.
+
+- =probe_largen_solve_levers= path E: =Solver::with_parallel(true)= vs
+  =Solver::with_parallel(false)=, =RefineOptions::with_max_steps(1)=,
+  best-of-5. Both sides run =SolveCore::Auto=, so this is a pure
+  *schedule* comparison. Reported geomean 0.92 (parallel slower).
+- =probe_bench_solve_noise=: =Solver::with_parallel(true)= vs the free
+  =solve_sparse_refined=, =RefineOptions::default()=, median-of-15.
+  Reported geomean 1.21 (parallel faster), incl. cont5_late_kkt 1.80x.
+
+The free function hardcodes =SolveCore::SharedVector=
+(=src/numeric/solve.rs:2077=) while =Solver= runs =Auto=, which picks
+=ContribBlock= on six of these seven matrices. So the second ratio folds
+the *core* change in with the schedule change -- and at a different
+refinement depth: =DEFAULT_REFINE_MAX_STEPS = 10= (=solve.rs:1954=), not 1.
+
+Confirmed =Solver::refine_into= (=src/numeric/solver.rs:1690-1722=) passes
+=SolveCore::Auto= on both branches, differing only in whether the pool is
+installed. So par/ser through =Solver= *is* schedule-only and bit-neutral
+per #177; the mistake was using =solve_sparse_refined= as the serial arm.
+
+Wrote =probe_solve_reconcile= to measure all three configurations
+interleaved within each repetition, at both depths, and attribute
+core / schedule / depth separately. Interleaving rather than blocking so
+machine drift hits all three equally -- the earlier cross-run spreads (up
+to 2.20x on the same matrix) are exactly what blocked measurement buys
+you.
+
+Implication: no correction goes on #131 or #189 until this lands. The
+0.92 figure I already posted to #131 is a schedule-only number at depth
+1; whether it is the number a host cares about depends on which depth and
+which core the host actually runs.
+
+* 09:35 :perf:solve:reconciled:issue131:issue189:
+=probe_solve_reconcile=, 11 reps, three configs interleaved per repetition,
+both refinement depths, one process:
+
+|                  |     n | core sv/au | sched au/ap | shipped sv/ap | corr |
+|------------------+-------+------------+-------------+---------------+------|
+| bcsstk38         |  8032 |       1.02 |        0.90 |          0.91 |    0 |
+| r05_kkt          | 14842 |       1.65 |        1.15 |          1.90 |    1 |
+| bratu3d          | 27792 |       1.31 |        0.99 |          1.29 |    0 |
+| qap15_kkt        | 50880 |       1.37 |        1.05 |          1.45 |    2 |
+| dirichlet120_kkt | 54363 |       1.12 |        1.00 |          1.12 |    0 |
+| cont-201         | 80595 |       1.45 |        0.98 |          1.42 |    0 |
+| cont5_late_kkt   | 180900|       1.88 |        1.01 |          1.90 |    1 |
+| geomean steps=1  |       |       1.37 |        1.01 |          1.38 |      |
+| geomean default  |       |       1.30 |        0.98 |          1.27 |      |
+
+Three conclusions, two of which overturn what I posted an hour ago.
+
+1. *The parallel solve schedule buys nothing -- confirmed, and cleanly.*
+   geomean 1.01 (steps=1) / 0.98 (default), per-matrix 0.85..1.15. The
+   #131 conclusion survives. What does not survive is the 0.92 figure and
+   the spread table behind it.
+
+2. *"The measurement is not reproducible" was false -- my method was.*
+   The 1.44x..2.20x same-matrix spreads I posted to both issues came from
+   comparing configurations measured in separate blocks and separate runs.
+   Interleaved within a repetition, the same comparisons are stable to
+   ~1.0-1.15x. Blocked measurement produced a 2.4x error on r05_kkt: I
+   reported CB-parallel at 0.67 vs shared-vector; interleaved it is 1.65x
+   *faster*. Nothing about the machine changed.
+
+3. *New, and the real finding: =SolveCore::Auto= is worth 1.30-1.37x
+   geomean and the bench cannot see any of it.* =solve_sparse_refined=
+   hardcodes =SolveCore::SharedVector= (=solve.rs:2077=); =Solver= runs
+   =Auto=. So the solve column feral publishes is a configuration no host
+   runs, and it under-reports the shipped path by geomean 1.27-1.38x, up
+   to 1.90x on cont5_late_kkt. That is #189 item 1, and it is a much
+   bigger deal than "the harness cannot observe the CB core."
+
+Corollary that also overturns a posted claim: =cb_core_profitable= is
+*well calibrated*, not mis-calibrated. It picks ContribBlock on exactly
+the six matrices where core > 1 (1.12..1.88) and SharedVector on
+bcsstk38, the one where the core is a wash (1.02). 7/7. My "approves the
+losing case r05_kkt at 0.67" was the blocked-measurement artifact above.
+Withdraw the "re-fit the gate against worker count" rescope item.
+
+Refinement depth is a non-issue: corrections actually run at default
+depth are 0 or 1 on six of seven matrices (qap15_kkt runs 2), so
+=max_steps=1= and =max_steps=10= are nearly the same call. The depth
+hypothesis for the two probes' disagreement is dead; the core confound
+explains all of it.
+
+* 09:45 :perf:solve:batching:reverified:
+Re-measured the batching lever interleaved (=probe_batch_interleaved=,
+11 reps, nrhs=13, =solve_into= x13 vs =solve_many_into=), because after
+the above every blocked number is suspect:
+
+  bcsstk38 2.20  r05_kkt 2.80  bratu3d 2.44  qap15_kkt 2.31
+  dirichlet120_kkt 2.37  cont-201 2.62  cont5_late_kkt 2.58
+  geomean 2.47x  min 2.20x
+
+Blocked measurement had said geomean 2.29x, min 1.70x. Batching survives
+and is slightly better than reported. This is the one lever whose blocked
+and interleaved numbers agree -- consistent with it having been stable
+across runs all along, unlike the schedule ratio.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -227,3 +227,177 @@ Blocked measurement had said geomean 2.29x, min 1.70x. Batching survives
 and is slightly better than reported. This is the one lever whose blocked
 and interleaved numbers agree -- consistent with it having been stable
 across runs all along, unlike the schedule ratio.
+
+* 10:05 :bench:issue189:step1:harness:
+Step 1 of =dev/plans/large-n-solve-gate.md=: switched the sparse KKT
+corpus solve timing (=src/bin/bench.rs:1963=, plus the resample closure
+at =:1988=) off the free =solve_sparse_refined= and onto
+=solve_sparse_refined_auto_into(.., parallel = false, ..)=.
+
+Rationale is the 09:35 measurement: the free function hardcodes
+=SolveCore::SharedVector= (=solve.rs:2077=) while every =Solver= entry
+dispatches through =Auto=, so the published solve column measured a core
+no host runs.
+
+Chose =parallel = false= deliberately rather than installing a pool. Per
+#177 the pool is schedule-only and bit-neutral, and the same probe
+measures that schedule at geomean 1.01/0.98 -- nothing. Serial keeps the
+reading free of thread-count variance while still measuring the host's
+*arithmetic*. Timing =ap= instead would import scheduler noise for no
+measurable gain.
+
+Expected effect on the aggregate is small and I want that on the record
+before the numbers land: the corpus is ~154k matrices dominated by tiny
+ones where =Auto= picks =SharedVector= anyway. The 1.30-1.37x was
+measured on n = 8e3..1.8e5, a thin slice of the corpus. If the geomean
+barely moves, that is the expected outcome -- the point of the change is
+that the column now describes the core hosts run, not that the number
+improves.
+
+Note the reported *residual* also changes on matrices where =Auto= picks
+=ContribBlock=: the two cores are different reassociations (#177), so
+=rel_res= moves by ~kappa*eps. Tolerance is =n * eps * 1e6=, generous
+enough that this should not flip any pass/fail, but it is a real change
+to a reported number and gets checked against the run.
+
+=cargo clippy --bin bench -- -D warnings= clean; release build clean.
+
+* 10:35 :bench:regression:unresolved:
+Bench run with the Step 1 change (=Auto= core on the sparse solve
+timing). *Sparse small-frontal exit partition FAILS: p90 2.03 vs target
+<= 2.0*, against 1.58 PASS in session 2026-08-19-05. Reporting before
+diagnosis per CLAUDE.md.
+
+|                          | 2026-08-19-05 | this run |
+|--------------------------+---------------+----------|
+| sparse factor/MUMPS gmean|          0.45 |     0.51 |
+| sparse factor/MUMPS p50  |          0.32 |     0.40 |
+| sparse factor/MUMPS p90  |          1.58 |     2.03 |
+| sparse factor/MUMPS max  |         10.58 |    68.79 |
+| sparse solve/MUMPS gmean |          0.08 |     0.08 |
+| sparse solve/MUMPS p50   |          0.08 |     0.08 |
+| sparse solve/MUMPS p90   |          0.15 |     0.17 |
+| sparse solve/MUMPS max   |          2.71 |    23.83 |
+| dense small-frontal p90  |          1.58 |     1.73 |
+| dense medium p90         |          2.00 |     2.13 |
+
+Two reasons to suspect machine state rather than the change:
+
+1. The failing number is the *factor* ratio. The change touches only the
+   solve timing call; it cannot affect factorization at all.
+2. The *dense* partition also degraded (1.58 -> 1.73, 2.00 -> 2.13), and
+   the dense loop shares no code with the edit --
+   =src/dense/solve.rs:69= is a separate implementation with no
+   =SolveCore=. It is an untouched control and it moved the same
+   direction.
+
+But the solve max (2.71 -> 23.83) is exactly where a wrong core choice
+would show, so "obviously the machine" is not good enough. Stashed the
+change and started a control run on unmodified code, same machine, same
+session. That is the A/B I should have had before drawing any conclusion
+-- the whole lesson of 09:35.
+
+* 11:05 :bench:regression:diagnosed:harness:
+Control run settles it and refutes my own hypothesis from 10:35.
+
+Stashed the Step 1 change, rebuilt, re-ran on the same machine in the
+same session. *Unmodified code: sparse small-frontal p90 1.58 PASS,
+dense 1.58 / 2.00 PASS* -- reproducing 2026-08-19-05 exactly. So the
+2.03 FAIL is caused by the change, not by machine state. The reasoning
+at 10:35 -- "the dense partition also degraded, and it shares no code" --
+was coincidence I read as evidence. It did not reproduce.
+
+Mechanism, and it is the same failure mode as everything else today:
+
+=resample_or_fallback= (=src/bin/bench.rs:1060=) runs *factor and solve
+interleaved* in one closure, =RESAMPLE_COLD_REPS = 5= times, and reduces
+=factor_us= by **min** across those reps. So whatever the solve does to
+cache and allocator state is what the next replicate's factor is measured
+in. Change the solve and the factor reading moves.
+
+And the population it moves on is not arbitrary: =should_resample=
+(=:1042=) fires when =mumps_timing.factor_us < 200=, i.e. small matrices
+-- which is exactly the =small-frontal (<200)= bucket that failed. The
+buckets and the resample predicate select the same matrices.
+
+My version made it worse than necessary by allocating =rs_x= *inside* the
+timed solve region on every replicate: an n-double alloc-and-zero per
+rep, plus allocator churn feeding the next rep's factor. Hoisted the
+buffer to one allocation per matrix, reused across replicates. Re-running.
+
+Two things to carry forward regardless of how the re-run lands:
+
+1. This is a pre-existing harness defect, not something the change
+   introduced. Any solve-side change perturbs the small-matrix factor
+   reading today. The denoise loop was built (2026-04-20-01) to make
+   small-matrix readings *stable*; interleaving the two phases inside it
+   makes them *coupled* instead.
+2. It belongs in the Step 1 scope in =dev/plans/large-n-solve-gate.md=,
+   which already flagged the min/median reduction as "needs restating for
+   a gate." Restating is not enough -- the phases need separate timing
+   passes so one cannot leak into the other.
+
+* 11:25 :bench:resolved:step1:
+Re-run with the solve buffer hoisted out of the timed region: *FAIL
+resolved.*
+
+| bucket                   | baseline 08-19-05 | control (unmod) | with change |
+|--------------------------+-------------------+-----------------+-------------|
+| sparse small-frontal p90 |         1.58 PASS |       1.58 PASS |   1.54 PASS |
+| sparse medium p90        |         1.58 PASS |       1.58 PASS |   1.54 PASS |
+| dense small-frontal p90  |         1.58 PASS |       1.58 PASS |   1.59 PASS |
+| dense medium p90         |         2.00 PASS |       2.00 PASS |   1.96 PASS |
+
+Worst sparse factor ratio 68.79 -> 9.29. The 1.58 -> 1.54 movement is
+within run-to-run noise and is *not* claimed as an improvement; the claim
+is only that the regression is gone.
+
+So the entire 2.03 FAIL was the per-replicate allocation inside the timed
+solve region, feeding the next replicate's factor through the min
+reduction. An 8 KB alloc-and-zero per rep at n < 1000 was worth 1.58 ->
+2.03 on a p90 over 153,455 matrices. That is a sharper demonstration of
+the coupling than I would have designed on purpose.
+
+The coupling itself is still there -- =resample_or_fallback= still
+interleaves factor and solve, so the next solve-side change can do this
+again. Recorded as a Step 1 item rather than fixed here: fixing it means
+restructuring the reduction, which changes every small-matrix number in
+the corpus and deserves its own commit and its own before/after.
+
+* 12:10 :bench:confirmed:spread:
+Third full bench run (complete output captured, not =| tail -25=), to get
+the ratio tables the checkpoint needs and to serve as a second
+confirmation of the fix.
+
+| bucket                   | baseline 08-19-05 | control (stashed) | run 2 | run 3 |
+|--------------------------+-------------------+-------------------+-------+-------|
+| sparse small-frontal p90 |              1.58 |              1.58 |  1.54 |  1.61 |
+| sparse medium p90        |              1.58 |              1.58 |  1.54 |  1.61 |
+| dense small-frontal p90  |              1.58 |              1.58 |  1.59 |  1.64 |
+| dense medium p90         |              2.00 |              2.00 |  1.96 |  1.98 |
+
+All PASS. The two post-fix runs bracket the baseline (1.54, 1.61 vs
+1.58), which is the spread number Step 1 asked for: run-to-run movement
+of the sparse small-frontal p90 on this machine is about +/-0.04, ~2.5%.
+Any future claim of a bench improvement smaller than that is noise. This
+also retires the "with change = 1.54" reading from the 11:25 entry as a
+point estimate -- the honest statement is that the change is
+indistinguishable from baseline on the factor partition, which is what it
+should be, since it touches only the solve.
+
+Sparse aggregate, run 3 (=solve/MUMPS=): geomean 0.08, p50 0.08, p90
+0.16, p99 0.88, max 3.12. Baseline was 0.08 / 0.08 / 0.15 / --- / 2.71.
+The geomean and p50 did not move, exactly as predicted in the 10:05 entry
+before the first run: the ~154k-matrix corpus is dominated by small
+matrices where =Auto= picks =SharedVector= anyway, so timing the =Auto=
+core cannot show up in the aggregate. The 1.30x that
+=probe_solve_reconcile= measures lives entirely at n >= 8k, and the
+corpus has almost none of that. Implication for Step 2: the large-n gate
+needs its own matrix set; it will never be visible in this harness's
+aggregate.
+
+The =factor/MUMPS= max fell 68.79 -> 9.71 and the worst-offender list
+changed identity (CRESC100/MUONSINE -> ACOPR14/KIRBY2). That tail is
+resample-loop noise on sub-millisecond matrices, not a real factor
+change; the max column is not a stable statistic here and should not be
+quoted as a result.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -1,0 +1,127 @@
+#+TITLE: FERAL session journal 2026-08-20-01
+#+STARTUP: overview
+
+* 08:05 :coverage:codecov:ci:
+Codecov wired up and merged (PR #188, 9b9e882). Live upload confirmed:
+90.41% (30,989/34,275 lines, 80 files). Two findings worth keeping.
+
+The coverage job runs =--workspace --exclude feral-diagnostics=, which
+runs MORE tests than ci.yml: bare =cargo test= at the workspace root
+resolves to the =feral= package alone, so the six ordering crates
+(feral-ordering-core 69, feral-metis 59, feral-kahip 63, feral-scotch 45,
+feral-amd 12, feral-amf 10 = 258 tests) had never run in CI. All passed.
+
+=dirichlet120_parallel_factor_does_not_deadlock= is =--skip=ped in the
+coverage job only: under llvm-cov instrumentation it takes 123.25s
+against its hard 120s budget (=test result: FAILED. 0 passed; 1 failed;
+finished in 123.25s=), while passing under both =cargo test= and
+=cargo test --release=. Instrumentation overhead, not an issue-#102
+regression. The test is NOT weakened -- ci.yml's =check= job still
+asserts 120s on every push. Audited: it is the only test in the tree
+with a wall-clock assertion.
+
+* 08:20 :perf:solve:probe:issue131:issue189:
+Wrote =crates/feral-diagnostics/src/bin/probe_largen_solve_levers.rs= to
+measure -- rather than assert from source reading -- the two solve-phase
+levers I had just filed on #131 and #189.
+
+Motivation: my #131 comment argued from source that the CB parallel core
+was unreachable performance. That is a claim about numbers, and I had
+taken no numbers.
+
+Probe design: factor once, then produce the same NRHS=13 solutions four
+ways (A serial =solve_sparse= x13, B =solve_sparse_cb(false)= x13,
+C =solve_sparse_cb(true)= x13, D =solve_sparse_many(13)= x1), best-of-5
+wall clock, each path reported with its own relative residual since the
+CB and shared-vector cores are different reassociations (#177). Then a
+sweep of nrhs through =BLAS3_NRHS_THRESHOLD= comparing looped-single
+against =solve_sparse_many= per-RHS.
+
+Added two things after the first results came in:
+- A bit-level detector for =SolveCore::Auto='s choice. =cb_core_profitable=
+  is private, but the two cores differ numerically, so running
+  =solve_sparse_refined_auto_into= with =max_steps=0= and bit-comparing
+  against each explicit core identifies the pick exactly.
+- E: end-to-end =Solver::solve_refined= with =with_parallel(true/false)=.
+  =tests/parallel_parity.rs:4-8= contracts the parallel factor to be
+  bit-equal to the sequential one, so both sides hold the same factor and
+  =Auto= makes the same choice -- this is a pure schedule comparison of
+  the shipped path.
+
+* 08:35 :perf:solve:issue131:refuted:
+Ran three passes. First pass (4 matrices) and the n=180,900 pass each had
+the machine to themselves; a third overlapped another probe and is noted
+as contended. Final clean sequential pass over 8 matrices.
+
+Clean pass, 14 rayon threads, best-of-5. E = refined e2e parallel/serial,
+C = CB-parallel vs 13x serial, D = solve_many(13) vs 13x serial:
+
+| matrix           |       n | Auto picks   |    E |    C |    D |
+|------------------+---------+--------------+------+------+------|
+| bcsstk38         |    8032 | SharedVector | 0.98 | 1.07 | 1.88 |
+| r05_kkt          |   14842 | ContribBlock | 0.74 | 0.67 | 2.35 |
+| bratu3d          |   27792 | ContribBlock | 1.16 | 0.56 | 2.10 |
+| qap15_kkt        |   50880 | ContribBlock | 1.18 | 1.01 | 2.43 |
+| dirichlet120_kkt |   54363 | ContribBlock | 1.04 | 0.81 | 2.51 |
+| cont-201         |   80595 | ContribBlock | 0.41 | 1.69 | 2.99 |
+| cont5_late_kkt   |  180900 | ContribBlock | 1.39 | 1.82 | 2.65 |
+| c-big            |  345241 | ContribBlock | 0.90 | 1.03 | 1.70 |
+| geomean          |         |              | 0.92 | 1.00 | 2.29 |
+
+Conclusion 1: the #131 parallel-solve lever does not exist as filed.
+Geomean 1.00 for the core, 0.92 for the shipped path that actually uses
+it. I twice reached a wrong intermediate conclusion before this --
+first "refuted, negative everywhere" from a 4-matrix pass, then
+"n-dependent with a crossover near 1e5" after cont5_late_kkt returned
+1.97. Both died on more data: bratu3d (n=27,792) gave 1.23 in one run and
+0.56 in another, and c-big (n=345,241) only 1.03-1.12. It is not size and
+it is not shape.
+
+Conclusion 2 (the actual finding): the measurement is not reproducible.
+Same matrix, across runs -- bratu3d 0.56<->1.23 (2.20x), cont-201
+0.85<->1.69 (1.99x), dirichlet120 0.81<->1.39 (1.72x). Best-of-5 did not
+tame it. Only cont5_late_kkt reproduces (1.82/1.97/1.98) and only r05_kkt
+reproducibly loses (0.46/0.63/0.67). We currently cannot distinguish a 2x
+solve regression from scheduler noise, which promotes #189 above #131.
+
+Conclusion 3: =cb_core_profitable= approves ContribBlock on 7 of 8
+matrices, including r05_kkt where the approved configuration runs at
+0.67. =solve_sparse_cb(.., true)= does honor =plan.worthwhile=
+(=src/numeric/solve.rs:1275=), so these were gate-approved losses. The
+gate's own doc comment (=solve.rs:1007=) records that it was calibrated
+on 4 workers; this box has 14.
+
+* 08:40 :perf:solve:blas3:confirmed:
+Isolated the BLAS3 kernel effect from the nrhs effect by patching
+=BLAS3_NRHS_THRESHOLD= 32 -> 2 (=src/numeric/solve.rs:17=), rebuilding,
+re-running, then reverting. Per-RHS microseconds on the =many= path,
+thr=32 -> thr=2:
+
+| nrhs | cont-201 | dirichlet120 | qap15 |  r05 |
+|------+----------+--------------+-------+------|
+|    8 |     1.70 |         2.10 |  1.57 | 1.96 |
+|   16 |     1.25 |         2.28 |  1.28 | 1.31 |
+|   24 |     1.24 |         1.26 |  1.27 | 1.30 |
+|   32 |     1.01 |         0.94 |  1.09 | 1.01 |
+
+The nrhs=32 row is an internal control -- both configurations take the
+BLAS-3 path there, and they agree to within noise. So the 1.2-2.3x in the
+8..31 band is the kernel, not the batching.
+
+Two caveats. Run-to-run spread on these is 20-30%. And nrhs=13 is
+consistently worse per-RHS than nrhs=16 in every single case, which looks
+like a ragged register-block remainder at odd panel widths and is worth
+its own look.
+
+Sequencing point that is easy to miss: this lever is unreachable until a
+host batches. =BLAS3_NRHS_THRESHOLD= only exists on the multi-RHS path,
+so while pounce loops single-RHS
+(=low_rank_aug_system_solver.rs:497=), nrhs=1 and the constant never
+comes into play. #189 item 4 buys nothing until pounce#698's batching
+lands.
+
+* 08:45 :perf:solve:batching:confirmed:
+=solve_sparse_many(13)= against 13 looped single solves: geomean 2.29x,
+median 2.39x, never below 1.70x, and stable across runs. This is the only
+robust lever measured today, and the work is pounce-side (already
+reported at pounce#698). feral already has the API.

--- a/dev/journal/2026-08-20-01.org
+++ b/dev/journal/2026-08-20-01.org
@@ -757,3 +757,71 @@ no probe output, research note, or journal entry behind them. Committing it
 separately from #190 for exactly that reason: the mathematical argument is
 sound and self-contained, the cited numbers are not independently checkable
 here and should be re-derived before they are quoted anywhere else.
+
+* 23:05 :issue-190:measurement:unfavorable:
+Ran =probe_refine_stop_criterion= (best-of-5 wall, seven matrices, two RHS
+families) to test #190's stated premise: "on a large ill-conditioned system
+the eps*sqrt(n) target is not reachable and the loop always runs the full
+budget." Output: =/tmp/feralmsg/probe190b.txt=.
+
+*The premise does not reproduce on this corpus.* With a well-scaled RHS the
+default criterion converges in 0-2 steps on every matrix -- never at the
+10-step cap:
+
+: matrix            n        default steps   omega
+: r05_kkt           14842    0  Converged    4.546e-13
+: qap15_kkt         50880    2  Converged    2.690e-16
+: dirichlet120_kkt  54363    0  Converged    1.679e-14
+: cont-201          80595    0  Converged    8.720e-14
+: cont5_late_kkt    180900   1  Converged    1.711e-16
+: bratu3d           27792    0  Converged    2.467e-15
+: bcsstk38          8032     0  Converged    1.324e-15
+
+So there is no wasted-step saving to claim. The largest local matrix is
+=c-big= at n=345241; the n=118276 system #190 cites is a pounce *runtime*
+KKT and is not in the local corpus, so the premise is untested at its own
+scale, not refuted at it. Stated as a corpus limit, not as vindication.
+
+*What the measurement did find is a correctness gap, not a speed gap.* With
+a badly-scaled RHS (entries 1e-6..1e6, alternating sign) the default
+declares =Converged= at normwise rel ~1e-14..1e-17 while the componentwise
+backward error is up to eleven orders worse:
+
+: matrix            default: steps  rel        omega      | BE(1e-12): steps  omega      cost
+: r05_kkt                   0       2.674e-14  9.520e-5   | 1                 2.655e-16  0.48x
+: bratu3d                   0       4.141e-16  8.953e-6   | 1                 3.170e-16  0.48x
+: cont-201                  0       3.385e-16  3.860e-7   | 1                 2.909e-16  0.48x
+: dirichlet120_kkt          0       7.720e-17  4.310e-10  | 1                 2.658e-16  0.49x
+: bcsstk38                  0       2.456e-15  1.098e-10  | 1                 7.742e-16  0.39x
+: qap15_kkt                 2       1.303e-16  1.229e-10  | 8 Stagnated       4.218e-11  0.32x
+: cont5_late_kkt            1       1.867e-16  8.398e-14  | 1 (BE 1e-14: 2)   4.474e-16  0.61x
+
+Six of seven: the default stops at a solution that is *not* backward stable
+componentwise, and reports success. One =BackwardError= step fixes it. The
+=rel= column is the point -- 4.14e-16 on bratu3d looks like a perfect solve
+and sits next to omega = 8.95e-6. A normwise test cannot see this because
+=||r||_2/||b||_2= is dominated by the rows where |b_i| ~ 1e6 and says
+nothing about the rows where |b_i| ~ 1e-6.
+
+*Cost, stated plainly: the criterion buys quality, not speed.* The fix is
+~2x on the solve (0.39x-0.61x "vs def"), factor excluded. The only speedups
+measured are (a) qap15 easy, =BackwardError(1e-10)= 1.45x by stopping at
+omega 8.755e-12 instead of 2.690e-16, and (b) qap15 hard,
+=RelativeResidual(1e-12)= 1.49x at omega 8.038e-10 vs the default's
+1.229e-10 -- faster *and worse*. Both are the caller choosing to buy less
+accuracy, which is exactly what the knob is for, but neither is a free gain.
+
+*Caveat the docs must carry:* the new knob can burn the budget the same way
+the old constant did. qap15_kkt hard with =BackwardError(1e-14)= runs 8
+steps, exits =Stagnated=, lands at omega 4.218e-11 -- 0.32x for nothing,
+because 1e-14 is below what that factorization can deliver. An unreachable
+componentwise target has the identical failure mode #190 complained about.
+=BackwardError(1e-10)= on the same system converges in 3 steps at
+essentially the same omega (4.388e-11).
+
+Conclusion against the standing bar ("rigorous, thoroughly correct, and
+result in performance gains, or we will not include it in a release"): the
+work is rigorous and correct, and it is *not* a performance gain. If it
+ships, it ships as an accuracy/observability feature with an honest note
+that the default is unchanged and the new criteria cost roughly one extra
+solve. That is a call for the human, not for me.

--- a/dev/journal/2026-08-21-01.org
+++ b/dev/journal/2026-08-21-01.org
@@ -1,0 +1,215 @@
+#+TITLE: Session journal 2026-08-21-01
+#+STARTUP: showeverything
+
+Continues 2026-08-20-01 across midnight. Standing instruction from the human:
+"we need to fix the deficiency gap with ma57/mumps if there is one because
+this is causing an issue on a class of problems in pounce. surprisingly, it
+works well for the vast majority of problems."
+
+* 00:40 :pivot-threshold:hypothesis:refuted:
+I had claimed feral's =pivot_threshold = 1e-8= was a six-order deficiency
+against MA57/MUMPS, whose *library* defaults are =CNTL(1) = 0.01=. I changed
+=src/numeric/factorize.rs:645= to =1e-2= on that basis.
+
+*The claim is wrong.* Ipopt does not use the library defaults. Read from
+=ref/Ipopt=:
+
+: IpMa27TSolverInterface.cpp:97    ma27_pivtol   default 1e-8
+: IpMa57TSolverInterface.cpp:205   ma57_pivtol   default 1e-8
+: IpMumpsSolverInterface.cpp:131   mumps_pivtol  default 1e-6
+
+Ipopt deliberately lowers pivtol *below* the library defaults, because in an
+IPM the accuracy is bought back by inertia correction and iterative
+refinement, not by pivoting hard. feral's 1e-8 already matches the MA27/MA57
+port that pounce is replacing, and =tests/issue_2_kkt_ls_init.rs:32=
+(=numeric_params_default_uses_sparse_pivot_threshold=) pins it for exactly
+that reason. That test is correct; I left it untouched.
+
+Reverted with =git checkout src/numeric/factorize.rs=. Recorded in
+=dev/tried-and-rejected.md=. No pivot-threshold change ships.
+
+* 01:20 :forceaccept:inertia:ruled-out:
+Two more candidate explanations for the pounce gap, both measured with
+=probe_forceaccept_residual= on the seven large matrices:
+
+- ForceAccept: =inertia.zero == 0= and =n_tiny == 0= on all seven. No pivot
+  was force-accepted, so the "we accepted a tiny pivot and ate the error"
+  story does not apply.
+- Inertia: feral's inertia matches canonical MUMPS 5.8.2 *exactly* on all
+  seven, including =qap15_kkt= at 22275/28605/0 with =cond1 = 3.9e12=.
+
+Also checked the escalation ladder: =pounce-feral/src/lib.rs:1368= does
+forward =increase_quality= into feral's =Solver::increase_quality()=, so
+Ipopt's =IncreaseQuality()= path is wired. Not the gap either.
+
+* 02:05 :measurement:artifact:correction:
+The "nine orders short on qap15_kkt" figure in
+=probe_vs_mumps_residual='s doc comment is an artifact of my own making: it
+compares feral *unrefined* against MUMPS *with* =ICNTL(10)=2= refinement on.
+
+Measured properly (feral refined vs MUMPS refined, well-scaled RHS,
+identical systems and identical =b=): feral matches or beats MUMPS on all
+seven. There is no factorization-quality gap on this corpus. Rewrote the
+probe's doc comment; the wrong number is not left standing anywhere.
+
+* 03:30 :issue-190:defect:found:
+*The gap is the stopping criterion, not the factorization.*
+
+=RefineOptions::default()= stopped on =EpsSqrtN=: =||r||_2 < eps*sqrt(n)*||b||_2=.
+That is *normwise*, so it is dominated by the rows carrying the largest
+right-hand-side entries. MUMPS's =ICNTL(10)= refinement instead stops on the
+Arioli-Demmel-Duff *componentwise* backward error against
+=CNTL(2) = sqrt(eps)= (=ref/mumps/src/dini_defaults.F:1094=).
+
+On a RHS spanning twelve orders (=v[i] = +/-10^((i%13)-6)=, the shape an IPM
+produces near convergence, where the dual / primal / complementarity blocks
+differ by many orders), feral reported =Converged= at step 0 while MUMPS,
+same matrix, same =b=, returned machine precision:
+
+: matrix    feral omega (0 steps)   MUMPS omega1
+: r05_kkt   9.520e-5                3.608e-16
+: bratu3d   8.953e-6                2.844e-16
+: cont-201  3.860e-7                2.728e-16
+
+Eleven orders, and feral never refined once because its test was already
+satisfied. This is the shape the human described: fine on the vast majority
+of problems (well-scaled RHS -> the two tests agree), broken on a class
+(badly-scaled RHS -> they diverge). In an IPM the small-|b_i| rows are the
+complementarity residuals of near-active constraints -- exactly the rows
+that set the step.
+
+* 04:15 :issue-190:design:rejected:
+First fix attempted: make =BackwardError(sqrt(eps))= the default outright.
+
+*Failed =tests/parity.rs=:*
+
+: ROSZMAN1_0241 residual: feral=4.805e-14 > max(K*mumps=2.077e-14, floor=1.000e-14) = 2.077e-14
+
+=omega <= sqrt(eps)= can be satisfied while the normwise residual is looser
+than the old rule delivered, so swapping one test for the other regresses
+callers that depend on the normwise bound. Shipping it would have required
+loosening that gate, which needs human approval and is not warranted here.
+
+Second candidate, =BackwardError(f64::EPSILON)= (LAPACK =dgerfs='s target):
+measured with =OMEGA_EPS=1 HARD_RHS=1= and rejected -- it stagnates or
+exhausts the step budget on *five of seven* large matrices (up to 10 steps),
+reproducing exactly the cost pathology #190 complained about, while
+=sqrt(eps)= converges in at most one step.
+
+Both recorded in =dev/tried-and-rejected.md=.
+
+* 05:40 :issue-190:implement:
+Shipped instead: a new =StopCriterion::EpsSqrtNAndBackwardError(f64)=, the
+*conjunction* of the two tests, as the default with
+=DEFAULT_BACKWARD_ERROR_TARGET = sqrt(eps)= (MUMPS's =CNTL(2)=, same number
+for the same purpose).
+
+The conjunction is the point. It is strictly harder to satisfy than the old
+default, so *no caller can get a worse iterate than before* -- which is why
+it ships without touching a single tolerance. Best-iterate selection is by
+smallest =||r||_2= and =best_omega= tracks the omega of that same iterate,
+so the conjunctive test is self-consistent.
+
+Four edits in =src/numeric/solve.rs=: the constant + =Default= impl, the new
+variant, an arm in both =reached= closures (single- and multi-RHS), and both
+=wants_omega= matches widened so omega is actually computed.
+
+* 06:30 :issue-190:measurement:
+Cost, seven large matrices, both RHS families:
+
+- Well-scaled RHS: *identical to the old default on all seven* -- same step
+  counts, same iterates. The extra conjunct is already satisfied.
+- Badly-scaled RHS: the three worst go to 2.655e-16 / 3.170e-16 / 2.909e-16,
+  level with MUMPS, for *one* extra step each (5-14 ms).
+- Worst-case step count across the whole corpus: still 2, the same bound
+  =EpsSqrtN= already had.
+
+So the answer to the standing bar is: this is a *correctness* fix that is
+free on the well-scaled majority and costs one solve on the class that was
+broken. Full suite green: 953 passed, 0 failed, 112 suites.
+
+* 08:30 :issue-190:test:regression:
+The seven discovery matrices are gitignored (=tests/data/large/*=), so the
+regression test has to live on the tracked parity corpus. Wrote
+=probe_omega_parity_corpus= to find out whether the defect reproduces there.
+
+*It does: =EpsSqrtN= leaves omega > sqrt(eps) on 13 of 63 tracked matrices.*
+Worst offenders, as omega/sqrt(eps):
+
+: DEGENLPB_0046  3.590e2      DEGENLPA_0065  1.270e2
+: DEGENLPB_0045  3.008e2      ACOPP14_0003   4.308e1
+: DEGENLPB_0047  1.802e2
+
+and the new default fixes every one of them -- e.g. DEGENLPB_0047
+2.685e-6 -> 2.146e-16 in 1 step, HYDCAR20_0000 4.046e-8 -> 2.166e-16 in 2,
+HIMMELBJ_0032 4.554e-8 -> 2.035e-16 in 2.
+
+*Correction to an earlier reading of this probe:* I had noted HAHN1_0004
+(1.373e-8), HS109_0009 (4.844e-9) and VESUVIOU_0030 (7.289e-9) as "still
+above sqrt(eps)" and planned to scope the assertion around them. They are
+not -- all three are below sqrt(eps) = 1.4901e-8. I had compared them
+against =eps=, not =sqrt(eps)=. No scoping needed; the blanket assertion
+holds across the corpus.
+
+New =tests/issue190_componentwise_default.rs=, three tests, 0.64 s:
+
+1. =default_certifies_backward_stability_on_badly_scaled_rhs= -- every
+   factorable parity matrix (63) comes back with omega <= sqrt(eps).
+2. =normwise_criterion_alone_is_not_enough= -- pins five named fixtures
+   where =EpsSqrtN= alone leaves omega > 10*sqrt(eps), so the fixtures
+   cannot silently stop exercising the defect.
+3. =default_is_never_weaker_than_the_historical_rule= -- the conjunction
+   never produces a worse componentwise error than =EpsSqrtN= on any
+   corpus matrix. This is the property that lets it ship without approval.
+
+External oracle for the whole thing is canonical MUMPS 5.8.2, recorded in
+=dev/research/issue-190-refine-target.md=; the omega implementation is
+LAPACK =dgerfs='s guarded formula, not something I invented alongside it.
+
+* 12:05 :bench:control:unfavorable:regression:
+Session-end bench. *The solve tail regressed, my change caused it, and the
+control proves it rather than leaving it as a hypothesis.*
+
+=src/bin/bench.rs:1985= times the sparse solve with =RefineOptions::default()=,
+so the new criterion is directly in the measured path. Ran the bench with the
+shipped default, then reverted =Default for RefineOptions= to =EpsSqrtN=,
+rebuilt, and re-ran on the same quiet machine:
+
+: ratio                control (EpsSqrtN)   shipped default    delta
+: factor/MUMPS p90     1.54                 1.56               +1.3%  (noise)
+: solve/MUMPS  geomean 0.08                 0.08               none
+: solve/MUMPS  p50     0.08                 0.08               none
+: solve/MUMPS  p90     0.15                 0.20               +33%
+: solve/MUMPS  p99     0.71                 1.08               +52%
+: solve/SSIDS  geomean 0.94                 1.06               +13%
+: solve/SSIDS  p90     2.50                 3.60               +44%
+: solve/SSIDS  p99     8.33                 13.00              +56%
+
+*The shape is exactly what the design predicts.* Geomean and p50 are
+identical to three decimals -- the well-scaled majority never needed the
+extra conjunct and does not pay for it. The tail pays, because that is where
+the matrices live whose componentwise error was above sqrt(eps) and which
+now actually refine. On the tracked parity corpus that is 13 of 63 (21%),
+which is the right order to move a p90.
+
+Factor is unchanged within noise (1.54 vs 1.56), as it must be -- the change
+is confined to the refinement loop's stopping test. That also validates the
+control: if machine state were driving the solve numbers it would have
+moved factor too, and it did not.
+
+*Conclusion, stated against the standing bar.* This is a measured
+performance *cost* at the tail, not a gain. It buys MA57/MUMPS componentwise
+parity on a class of systems where feral was returning omega up to 9.5e-5
+and reporting =Converged=. I am not going to describe a 33-56% tail
+regression as free. Whether that trade ships is the human's call; the
+alternative is to keep =EpsSqrtN= as the default and make the conjunction
+opt-in, which costs pounce the fix it asked for.
+
+Unlike 2026-08-20-02, no part of this is attributed to machine state.
+
+* 12:20 :bench:inertia:gate:
+Inertia gate holds: *154531/154590 (100.0%) match vs MUMPS*. All four Phase
+2.8.1 exit partitions PASS and sit at the bottom of the observed band --
+sparse small-frontal 1.56, sparse medium 1.56, dense small-frontal 1.58,
+dense medium 2.00, against the 08-19-05 baseline of 1.58/1.58/1.58/2.00.
+Factor/MUMPS max fell 71.94 -> 11.05, the machine-quietness signature.

--- a/dev/plans/issue-190-refine-target.md
+++ b/dev/plans/issue-190-refine-target.md
@@ -1,0 +1,58 @@
+# Plan — issue #190: residual target + outcome for iterative refinement
+
+Research note: `dev/research/issue-190-refine-target.md`. Read it first;
+this file is the execution order only.
+
+Decision taken with the user 2026-08-20: ship **both** criteria
+(normwise target as #190 asks, plus componentwise backward error), via a
+`StopCriterion` enum. Release shape deferred until #190 is measured.
+
+## Order of work
+
+1. **`abs_symv` on `CscMatrix`** — `y = |A|·|x|`, same lower-triangle
+   loop as `symv` with `.abs()` on both factors. Test against a dense
+   reference on a matrix with mixed signs, and assert `abs_symv` of a
+   non-negative matrix equals `symv` of it.
+2. **`backward_error(matrix, x, rhs, r) -> f64`** — LAPACK `dgerfs`
+   guarded form, formula quoted in the research note. External oracle:
+   values computed independently in Python from the published formula.
+   Tests written *before* the Rust body.
+3. **`StopCriterion` + `RefineOptions { max_steps, stop }`** — builders
+   `with_max_steps`, `with_target`, `with_backward_error`, `and_*`.
+   Drop the `Eq` derive (an `f64` payload forbids it), keep `PartialEq`.
+4. **`RefineOutcome` / `RefineStop`** — `Copy`, four exit variants.
+5. **Wire the single-RHS core** (`solve_sparse_refined_core`): replace
+   the `relative_reached` closure with a criterion dispatch, track which
+   exit fired, return the outcome.
+6. **Wire the multi-RHS refiner** (`solve_sparse_many_refined_into`):
+   same criterion per column, aggregate the outcome as max/worst.
+7. **`Solver::solve_refined_into` / `solve_many_refined_into`** — return
+   the outcome instead of `()`.
+8. **Docs**: `RefineOptions` type docs, CHANGELOG, and the `#[non_exhaustive]`
+   question answered in the negative (public fields kept, per the API
+   sketch in #190).
+
+## Test obligations (each must be able to fail)
+
+- `EpsSqrtN` default is **bit-identical** to `7de1a93` on the existing
+  refinement tests — this is the no-regression gate, and it is what
+  makes the change safe to ship without tolerance sign-off.
+- A loose `RelativeResidual` target stops in strictly fewer steps than
+  the default on a matrix where the default runs to the cap, and
+  `outcome.stop` reads `Converged` rather than `MaxSteps`.
+- `RefineStop::MaxSteps` is reported when, and only when, the cap binds.
+- `backward_error` matches the Python oracle to `1e-15` relative on a
+  well-scaled case, a badly-scaled case, and a case with a zero row in
+  the denominator (the `safe1`/`safe2` branch).
+- Cap still beats target: a met target at step 1 returns at step 1 under
+  `max_steps = 10`; raising `max_steps` never adds work to a converged
+  system (#178's invariant, re-asserted under each criterion).
+- Multi-RHS under each criterion agrees column-for-column with the
+  single-RHS refiner on the same columns.
+
+## Out of scope, recorded
+
+`max_steps = 0` remains unusable for the host because
+`ZeroPivotAction::ForceAccept` can leave a residual against the
+factorized system. That needs threshold pivoting with delayed pivots,
+not a stopping rule. Not attempted here.

--- a/dev/plans/large-n-solve-gate.md
+++ b/dev/plans/large-n-solve-gate.md
@@ -1,0 +1,183 @@
+# Plan — a solve-phase performance gate that measures the path hosts use
+
+Issue: #189 (items 1–3). Blocks: #131.
+Status: planning. Step 1 scoped from measurement; no bench code written yet.
+
+## Why this is first
+
+#131 asked for a parallel-solve entry point on `Solver`. Two probes
+(session 2026-08-20-01) answer that and turn up a harness defect that is
+larger than the thing #131 proposed to fix.
+
+`crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs` times three
+configurations interleaved within each repetition — `sv` = the serial
+shared-vector core the bench uses, `au` = `SolveCore::Auto` serial,
+`ap` = `Auto` parallel (the host path) — 11 reps, medians, one process.
+Ratios > 1 mean the second configuration is faster.
+
+| matrix | n | core `sv/au` | sched `au/ap` | bench→shipped `sv/ap` |
+|---|---:|---:|---:|---:|
+| bcsstk38 | 8,032 | 1.02 | 0.90 | 0.91 |
+| r05_kkt | 14,842 | 1.65 | 1.15 | 1.90 |
+| bratu3d | 27,792 | 1.31 | 0.99 | 1.29 |
+| qap15_kkt | 50,880 | 1.37 | 1.05 | 1.45 |
+| dirichlet120_kkt | 54,363 | 1.12 | 1.00 | 1.12 |
+| cont-201 | 80,595 | 1.45 | 0.98 | 1.42 |
+| cont5_late_kkt | 180,900 | 1.88 | 1.01 | 1.90 |
+| **geomean, `steps=1`** | | **1.37** | **1.01** | **1.38** |
+| **geomean, default depth** | | **1.30** | **0.98** | **1.27** |
+
+Two readings:
+
+- **#131's parallel schedule is a wash** — geomean 1.01/0.98, nothing
+  outside 0.85–1.15. That confirms the issue's conclusion.
+- **The bench under-reports the shipped solve by geomean 1.27–1.38×,**
+  up to 1.90×, because it times a core no host runs. This is a
+  correctness defect in the harness, not a coverage gap, and it is why
+  the gate comes first: extending the current measurement to more
+  matrices would extend the wrong measurement.
+
+### Retracted: the variance argument
+
+An earlier version of this plan argued from same-matrix spreads of up to
+2.20× between runs and concluded "we cannot presently tell a 2× solve
+regression from scheduler noise." That was an artifact of measuring
+configurations in **separate blocks and separate runs**. Interleaved, the
+same comparisons are stable to ~1.0–1.15×; on `r05_kkt` the blocked
+method was off by 2.4× (reported 0.67, actual 1.65). The solver is
+reproducible; the old harness was not. Design consequence in Step 1.
+
+## Code inspection — what the bench measures today
+
+`src/bin/bench.rs`, KKT corpus loop at `:1670-1700`:
+
+```rust
+let t1 = Instant::now();
+let x = match solve_refined(&matrix, &factors, &rhs) { ... };
+let solve_us = t1.elapsed().as_micros();
+```
+
+Four properties of that line, all of which the gate has to deal with:
+
+1. **`solve_refined` hardcodes the serial shared-vector core.** It reaches
+   `solve_sparse_refined_opts`, which passes `SolveCore::SharedVector`
+   (`src/numeric/solve.rs:2077`). The free functions never install a rayon
+   pool — `Solver::refine_into` (`src/numeric/solver.rs:1719`) is the only
+   place that does. So the bench cannot observe either the CB core or the
+   parallel schedule, which is exactly what #131 is about.
+2. **Single RHS.** `solve_sparse_many` is never benchmarked, so the lever
+   that measures geomean 2.29× is invisible to the harness.
+3. **Single shot at large n.** `should_resample` (`:1042`) triggers on
+   `mumps_timing.factor_us < 200`, i.e. only on *tiny* matrices. The
+   denoise was built for the "tens-of-µs scale" noise diagnosed in session
+   2026-04-20-01 (`dev/plans/bench-denoise.md`). Large matrices — the ones
+   #189 wants to gate, and the ones I measured 2× spread on — get exactly
+   one sample.
+4. `solve_us` for resampled matrices is the **median** of 5, while
+   `factor_us` is the **min** (`:1080`). Reasonable for the small-matrix
+   case it was written for; needs restating for a gate.
+
+Property 3 is the one that inverts the intent: replication is applied
+where the matrices are cheap and omitted where they are noisy.
+
+The bucket definitions (`:660-666`) are then:
+
+```rust
+if t.max_front < 200 && t.n <= 1_000   { small.push(r); }
+if t.max_front < 500 && t.n <= 10_000  { medium.push(r); }
+```
+
+with `r` a factor ratio in both cases. `MatrixTiming.solve_us` and
+`OracleTiming.solve_us` both already exist, and solve ratios are already
+computed for the report at `:493` and `:500` — so plumbing is not the
+work. Deciding what to measure is.
+
+## Sequence
+
+The steps are ordered so each one produces evidence the next one needs.
+Nothing here sets a numeric target until a measurement exists to set it
+from — #189 item 1 says "from a first measurement rather than guessed",
+and that constraint is the whole point.
+
+### Step 1 — time the path hosts take, interleaved
+
+The defect above is the first fix, and it is small: the bench must time
+`Solver::solve_refined` with a pool installed rather than the free
+`solve_refined`, so the reading describes `SolveCore::Auto` — the core
+every host gets.
+
+- Switch the KKT-corpus solve timing at `:1670-1700` onto `Solver`.
+  Expect the reported solve column to *improve* by geomean ~1.3× on
+  large matrices; that is not a speedup, it is the harness starting to
+  measure the shipped path, and the CHANGELOG has to say so or the next
+  reader will misread the jump as a regression fixed.
+- Where two configurations are compared, interleave them within each
+  repetition rather than timing one then the other. This — not a larger
+  N — is what made the probe reproducible. Blocked best-of-5 carried a
+  2.4× error that 11 interleaved reps removed entirely.
+- Decouple the resample predicate from matrix size. `should_resample`
+  (`:1042`) triggers on `mumps_timing.factor_us < 200`, so replication
+  lands on cheap matrices and is omitted on the ones a gate would watch.
+  Replicate based on "this row feeds a gate" instead.
+- Report **spread** alongside the statistic. Interleaved medians on the
+  large matrices hold to ~1.05×, so this is a cheap assertion to make and
+  a cheap one to check, not a hedge.
+- Exit criterion: a repeated bench run over `tests/data/large/` reports a
+  solve-ratio spread we can state, and the solve column reflects `Auto`.
+
+### Step 2 — measure the paths hosts actually take
+
+Add solve timings for the configurations that exist in the wild, since
+gating only the serial single-RHS shared-vector path gates something
+pounce never calls:
+
+- `Solver::solve_many` at `nrhs` = 1, 13, 32 (the batching + BLAS-3
+  path). Interleaved against the looped single-RHS equivalent this
+  measures geomean **2.47×**, min 2.20×
+  (`probe_batch_interleaved.rs`) — the largest reproducible solve-path
+  lever there is, and entirely invisible to the harness today.
+
+`Solver::solve_refined` with a pool moves to Step 1, since it is the fix
+for the defect rather than an addition.
+
+Report only. No verdicts yet.
+
+### Step 3 — the large-n bucket, with targets read off Steps 1–2
+
+`n > 10^4`, gating `factor/MUMPS` and `solve/MUMPS`. Targets set from the
+distribution the first two steps produce, with the spread from Step 1
+folded into the margin.
+
+### Step 4 — the fixture question (#189 item 3, split-out candidate)
+
+`tests/data/large/` is gitignored, so `large_matrix_smoke` SKIPs on CI
+and any baseline recorded there is enforced locally only. Two honest
+options — enforce at release from a recorded baseline, or make a small
+number of matrices fetchable in CI. This is a real decision and should
+not be smuggled in with the rest.
+
+## What this plan does not do
+
+- It does not add a `Solver::solve_auto` entry point. The parallel
+  schedule measures 1.01/0.98 geomean; there is nothing for that entry
+  point to deliver.
+- It does not re-fit `cb_core_profitable`. An earlier version of this
+  plan held that item open on the grounds that the predicate approves
+  `ContribBlock` on a matrix running at 0.67. That 0.67 was the blocked-
+  measurement artifact; interleaved, `r05_kkt` runs at 1.65. The gate is
+  in fact correct on all seven matrices — `ContribBlock` on exactly the
+  six where the core wins serially (1.12–1.88), `SharedVector` on
+  `bcsstk38` where the two cores are a wash (1.02). There is no evidence
+  it needs re-fitting, and since it picks a *core* any change to it is
+  #177-visible arithmetic. Closed, not deferred.
+- It does not touch `BLAS3_NRHS_THRESHOLD` (#189 item 4). That lever
+  measures 1.2–2.3× but is unreachable until a host batches, and it is a
+  last-bits change needing a CHANGELOG entry. It is real, it is just not
+  blocking anything.
+
+## Oracle discipline
+
+Per CLAUDE.md: implementation and test oracle must not both be written in
+one session without an external source. The oracle here is MUMPS/SSIDS
+sidecar timings already in `external_benchmarks/`, which is external. The
+probe's numbers are a cross-check on plausibility, not the oracle.

--- a/dev/plans/large-n-solve-gate.md
+++ b/dev/plans/large-n-solve-gate.md
@@ -1,7 +1,9 @@
 # Plan — a solve-phase performance gate that measures the path hosts use
 
 Issue: #189 (items 1–3). Blocks: #131.
-Status: planning. Step 1 scoped from measurement; no bench code written yet.
+Status: Step 1 partially landed — the bench now times the `Auto` core
+(`src/bin/bench.rs`). Remaining Step 1 work: decouple factor from solve
+inside the resample loop, and report spread.
 
 ## Why this is first
 
@@ -121,9 +123,26 @@ every host gets.
   Replicate based on "this row feeds a gate" instead.
 - Report **spread** alongside the statistic. Interleaved medians on the
   large matrices hold to ~1.05×, so this is a cheap assertion to make and
-  a cheap one to check, not a hedge.
+  a cheap one to check, not a hedge. Measured on this machine over three
+  full corpus runs (two post-change, one control): the sparse
+  small-frontal factor p90 moves 1.54 / 1.58 / 1.61, about ±2.5%; the
+  aggregate `solve/MUMPS` p90 moves 0.15 / 0.16 / 0.17. Any claimed bench
+  improvement smaller than that is noise.
+- **Decouple factor from solve inside the resample loop.** Landing the
+  `Auto` switch turned up a pre-existing defect: `resample_or_fallback`
+  (`:1060`) runs factor *and* solve interleaved in one closure five times
+  and reduces `factor_us` by **min**, so the solve's cache and allocator
+  footprint is the state the next replicate's factor is timed in. A
+  solve-side change moved the sparse small-frontal factor p90 from 1.58
+  to 2.03 (FAIL) on exactly the matrices `should_resample` selects — the
+  predicate and the bucket both key on the same small matrices. The
+  immediate trigger was an allocation inside the timed region and is
+  fixed; the coupling is not. Give the two phases separate timing passes.
+  This changes every small-matrix number in the corpus, so it needs its
+  own commit and its own before/after.
 - Exit criterion: a repeated bench run over `tests/data/large/` reports a
-  solve-ratio spread we can state, and the solve column reflects `Auto`.
+  solve-ratio spread we can state, the solve column reflects `Auto`, and
+  a solve-side no-op change provably does not move `factor_us`.
 
 ### Step 2 — measure the paths hosts actually take
 

--- a/dev/research/blas3-threshold-refit.md
+++ b/dev/research/blas3-threshold-refit.md
@@ -1,0 +1,250 @@
+# Research — is `BLAS3_NRHS_THRESHOLD = 32` costing pounce anything?
+
+Issue: #189 item 4. Related: #131, pounce#698.
+Status: **fix landed, bit-neutral** — the threshold is unchanged; the defect
+found was in the panel GEMM's tail handling.
+
+## The question
+
+`BLAS3_NRHS_THRESHOLD` (`src/numeric/solve.rs:17`) routes `solve_sparse_many`
+through the register-blocked BLAS-3 panel kernels at `nrhs >= 32` and through
+the rank-1 kernels below. The claim to test: 32 is too high, pounce runs
+below it, and lowering it is free performance.
+
+## Finding 1 — 32 has never been measured
+
+The constant's own doc comment cites "the `k ~ 16` crossover from
+`dev/research/multi-rhs.md` D3". Following that citation:
+
+- **`multi-rhs.md` D3 is a design note, written before the kernels existed.**
+  Its statement is "Real BLAS-3 trsm/gemm shapes start paying off above
+  `k ~ 16`; the IPM hot path doesn't go there." That is a rule of thumb about
+  BLAS shapes in general. There is no measurement in D3, and none of feral.
+- **`issue-57-blas3-panel.md:121` then picks 32 relative to that assertion**:
+  "D3 put the BLAS-3 crossover at `k ~ 16`; 32 is a conservative crossover
+  that guarantees the microkernel's fixed setup [is amortized]".
+- **Its Results section (2026-05-30) measures `nrhs` in {31, 32, 37, 64, 256}
+  only**, and only on 2-D Laplacians (`n` = 484, 1024, 2025).
+
+So the shipped constant is a safety margin applied to an unmeasured estimate,
+and the entire band 2..31 — plus every KKT matrix — is unmeasured. The
+citation chain reads like evidence and is not.
+
+This is the same failure mode as the retracted `cb_core_profitable` claim in
+`dev/journal/2026-08-20-01.org`: a number that everyone downstream treats as
+measured because it is written down precisely.
+
+## Finding 2 — lowering it breaks a documented bit-for-bit contract
+
+`tests/multi_rhs.rs:227` `solve_many_refined_band_16_31_is_bit_identical_to_per_column`
+and `:256` `solve_many_refined_indef_band_is_bit_identical_to_per_column`
+assert, at `nrhs` = 24 and 20 respectively:
+
+```rust
+// Bit-identical: not merely "close". Tolerance is exact zero.
+assert_eq!(max_diff, 0.0, "max |batched - per-column| = {max_diff:.3e}");
+```
+
+The contract exists because `BLAS3_REFINE_THRESHOLD = 16` routes *refinement*
+through the batched path at `nrhs >= 16`, and bit-identity with the per-column
+refiner is what makes that safe (issue #58). It holds only because
+`solve_sparse_many` stays on the rank-1 kernels below 32.
+
+Lowering `BLAS3_NRHS_THRESHOLD` below 25 fails the first test; below 21 fails
+the second. Neither can be repaired by relaxing the assertion without
+approval — the assertion *is* the contract, and CLAUDE.md forbids loosening a
+tolerance unilaterally.
+
+**This is not an abstract concern.** pounce calls
+`solve_many_refined(m, &self.afs, self.n_s)` at
+`../pounce/crates/pounce-feral/src/schur.rs:303` — the exact guarded path.
+A threshold change would silently alter the W matrix that pounce's Schur
+complement is built from. pounce#710 was the same class of issue.
+
+## Finding 3 — pounce's hot path is `nrhs = 1`, not 2 and not 24
+
+Call-site census in `../pounce`:
+
+| path | file | nrhs |
+|---|---|---|
+| IPM factor + back-solve | `kkt/std_aug_system_solver.rs:497` | **1**, hardcoded |
+| IPM re-solve | `kkt/std_aug_system_solver.rs:625` | **1**, hardcoded |
+| sensitivity / jacrev cotangents | `pd_full_space_solver.rs:719,957` via `try_resolve_many_flat` | = parameter count |
+| Schur W formation | `pounce-feral/src/schur.rs:303` | = `n_s`, caller-supplied |
+| Schur block back-substitution | `pounce-feral/src/schur.rs:391` | **loops columns** (pounce#698) |
+
+So the dominant interior-point path never reaches *any* multi-RHS kernel —
+it is single-RHS, and `BLAS3_NRHS_THRESHOLD` is irrelevant to it. The
+threshold can only matter for sensitivity solves with few parameters and for
+the opt-in Schur path with small `n_s`.
+
+The Schur path is opt-in ("the caller opts in by supplying the block",
+`kkt/schur_aug_system_solver.rs:14`) and `n_s` is problem data, not a
+constant, so no single re-fit is right for all callers.
+
+## What would have to be true for a re-fit to be worth shipping
+
+1. BLAS-3 must actually beat rank-1 somewhere in `[16, 32)` on KKT matrices,
+   by a margin larger than the measured run-to-run spread.
+2. The winning band must be one a real pounce caller occupies.
+3. The bit-identity contract must be either preserved or consciously traded
+   away with human approval and a recorded justification.
+
+If (1) fails, the answer is "leave 32 alone, fix the citation" and nothing
+ships. That is a legitimate outcome and is the one to expect if the D3
+rule of thumb was roughly right.
+
+## Method
+
+`crates/feral-diagnostics/src/bin/probe_blas3_crossover.rs`. For each of the
+seven large KKTs and each `nrhs` in {2,4,6,8,10,12,14,16,20,24,28,31,32,40,48},
+**both kernels are timed at the same `nrhs`, alternating within each of 9
+replicates, in one process**. The `kernel-probe` Cargo feature (off by default,
+compiled out entirely) exposes `set_blas3_nrhs_threshold`, so the dispatch can
+be flipped between the two solves. The probe also reports
+`max |rank1 - blas3|`, since that difference is what a threshold cut would
+trade away. All buffers are allocated outside every timed region.
+
+### The method this replaced, and why it failed
+
+The first attempt built two binaries — stock (32) and patched to 2 — and ran
+them alternating, treating alternation as sufficient defence against drift. It
+is not, and the data was discarded rather than reported. A full sweep takes
+~25 minutes, so "adjacent" runs are 25 minutes apart: blocked measurement with
+an interleaved label. Two controls caught it. The looped single-RHS path, which
+is byte-identical in both builds and must read 1.00, read **1.15, 1.58, 1.97,
+2.10**. And at `nrhs >= 32`, where both builds dispatch to the *same* kernel and
+the ratio must be exactly 1.00, it read **0.86-0.90**. Full write-up in
+`dev/tried-and-rejected.md`.
+
+## Results
+
+### The threshold is the wrong question. The row stride was.
+
+Timing both kernels at the same `nrhs` shows a sawtooth, not a crossover.
+`rank1 / blas3` on bcsstk38 — above 1.0 means BLAS-3 wins:
+
+| nrhs | 2 | 4 | 6 | **8** | 10 | 12 | 14 | **16** | 20 | **24** | 28 | 31 | **32** |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| ratio | 1.00 | 0.83 | 0.79 | **2.12** | 1.40 | 1.06 | 0.89 | **1.60** | 1.00 | **1.36** | 1.14 | 1.03 | **1.31** |
+
+BLAS-3 wins decisively at every multiple of 8 and degrades as `nrhs` moves
+away from one. The period is `NR = 8`.
+
+The cleanest statement of it needs no curve fit and no cross-process
+comparison — compare `nrhs = 31` against `nrhs = 32` *within one run*.
+`nrhs = 31` is 3% *less* work, so a healthy kernel gives ~0.97:
+
+| matrix | bcsstk38 | r05_kkt | bratu3d | qap15_kkt | dirichlet120_kkt | cont-201 | cont5_late_kkt |
+|---|---|---|---|---|---|---|---|
+| t(31)/t(32) | 1.61 | 1.41 | 1.79 | 1.47 | 1.80 | 1.47 | 1.64 |
+
+All seven. Doing less work took 1.4-1.8x longer.
+
+### First hypothesis — the scalar column tail — was real but secondary
+
+`gemm_scalar_block` handled the `nrhs % NR` column tail with an unblocked
+triple loop: for *every* output element it re-walked all of `A`'s row (stride
+`col_stride`) and `B`'s column (stride `nrhs`), with no reuse. Fitting
+`blas3_us` on the multiples of 8 and attributing the excess to the tail
+columns put a tail column at 1.6-5.1x a blocked column.
+
+Replacing it with `gemm_tile` (full `NR`-width register tiles, unused lanes
+zero-padded) moved `t(31)/t(32)` from 1.41-1.80 to only **1.39-1.51**. A real
+improvement, and bit-neutral, but not the cause.
+
+**The discriminating experiment.** `nrhs = 33` has *one* tail column;
+`nrhs = 31` has *seven*. If tail-column count drives the cost they should
+differ sharply. On bratu3d:
+
+| nrhs | 31 | **32** | 33 | 34 | 36 | 38 | **40** |
+|---|---|---|---|---|---|---|---|
+| blas3 us | 72,298 | **46,582** | 74,154 | 74,043 | 76,060 | 80,859 | **58,760** |
+
+`nrhs = 33` costs 1.59x `nrhs = 32` while doing 3% *more* work, and matches
+`nrhs = 31` to within 3%. Tail-column count does not predict the cost. The
+row stride does: 32 and 40 doubles are 256 and 320 bytes — whole multiples of
+a 64-byte cache line — and 31, 33, 34, 36, 38 are not.
+
+### Cause and fix — cache-line alignment of the row-major stride
+
+`y` and `w` are row-major with leading dimension `nrhs` (issue #57). When
+`nrhs` is not a multiple of 8, every row of every supernode panel straddles
+cache lines, and the misalignment compounds across the gather, the kernels,
+and the scatter.
+
+`padded_ldw(nrhs) = nrhs.div_ceil(8) * 8` is now the row stride for the panel
+path, so every row starts on a cache-line boundary. The padded columns carry
+a zero right-hand side and are never read back, so every real column's
+arithmetic and its order are untouched. The rank-1 path keeps the raw `nrhs`
+stride — it gains nothing from the padding and would only pay for the extra
+columns.
+
+**Result — the sawtooth is gone**, and this is a within-run statistic, immune
+to cross-process drift:
+
+| matrix | t(31)/t(32) before | after |
+|---|---|---|
+| bcsstk38 | 1.61 | **0.98** |
+| r05_kkt | 1.41 | **1.00** |
+| bratu3d | 1.79 | **1.00** |
+
+### How much of this ships
+
+The probe forces BLAS-3 at every `nrhs`. The shipped library runs it only at
+`nrhs >= 32`, so the large ratios above at `nrhs` 6-31 describe a path that
+does **not** ship at those widths — they are diagnostic, not a user-visible
+gain. Quoting them as the headline would overstate the result by ~35%.
+
+The shipped regime is `nrhs >= 32` and not a multiple of 8. At `nrhs = 33`,
+measured two independent ways that agree:
+
+| matrix | t(33)/t(32) unpadded | padded | anchored speedup | raw us, unpadded -> padded |
+|---|---|---|---|---|
+| bcsstk38 | 1.49 | 1.24 | **1.21x** | 10,093 -> 8,272 (1.22x) |
+| r05_kkt | 1.41 | 0.88 | **1.59x** | 15,194 -> 12,426 (1.22x) |
+| bratu3d | 1.59 | 1.21 | **1.32x** | 74,154 -> 56,230 (1.32x) |
+
+**Geomean 1.36x** on the multi-RHS BLAS-3 solve, for the 7-in-8 `nrhs` values
+that are not a multiple of 8.
+
+The residual `t(33)/t(32) ~ 1.21` after the fix is not leftover misalignment —
+it is exactly `40/33 = 1.21`, the cost of solving the 7 padding columns. The
+padding buys alignment by doing up to `8/nrhs` extra flops, so the waste is
+21% at `nrhs = 33`, 7% at 100, under 1% at 1000.
+
+**Follow-up available, not taken here:** keep the aligned stride but iterate
+only the `nrhs` live columns, masking the final tile — `gemm_tile` already
+supports a partial tile via its `live` parameter. That would recover the
+remaining ~18% at `nrhs = 33`. It needs a second parameter (stride vs. live
+width) threaded through all five kernels, so it is a separate change with its
+own before/after.
+
+**Bit-neutral**, three independent checks:
+
+1. `gemm_tail_tests::panel_gemm_is_bit_identical_to_the_reference_on_every_tail_shape`
+   asserts `to_bits()` equality against a scalar left-fold reference over 800
+   shapes (16 `nrhs` x 10 `m_dim` x 5 `k_dim`), covering every `nrhs % 8` and
+   `m_dim % 4` residue.
+2. The probe reports `max |rank1 - blas3|`; rank-1 is untouched, so any change
+   in the BLAS-3 output moves it. Unchanged at every point compared.
+3. `tests/multi_rhs.rs` — all 13 pass, including both
+   `assert_eq!(max_diff, 0.0)` band contracts and the BLAS-3 parity tests.
+
+So no threshold change, no tolerance change, and no sign-off on the Finding 2
+contract is needed. **`BLAS3_NRHS_THRESHOLD` stays at 32.**
+
+### Accuracy of the two kernels, measured
+
+Independently of the fix, the probe answers what Finding 2 asserted
+qualitatively. `max |rank1 - blas3| / max |x|` is round-off, not zero:
+1e-16 to 3e-16 on bcsstk38, 5e-15 on r05_kkt, 2e-14 on bratu3d. Small, but
+categorically not the `0.0` the band tests assert. Finding 2 stands: a
+threshold cut cannot be made bit-neutral, and remains gated on human approval.
+
+### What this does and does not buy pounce
+
+It is live on the Schur path today — `schur.rs:303` calls
+`solve_many_refined(m, &self.afs, self.n_s)` with `n_s` problem data, so it
+lands on a non-multiple of 8 seven times in eight. It does **not** touch the
+IPM hot path, which is `nrhs = 1` and hardcoded (Finding 3).

--- a/dev/research/issue-190-refine-target.md
+++ b/dev/research/issue-190-refine-target.md
@@ -1,0 +1,235 @@
+# Issue #190 — a residual *target* for iterative refinement
+
+Research note. Written before any implementation, per CLAUDE.md.
+Predecessor: `dev/research/refinement-cap-2026-08-19.md` (issue #178),
+which added the step cap this note argues is the wrong knob.
+
+## The claim under test
+
+Issue #190 says the per-call step cap shipped by #178 is unusable as a
+lever for an interior-point host, because the *target* the loop is
+driving toward is unreachable on the matrices that matter, so the loop
+always runs to the cap and every cap value is a different arbitrary
+answer.
+
+## Verification of the issue's code claims
+
+All five check out against the tree at `7de1a93`. The issue cites
+`numeric/solve.rs:2574` and `:2749`; those line numbers predate
+`a0b4d64`, which added ~250 lines above them. Located by content
+instead:
+
+| claim | site | verdict |
+|---|---|---|
+| convergence threshold hardwired `ε·√n` | `solve.rs:2693` (single), `:2872` (many) | confirmed |
+| `RefineOptions` carries only `max_steps` | `solve.rs:2118` | confirmed |
+| ForceAccept can leave a residual (quoted) | `solve.rs:2146` | confirmed verbatim |
+| `solve_refined_into` discards diagnostics | `solver.rs:1676` | confirmed |
+| `solve_many_refined_into` discards diagnostics | `solver.rs:1824` | confirmed |
+
+And the arithmetic: at `n = 118 276`, `ε·√n = 7.636e-14`. A relative
+residual that small is not reachable on a near-singular KKT, so the
+mechanism the issue describes — every step improves slightly, the
+2-strike rule never fires, the divergence guard never fires, the loop
+runs to `max_steps` — follows.
+
+## Finding 1: the cap has no principled value, and the sweep shows it
+
+From #190's corpus sweep, `max_steps` is not monotone in outcome:
+`cresc4` under L-BFGS is `InfeasibleProblemDetected` at `k = 1` — a
+false infeasibility verdict on a feasible problem in 32 iterations —
+but fine at `k = 0`, `2`, and `10`. `eigena2` is `Optimal` at `k = 5`,
+`SolvedToAcceptableLevel` at `k = 10`, and `ErrorInStepComputation` at
+`k ∈ {0,1,2,3,4}`.
+
+That is what a knob looks like when it does not control the quantity the
+caller cares about. Under a target the loop cannot reach, the
+best-iterate contract returns whichever of the `k+1` non-converged
+iterates happened to have the smallest `‖r‖₂`, and the issue's argument
+that this has no reliable relationship to the quality of the host's
+Newton step is sound: `‖r‖₂` is measured on the *condensed* symmetric
+system, and the host refines against the unreduced one (Wächter &
+Biegler §3.10).
+
+Note what this does **not** say. It does not say refinement is useless —
+`max_steps = 0` loses the badly-scaled LP outright (`RestorationFailed`).
+It says the *stopping rule* is the thing without a caller-visible knob.
+
+## Finding 2: `‖r‖₂/‖b‖₂` is a weaker measure than the issue's own goal
+
+#190 states the goal precisely: the host "wants the backend to return
+what a stable `LDLᵀ` would have returned — a backward-stable solve of
+the system it factorized." That is a statement about *backward* error,
+and the normwise relative residual is only a proxy for it.
+
+The direct measure is the componentwise backward error of Arioli,
+Demmel & Duff (1989):
+
+    ω = max_i |r_i| / (|A|·|x| + |b|)_i
+
+`ω ≤ u` means the computed `x` is the exact solution of `(A+δA)x =
+b+δb` with `|δA| ≤ ω|A|` and `|δb| ≤ ω|b|` — componentwise, relative,
+entry by entry. That is exactly the contract Ipopt's design assumes of
+a backend and that MA27/MA57/MUMPS deliver by threshold pivoting. It is
+also what those solvers report: MA57 `RINFO(6..8)`, MUMPS `RINFO(7)`
+and `RINFO(8)`, both driven by their refinement controls.
+
+Two properties matter here:
+
+1. **It has a principled stopping point.** `ω ≲ u` is "the solve is
+   honest", full stop. No caller has to guess a number. A normwise
+   target requires the caller to invent one — which #190 accepts
+   ("that becomes something we can sweep"), but a sweep is only needed
+   because the criterion has no canonical value.
+2. **It is scale-aware where the normwise measure is not.** The
+   denominator is formed per row from the actual magnitudes present in
+   that row. #190's own corpus includes a badly-scaled LP at data scale
+   `1e11`; a single `‖r‖₂/‖b‖₂` number over such a system is dominated
+   by the largest-magnitude rows and says nothing about the small ones.
+
+Cost: `(|A|·|x|)_i` is one extra pass over `A` per step, the same shape
+as the residual matvec already being run. **Zero extra solves.** This is
+the reason to prefer it over anything derived from `kappa_1_est`.
+
+### The denominator needs the LAPACK/ADD guard
+
+Naïve `ω` is fragile: a row where `(|A||x| + |b|)_i` underflows toward
+zero produces a spuriously enormous ratio, and refinement cannot fix it,
+so the criterion would never fire — reproducing the exact failure mode
+#190 reports for `ε·√n`. ADD handle this with an `ω₁/ω₂` split; LAPACK's
+`dgerfs` implements the practical form, and that is what this note
+adopts:
+
+    safe1 = (n+1) * f64::MIN_POSITIVE
+    safe2 = safe1 / f64::EPSILON
+
+    d_i = (|A|·|x| + |b|)_i
+    if d_i > safe2:  term = |r_i| / d_i
+    else:            term = (|r_i| + safe1) / (d_i + safe1)
+    ω = max_i term
+
+Adopting a published formula verbatim also solves the oracle problem:
+CLAUDE.md forbids writing the implementation and the test oracle in the
+same session without an external source. The formula above **is** the
+external source, and expected values can be produced independently in
+Python from it.
+
+## Finding 3: do not plumb `RefinementDiagnostics` through the hot path
+
+#190's second ask is to surface the step count through
+`Solver::solve_refined_into` / `solve_many_refined_into`. The obvious
+reading — return `RefinementDiagnostics` — is wrong, and expensively so.
+
+`solve.rs:2596` gates `kappa_1_est` on `with_diagnostics`:
+
+```rust
+let (anorm_1, kappa_1_est) = if with_diagnostics && n > 0 {
+    let a1 = matrix_norm_1(matrix);
+    let inv1 = estimate_inverse_norm_1(factors)?;
+    (a1, a1 * inv1)
+} else { (0.0, 0.0) };
+```
+
+`estimate_inverse_norm_1` is Hager–Higham; the struct's own doc comment
+puts it at **3–5 extra solves per refinement run**. On #190's 58 014-
+variable benchmark, back-solve is already 48.962 s at `max_steps = 10`.
+Routing the host's normal call through the diagnostics path would
+multiply precisely the cost the issue exists to cut.
+
+The issue itself allows the cheap answer ("even just `usize`"). Every
+value a host needs is already computed inside the loop and thrown away:
+how many corrections ran, the relative residual of the returned iterate,
+and — the one that actually answers "did the budget bind?" — *which
+exit fired*. A small `Copy` struct carrying those three costs nothing.
+
+The four exits are already distinct in the code and worth naming:
+target reached, cap reached, 2-strike plateau, 100× divergence guard.
+"Ran to the cap" and "bottomed out after two non-improving steps" are
+very different diagnoses for a host, and back-solve wall time cannot
+distinguish them.
+
+## Design
+
+### `StopCriterion`
+
+```rust
+pub enum StopCriterion {
+    /// Today's rule: ‖r‖₂ < ε·√n·‖b‖₂. Default; bit-for-bit historical.
+    EpsSqrtN,
+    /// ‖r‖₂/‖b‖₂ ≤ t. #190's ask.
+    RelativeResidual(f64),
+    /// ω ≤ t, componentwise backward error (ADD 1989 / LAPACK dgerfs).
+    BackwardError(f64),
+}
+```
+
+`RefineOptions` becomes `{ max_steps, stop }`. `Default` is
+`{ DEFAULT_REFINE_MAX_STEPS, EpsSqrtN }`, so every existing call is
+unchanged in behavior *and* in arithmetic.
+
+`EpsSqrtN` keeps the strict `<` it has today so the default path is
+bit-identical. The two target variants use `≤`, so a target of `0.0`
+means "only an exact zero residual stops you" rather than "unreachable".
+
+Fallout: `RefineOptions` currently derives `Eq`; `f64` inside the enum
+forces that to `PartialEq` only. Combined with the new field breaking
+`RefineOptions { max_steps: k }` struct-literal construction, this is a
+minor bump. Both breaks land together, once.
+
+### `RefineOutcome`
+
+```rust
+pub struct RefineOutcome {
+    pub steps: usize,             // corrections actually performed
+    pub relative_residual: f64,   // ‖r‖₂/‖b‖₂ of the returned iterate
+    pub stop: RefineStop,
+}
+
+pub enum RefineStop { Converged, MaxSteps, Stagnated, Diverged }
+```
+
+Returned from the four `*_into` entry points — `solve_sparse_refined_into`,
+`solve_sparse_many_refined_into`, `Solver::solve_refined_into`,
+`Solver::solve_many_refined_into` — changing `Result<(), _>` to
+`Result<RefineOutcome, _>`. Callers writing `f(..)?;` are unaffected.
+The `Vec`-returning convenience forms keep their signatures.
+
+Multi-RHS aggregates over columns rather than allocating a per-column
+vector: `steps` and `relative_residual` are maxima, and `stop` takes the
+first match in the order `MaxSteps > Diverged > Stagnated > Converged` —
+`MaxSteps` ranks first because "did the budget bind" is the question
+being asked.
+
+### Priority of exits is unchanged
+
+The cap stays a cap. A target that is met at step 1 returns at step 1
+under `max_steps = 10`; a cap of 10 never *adds* work. This was #178's
+invariant and it survives verbatim, because the criterion is evaluated
+at the top of the loop body exactly where `relative_reached` is today.
+
+## What this does not fix
+
+#190 observes that the architecturally correct setting for the host is
+`max_steps = 0`, and that FERAL cannot offer it because
+`ZeroPivotAction::ForceAccept` lets the raw solve leave a residual
+against the very system it factorized — which is why the badly-scaled LP
+dies at `k = 0`. A stopping-criterion knob does not change that. The
+real answer there is threshold pivoting with delayed pivots, as
+MA27/MA57/MUMPS do. Out of scope for #190; recorded so it is not lost.
+
+Nor does this note claim a target will make the corpus sweep come out
+well. It makes the sweep *possible*, which is the stated ask. The
+numbers are pounce-side work.
+
+## References
+
+- [feral#190](https://github.com/jkitchin/feral/issues/190)
+- [pounce#698](https://github.com/jkitchin/pounce/issues/698) obs. 5,
+  [pounce#710](https://github.com/jkitchin/pounce/issues/710)
+- `dev/research/refinement-cap-2026-08-19.md` — issue #178, the step cap
+- `dev/research/issue-58-batched-refinement.md` — the multi-RHS refiner
+- Arioli, Demmel & Duff, "Solving sparse linear systems with sparse
+  backward error", SIMAX 10(2), 1989
+- LAPACK `dgerfs` — the `safe1`/`safe2` guarded `BERR` formula
+- Wächter & Biegler 2006, §3.10 — why the host refines a different system
+- MA57 `RINFO(6..8)`; MUMPS `ICNTL(10)`, `RINFO(7..8)`

--- a/dev/research/issue-190-refine-target.md
+++ b/dev/research/issue-190-refine-target.md
@@ -233,3 +233,174 @@ numbers are pounce-side work.
 - LAPACK `dgerfs` — the `safe1`/`safe2` guarded `BERR` formula
 - Wächter & Biegler 2006, §3.10 — why the host refines a different system
 - MA57 `RINFO(6..8)`; MUMPS `ICNTL(10)`, `RINFO(7..8)`
+
+---
+
+# Addendum, 2026-08-21 — the MA57/MUMPS gap is the *criterion*, not the pivot
+
+The section above ("What this does not fix") blames the residual on
+`ZeroPivotAction::ForceAccept` and prescribes threshold pivoting "as
+MA27/MA57/MUMPS do". Both halves were measured this session and both are
+wrong. What is actually behind FERAL's bad componentwise residuals is the
+default stopping criterion, and the fix is a one-line default change.
+
+## What was ruled out
+
+**ForceAccept never fires.** `probe_forceaccept_residual` over the seven
+large corpus matrices: `inertia.zero == 0` and `n_tiny == 0` on every
+one, so no column is ever zeroed. The residual is not dropped pivots.
+
+**The pivot threshold is already at parity.** FERAL ships
+`pivot_threshold = 1e-8`. The standalone library defaults are 0.01
+(MUMPS `CNTL(1)` for SYM=2, `ref/mumps/src/dini_defaults.F:111`; SPRAL
+SSIDS `options%u`, `ref/spral/src/ssids/datatypes.f90:262`), which looks
+like a six-order gap — but Ipopt, the host pounce ports, deliberately
+overrides all of them *downward*:
+
+| Ipopt option | default | source |
+|---|---:|---|
+| `ma27_pivtol` | 1e-8 | `IpMa27TSolverInterface.cpp:97` |
+| `ma57_pivtol` | 1e-8 | `IpMa57TSolverInterface.cpp:205` |
+| `mumps_pivtol` | 1e-6 | `IpMumpsSolverInterface.cpp:131` |
+
+So FERAL's 1e-8 already matches MA27/MA57 under Ipopt exactly. The pin
+in `tests/issue_2_kkt_ls_init.rs:32` cites the right authority and was
+correct to reject a change to 0.01. Ipopt gets away with a loose pivtol
+because it *escalates*: `PdFullSpaceSolver` calls `IncreaseQuality()`
+when refinement stagnates (`IpPDFullSpaceSolver.cpp:296` and `:554`),
+raising pivtol to `min(pivtolmax, pivtol^0.75)`
+(`IpMa57TSolverInterface.cpp:832`), capped at `ma57_pivtolmax = 1e-4`.
+FERAL has that ladder (`Solver::increase_quality`) and `pounce-feral`
+wires it, so this is not a gap either.
+
+## The head-to-head that found the real gap
+
+Canonical MUMPS 5.8.2 (`external_benchmarks/mumps_oracle`, `CNTL(1)`
+0.01, `ICNTL(10) = 2`, `ICNTL(11) = 1`) against FERAL defaults, same
+seven matrices, byte-identical RHS.
+
+**Inertia matches MUMPS exactly on all seven**, including
+`qap15_kkt` 22275/28605/0 at `cond1 = 3.9e12`. The gate holds.
+
+Well-scaled RHS (`v[i] = 1 + (i%7)/8`): FERAL's refined relative
+residual beats MUMPS on five of seven and ties on the other two. No gap.
+
+Badly-scaled RHS (`v[i] = ±10^((i%13)-6)`, entries spanning 12 orders —
+the shape an IPM produces near convergence, where dual, primal and
+complementarity blocks differ by many orders):
+
+| matrix | FERAL ω, refined | MUMPS ω1 | FERAL steps |
+|---|---:|---:|---:|
+| r05_kkt | **9.520e-5** | 3.608e-16 | **0** |
+| bratu3d | **8.953e-6** | 2.844e-16 | **0** |
+| cont-201 | **3.860e-7** | 2.728e-16 | **0** |
+| qap15_kkt | 1.229e-10 | 1.023e-12 | 2 |
+| dirichlet120_kkt | 4.310e-10 | 6.175e-11 | 0 |
+| bcsstk38 | 1.098e-10 | 1.919e-11 | 0 |
+| cont5_late_kkt | 8.398e-14 | 3.848e-16 | 1 |
+
+Nine to eleven orders on the top three, and on those three FERAL took
+**zero** refinement steps and reported `Converged`.
+
+That is the whole mechanism. `StopCriterion::EpsSqrtN` tests
+`‖r‖₂/‖b‖₂ < ε·√n`. It is normwise, so it is dominated by the rows
+carrying the largest RHS entries. With entries spanning 1e-6..1e6 the
+test passes at once — `r05_kkt` reaches `‖r‖₂/‖b‖₂ = 2.674e-14` on the
+raw solve — while the rows carrying the *small* entries still have
+`ω = 9.5e-5`. FERAL then declares victory and never refines. MUMPS does
+not have this failure mode because its `ICNTL(10)` loop stops on the
+componentwise ω against `CNTL(2)`, not on a norm ratio.
+
+In an interior-point method the small RHS blocks are the complementarity
+residuals of near-active constraints — precisely the rows that set the
+step. So FERAL returns a step that is componentwise wrong exactly where
+it matters, silently, on badly-scaled systems only. That is the "works
+for the vast majority, fails on a class" signature.
+
+## Choosing the target
+
+Same seven matrices, badly-scaled RHS, `max_steps = 10`:
+
+| criterion | worst ω | max steps | outcomes |
+|---|---:|---:|---|
+| `EpsSqrtN` (shipped) | 9.5e-5 | 2 | all `Converged`, three of them wrong |
+| `BackwardError(√ε)` | 8.0e-10 | **1** | 7/7 `Converged` |
+| `BackwardError(ε)` | 4.2e-11 | **10** | 5/7 `Stagnated`/`MaxSteps` |
+
+`ε` is LAPACK `dgerfs`'s target and is unreachable here: it stagnates or
+exhausts the budget on five of seven, which is the very cost pathology
+#190 was filed about. `√ε = 1.4901161193847656e-8` is MUMPS's `CNTL(2)`
+(`ref/mumps/src/dini_defaults.F:1094`) and converges in at most one step
+on all fourteen (matrix, RHS) combinations.
+
+It is also *cheaper than what ships today* on well-scaled input:
+`qap15_kkt` goes 2 steps → 1, `cont5_late_kkt` 1 → 0, and no matrix
+takes more. So the change is strictly better on both axes — it does not
+trade speed for accuracy.
+
+## The decision
+
+A *pure* `BackwardError(√ε)` default was implemented first and rejected:
+it fixes the componentwise gap but stops earlier than `EpsSqrtN` on the
+normwise scale, and `tests/parity.rs` caught the regression —
+`ROSZMAN1_0241` went to `feral = 4.805e-14` against a MUMPS-anchored
+gate of `2.077e-14`. Shipping it would have required loosening that
+gate, which CLAUDE.md forbids without sign-off, and rightly: the gate
+was measuring something real.
+
+What shipped instead is the conjunction. `StopCriterion` gains
+`EpsSqrtNAndBackwardError(f64)`, and `RefineOptions::default().stop`
+becomes `EpsSqrtNAndBackwardError(DEFAULT_BACKWARD_ERROR_TARGET)` with
+`DEFAULT_BACKWARD_ERROR_TARGET = √ε`. Refinement stops only when
+`‖r‖₂ < ε·√n·‖b‖₂` **and** `ω ≤ √ε`. Both halves are evaluated on the
+same best-iterate (smallest `‖r‖₂`), which is what `best_omega` already
+tracked, so the returned `x` satisfies both simultaneously.
+
+Because the new criterion is strictly harder to satisfy than the old
+one, the default can only ever refine *more*, never less. No existing
+caller's accuracy regresses, no gate needs loosening, and the
+`EpsSqrtN`, `RelativeResidual` and `BackwardError` variants are all
+unchanged for callers who pin them.
+
+### Measured, seven-matrix large corpus, both RHS families
+
+Well-scaled RHS: **identical to the old default on all seven** — same
+step counts (0,0,0,0,0,1,2), same residuals. The conjunction costs
+nothing where the normwise rule was already right.
+
+Badly-scaled RHS, new default vs old:
+
+| matrix | steps | ω before | ω after | MUMPS ω1 |
+|---|---:|---:|---:|---:|
+| r05_kkt | 0 → 1 | 9.520e-5 | **2.655e-16** | 3.608e-16 |
+| bratu3d | 0 → 1 | 8.953e-6 | **3.170e-16** | 2.844e-16 |
+| cont-201 | 0 → 1 | 3.860e-7 | **2.909e-16** | 2.728e-16 |
+| qap15_kkt | 2 | 1.229e-10 | 1.229e-10 | 1.023e-12 |
+| cont5_late_kkt | 1 | 8.398e-14 | 8.398e-14 | 3.848e-16 |
+| dirichlet120_kkt | 0 | 4.310e-10 | 4.310e-10 | 6.175e-11 |
+| bcsstk38 | 0 | 1.098e-10 | 1.098e-10 | 1.919e-11 |
+
+The three that were nine to eleven orders behind MUMPS now match it, at
+a cost of one correction step each (5-14 ms). The worst-case step count
+across all fourteen combinations is still 2 — the bound `EpsSqrtN`
+already had. The four unchanged rows were already inside `√ε`.
+
+## What this leaves open
+
+`ω ≤ √ε` is MUMPS's stopping rule, not a claim of parity on the final
+number: MUMPS still reports a tighter ω on `cont5_late_kkt`,
+`dirichlet120_kkt` and `bcsstk38` because `ICNTL(10) = 2` keeps
+refining past the point FERAL stops. Those FERAL values are all inside
+`√ε` and therefore certified; closing the remaining two-order margin
+would mean refining past the criterion, which is a separate question.
+
+#190's own ask — a *reachable* target, because `ε·√n = 7.88e-14` at
+`n = 126028` is not attainable and refinement burned 48.96 s of
+backsolves — is **not** answered by this change. The conjunction keeps
+the `EpsSqrtN` half, so an unreachable normwise target still runs the
+budget out. That case is served by the opt-in
+`RefineOptions::with_target` / `with_backward_error` that shipped with
+`f547bc5`, which is the right place for it: a host that knows its own
+accuracy requirement should state it rather than have the default
+guess. The default's job is to be safe, and safety here means never
+returning less than it used to.

--- a/dev/sessions/2026-08-20-01.md
+++ b/dev/sessions/2026-08-20-01.md
@@ -1,0 +1,223 @@
+# Session 2026-08-20-01
+
+## Unfavorable comparison, reported first (per CLAUDE.md)
+
+**A bench run in this session FAILED the Phase 2.8.1 sparse exit gate**:
+sparse small-frontal factor p90 **2.03 vs target ≤ 2.0**, against a
+baseline of 1.58 from session 2026-08-19-05. It was caused by a change
+made in this session and is now fixed; two confirming runs report 1.54
+and 1.61, both PASS. The full arc is in **Regression** below, including
+the hypothesis I published in the journal that the control run refuted.
+
+**Two conclusions I had posted publicly in the previous session were
+wrong and have been retracted**, both from the same methodological
+error. See **Corrections** below.
+
+## Goal
+
+Continue the prioritized list from issue #189 / #131:
+
+1. (pounce-side, filed at pounce#698 — no feral work)
+2. **#189 items 1–3, the large-n solve gate** ← this session
+3. #189 item 4, `BLAS3_NRHS_THRESHOLD` — blocked on (1)
+4. #131 — rescope, do not implement `solve_auto`
+
+Before starting (2), settle a contradiction: two probes from the previous
+session disagreed about whether the solve measurement was reproducible at
+all. They were separate probes on separate runs, so nothing could be
+concluded from the pair.
+
+## Corrections — blocked measurement produced two wrong published claims
+
+The previous session's probes timed configuration A to completion, then
+configuration B. That lets machine drift between the two blocks appear as
+an effect of the configuration. Re-measuring with A and B **interleaved
+inside each repetition** removed it. On the strength of the blocked
+numbers I had posted:
+
+- **"The measurement is not reproducible"**, with a spread table showing
+  1.44×–2.20× movement on the same matrix. **Retracted.** The
+  irreproducibility was my method, not the solver.
+- **"`cb_core_profitable` looks mis-calibrated"**, specifically that it
+  approves `ContribBlock` on `r05_kkt` where the approved configuration
+  runs at 0.67×. **Retracted.** Interleaved, `r05_kkt` runs at **1.65×
+  faster** — a 2.4× error on the same machine with the same binary. The
+  gate is correct on **7 of 7** matrices.
+
+Retractions posted:
+- feral#131 — https://github.com/jkitchin/feral/issues/131#issuecomment-5356330763
+- feral#189 — https://github.com/jkitchin/feral/issues/189#issuecomment-5356336437
+
+## Accomplished
+
+### 1. Reconciled the contradiction (`2ba437d`)
+
+`crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs` separates the
+three things the old probes had confounded — the **core**
+(`SharedVector` vs `Auto`), the **schedule** (serial vs rayon pool), and
+the **refinement depth** — and measures all three interleaved within each
+of 11 reps, in one process. Ratios > 1 mean the second config is faster.
+
+| matrix | n | core `sv/au` | sched `au/ap` | shipped `sv/ap` | corrections run |
+|---|---:|---:|---:|---:|---:|
+| bcsstk38 | 8,032 | 1.02 | 0.90 | 0.91 | 0 |
+| r05_kkt | 14,842 | 1.65 | 1.15 | 1.90 | 1 |
+| bratu3d | 27,792 | 1.31 | 0.99 | 1.29 | 0 |
+| qap15_kkt | 50,880 | 1.37 | 1.05 | 1.45 | 2 |
+| dirichlet120_kkt | 54,363 | 1.12 | 1.00 | 1.12 | 0 |
+| cont-201 | 80,595 | 1.45 | 0.98 | 1.42 | 0 |
+| cont5_late_kkt | 180,900 | 1.88 | 1.01 | 1.90 | 1 |
+| **geomean, steps=1** | | **1.37** | **1.01** | **1.38** | |
+| **geomean, default depth** | | **1.30** | **0.98** | **1.27** | |
+
+Findings:
+
+- **#131's "the schedule is a wash" conclusion survives** and is cleaner
+  than when it was drawn: 1.01 / 0.98 geomean, nothing outside 0.85–1.15.
+- **The core is worth 1.30–1.37× geomean** — and the bench could not see
+  any of it, because the bench pinned `SharedVector`. This is new, and it
+  is what Step 1 acts on.
+- **The refinement-depth hypothesis is dead.** `DEFAULT_REFINE_MAX_STEPS`
+  is 10 (`src/numeric/solve.rs:1954`), but the corrections *actually run*
+  are 0–2 across the whole set; only `qap15_kkt` exceeds one. There is no
+  depth overhead to reclaim.
+
+### 2. Re-verified the batching finding interleaved (`2ba437d`)
+
+`probe_batch_interleaved.rs`, 11 reps, 13 RHS, `solve_into`×13 vs
+`solve_many_into`: bcsstk38 2.20, r05_kkt 2.80, bratu3d 2.44, qap15_kkt
+2.31, dirichlet120_kkt 2.37, cont-201 2.62, cont5_late_kkt 2.58 →
+**geomean 2.47×, min 2.20×**. The blocked measurement had said 2.29× /
+1.70×, so the finding reported to pounce#698 was real and if anything
+under-stated. `probe_bench_solve_noise.rs` — the probe with the confound
+— is committed alongside for provenance.
+
+### 3. Step 1 of the gate plan: the bench times the core hosts run
+
+`src/bin/bench.rs` switched from `solve_sparse_refined` (which pins
+`SolveCore::SharedVector`, `src/numeric/solve.rs:2077`) to
+`solve_sparse_refined_auto_into`, with `parallel = false`. Recorded in
+`dev/decisions.md`.
+
+As **predicted in the journal before the run**, the corpus aggregate did
+not move: `solve/MUMPS` geomean 0.08 and p50 0.08, identical to baseline.
+The ~154k-matrix corpus is almost entirely small matrices where `Auto`
+picks `SharedVector` anyway. **Implication for Step 2: the 1.30× lives at
+n ≥ 8k and will never be visible in this harness's aggregate — the
+large-n gate needs its own matrix set.**
+
+## Regression — the 2.03 FAIL, in order
+
+1. First bench run after the change: sparse small-frontal p90 **2.03,
+   FAIL** (baseline 1.58).
+2. I journaled a hypothesis that this was machine state, on two grounds:
+   the failing metric is the *factor* ratio, which a solve-side change
+   cannot touch, and the untouched *dense* partition had also degraded
+   (1.58 → 1.73, 2.00 → 2.13).
+3. A control run on stashed, unmodified code reproduced **1.58 PASS** and
+   dense **1.58 / 2.00 PASS** exactly. **My machine-state hypothesis was
+   refuted.** The dense movement was coincidence that I read as evidence.
+4. Actual cause: `resample_or_fallback` (`src/bin/bench.rs:1060`) runs
+   factor and solve **interleaved in one closure**, five times, and
+   reduces `factor_us` by **min**. My change allocated the solve output
+   buffer inside that closure, so an n-double alloc-and-zero sat in the
+   timed solve region *and* perturbed the allocator state the next
+   replicate's factor was timed in — on exactly the matrices
+   `should_resample` selects (MUMPS factor < 200 µs), which is the same
+   population as the small-frontal bucket. An ~8 KB allocation per
+   replicate at n < 1000 was worth 1.58 → 2.03 on a p90 over 153,455
+   matrices.
+5. Fix: hoist the buffer to one allocation per matrix. Confirmed twice.
+
+**The coupling itself is still there** and is not fixed. It is recorded
+as a Step 1 item in `dev/plans/large-n-solve-gate.md`, deliberately not
+fixed here: separating the two phases changes every small-matrix number
+in the corpus and deserves its own commit and its own before/after.
+
+## Benchmark Results
+
+Three full corpus runs plus the 08-19-05 baseline:
+
+| bucket | baseline 08-19-05 | control (unmodified) | run 2 | run 3 |
+|---|---:|---:|---:|---:|
+| sparse small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
+| sparse medium p90 (≤3.0) | 1.58 PASS | 1.58 PASS | 1.54 PASS | 1.61 PASS |
+| dense small-frontal p90 (≤2.0) | 1.58 PASS | 1.58 PASS | 1.59 PASS | 1.64 PASS |
+| dense medium p90 (≤3.0) | 2.00 PASS | 2.00 PASS | 1.96 PASS | 1.98 PASS |
+
+The two post-change runs **bracket** the baseline (1.54, 1.61 vs 1.58).
+The honest reading is that the change is indistinguishable from baseline
+on the factor partition — which is correct, since it touches only the
+solve. **The 1.54 is not claimed as an improvement.** Run-to-run spread
+on this machine is ~±2.5%; that is now recorded in the plan as the floor
+below which a bench claim is noise.
+
+Run 3, full sparse aggregate:
+
+```
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.61       3.27       9.71
+solve/MUMPS        153560       0.08       0.08       0.16       0.88       3.12
+factor/SSIDS       154500       0.04       0.03       0.32       0.96       2.26
+solve/SSIDS        154500       0.96       1.00       2.83      10.25      43.00
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.64     <= 2.0     PASS
+medium (<500)            152145     1.98     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.61     <= 2.0     PASS
+medium (<500)            153560     1.61     <= 3.0     PASS
+```
+
+Note on the `factor/MUMPS` **max** column: it reads 9.71 here, 68.79 on
+the FAIL run, and the worst-offender list changes identity between runs
+(CRESC100/MUONSINE ↔ ACOPR14/KIRBY2). That tail is resample-loop noise on
+sub-millisecond matrices. **The max is not a stable statistic in this
+harness and should not be quoted as a result.**
+
+## Decisions Made
+
+- **The bench times `SolveCore::Auto`, serially** (`dev/decisions.md`,
+  2026-08-20). `Auto` because it is what every `Solver` entry point
+  dispatches to, so the published number should describe the path hosts
+  run. `parallel = false` because #177 makes the pool bit-neutral and the
+  probe measures the schedule at 0.98–1.01×, so holding it fixed costs
+  nothing and keeps the reading free of thread-count variance. The entry
+  also records the regression and why the resample coupling is left in
+  place for now.
+
+## Abandoned Approaches
+
+- **Blocked A-then-B timing for solve-configuration comparisons.** Not a
+  style preference — it produced two specific wrong published claims (see
+  Corrections), including a 2.4× error on `r05_kkt` on the same machine
+  with the same binary. All three probes committed this session interleave
+  within each repetition.
+- **The refinement-depth lever.** `DEFAULT_REFINE_MAX_STEPS = 10` looked
+  like slack worth reclaiming; corrections actually run are 0–2 on the
+  corpus, so there is nothing there.
+- **"The FAIL is machine state."** Stated in the journal with two
+  supporting observations, then refuted by a control run on unmodified
+  code that reproduced the baseline exactly.
+
+## Next Session Should
+
+1. **Finish Step 1** of `dev/plans/large-n-solve-gate.md`: decouple factor
+   from solve inside `resample_or_fallback`. Own commit, own before/after
+   — it moves every small-matrix number. Exit criterion is already
+   written: a solve-side no-op must provably not move `factor_us`.
+2. **Step 2** — build the large-n matrix set. This session established
+   that the existing corpus cannot see solve-phase work at all, so the
+   gate needs its own matrices; the seven in `probe_solve_reconcile` are
+   the obvious seed.
+3. **#189 item 4** (`BLAS3_NRHS_THRESHOLD = 32`) remains unreachable
+   while hosts loop single-RHS. Still blocked on pounce#698.
+4. **#131** — rescope. The schedule question it opened is answered (a
+   wash, now measured cleanly twice). Do not implement `solve_auto`.

--- a/dev/sessions/2026-08-20-02.md
+++ b/dev/sessions/2026-08-20-02.md
@@ -116,10 +116,30 @@ Full suite green; `cargo clippy --all-targets --all-features` clean.
 
 ### What it buys pounce
 
-Live on the Schur path today — `schur.rs:303` calls `solve_many_refined` with
-`n_s`, which is problem data and therefore a non-multiple of 8 seven times in
-eight. It does **not** touch pounce's IPM hot path, which is `nrhs = 1` and
-hardcoded (`std_aug_system_solver.rs:497,625`).
+*Corrected 2026-08-20 after reading pounce issue #698 comment 5359027510,
+which named a third multi-RHS call site this section had missed. The original
+text said only "live on the Schur path" and did not state how narrow that is.*
+
+pounce has three multi-RHS-capable call sites. The fix reaches exactly one.
+
+| pounce call site | nrhs | reached? |
+|---|---|---|
+| `std_aug_system_solver.rs:497,625` (IPM) | 1, hardcoded | no |
+| `pounce-feral/src/lib.rs:1004,1006` (batched backsolve) | **6** | **no — below the 32 threshold** |
+| `pounce-feral/src/schur.rs:303,304` | `n_s` | yes, when `n_s >= 32` |
+
+The batched backsolve runs at `nrhs = 6` because that is
+`limited_memory_max_history`, confirmed in the pounce tree at
+`alg_builder.rs:1037` and `:1508`. Six is below `BLAS3_NRHS_THRESHOLD`, so
+that path dispatches to the rank-1 kernel and the panel-path stride change
+cannot touch it. That is the right dispatch anyway: the probe has rank-1
+beating BLAS-3 at `nrhs = 6` on all seven matrices (rank1/blas3 = 0.68-0.86),
+so there is no gain sitting unclaimed at pounce's batching width.
+
+The Schur path can exceed 32 — `schur_aug_system_solver.rs:36` sets
+`DEFAULT_MAX_SCHUR_FRAC = 0.5`, so `n_s` runs to half the KKT dimension — and
+`n_s` is problem data, hence a non-multiple of 8 seven times in eight. But it
+is one path under one condition, not a blanket speedup of pounce's solve.
 
 ## Benchmark Results
 

--- a/dev/sessions/2026-08-20-02.md
+++ b/dev/sessions/2026-08-20-02.md
@@ -26,8 +26,16 @@ untouched.
 The likely cause is machine state — the box had been under sustained compile
 and benchmark load for hours before this run. That is a hypothesis, not a
 result: I did not run a control on stashed code to test it, as was done on
-08-20-01 to refute a similar attribution. **Next session should re-run the
-bench cold before reading anything into these numbers.**
+08-20-01 to refute a similar attribution.
+
+> **RESOLVED, same day.** The cold re-run (built cold, 180 s settle, machine
+> quiet) put all four buckets at the *bottom* of the band: sparse
+> small-frontal **1.54**, sparse medium **1.54**, dense small-frontal
+> **1.59**, dense medium **1.97**. Two independent machine-state signatures
+> confirm the hot run rather than the change: `factor/MUMPS` max fell
+> **71.94 -> 9.10** and the worst-offender list changed identity entirely
+> (GAUSS2/CRESC100 cold vs HAIFAM/HAHN1 hot); `factor/SSIDS` p99 fell
+> 1.11 -> 0.95. `a0b4d64` did not regress the factor path.
 
 ## Goal
 
@@ -190,17 +198,22 @@ medium (<500)            153560     1.65     <= 3.0     PASS
 
 ## Next Session Should
 
-1. **Re-run the bench cold** before drawing any conclusion from the factor
-   p90 drift reported at the top of this file.
+1. ~~Re-run the bench cold~~ — **done, see the RESOLVED note above.**
 2. **Decide whether to ship.** This is the first change in this thread that
    clears the "rigorous, correct, real gain" bar. It is bit-neutral and needs
    no approval. Five commits sit unpushed on local `main`
    (`0ac4fb1`, `2ba437d`, `c09da70`, `c34475e`, `a0b4d64`).
-3. **Follow-up worth ~18% more at `nrhs = 33`:** keep the aligned stride but
-   iterate only the `nrhs` live columns, masking the final tile —
-   `gemm_tile` already takes a `live` parameter. Needs a stride-vs-live
-   distinction threaded through all five kernels, so it is a separate change
-   with its own before/after.
+3. ~~Follow-up worth ~18% more at `nrhs = 33`~~ — **tried and rejected the
+   same day; this estimate was wrong.** Iterating only the live columns with
+   a masked final tile is correct (1600-shape bit-identity sweep, mutation-
+   checked pad assertion, clippy clean) but **1.22x slower**: anchored
+   geomean 0.823x at `nrhs = 33`, 0.799x at 36, 0.797x at 47, and slower in
+   raw microseconds on all seven matrices. Null controls (`nrhs` 32/40/48,
+   where masking is a provable no-op) moved 1.019x, so ~1.9% drift against a
+   ~20% effect. The padding is not waste — it is what keeps every loop a
+   whole number of 8-wide vector operations. Reverted in full; see
+   `dev/tried-and-rejected.md`. **The `40/33` residual is not available
+   headroom and must not be described as such.**
 4. **Fix the `BLAS3_NRHS_THRESHOLD` doc comment**, which cites `multi-rhs.md`
    D3 as if it were a measurement. It is a pre-implementation rule of thumb.
 5. Still open from `dev/plans/large-n-solve-gate.md`: decouple factor from

--- a/dev/sessions/2026-08-20-02.md
+++ b/dev/sessions/2026-08-20-02.md
@@ -1,0 +1,187 @@
+# Session 2026-08-20-02
+
+## Unfavorable comparison, reported first (per CLAUDE.md)
+
+The session-end bench is at or slightly above the top of the previously
+observed band on the factor partitions:
+
+| bucket | baseline 08-19-05 | 08-20-01 runs | this run |
+|---|---:|---:|---:|
+| sparse small-frontal p90 | 1.58 | 1.54 / 1.61 | **1.65** |
+| sparse medium p90 | 1.58 | 1.54 / 1.61 | **1.65** |
+| dense small-frontal p90 | 1.58 | 1.59 / 1.64 | **1.66** |
+| dense medium p90 | 2.00 | 1.96 / 1.98 | **2.04** |
+
+All four still PASS their targets, and `solve/MUMPS` geomean and p50 held at
+0.08 exactly. But this is the worst of the four runs recorded across the two
+sessions, and it is +4.4% on the sparse buckets against the 08-19-05 baseline.
+
+**This session's change cannot mechanically account for it.** The bench times
+factorization and a *single-RHS* solve; the change is confined to
+`solve_sparse_core_many_into` and the panel GEMM reached only from
+`fwd_blas3`/`back_blas3`, which the multi-RHS path alone calls. The
+single-RHS core (`solve_sparse_core_into`) and the whole factorization are
+untouched.
+
+The likely cause is machine state — the box had been under sustained compile
+and benchmark load for hours before this run. That is a hypothesis, not a
+result: I did not run a control on stashed code to test it, as was done on
+08-20-01 to refute a similar attribution. **Next session should re-run the
+bench cold before reading anything into these numbers.**
+
+## Goal
+
+Answer issue #189 item 4: is `BLAS3_NRHS_THRESHOLD = 32` costing pounce
+anything? Under the standing bar for this work — rigorous, thoroughly
+correct, and a real performance gain, or it does not ship.
+
+## Accomplished
+
+### The threshold is fine. There was a defect underneath it.
+
+`BLAS3_NRHS_THRESHOLD` is unchanged at 32. What the investigation found
+instead: the row-major multi-RHS work buffers used a leading dimension of
+exactly `nrhs`, so any `nrhs` that is not a multiple of 8 makes every row of
+every supernode panel straddle a cache line, compounding across the gather,
+the kernels and the scatter.
+
+Evidence, all within a single process so no cross-process drift can reach it.
+`t(31)/t(32)` — `nrhs = 31` is 3% *less* work, so a healthy kernel gives
+~0.97:
+
+| matrix | before | after |
+|---|---:|---:|
+| bcsstk38 | 1.61 | 1.06 |
+| r05_kkt | 1.41 | 0.73 |
+| bratu3d | 1.79 | 1.38 |
+| qap15_kkt | 1.47 | 0.88 |
+| dirichlet120_kkt | 1.80 | 0.96 |
+| cont-201 | 1.47 | 0.97 |
+| cont5_late_kkt | 1.64 | 1.00 |
+
+Doing less work took 1.4-1.8x longer on all seven. Fix: `padded_ldw(nrhs) =
+nrhs.div_ceil(8) * 8` as the panel path's row stride. Committed `a0b4d64`.
+
+### The first diagnosis was wrong, and the experiment that caught it
+
+I first attributed the sawtooth to `gemm_scalar_block`, which handled the
+`nrhs % 8` column tail with an unblocked triple loop — for every output
+element it re-walked all of `A`'s row and `B`'s column with no reuse. Real
+inefficiency, and replacing it with `gemm_tile` (full-width register tiles,
+unused lanes zero-padded) is kept. But it moved `t(31)/t(32)` only from
+1.41-1.80 to 1.39-1.51, so it was not the cause.
+
+The discriminating experiment: `nrhs = 33` has **one** tail column where
+`nrhs = 31` has **seven**. On bratu3d they cost 74,154 us and 72,298 us —
+the same, both ~1.55x `nrhs = 32`. Tail-column count does not predict the
+cost. The stride does.
+
+### Scope of the gain, stated honestly
+
+The probe forces BLAS-3 at every `nrhs`; the library dispatches to it only at
+`nrhs >= 32`. Across all measured points the anchored geomean is 1.83x, but
+those points include widths where BLAS-3 does not ship — **quoting 1.83x
+would overstate the user-visible result by ~35%.**
+
+Shipped regime (`nrhs >= 32`, not a multiple of 8), at `nrhs = 33`:
+
+| matrix | anchored | raw us |
+|---|---:|---|
+| bcsstk38 | 1.21x | 10,093 -> 8,272 |
+| r05_kkt | 1.59x | 15,194 -> 12,426 |
+| bratu3d | 1.32x | 74,154 -> 56,230 |
+
+**Geomean 1.36x**, for the 7-in-8 `nrhs` values that are not a multiple of 8.
+Anchored on `nrhs = 32`, whose code path is byte-identical before and after
+(`padded_ldw(32) == 32`), so uniform drift cancels.
+
+The residual `t(33)/t(32) ~ 1.21` is not leftover misalignment — it is
+exactly `40/33`, the cost of solving the 7 padding columns.
+
+### Bit-for-bit unchanged, three independent checks
+
+1. New `gemm_tail_tests::panel_gemm_is_bit_identical_to_the_reference_on_every_tail_shape`
+   — `to_bits()` equality against a scalar left-fold reference over 800 shapes
+   (16 `nrhs` x 10 `m_dim` x 5 `k_dim`), covering every `nrhs % 8` and
+   `m_dim % 4` residue.
+2. The probe's `max |rank1 - blas3|` column, unchanged at all 105 measured
+   (matrix, `nrhs`) points. Rank-1 is untouched, so any change in the BLAS-3
+   output would move it.
+3. All 13 `tests/multi_rhs.rs` pass, including both
+   `assert_eq!(max_diff, 0.0)` band contracts that pounce's Schur path
+   (`schur.rs:303`) depends on.
+
+So: no threshold change, no tolerance change, no human sign-off required.
+Full suite green; `cargo clippy --all-targets --all-features` clean.
+
+### What it buys pounce
+
+Live on the Schur path today — `schur.rs:303` calls `solve_many_refined` with
+`n_s`, which is problem data and therefore a non-multiple of 8 seven times in
+eight. It does **not** touch pounce's IPM hot path, which is `nrhs = 1` and
+hardcoded (`std_aug_system_solver.rs:497,625`).
+
+## Benchmark Results
+
+```
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.46       0.33       1.65       4.13      71.94
+solve/MUMPS        153560       0.08       0.08       0.16       0.88      25.59
+factor/SSIDS       154500       0.04       0.03       0.34       1.11      23.34
+solve/SSIDS        154500       0.96       1.00       2.83      10.25     583.65
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.66     <= 2.0     PASS
+medium (<500)            152145     2.04     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.65     <= 2.0     PASS
+medium (<500)            153560     1.65     <= 3.0     PASS
+```
+
+## Decisions Made
+
+- The row stride of the row-major multi-RHS buffers is padded to a whole
+  `NR`-column tile on the panel path, and left raw on the rank-1 path. The
+  padding buys cache-line alignment at the cost of up to `8/nrhs` extra flops
+  (21% at `nrhs = 33`, 7% at 100, under 1% at 1000).
+- `BLAS3_NRHS_THRESHOLD` stays at 32. Its documented justification is still a
+  circular citation (Finding 1 in the research note) and should be corrected
+  in the doc comment, but the constant itself is not the problem.
+- `kernel-probe` is a permanent, off-by-default Cargo feature. It exists
+  because cross-process kernel A/B does not work on this machine.
+
+## Abandoned Approaches
+
+- **Two-build cross-process kernel comparison** — discarded as contaminated,
+  no number from it reported. Appended to `dev/tried-and-rejected.md` with
+  the failing controls (identical-code anchor drifted to 2.10; a null control
+  that must read 1.00 read 0.86-0.90).
+- **The scalar-column-tail hypothesis as the *cause*** — refuted by the
+  `nrhs = 33` experiment. The tail rewrite is kept on its own merits
+  (bit-neutral, and a prerequisite for the follow-up below), but it is not
+  why the sawtooth existed.
+- **One after-fix probe run** — self-contaminated by running
+  `cargo test --release` concurrently with it. Discarded and re-run quiet.
+
+## Next Session Should
+
+1. **Re-run the bench cold** before drawing any conclusion from the factor
+   p90 drift reported at the top of this file.
+2. **Decide whether to ship.** This is the first change in this thread that
+   clears the "rigorous, correct, real gain" bar. It is bit-neutral and needs
+   no approval. Five commits sit unpushed on local `main`
+   (`0ac4fb1`, `2ba437d`, `c09da70`, `c34475e`, `a0b4d64`).
+3. **Follow-up worth ~18% more at `nrhs = 33`:** keep the aligned stride but
+   iterate only the `nrhs` live columns, masking the final tile —
+   `gemm_tile` already takes a `live` parameter. Needs a stride-vs-live
+   distinction threaded through all five kernels, so it is a separate change
+   with its own before/after.
+4. **Fix the `BLAS3_NRHS_THRESHOLD` doc comment**, which cites `multi-rhs.md`
+   D3 as if it were a measurement. It is a pre-implementation rule of thumb.
+5. Still open from `dev/plans/large-n-solve-gate.md`: decouple factor from
+   solve inside `resample_or_fallback`; Step 2 large-n matrix set.

--- a/dev/sessions/2026-08-20-03.md
+++ b/dev/sessions/2026-08-20-03.md
@@ -1,0 +1,237 @@
+# Session 2026-08-20-03
+
+## Unfavorable result, reported first (per CLAUDE.md)
+
+**Issue #190's stated premise does not reproduce on this corpus, and the
+feature built for it is not a performance gain.**
+
+#190 argues the hardwired `ε·√n` convergence target is unreachable on large
+ill-conditioned systems, so every refined solve runs the full 10-step budget
+and pays for iterations that buy nothing. Measured (`probe_refine_stop_criterion`,
+best-of-5 wall, seven matrices, well-scaled RHS):
+
+| matrix | n | default steps | stop | ω |
+|---|---:|---:|---|---:|
+| r05_kkt | 14,842 | 0 | Converged | 4.546e-13 |
+| qap15_kkt | 50,880 | 2 | Converged | 2.690e-16 |
+| dirichlet120_kkt | 54,363 | 0 | Converged | 1.679e-14 |
+| cont-201 | 80,595 | 0 | Converged | 8.720e-14 |
+| cont5_late_kkt | 180,900 | 1 | Converged | 1.711e-16 |
+| bratu3d | 27,792 | 0 | Converged | 2.467e-15 |
+| bcsstk38 | 8,032 | 0 | Converged | 1.324e-15 |
+
+Zero to two steps, never at the cap. There is no wasted-iteration saving to
+claim, and the feature must not be described as one.
+
+Stated in the other direction so the limit is on the record: the `n = 118,276`
+system #190 cites is a pounce *runtime* KKT and is not in the local corpus
+(largest local matrix is `c-big`, `n = 345,241`, not in this set). The premise
+is **untested at its own scale**, not refuted at it.
+
+The measured *cost* of the new criteria is ~2x on the refinement wall
+(0.39x–0.61x "vs def"), roughly one extra solve, factor excluded. The only
+speedups measured are the caller deliberately buying less accuracy: qap15 easy
+at `BackwardError(1e-10)` is 1.45x by stopping at ω 8.755e-12 instead of
+2.690e-16; qap15 hard at `RelativeResidual(1e-12)` is 1.49x and *worse*
+(ω 8.038e-10 vs the default's 1.229e-10).
+
+Against the standing bar for this thread — "rigorous, thoroughly correct, and
+result in performance gains, or we will not include it in a release" — #190
+clears the first two and **fails the third**. Ship-or-not is a human call; see
+"Next Session Should".
+
+## Goal
+
+Act on issue #190: the `ε·√n` refinement target is a hardwired constant with
+no principled value; let the caller say what "converged" means.
+
+## Accomplished
+
+### `StopCriterion`: the caller says what converged means (`f547bc5`)
+
+`RefineOptions` gains a `stop: StopCriterion` field with three variants:
+
+- `EpsSqrtN` — the historical test, still the default, bit-for-bit unchanged.
+- `RelativeResidual(t)` — stop at `‖r‖₂ ≤ t·‖b‖₂`.
+- `BackwardError(t)` — stop at `maxᵢ |rᵢ| / (|A||x| + |b|)ᵢ ≤ t`
+  (Arioli–Demmel–Duff 1989; MA57 `RINFO(6..8)`, MUMPS `RINFO(7..8)`).
+
+The `*_refined_into` entry points now return
+`RefineOutcome { steps, relative_residual, stop }` where `stop` is
+`Converged | MaxSteps | Stagnated | Diverged`. All three values are already
+computed by the loop, so reporting them costs nothing. `RefinementDiagnostics`
+is deliberately *not* returned here — it computes a Hager–Higham condition
+estimate costing 3–5 extra solves (`solve.rs:2596`), which would dominate the
+hot path. Existing callers compile unchanged.
+
+The backward-error step costs one extra pass over `A` (`abs_symv`) and **no**
+extra solves.
+
+**Oracle, per the no-self-oracle rule.** The formula is LAPACK `dgerfs`'s,
+including its `safe1 = (n+1)·MIN_POSITIVE` / `safe2 = safe1/EPSILON` underflow
+guard. Expected values for the four unit tests were computed independently in
+Python from the published formula before any Rust was written. One documented
+deviation: a row whose denominator is exactly zero contributes `0`, not
+LAPACK's `1`, because `dᵢ == 0` forces every `|aᵢⱼ||xⱼ| = 0` and `|bᵢ| = 0`,
+hence `rᵢ = 0` exactly.
+
+15 integration tests in `tests/issue190_refine_target.rs`.
+
+### Test constants are measured, not guessed
+
+Three of the fifteen tests failed on first run because I picked target values
+below what the fixture can reach — the implementation was correct and reported
+`MaxSteps` accurately. Rather than loosen anything, I wrote a throwaway probe
+and measured the fixture's convergence ladder, which contracts ~3.0× per step
+to a 10-step floor of rel `1.06e-7` / ω `7.05e-8`:
+
+```
+k:      1        2        3        4        5
+rel: 2.37e-3  7.74e-4  2.55e-4  8.38e-5  2.76e-5
+ome: 1.21e-3  4.85e-4  1.66e-4  5.53e-5  1.82e-5
+k:      6        7        8        9       10
+rel: 9.07e-6  2.99e-6  9.82e-7  3.23e-7  1.06e-7
+ome: 6.01e-6  1.98e-6  6.51e-7  2.14e-7  7.05e-8
+```
+
+The ladder is recorded in the test module comment so the constants stay
+checkable. No tolerance was loosened; no approval needed.
+
+### An unplanned finding that supports the design
+
+On the 20-column `many_rhs` fixture, ω spans **2.7×** across columns
+(2.86e-8 … 7.65e-8) where `‖r‖₂/‖b‖₂` spans **42×** (1.06e-7 … 4.46e-6).
+Batched step counts at a fixed target:
+
+| target | rel steps | berr steps |
+|---|---|---|
+| 1e-3 | 6 Converged | 2 Converged |
+| 1e-4 | 8 Converged | 4 Converged |
+| 1e-5 | 10 Converged | 6 Converged |
+| 1e-6 | 10 **MaxSteps** | 8 Converged |
+| 1e-7 | 10 **MaxSteps** | 10 Converged |
+
+A batched *normwise* target is hostage to its worst-scaled column. This is a
+stronger argument than the research note had, and it lands on the exact path
+pounce's Schur solver uses.
+
+### `needs_refinement` now measures growth, not magnitude (`849caea`)
+
+`Factors::needs_refinement` was set whenever any `|L_ij| > 1e6`. That is a
+statement about the *magnitude* of `L` — a property of the caller's scaling —
+not about growth. It now compares against `1/u`, the multiplier bound that
+threshold partial pivoting with `pivot_threshold = u` actually promises. With
+no threshold in force (`u = 0`) the old absolute `1e6` remains as fallback.
+Four new cases in `growth_flag_tests`, including that the same `L` is accepted
+at `u = 1e-8` and rejected at `u = 0.5`.
+
+**Provenance caveat, stated because it matters.** The doc comment on this
+change cites a pounce measurement (126,028-order KKT; 91 of 108 factorizations
+flagged at actual growth 8.7e-8, max|L| 5.1e7 against a promised 1e8) that
+appears **nowhere** in `dev/` or in any session transcript except inside the
+diff itself. I could not verify it. It was committed separately with that
+caveat in the commit body precisely so it can be reverted alone. The
+mathematical argument — `|L_ij| ≤ 1/u` is what TPP contracts to deliver —
+stands independently of the unverified number.
+
+### Docs corrected against the measurement (`65f488c`)
+
+`CHANGELOG.md`, `README.md` and the `solve_sparse_refined` doc comment each
+asserted #190's unreachable-target premise as fact. All three now lead with
+the correctness gap instead, state the measured ~2x cost, and carry the new
+caveat that an unreachable *componentwise* target overruns exactly as the old
+constant did. The original `decisions.md` entry for #190 was left untouched
+per the append-only rule; a follow-up entry records the measurement.
+
+## Benchmark Results
+
+```
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.56       3.25       9.20
+solve/MUMPS        153560       0.08       0.08       0.15       0.73       2.60
+factor/SSIDS       154500       0.04       0.03       0.32       0.94       1.96
+solve/SSIDS        154500       0.94       1.00       2.50       8.67      29.00
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.56     <= 2.0     PASS
+medium (<500)            153560     1.56     <= 3.0     PASS
+```
+
+Quiet machine, nothing else running. This is the best of the recent runs and
+sits at the bottom of the observed band — better than 08-20-02's hot run on
+every bucket and level with its cold re-run:
+
+| bucket | 08-19-05 baseline | 08-20-02 hot | 08-20-02 cold | this run |
+|---|---:|---:|---:|---:|
+| sparse small-frontal p90 | 1.58 | 1.65 | 1.54 | **1.56** |
+| sparse medium p90 | 1.58 | 1.65 | 1.54 | **1.56** |
+| dense small-frontal p90 | 1.58 | 1.66 | 1.59 | **1.58** |
+| dense medium p90 | 2.00 | 2.04 | 1.97 | **2.00** |
+
+All four PASS. `solve/MUMPS` geomean 0.08 and p50 0.08 unchanged. The
+machine-state signature the previous session identified is visible again in
+the right direction: `factor/MUMPS` max is **9.20** here against 71.94 on the
+hot run, and `factor/SSIDS` p99 is 0.94 against 1.11.
+
+Neither of this session's commits should touch the bench path — the bench
+times factorization and a single-RHS solve, `849caea` changes only which
+matrices set an advisory `needs_refinement` flag (read by nobody in the bench),
+and `f547bc5` adds a criterion whose default is bit-for-bit the old behavior.
+The numbers are consistent with that.
+
+## Decisions Made
+
+- **The stopping criterion is an enum, not a numeric field.** A bare tolerance
+  cannot express "machine precision for this `n`" and a bare `n`-scaled
+  constant cannot express "backward stable." Both are wanted; the enum is the
+  only shape that keeps `EpsSqrtN` bit-identical while admitting the other two.
+- **`RefineOutcome`, not `RefinementDiagnostics`, on the hot path.** The full
+  diagnostics computes a Hager–Higham 1-norm estimate at a cost of 3–5 extra
+  solves. `RefineOutcome`'s three fields are already in hand.
+- **`RefineStop` orders `Converged < Stagnated < Diverged < MaxSteps`** so a
+  caller can compare severity.
+- **#190 ships (if it ships) as an accuracy feature.** Appended to
+  `decisions.md` as a follow-up entry; see the unfavorable-result section above.
+- **`needs_refinement` compares against `1/u`.** TPP's own contract is the
+  right bound for a growth flag; `1e6` was a magnitude test wearing a growth
+  test's name.
+
+## Abandoned Approaches
+
+Nothing was abandoned this session. Three test constants were *corrected* after
+measurement (they were guessed too tight and the tests correctly reported
+`MaxSteps`), which is not the same thing — no code path was tried and dropped,
+and no tolerance was loosened.
+
+## Next Session Should
+
+1. **Decide whether #190 ships, now that it is measured.** It is rigorous and
+   correct, it fixes a real correctness gap (the default silently accepts
+   ω = 9.5e-5 on a badly-scaled RHS), and it is **not** a performance gain —
+   it costs ~2x on the refinement wall. That fails the stated release bar as
+   written, so this needs a human call rather than a default.
+2. **Verify or drop the pounce provenance in `849caea`'s doc comment.** The
+   126,028-order KKT measurement it cites is unverifiable from this repo. Either
+   find it in the pounce tree and cite it properly, or cut the number and keep
+   the mathematical argument, which stands alone.
+3. **Fix the `BLAS3_NRHS_THRESHOLD` doc comment** (carried from 08-20-02): it
+   cites `multi-rhs.md` D3 as if it were a measurement; it is a
+   pre-implementation rule of thumb.
+4. **Measure #190 at its own scale if a matrix can be obtained.** The premise
+   is untested at `n ≈ 118,276` on an IPM-generated KKT, which is where #190
+   claims it bites. Either get that matrix out of pounce or stop citing the
+   claim.
+5. Still open from `dev/plans/large-n-solve-gate.md`: decouple factor from
+   solve inside `resample_or_fallback`; Step 2 large-n matrix set.
+6. **Twelve commits sit unpushed on local `main`** (through the checkpoint commit), per the
+   standing "no branch, no PR until this is ready for pounce" instruction.

--- a/dev/sessions/2026-08-21-01.md
+++ b/dev/sessions/2026-08-21-01.md
@@ -1,0 +1,179 @@
+# Session 2026-08-21-01
+
+## Unfavorable result, reported first (per CLAUDE.md)
+
+**The solve tail regressed 33–56%, this session's change caused it, and a
+controlled A/B proves that rather than leaving it as a hypothesis.**
+
+`src/bin/bench.rs:1985` times the sparse solve with `RefineOptions::default()`,
+so the new stopping criterion sits directly in the measured path. I ran the
+bench with the shipped default, then reverted `Default for RefineOptions` to
+`EpsSqrtN`, rebuilt, and re-ran on the same quiet machine:
+
+| ratio | control (`EpsSqrtN`) | shipped default | delta |
+|---|---:|---:|---:|
+| factor/MUMPS p90 | 1.54 | 1.56 | +1.3% (noise) |
+| solve/MUMPS geomean | 0.08 | 0.08 | none |
+| solve/MUMPS p50 | 0.08 | 0.08 | none |
+| solve/MUMPS p90 | 0.15 | **0.20** | **+33%** |
+| solve/MUMPS p99 | 0.71 | **1.08** | **+52%** |
+| solve/SSIDS geomean | 0.94 | **1.06** | **+13%** |
+| solve/SSIDS p90 | 2.50 | **3.60** | **+44%** |
+| solve/SSIDS p99 | 8.33 | **13.00** | **+56%** |
+
+**The shape is what the design predicts.** Geomean and p50 are identical to
+three decimals — the well-scaled majority never needed the extra conjunct
+and does not pay for it. The tail pays, because that is where the matrices
+live whose componentwise error was above `√ε` and which now actually refine.
+On the tracked parity corpus that is 13 of 63 (21%), the right order to move
+a p90.
+
+Factor is unchanged within noise, as it must be — the change is confined to
+the refinement loop's stopping test. That also validates the control: machine
+state would have moved factor too, and did not. **Unlike 2026-08-20-02,
+nothing here is attributed to machine state.**
+
+**Against the standing bar** ("rigorous, thoroughly correct, and result in
+performance gains, or we will not include it in a release"): this is a
+measured performance *cost*, not a gain. It buys MA57/MUMPS componentwise
+parity on systems where feral returned ω up to 9.5e-5 and reported
+`Converged`. Whether that trade ships is the human's call. The alternative is
+to keep `EpsSqrtN` as the default and make the conjunction opt-in — which
+costs pounce the fix it asked for.
+
+## Goal
+
+Human instruction: *"we need to fix the deficiency gap with ma57/mumps if
+there is one because this is causing an issue on a class of problems in
+pounce. surprisingly, it works well for the vast majority of problems."*
+
+## Accomplished
+
+### Four candidate causes measured and ruled out
+
+| hypothesis | verdict | evidence |
+|---|---|---|
+| ForceAccept eating error | no | `inertia.zero == 0`, `n_tiny == 0` on all seven large matrices |
+| pivot threshold too low | no | Ipopt sets `ma27_pivtol` 1e-8, `ma57_pivtol` 1e-8, `mumps_pivtol` 1e-6 — *below* library defaults; feral's 1e-8 already matches |
+| escalation ladder not wired | no | `pounce-feral/src/lib.rs:1368` forwards `increase_quality` |
+| inertia disagreement | no | exact match with MUMPS 5.8.2 on all seven, incl. `qap15_kkt` at `cond1 = 3.9e12` |
+
+I had previously asserted the pivot threshold *was* the gap and changed it to
+1e-2. That was wrong and is reverted; see `dev/tried-and-rejected.md`.
+
+### The gap is the stopping criterion
+
+`EpsSqrtN` (`‖r‖₂ < ε·√n·‖b‖₂`) is normwise, so it is dominated by the rows
+carrying the largest RHS entries. MUMPS's `ICNTL(10)` stops instead on the
+Arioli–Demmel–Duff *componentwise* backward error against `CNTL(2) = √ε`
+(`ref/mumps/src/dini_defaults.F:1094`).
+
+On a RHS spanning twelve orders — the shape an IPM produces near convergence —
+feral reported `Converged` at step 0 where MUMPS reached machine precision:
+
+| matrix | feral ω (old default) | MUMPS ω1 |
+|---|---:|---:|
+| `r05_kkt` | 9.520e-5, 0 steps | 3.608e-16 |
+| `bratu3d` | 8.953e-6, 0 steps | 2.844e-16 |
+| `cont-201` | 3.860e-7, 0 steps | 2.728e-16 |
+
+In an IPM the small-|bᵢ| rows are the complementarity residuals of near-active
+constraints — exactly the rows that set the step. That is why this shows up on
+a class of problems, not uniformly, which matches the reported symptom.
+
+### The fix, and why it is a conjunction
+
+New `StopCriterion::EpsSqrtNAndBackwardError(f64)`, defaulting to
+`DEFAULT_BACKWARD_ERROR_TARGET = √ε` (MUMPS's `CNTL(2)`, same number for the
+same purpose). It requires **both** tests, so it is strictly harder to satisfy
+than the old default and **no caller can receive a worse iterate than before**
+— which is why it ships without touching a tolerance or a residual gate.
+`EpsSqrtN` stays available, bit-for-bit unchanged.
+
+### Regression coverage
+
+`tests/issue190_componentwise_default.rs`, three tests, 0.64 s, on the tracked
+parity corpus (the seven discovery matrices are gitignored):
+
+1. `default_certifies_backward_stability_on_badly_scaled_rhs` — all 63
+   factorable matrices return ω ≤ √ε.
+2. `normwise_criterion_alone_is_not_enough` — pins five fixtures where
+   `EpsSqrtN` alone leaves ω > 10·√ε. The defect reproduces on 13 of 63;
+   worst DEGENLPB_0046 at 359×√ε.
+3. `default_is_never_weaker_than_the_historical_rule` — the conjunction never
+   produces a worse componentwise error than `EpsSqrtN` on any corpus matrix.
+
+Oracle is external throughout: canonical MUMPS 5.8.2 for the target, LAPACK
+`dgerfs`'s guarded formula for the ω computation.
+
+### Provenance cleanup
+
+`849caea`'s doc comments attributed the growth-flag change to a specific
+pounce run (126028-order KKT, 91 of 108 factorizations, growth 8.7e-8, 84% of
+the run, a `deb7` fixture at max|L| = 4.2e13). None of that is recorded
+anywhere in this repository, so it is unverifiable from the tree it documents.
+The numbers are removed; the scale-free argument, which does not depend on
+them, is what the comments now say. Test inputs unchanged. No behavior change.
+
+## Benchmark Results
+
+Inertia gate: **154531/154590 (100.0%) match vs MUMPS** — holds.
+
+```
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.44       0.30       1.56       3.45      11.05
+solve/MUMPS        153560       0.08       0.08       0.20       1.08       4.56
+factor/SSIDS       154500       0.04       0.03       0.32       1.02       2.49
+solve/SSIDS        154500       1.06       1.00       3.60      13.00      52.33
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.56     <= 2.0     PASS
+medium (<500)            153560     1.56     <= 3.0     PASS
+```
+
+All four partitions PASS and sit at the bottom of the observed band against
+the 08-19-05 baseline of 1.58/1.58/1.58/2.00. `factor/MUMPS` max fell
+71.94 → 11.05, the machine-quietness signature. The solve regression is
+covered at the top of this file.
+
+Suite: **956 passed, 0 failed, 113 suites.** `cargo clippy -- -D warnings` and
+`cargo clippy -p feral-diagnostics --all-targets -- -D warnings` both clean.
+
+## Decisions Made
+
+- The default refinement criterion is now conjunctive. Full entry in
+  `dev/decisions.md`, 2026-08-21.
+
+## Abandoned Approaches
+
+All three in `dev/tried-and-rejected.md` with their failing cases:
+
+- Raising `pivot_threshold` 1e-8 → 1e-2 — premise false, Ipopt sets 1e-8.
+- `BackwardError(√ε)` alone as the default — fails `tests/parity.rs` on
+  ROSZMAN1_0241 (feral=4.805e-14 > 2.077e-14).
+- `BackwardError(f64::EPSILON)` — stagnates or exhausts the budget on five of
+  seven large matrices under the badly-scaled RHS.
+
+## Next Session Should
+
+1. **Get a decision on the tail regression.** 33–56% at p90/p99 on the solve,
+   bought for componentwise parity. If that trade is not acceptable, the
+   fallback is `EpsSqrtN` as default with the conjunction opt-in — but that
+   returns pounce to the broken behavior on the affected class.
+2. Post the drafted #190 comment (`/tmp/feralmsg/i190_comment.md`, 109 lines)
+   and close #190 as *completed* once the PR merges.
+3. File the plateau / `residual_improvement_factor` item as its own issue.
+4. Investigate `qap15_kkt`'s ω 1.229e-10 vs MUMPS 1.023e-12 — a separate,
+   smaller item; both are inside `√ε` so both are certified.
+5. Fix the `BLAS3_NRHS_THRESHOLD` doc comment, which still cites `multi-rhs.md`
+   D3 as if it were a measurement (carried from 08-20-02).
+6. Still open from `dev/plans/large-n-solve-gate.md`: decouple factor from
+   solve inside `resample_or_fallback`; Step 2 large-n matrix set.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5805,3 +5805,75 @@ behind a mask.
 `40/33` residual is not recoverable this way and should not be described as
 "available headroom" in future notes. Reverted in full; no code from this
 attempt was kept.
+
+## 2026-08-21 — raising `pivot_threshold` from 1e-8 to 1e-2 to "match MA57/MUMPS"
+
+**Tried.** Changed `NumericParams::default()`'s `pivot_threshold`
+(`src/numeric/factorize.rs:645`) from `1e-8` to `1e-2`, on my claim that
+feral was six orders below MA57 and MUMPS, whose library defaults are
+`CNTL(1) = 0.01`, and that this was the pounce deficiency gap.
+
+**Why it was wrong.** The premise is false. Ipopt does not use the library
+defaults — it deliberately lowers them, because in an interior-point method
+accuracy is recovered by inertia correction and iterative refinement rather
+than by pivoting hard. From `ref/Ipopt`:
+
+| Ipopt option | default | source |
+|---|---:|---|
+| `ma27_pivtol` | 1e-8 | `IpMa27TSolverInterface.cpp:97` |
+| `ma57_pivtol` | 1e-8 | `IpMa57TSolverInterface.cpp:205` |
+| `mumps_pivtol` | 1e-6 | `IpMumpsSolverInterface.cpp:131` |
+
+feral's 1e-8 already matches the MA27/MA57 configuration pounce is
+replacing. `tests/issue_2_kkt_ls_init.rs:32`
+(`numeric_params_default_uses_sparse_pivot_threshold`) pins it for exactly
+this reason and cites `ma27_pivtol`; that test is correct and was left
+untouched.
+
+Independently, the threshold was already measured not to be the cause:
+`probe_pivot_threshold_residual` sweeps it from 1e-8 to 0.5 on `qap15_kkt`
+and the unrefined relative residual does not move off ~3e-6.
+
+**Disposition.** Reverted in full (`git checkout src/numeric/factorize.rs`).
+No pivot-threshold change ships. The real gap was the refinement stopping
+criterion — see `dev/decisions.md`, 2026-08-21.
+
+## 2026-08-21 — `BackwardError(√ε)` alone as the default stopping criterion
+
+**Tried.** Replacing `RefineOptions::default()`'s `StopCriterion::EpsSqrtN`
+with `StopCriterion::BackwardError(√ε)`, to match what MUMPS's `ICNTL(10)`
+refinement stops on (`CNTL(2) = √ε`).
+
+**Failed `tests/parity.rs`:**
+
+```
+ROSZMAN1_0241 residual: feral=4.805e-14 > max(K*mumps=2.077e-14, floor=1.000e-14) = 2.077e-14
+```
+
+`ω ≤ √ε` can be satisfied while the normwise residual is looser than the old
+rule delivered, so swapping one test for the other regresses callers that
+depend on the normwise bound. Shipping it would have required loosening that
+gate — which needs human approval and is not justified when a correct
+alternative exists.
+
+**Disposition.** Replaced by the conjunction,
+`StopCriterion::EpsSqrtNAndBackwardError(√ε)`, which is strictly harder to
+satisfy than the old default and therefore cannot regress any caller.
+ROSZMAN1_0241 and the rest of `tests/parity.rs` pass unchanged under it.
+
+## 2026-08-21 — `BackwardError(f64::EPSILON)` as the componentwise target
+
+**Tried.** Using `f64::EPSILON` — LAPACK `dgerfs`'s componentwise target —
+rather than `√ε` for `DEFAULT_BACKWARD_ERROR_TARGET`. Measured with
+`OMEGA_EPS=1 HARD_RHS=1 probe_vs_mumps_residual`.
+
+**Failed on cost.** Under the badly-scaled RHS it stagnates or exhausts the
+step budget on **five of the seven** large matrices, taking up to 10
+correction steps, while `√ε` converges on the same systems in at most one.
+That is precisely the wasted-budget pathology issue #190 complained about,
+reintroduced from the other direction.
+
+**Disposition.** Rejected. `√ε` is what MUMPS itself targets
+(`ref/mumps/src/dini_defaults.F:1094`), so matching it is both the cheaper
+and the better-justified choice. Recorded in the doc comment on
+`DEFAULT_BACKWARD_ERROR_TARGET` so it is not retried.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5709,3 +5709,41 @@ identical hash over every `L`/`D` bit in storage order across
 4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
 is a performance-only change. Not yet established on a matrix that actually
 delays a pivot — all three report `d0`.
+
+## 2026-08-20 — Two-build cross-process comparison of the multi-RHS kernels (rejected: contaminated)
+
+To find where the rank-1 and BLAS-3 multi-RHS kernels actually cross over, I
+built two release binaries of `probe_blas3_crossover` — one stock
+(`BLAS3_NRHS_THRESHOLD = 32`) and one patched to 2 — and ran them alternating,
+on the theory that alternation cancels machine drift. It does not, and the data
+had to be thrown away.
+
+**Symptoms.** Two independent controls failed:
+
+1. *Anchor drift.* The probe also timed the looped single-RHS path, which is
+   byte-identical in both builds. Its cross-build ratio must read 1.00. Across
+   four run pairs it read **1.15, 1.58, 1.97, 2.10**.
+2. *Null control.* At `nrhs ∈ {32, 40, 48}` both builds dispatch to the *same*
+   BLAS-3 kernel, so the batched ratio must be exactly 1.00. It read
+   **0.86–0.90** — a ≥10% systematic bias with no possible code cause.
+
+**Why.** A full sweep is ~25 minutes, so two "adjacent" runs are 25 minutes
+apart. That is blocked measurement with an interleaved label on it — the same
+error behind the two claim retractions earlier the same day, one level up the
+stack. Cross-process A/B of a few-millisecond kernel does not work on this
+machine at this cadence.
+
+The remaining runs were killed (`pkill -f probe_blas3_crossover`, 0 left) and
+no number from the paired dataset was reported as a result.
+
+**Replaced by** an in-process design: the `kernel-probe` feature (off by
+default, compiled out entirely) exposes
+`set_blas3_nrhs_threshold`, so one process can time rank-1 and BLAS-3 at the
+*same* `nrhs`, alternating within each repetition — microseconds apart instead
+of 25 minutes. See `dev/research/blas3-threshold-refit.md`.
+
+**Kept from this attempt:** the single-build, single-process runs are valid,
+because looped-vs-batched was measured within one process. Two findings survive
+and are recorded in the research note: the 31→32 dispatch discontinuity (3% more
+work, batched time *drops* 1.36–1.77×), and that at `nrhs ∈ {2, 4}` batching is
+**21–27% slower** than looping single-RHS solves.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5747,3 +5747,61 @@ because looped-vs-batched was measured within one process. Two findings survive
 and are recorded in the research note: the 31→32 dispatch discontinuity (3% more
 work, batched time *drops* 1.36–1.77×), and that at `nrhs ∈ {2, 4}` batching is
 **21–27% slower** than looping single-RHS solves.
+
+## 2026-08-20 — Masked-tile iteration over only the live multi-RHS columns (rejected: 1.22x SLOWER)
+
+**What was tried.** After `a0b4d64` padded the multi-RHS row stride to a
+cache line, the residual cost at `nrhs = 33` was exactly `40/33` — the
+arithmetic on the 7 zero pad columns. The obvious follow-up: keep the padded
+*stride* for alignment, but iterate only the `nrhs` live columns, with a
+masked final tile. `gemm_tile` already took a `live` argument, so the kernel
+side was ready. Implemented by threading a stride-vs-live distinction (`ld`
+vs `nrhs`) through `fwd_blas3`, `back_blas3`, `dsolve_node` and
+`gemm_panel_minus`, leaving the main `MR x NR` register loop byte-identical.
+
+**It was correct.** Full suite green (445 passed, 0 failed), clippy
+`--all-targets --all-features -D warnings` RC=0, and the bit-identity sweep
+extended to 1600 shapes covering both stride regimes plus a new assertion
+that the pad columns come back bit-for-bit unwritten. That assertion was
+mutation-checked: re-injecting the full-`ld` column loop fails it with
+`pad column 1 written at row 0 for nrhs=1 ld=8`. The rank1-vs-blas3 max abs
+diff was unchanged at all 42 measured points.
+
+**It was slower.** Anchored on `nrhs = 32` (identical machine code in both
+builds), geomean across seven large KKT matrices:
+
+| nrhs | pad cols | before `t(n)/t(32)` | after | masking speedup |
+|---:|---:|---:|---:|---:|
+| 33 | 7 | 1.225 | 1.490 | **0.823x** |
+| 36 | 4 | 1.254 | 1.570 | **0.799x** |
+| 47 | 1 | 1.486 | 1.865 | **0.797x** |
+
+Slower in raw microseconds too, on every matrix, at `nrhs = 33`: 7081->8859,
+10553->12916, 49446->66054, 98328->109038, 103250->138675, 57546->66620,
+193056->243217 (1.11x to 1.34x worse).
+
+**The A/B is trustworthy.** `nrhs` in {32, 40, 48} are multiples of 8, where
+`padded_ldw(n) == n` makes the masking a provable no-op — identical machine
+code in both builds. Those null controls moved 1.019x (range 0.973-1.046),
+so the drift term is ~1.9% against a ~20% effect.
+
+**Why, as far as the measurement shows.** Pre-mask, cost was a pure function
+of `padded_ldw(nrhs)`, confirmed three ways: `t(36) ~ t(40)` on all seven
+matrices (7059 vs 7111 us on bcsstk38; 104460 vs 104470 on dirichlet120),
+`t(47) ~ t(48)` on all seven, and `t(33)/t(32) = 1.225` against `40/33 =
+1.212` predicted. Post-mask, cost tracks neither model — 1.490 at `nrhs = 33`
+is worse than the 1.250 pad model *and* far worse than the 1.031 work model.
+
+Mechanism is inference, not measurement: iterating a non-multiple-of-8 column
+count appears to cost more than the arithmetic it saves, presumably because
+the fixed-width `NR = 8` tile is what lets the loops compile to whole
+vector operations, and a variable-length `live` tail reintroduces exactly the
+per-row irregularity the padding was added to remove. **The pad columns are
+not waste — they are what keeps every loop a whole number of 8-wide
+operations.** 8 extra multiply-adds on aligned lanes beat 7 skipped ones
+behind a mask.
+
+**Consequence.** `a0b4d64`'s padded stride stands as the final form. The
+`40/33` residual is not recoverable this way and should not be described as
+"available headroom" in future notes. Reverted in full; no code from this
+attempt was kept.

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -18,8 +18,8 @@ use feral::symbolic::{
 };
 use feral::{
     factor, factor_single_front, read_mtx, read_sidecar, solve, solve_refined,
-    solve_sparse_refined, BunchKaufmanParams, FeralError, Inertia, KktSidecar, SymmetricMatrix,
-    ZeroPivotAction,
+    solve_sparse_refined_auto_into, BunchKaufmanParams, FeralError, Inertia, KktSidecar,
+    RefineOptions, SymmetricMatrix, ZeroPivotAction,
 };
 
 /// A KKT matrix that failed inertia or residual on a given solver path.
@@ -1959,21 +1959,50 @@ fn main() {
             Some(r) => r,
             None => continue,
         };
+        // Issue #189 item 1: time the core hosts actually run. The free
+        // `solve_sparse_refined` hardcodes `SolveCore::SharedVector`
+        // (`src/numeric/solve.rs:2077`), while every `Solver` entry point
+        // dispatches through `SolveCore::Auto` — which picks `ContribBlock`
+        // on most of the KKT corpus. Timing the shared-vector core therefore
+        // measured a configuration no host runs, and under-reported the
+        // shipped solve by geomean 1.27-1.38x over n = 8e3..1.8e5, up to
+        // 1.90x on `r05_kkt` and `cont5_late_kkt`
+        // (`crates/feral-diagnostics/src/bin/probe_solve_reconcile.rs`).
+        //
+        // `parallel = false` on purpose. Per #177 the pool changes only the
+        // schedule, never the arithmetic, and the same probe measures that
+        // schedule at geomean 1.01 / 0.98 — i.e. nothing. Running serially
+        // keeps this reading free of thread-count variance while still
+        // measuring the host's core.
+        let mut x = vec![0.0; n];
         let ts = Instant::now();
-        let x = match solve_sparse_refined(&csc, &sp_factors, &rhs) {
-            Ok(x) => x,
-            Err(e) => {
-                eprintln!("  {}: sparse solve failed: {}", entry.name, e);
-                sp_solve_fail += 1;
-                continue;
-            }
-        };
+        if let Err(e) = solve_sparse_refined_auto_into(
+            &csc,
+            &sp_factors,
+            &rhs,
+            &mut x,
+            false,
+            RefineOptions::default(),
+        ) {
+            eprintln!("  {}: sparse solve failed: {}", entry.name, e);
+            sp_solve_fail += 1;
+            continue;
+        }
         let sp_solve_us = ts.elapsed().as_micros();
 
         // Multi-sample denoise for fast matrices — see dev/plans/bench-denoise.md.
         // Symbolic + numeric factor are re-run inside the same timed block as the
         // single-shot pass so the semantics of `factor_us` (sym + numeric) match
         // MUMPS/SSIDS.
+        //
+        // The solve buffer is allocated once and reused across replicates.
+        // Allocating inside the closure puts an n-double alloc-and-zero in
+        // the timed solve region *and* perturbs the allocator state that the
+        // next replicate's factor is measured in — and since `factor_us`
+        // reduces by min over 5 interleaved factor+solve reps, that leaks
+        // into the factor reading on exactly the matrices `should_resample`
+        // selects (MUMPS factor < 200 us, i.e. the small-frontal bucket).
+        let mut rs_x = vec![0.0; n];
         let (sp_factor_us_final, sp_solve_us_final) = if should_resample(entry) {
             resample_or_fallback((sp_factor_us, sp_solve_us), || {
                 let tf = Instant::now();
@@ -1985,7 +2014,14 @@ fn main() {
                     factorize_multifrontal(&csc, &rs_sym, &sparse_numeric_params)?;
                 let f = tf.elapsed().as_micros();
                 let ts = Instant::now();
-                solve_sparse_refined(&csc, &rs_factors, &rhs)?;
+                solve_sparse_refined_auto_into(
+                    &csc,
+                    &rs_factors,
+                    &rhs,
+                    &mut rs_x,
+                    false,
+                    RefineOptions::default(),
+                )?;
                 let s = ts.elapsed().as_micros();
                 Ok::<(u128, u128), FeralError>((f, s))
             })

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -415,19 +415,63 @@ pub(crate) fn ssids_det_floor_fail(d11: f64, d21: f64, d22: f64) -> bool {
 /// 1e6 is a conservative trigger: matrices with growth in [2.78, 1e6]
 /// converge in 1–2 IR steps without being flagged here; matrices above
 /// 1e6 are catastrophic and need IR for any reasonable accuracy.
+/// Multiplier bound used when no pivot threshold is in force.
+///
+/// With `pivot_threshold = 0.0` every non-zero pivot is accepted, so the
+/// factorization makes no promise about `|L_ij|` and there is no
+/// invariant to check. This absolute constant is the fallback: it is a
+/// magnitude, not a growth factor, and it is only as meaningful as the
+/// caller's scaling. Callers that want a real signal should set a pivot
+/// threshold.
 const L_GROWTH_THRESHOLD: f64 = 1e6;
 
-/// Sets `*needs_refinement = true` when any `|L_ij| > L_GROWTH_THRESHOLD`.
-/// Called at every dense-factor exit path so callers using plain
-/// `Solver::solve` (rather than `solve_refined`) get a programmatic
-/// signal — `factors.needs_refinement` — that the factor is too
-/// unstable for plain forward/back substitution.
-fn flag_growth_for_refinement(l: &[f64], needs_refinement: &mut bool) {
+/// Multiplier bound implied by the pivot threshold actually in force.
+///
+/// Threshold partial pivoting accepts a candidate only when it is within
+/// a factor `u` of its column maximum, which bounds the multipliers by
+/// `|L_ij| <= 1/u`. That is the promise the factorization makes, so it
+/// is also the right thing to check it against: exceeding it means the
+/// pivoting did not deliver its own contract on this matrix, which is
+/// exactly when plain substitution is untrustworthy.
+///
+/// The bound moves with the threshold, which is what makes it useful
+/// under an interior-point host: `Solver::increase_quality` walks `u`
+/// from 1e-8 up towards `pivtol_max = 0.5`, tightening the promise at
+/// each step, and the signal tightens with it.
+fn multiplier_bound(params: &BunchKaufmanParams) -> f64 {
+    if params.pivot_threshold > 0.0 {
+        1.0 / params.pivot_threshold
+    } else {
+        L_GROWTH_THRESHOLD
+    }
+}
+
+/// Sets `*needs_refinement = true` when any `|L_ij|` exceeds the
+/// multiplier bound the pivot threshold promised (see
+/// [`multiplier_bound`]). Called at every dense-factor exit path so
+/// callers using plain `Solver::solve` (rather than `solve_refined`) get
+/// a programmatic signal — `factors.needs_refinement` — that the factor
+/// is too unstable for plain forward/back substitution.
+///
+/// This used to compare against a fixed `1e6` regardless of the
+/// threshold in force, which made it a statement about the *magnitude*
+/// of `L` rather than about growth, and therefore about the caller's
+/// scaling rather than about the factorization. Measured under pounce on
+/// a 126028-order interior-point KKT (pounce gh#710 follow-up), that
+/// fired on 91 of 108 factorizations whose actual growth factor
+/// `max|L| / max|A|` was 8.7e-8 — `L` entries eight orders *smaller*
+/// than the matrix's own — purely because the matrix carried entries
+/// around 1e13 and `1e6` is not a scale-free number. At the same
+/// caller's `u = 1e-8` the promised bound is 1e8, and the largest `|L|`
+/// observed anywhere in that run was 5.1e7: inside the contract, every
+/// time. The flag now says so.
+fn flag_growth_for_refinement(l: &[f64], params: &BunchKaufmanParams, needs_refinement: &mut bool) {
     if *needs_refinement {
         return;
     }
+    let bound = multiplier_bound(params);
     for &v in l {
-        if v.abs() > L_GROWTH_THRESHOLD {
+        if v.abs() > bound {
             *needs_refinement = true;
             return;
         }
@@ -1325,7 +1369,7 @@ pub fn factor(
 
     let inertia = Inertia::new(pos, neg, zero);
 
-    flag_growth_for_refinement(&l, &mut needs_refinement);
+    flag_growth_for_refinement(&l, params, &mut needs_refinement);
 
     Ok((
         Factors {
@@ -1937,7 +1981,7 @@ fn factor_frontal_in_place_with_scratch_impl(
         perm_inv[p] = i;
     }
 
-    flag_growth_for_refinement(&l, &mut needs_refinement);
+    flag_growth_for_refinement(&l, params, &mut needs_refinement);
 
     let result = FrontalFactors {
         nrow,
@@ -2459,7 +2503,7 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
         perm_inv[p] = i;
     }
 
-    flag_growth_for_refinement(&l, &mut needs_refinement);
+    flag_growth_for_refinement(&l, params, &mut needs_refinement);
 
     // Return the pack pool to the scratch for the next front.
     scratch.pack_pool = pack_pool;
@@ -2696,7 +2740,7 @@ pub fn factor_frontal_diagonal_in_place(
     let perm_inv = perm.clone();
 
     let mut needs_refinement = false;
-    flag_growth_for_refinement(&l, &mut needs_refinement);
+    flag_growth_for_refinement(&l, params, &mut needs_refinement);
 
     Ok(FrontalFactors {
         nrow,
@@ -5739,11 +5783,28 @@ fn set_l_column_identity(a: &mut [f64], n: usize, k: usize) {
 mod growth_flag_tests {
     use super::*;
 
+    /// The old fixed-`1e6` behaviour, which is now what you get only when
+    /// no pivot threshold is in force — i.e. when the factorization made
+    /// no promise and there is no invariant to check.
+    fn no_threshold() -> BunchKaufmanParams {
+        BunchKaufmanParams {
+            pivot_threshold: 0.0,
+            ..BunchKaufmanParams::default()
+        }
+    }
+
+    fn with_threshold(u: f64) -> BunchKaufmanParams {
+        BunchKaufmanParams {
+            pivot_threshold: u,
+            ..BunchKaufmanParams::default()
+        }
+    }
+
     #[test]
     fn growth_below_threshold_does_not_flag() {
         let l = vec![1.0, 2.78, -2.5, 0.0, 100.0, -999_999.0];
         let mut flag = false;
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(!flag, "max|L| = 999_999 < 1e6 should not flag");
     }
 
@@ -5751,7 +5812,7 @@ mod growth_flag_tests {
     fn growth_above_threshold_flags() {
         let l = vec![1.0, 2.0, 1.5e6, -3.0];
         let mut flag = false;
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(flag, "max|L| = 1.5e6 > 1e6 must flag");
     }
 
@@ -5759,7 +5820,7 @@ mod growth_flag_tests {
     fn catastrophic_growth_flags() {
         let l = vec![1.0, 1.0, 8.06e16, 1.0];
         let mut flag = false;
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(flag, "max|L| = 8e16 (bratu3d-class) must flag");
     }
 
@@ -5767,7 +5828,7 @@ mod growth_flag_tests {
     fn negative_large_entry_flags() {
         let l = vec![-2e10, 1.0];
         let mut flag = false;
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(flag, "negative large |L| must flag");
     }
 
@@ -5775,7 +5836,7 @@ mod growth_flag_tests {
     fn already_set_flag_is_preserved() {
         let l = vec![0.0, 0.0]; // would not flag on its own
         let mut flag = true; // pre-set by zero-pivot path
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(flag, "must not clobber pre-set flag");
     }
 
@@ -5783,7 +5844,7 @@ mod growth_flag_tests {
     fn empty_l_does_not_flag() {
         let l: Vec<f64> = vec![];
         let mut flag = false;
-        flag_growth_for_refinement(&l, &mut flag);
+        flag_growth_for_refinement(&l, &no_threshold(), &mut flag);
         assert!(!flag);
     }
 
@@ -5794,8 +5855,55 @@ mod growth_flag_tests {
         // always also has Inf. This is an explicit doc of behavior.
         let l_inf = vec![1.0, f64::INFINITY];
         let mut flag = false;
-        flag_growth_for_refinement(&l_inf, &mut flag);
+        flag_growth_for_refinement(&l_inf, &no_threshold(), &mut flag);
         assert!(flag, "Inf entry must trigger");
+    }
+
+    /// The bound tracks the threshold rather than a constant. At
+    /// `u = 1e-8` the promise is `|L| <= 1e8`, so an `|L|` of 5.1e7 —
+    /// the largest observed across 108 factorizations of pounce's
+    /// 126028-order KKT — is inside the contract and must not flag,
+    /// even though it is fifty times the old fixed `1e6`.
+    #[test]
+    fn the_bound_follows_the_pivot_threshold() {
+        let inside = vec![1.0, 5.07e7, -2.46e6];
+        let mut flag = false;
+        flag_growth_for_refinement(&inside, &with_threshold(1e-8), &mut flag);
+        assert!(!flag, "|L| = 5.07e7 is inside the 1/u = 1e8 promise");
+
+        // The same L against the old constant: this is the regression
+        // being fixed, and it is why 84% of that run was flagged.
+        let mut flag = false;
+        flag_growth_for_refinement(&inside, &no_threshold(), &mut flag);
+        assert!(flag, "the fallback still uses the absolute constant");
+    }
+
+    /// ...and a genuine violation still flags. `deb7` (pounce's fixture
+    /// corpus, exact-Hessian leg) reaches `max|L| = 4.2e13` at the same
+    /// `u = 1e-8`, five orders past the promise: the pivoting did not
+    /// deliver its own contract there, which is precisely the condition
+    /// the flag exists to report.
+    #[test]
+    fn a_multiplier_past_the_promise_still_flags() {
+        let violating = vec![1.0, 4.24e13];
+        let mut flag = false;
+        flag_growth_for_refinement(&violating, &with_threshold(1e-8), &mut flag);
+        assert!(flag, "|L| = 4.24e13 is five orders past 1/u = 1e8");
+    }
+
+    /// Escalation tightens the promise, so it must tighten the signal.
+    /// `Solver::increase_quality` walks `u` from 1e-8 towards 0.5; the
+    /// same `L` that was acceptable at 1e-8 is a violation at 0.5.
+    #[test]
+    fn raising_the_threshold_tightens_the_signal() {
+        let l = vec![1.0, 1e3];
+        let mut flag = false;
+        flag_growth_for_refinement(&l, &with_threshold(1e-8), &mut flag);
+        assert!(!flag, "|L| = 1e3 is well inside 1/u = 1e8");
+
+        let mut flag = false;
+        flag_growth_for_refinement(&l, &with_threshold(0.5), &mut flag);
+        assert!(flag, "|L| = 1e3 is past 1/u = 2 at MA27-style u = 0.5");
     }
 }
 

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -456,15 +456,13 @@ fn multiplier_bound(params: &BunchKaufmanParams) -> f64 {
 /// This used to compare against a fixed `1e6` regardless of the
 /// threshold in force, which made it a statement about the *magnitude*
 /// of `L` rather than about growth, and therefore about the caller's
-/// scaling rather than about the factorization. Measured under pounce on
-/// a 126028-order interior-point KKT (pounce gh#710 follow-up), that
-/// fired on 91 of 108 factorizations whose actual growth factor
-/// `max|L| / max|A|` was 8.7e-8 — `L` entries eight orders *smaller*
-/// than the matrix's own — purely because the matrix carried entries
-/// around 1e13 and `1e6` is not a scale-free number. At the same
-/// caller's `u = 1e-8` the promised bound is 1e8, and the largest `|L|`
-/// observed anywhere in that run was 5.1e7: inside the contract, every
-/// time. The flag now says so.
+/// scaling rather than about the factorization. A matrix carrying
+/// entries around `1e13` trips a fixed `1e6` on factorizations whose
+/// actual growth factor `max|L| / max|A|` is orders of magnitude *below*
+/// one — `L` entries smaller than the matrix's own — purely because
+/// `1e6` is not a scale-free number. At a caller's `u = 1e-8` the
+/// promised bound is `1e8`, so such an `|L|` is inside the contract and
+/// should not flag. The flag now says so.
 fn flag_growth_for_refinement(l: &[f64], params: &BunchKaufmanParams, needs_refinement: &mut bool) {
     if *needs_refinement {
         return;
@@ -5860,10 +5858,9 @@ mod growth_flag_tests {
     }
 
     /// The bound tracks the threshold rather than a constant. At
-    /// `u = 1e-8` the promise is `|L| <= 1e8`, so an `|L|` of 5.1e7 —
-    /// the largest observed across 108 factorizations of pounce's
-    /// 126028-order KKT — is inside the contract and must not flag,
-    /// even though it is fifty times the old fixed `1e6`.
+    /// `u = 1e-8` the promise is `|L| <= 1e8`, so an `|L|` of 5.1e7 is
+    /// inside the contract and must not flag, even though it is fifty
+    /// times the old fixed `1e6`.
     #[test]
     fn the_bound_follows_the_pivot_threshold() {
         let inside = vec![1.0, 5.07e7, -2.46e6];
@@ -5872,17 +5869,17 @@ mod growth_flag_tests {
         assert!(!flag, "|L| = 5.07e7 is inside the 1/u = 1e8 promise");
 
         // The same L against the old constant: this is the regression
-        // being fixed, and it is why 84% of that run was flagged.
+        // being fixed: a scale-free bound and a fixed one disagree
+        // here, and the fixed one is wrong.
         let mut flag = false;
         flag_growth_for_refinement(&inside, &no_threshold(), &mut flag);
         assert!(flag, "the fallback still uses the absolute constant");
     }
 
-    /// ...and a genuine violation still flags. `deb7` (pounce's fixture
-    /// corpus, exact-Hessian leg) reaches `max|L| = 4.2e13` at the same
-    /// `u = 1e-8`, five orders past the promise: the pivoting did not
-    /// deliver its own contract there, which is precisely the condition
-    /// the flag exists to report.
+    /// ...and a genuine violation still flags. A `max|L|` of `4.2e13` at
+    /// `u = 1e-8` is five orders past the promise: the pivoting did not
+    /// deliver its own contract, which is precisely the condition the
+    /// flag exists to report.
     #[test]
     fn a_multiplier_past_the_promise_still_flags() {
         let violating = vec![1.0, 4.24e13];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ pub use numeric::solve::{
     solve_sparse_refined_auto_into, solve_sparse_refined_auto_opts, solve_sparse_refined_cb,
     solve_sparse_refined_cb_opts, solve_sparse_refined_into, solve_sparse_refined_opts,
     solve_sparse_refined_with_diagnostics, solve_sparse_refined_with_diagnostics_opts,
-    RefineOptions, RefinementDiagnostics, RefinementStep, SolveCore, DEFAULT_REFINE_MAX_STEPS,
+    RefineOptions, RefineOutcome, RefineStop, RefinementDiagnostics, RefinementStep, SolveCore,
+    StopCriterion, DEFAULT_REFINE_MAX_STEPS,
 };
 pub use numeric::solver::{FactorStats, FactorStatus, QualityLevel, Solver};
 pub use sparse::csc::{CscMatrix, CscPattern};

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2366,6 +2366,13 @@ impl RefineStop {
 /// satisfied, not violated. Reporting `1` for a structurally empty row
 /// would make any `BackwardError` target unreachable on such a system.
 ///
+/// **A non-finite row returns `f64::INFINITY`.** If `x` has overflowed,
+/// `|r|` and `d` both reach `inf` and their ratio is `NaN`; `NaN` loses
+/// every `>` comparison, so skipping such rows would let an all-`NaN`
+/// iterate report `ω = 0.0` and satisfy a
+/// [`StopCriterion::BackwardError`] target on the first test. `inf` is
+/// the only honest answer for an iterate that is not a solution at all.
+///
 /// `scratch` must be `n` long; it receives `|A|·|x|`.
 fn backward_error(
     matrix: &CscMatrix,
@@ -2381,6 +2388,17 @@ fn backward_error(
     let mut omega: f64 = 0.0;
     for i in 0..n {
         let d = scratch[i] + rhs[i].abs();
+        // A non-finite row means the iterate itself has blown up: an
+        // overflowed pivot sends `x` to `inf`, so `A*x` and hence both
+        // `r[i]` and `d` reach `inf` and `|r|/d` is `NaN`. `NaN` fails
+        // every `>` comparison, so without this guard the row is
+        // silently skipped -- and an all-`NaN` iterate would return
+        // `omega = 0.0`, i.e. read as *perfectly* backward stable and
+        // stop refinement on its first test. Report the worst possible
+        // backward error instead.
+        if !d.is_finite() || !r[i].is_finite() {
+            return f64::INFINITY;
+        }
         if d == 0.0 {
             // r[i] is provably 0 here; see the doc comment.
             continue;
@@ -4034,6 +4052,28 @@ mod tests {
         let x = [1.0, 0.0];
         let b = [1.0, 0.0];
         assert_eq!(omega_of(&m, &x, &b), 0.0, "empty row must contribute 0");
+    }
+
+    #[test]
+    fn backward_error_reports_infinity_on_a_non_finite_iterate() {
+        // A row where |r| and d are both `inf` makes the ratio `NaN`.
+        // `NaN` fails `term > omega`, so before the finiteness guard
+        // this returned 0.0 — a diverged iterate certifying itself as
+        // exactly backward stable, which would stop
+        // `StopCriterion::BackwardError` refinement on its first test.
+        let m = CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[1.0, 1.0]).expect("m");
+        let b = [1.0, 1.0];
+        for x in [
+            [f64::INFINITY, 1.0],
+            [f64::NAN, 1.0],
+            [f64::NEG_INFINITY, 1.0],
+        ] {
+            let om = omega_of(&m, &x, &b);
+            assert!(
+                om == f64::INFINITY,
+                "non-finite iterate {x:?} must report inf, got {om:e}"
+            );
+        }
     }
 
     #[test]

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2114,29 +2114,251 @@ pub const DEFAULT_REFINE_MAX_STEPS: usize = 10;
 /// same, since the residual matvec is skipped rather than computed and
 /// discarded. (Under the diagnostics entry point the matvec still runs:
 /// `steps[0]` is the point there.)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefineOptions {
     /// Maximum number of correction steps. See the type-level docs.
     pub max_steps: usize,
+    /// What "accurate enough" means. See [`StopCriterion`].
+    pub stop: StopCriterion,
 }
 
 impl Default for RefineOptions {
     fn default() -> Self {
         Self {
             max_steps: DEFAULT_REFINE_MAX_STEPS,
+            stop: StopCriterion::EpsSqrtN,
         }
     }
 }
 
 impl RefineOptions {
-    /// Options capping refinement at `max_steps` correction steps.
+    /// Options capping refinement at `max_steps` correction steps,
+    /// keeping the default [`StopCriterion::EpsSqrtN`].
     ///
     /// `RefineOptions::with_max_steps(1)` is the interior-point host's
     /// case: one correction per call, leaving the convergence decision to
     /// the host's own refinement loop.
     pub fn with_max_steps(max_steps: usize) -> Self {
-        Self { max_steps }
+        Self {
+            max_steps,
+            ..Self::default()
+        }
     }
+
+    /// Options targeting a normwise relative residual of `target`
+    /// (`‖r‖₂/‖b‖₂ ≤ target`), keeping the default step budget.
+    ///
+    /// This is issue #190's ask. See [`StopCriterion::RelativeResidual`]
+    /// for when [`Self::with_backward_error`] is the better measure.
+    pub fn with_target(target: f64) -> Self {
+        Self {
+            stop: StopCriterion::RelativeResidual(target),
+            ..Self::default()
+        }
+    }
+
+    /// Options targeting a componentwise backward error of `target`
+    /// (`ω ≤ target`), keeping the default step budget.
+    ///
+    /// `with_backward_error(f64::EPSILON)` is "stop once the solve is
+    /// backward stable" — the contract an interior-point host assumes of
+    /// its linear backend. See [`StopCriterion::BackwardError`].
+    pub fn with_backward_error(target: f64) -> Self {
+        Self {
+            stop: StopCriterion::BackwardError(target),
+            ..Self::default()
+        }
+    }
+
+    /// Builder: set the step cap, keeping the criterion already chosen.
+    pub fn and_max_steps(self, max_steps: usize) -> Self {
+        Self { max_steps, ..self }
+    }
+
+    /// Builder: set the stopping criterion, keeping the cap already chosen.
+    pub fn and_stop(self, stop: StopCriterion) -> Self {
+        Self { stop, ..self }
+    }
+}
+
+/// What a refinement call is trying to achieve — as distinct from
+/// [`RefineOptions::max_steps`], which only says how long it may try.
+///
+/// # Why this exists (issue #190)
+///
+/// Before #190 the target was hardwired to `ε·√n`. On a large
+/// near-singular KKT system that is not a target, it is an unreachable
+/// one: at `n = 118 276`, `ε·√n ≈ 7.6e-14`, each step improves the
+/// residual slightly so the 2-strike plateau exit never fires, the
+/// divergence guard never fires, and the loop runs to `max_steps` on
+/// every call. The step cap then becomes the *de facto* stopping rule,
+/// and it is a bad one: sweeping a 118-problem corpus, `max_steps` was
+/// not monotone in outcome — one problem returned a false infeasibility
+/// verdict at `k = 1` while succeeding at `k = 0`, `2` and `10`. A knob
+/// behaves that way when it does not control the quantity the caller
+/// cares about.
+///
+/// See `dev/research/issue-190-refine-target.md`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StopCriterion {
+    /// `‖r‖₂ < ε·√n·‖b‖₂` — FERAL's historical rule, and the default.
+    ///
+    /// Kept bit-for-bit, including the strict `<`, so every call that
+    /// does not opt into a target performs exactly the arithmetic it
+    /// did before #190.
+    EpsSqrtN,
+    /// `‖r‖₂/‖b‖₂ ≤ target` — normwise relative residual.
+    ///
+    /// Simple and cheap, but *normwise*: one number over the whole
+    /// system, dominated by its largest-magnitude rows. On a badly
+    /// scaled system it can read as converged while individual
+    /// equations are badly violated. The worked case in
+    /// `dev/research/issue-190-refine-target.md` has
+    /// `‖r‖₂/‖b‖₂ = 1.0e-36` and `ω = 5.0e-13` for the same iterate.
+    /// Prefer [`Self::BackwardError`] when the caller's real question is
+    /// "is this solve honest?".
+    RelativeResidual(f64),
+    /// `ω ≤ target`, where `ω = maxᵢ |rᵢ| / (|A|·|x| + |b|)ᵢ` is the
+    /// componentwise backward error of Arioli, Demmel & Duff (1989).
+    ///
+    /// `ω ≤ u` certifies that the computed `x` is the *exact* solution
+    /// of `(A+δA)x = b+δb` with `|δA| ≤ ω|A|` and `|δb| ≤ ω|b|`,
+    /// entry by entry. That is the property "a backward-stable `LDLᵀ`"
+    /// names, so unlike a relative-residual target it has a principled
+    /// value — `f64::EPSILON` — and the caller need not invent one.
+    /// It is also what MA57 (`RINFO(6..8)`) and MUMPS (`RINFO(7..8)`)
+    /// report.
+    ///
+    /// Costs one extra pass over `A` per step
+    /// ([`CscMatrix::abs_symv`]) and **no extra solves** — in contrast
+    /// to [`RefinementDiagnostics::kappa_1_est`], which costs 3–5.
+    BackwardError(f64),
+}
+
+/// Why a refinement call stopped, and how much it did.
+///
+/// Returned by the `*_into` refinement entry points. Everything here is
+/// computed by the refinement loop anyway; surfacing it costs nothing.
+///
+/// Issue #190 asked for this because back-solve wall time cannot
+/// distinguish "the budget bound" from "refinement bottomed out after
+/// two non-improving steps" — very different diagnoses for a host
+/// deciding what to pass next. The alternative, returning
+/// [`RefinementDiagnostics`], would have dragged in the Hager–Higham
+/// condition estimate and its 3–5 extra solves per call.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RefineOutcome {
+    /// Correction steps actually performed. `0` means the direct solve
+    /// already satisfied the criterion (or that `max_steps` was `0`).
+    ///
+    /// For a multi-RHS call this is the maximum over columns.
+    pub steps: usize,
+    /// `‖r‖₂/‖b‖₂` of the iterate that was returned, or `‖r‖₂` when
+    /// `‖b‖₂ = 0`.
+    ///
+    /// **`NaN` when `max_steps == 0`**: issue #178 requires that setting
+    /// cost exactly what an unrefined solve costs, so no residual is
+    /// formed and there is nothing honest to report. For a multi-RHS
+    /// call this is the maximum over columns.
+    pub relative_residual: f64,
+    /// Which exit fired. For a multi-RHS call, the worst over columns in
+    /// the order `MaxSteps > Diverged > Stagnated > Converged` —
+    /// `MaxSteps` ranks first because "did the budget bind?" is the
+    /// question this type exists to answer.
+    pub stop: RefineStop,
+}
+
+/// The four ways [`solve_sparse_refined_core`] can exit. See
+/// [`RefineOutcome::stop`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefineStop {
+    /// The [`StopCriterion`] was satisfied.
+    Converged,
+    /// The step budget was exhausted with the criterion unmet. This is
+    /// the signal that [`RefineOptions::max_steps`] was the binding
+    /// constraint — raise it, or loosen the criterion.
+    MaxSteps,
+    /// Two consecutive steps failed to improve the best `‖r‖₂`.
+    /// Refinement has bottomed out; more steps will not help.
+    Stagnated,
+    /// A step drove `‖r‖₂` past 100× the best seen. The best iterate is
+    /// still what gets returned.
+    Diverged,
+}
+
+impl RefineStop {
+    /// Rank for the multi-RHS aggregation described on
+    /// [`RefineOutcome::stop`]. Higher wins.
+    pub(crate) fn rank(self) -> u8 {
+        match self {
+            RefineStop::Converged => 0,
+            RefineStop::Stagnated => 1,
+            RefineStop::Diverged => 2,
+            RefineStop::MaxSteps => 3,
+        }
+    }
+
+    pub(crate) fn worst(self, other: RefineStop) -> RefineStop {
+        if other.rank() > self.rank() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+/// Componentwise backward error `ω = maxᵢ |rᵢ| / (|A|·|x| + |b|)ᵢ`,
+/// in the guarded form LAPACK's `dgerfs` uses for `BERR`:
+///
+/// ```text
+/// safe1 = (n+1)·f64::MIN_POSITIVE      safe2 = safe1 / f64::EPSILON
+/// dᵢ = (|A|·|x| + |b|)ᵢ
+/// dᵢ > safe2  →  |rᵢ| / dᵢ
+/// otherwise   →  (|rᵢ| + safe1) / (dᵢ + safe1)
+/// ```
+///
+/// The guard matters: an unguarded ratio on a row whose denominator has
+/// underflowed reports a spuriously enormous `ω` that refinement cannot
+/// reduce, which would make a [`StopCriterion::BackwardError`] target
+/// unreachable — reproducing the exact defect issue #190 reports for
+/// `ε·√n`.
+///
+/// **One deviation from `dgerfs`**, and it is deliberate: a row with
+/// `dᵢ == 0` contributes `0`, where LAPACK's guarded branch yields
+/// `safe1/safe1 = 1`. `dᵢ == 0` forces every `|aᵢⱼ||xⱼ|` and `|bᵢ|` to
+/// be zero, hence `rᵢ = bᵢ − (Ax)ᵢ = 0` exactly — the equation is
+/// satisfied, not violated. Reporting `1` for a structurally empty row
+/// would make any `BackwardError` target unreachable on such a system.
+///
+/// `scratch` must be `n` long; it receives `|A|·|x|`.
+fn backward_error(
+    matrix: &CscMatrix,
+    x: &[f64],
+    rhs: &[f64],
+    r: &[f64],
+    scratch: &mut [f64],
+) -> f64 {
+    let n = matrix.n;
+    matrix.abs_symv(x, scratch);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut omega: f64 = 0.0;
+    for i in 0..n {
+        let d = scratch[i] + rhs[i].abs();
+        if d == 0.0 {
+            // r[i] is provably 0 here; see the doc comment.
+            continue;
+        }
+        let term = if d > safe2 {
+            r[i].abs() / d
+        } else {
+            (r[i].abs() + safe1) / (d + safe1)
+        };
+        if term > omega {
+            omega = term;
+        }
+    }
+    omega
 }
 
 /// Solve A·x = rhs using the sparse factorization with iterative refinement.
@@ -2153,8 +2375,13 @@ impl RefineOptions {
 /// `dx = A⁻¹·r` can amplify error; tracking the best iterate guarantees
 /// the returned `x` is no worse than the unrefined `solve_sparse()` output.
 ///
-/// Convergence test: stop when `||r||₂ / ||b||₂ < ε·√n` (we've reached
-/// machine precision) or after 10 steps. 10 comes from FERAL's corpus,
+/// Convergence test: whichever `StopCriterion` the caller selected, or
+/// after 10 steps. The default criterion is `EpsSqrtN` — stop when
+/// `||r||₂ / ||b||₂ < ε·√n`, i.e. we've reached machine precision.
+/// On a large ill-conditioned system that target is not reachable and
+/// the loop always runs the full budget; `StopCriterion::BackwardError`
+/// is the one with a principled stopping value (issue #190). 10 comes
+/// from FERAL's corpus,
 /// not from MUMPS (whose `ICNTL(10)` default is `0` — no refinement at
 /// all; the comparison harness sets it to `2`): below 10 some
 /// near-rank-deficient KKT matrices
@@ -2211,8 +2438,8 @@ pub fn solve_sparse_refined_into(
     rhs: &[f64],
     x_out: &mut [f64],
     opts: RefineOptions,
-) -> Result<(), FeralError> {
-    solve_sparse_refined_core(
+) -> Result<RefineOutcome, FeralError> {
+    let (outcome, _) = solve_sparse_refined_core(
         matrix,
         factors,
         rhs,
@@ -2221,7 +2448,7 @@ pub fn solve_sparse_refined_into(
         SolveCore::SharedVector,
         opts,
     )?;
-    Ok(())
+    Ok(outcome)
 }
 
 /// Iterative refinement through the contribution-block solve core (issue
@@ -2325,8 +2552,8 @@ pub fn solve_sparse_refined_auto_into(
     x_out: &mut [f64],
     parallel: bool,
     opts: RefineOptions,
-) -> Result<(), FeralError> {
-    solve_sparse_refined_core(
+) -> Result<RefineOutcome, FeralError> {
+    let (outcome, _) = solve_sparse_refined_core(
         matrix,
         factors,
         rhs,
@@ -2335,7 +2562,7 @@ pub fn solve_sparse_refined_auto_into(
         SolveCore::Auto { parallel },
         opts,
     )?;
-    Ok(())
+    Ok(outcome)
 }
 
 /// Iterative refinement with tree-parallel execution requested, and the
@@ -2403,8 +2630,8 @@ pub fn solve_sparse_refined_parallel_into(
     rhs: &[f64],
     x_out: &mut [f64],
     opts: RefineOptions,
-) -> Result<(), FeralError> {
-    solve_sparse_refined_core(
+) -> Result<RefineOutcome, FeralError> {
+    let (outcome, _) = solve_sparse_refined_core(
         matrix,
         factors,
         rhs,
@@ -2413,7 +2640,7 @@ pub fn solve_sparse_refined_parallel_into(
         SolveCore::Auto { parallel: true },
         opts,
     )?;
-    Ok(())
+    Ok(outcome)
 }
 
 /// Per-step diagnostic data emitted by
@@ -2504,7 +2731,7 @@ pub fn solve_sparse_refined_with_diagnostics_opts(
     opts: RefineOptions,
 ) -> Result<(Vec<f64>, RefinementDiagnostics), FeralError> {
     let mut x = vec![0.0; factors.n];
-    let diag = solve_sparse_refined_core(
+    let (_outcome, diag) = solve_sparse_refined_core(
         matrix,
         factors,
         rhs,
@@ -2574,7 +2801,7 @@ fn solve_sparse_refined_core(
     with_diagnostics: bool,
     core: SolveCore,
     opts: RefineOptions,
-) -> Result<Option<RefinementDiagnostics>, FeralError> {
+) -> Result<(RefineOutcome, Option<RefinementDiagnostics>), FeralError> {
     let n = factors.n;
     if rhs.len() != n {
         return Err(FeralError::DimensionMismatch {
@@ -2649,7 +2876,16 @@ fn solve_sparse_refined_core(
     // exception: `steps[0]` carries that residual, so it runs the matvec
     // and then simply skips the loop.
     if opts.max_steps == 0 && !with_diagnostics {
-        return Ok(None);
+        return Ok((
+            RefineOutcome {
+                steps: 0,
+                // No residual was formed, so there is nothing honest to
+                // report. See `RefineOutcome::relative_residual`.
+                relative_residual: f64::NAN,
+                stop: RefineStop::MaxSteps,
+            },
+            None,
+        ));
     }
 
     // `x` is the working iterate the corrections accumulate into;
@@ -2693,18 +2929,56 @@ fn solve_sparse_refined_core(
     let threshold = f64::EPSILON * n_sqrt;
     let divergence_factor = 100.0;
     let b_norm = norm2(rhs);
-    // Target is a RELATIVE residual: ||r||/||b|| < ε·√n. When ||b|| = 0
-    // the true answer is x = 0 and r = -A·x; we target ||r|| < threshold
-    // directly in that case.
-    let relative_reached = |r_norm: f64| -> bool {
-        if b_norm > 0.0 {
-            r_norm < threshold * b_norm
-        } else {
-            r_norm < threshold
+    // Issue #190 made the *target* a per-call choice too. `EpsSqrtN`
+    // reproduces the historical rule exactly, strict `<` included, so
+    // callers that do not opt in run the same arithmetic they always
+    // did. The two target variants use `<=`, so `target = 0.0` means
+    // "only an exact zero residual stops you" rather than "unreachable".
+    //
+    // The residual targets are RELATIVE: ||r||/||b||. When ||b|| = 0 the
+    // true answer is x = 0 and r = -A·x; we compare ||r|| directly.
+    // `BackwardError` needs no such special case: its denominator
+    // carries |b| per row already.
+    let reached = |r_norm: f64, omega: f64| -> bool {
+        match opts.stop {
+            StopCriterion::EpsSqrtN => {
+                if b_norm > 0.0 {
+                    r_norm < threshold * b_norm
+                } else {
+                    r_norm < threshold
+                }
+            }
+            StopCriterion::RelativeResidual(t) => {
+                if b_norm > 0.0 {
+                    r_norm <= t * b_norm
+                } else {
+                    r_norm <= t
+                }
+            }
+            StopCriterion::BackwardError(t) => omega <= t,
         }
     };
 
     let rel_res = |rn: f64| if b_norm > 0.0 { rn / b_norm } else { rn };
+
+    // ω is only formed when it is the criterion; under the other two it
+    // stays `INFINITY` and is never read. One `abs_symv` per step, no
+    // extra solves.
+    let wants_omega = matches!(opts.stop, StopCriterion::BackwardError(_));
+    let mut omega_scratch = if wants_omega {
+        vec![0.0; n]
+    } else {
+        Vec::new()
+    };
+    // Evaluated on the *best* iterate, matching how the residual targets
+    // are tested against `best_r_norm`. Best-iterate selection itself is
+    // unchanged (smallest ||r||₂), so the contract in
+    // `solve_sparse_refined`'s docs holds under every criterion.
+    let mut best_omega = if wants_omega {
+        backward_error(matrix, &x, rhs, &r, &mut omega_scratch)
+    } else {
+        f64::INFINITY
+    };
 
     let mut steps: Vec<RefinementStep> = if with_diagnostics {
         let rr = rel_res(r_norm);
@@ -2720,8 +2994,15 @@ fn solve_sparse_refined_core(
     };
     let mut returned_step: usize = 0;
 
+    // Assume the budget binds; every other exit overwrites this, and a
+    // post-loop re-check catches the case where the final step happened
+    // to land on the target.
+    let mut stop = RefineStop::MaxSteps;
+    let mut steps_taken: usize = 0;
+
     for step in 1..=max_steps {
-        if relative_reached(best_r_norm) {
+        if reached(best_r_norm, best_omega) {
+            stop = RefineStop::Converged;
             break;
         }
 
@@ -2740,10 +3021,17 @@ fn solve_sparse_refined_core(
             r[i] = rhs[i] - r[i];
         }
         r_norm = norm2(&r);
+        steps_taken = step;
+        let omega = if wants_omega {
+            backward_error(matrix, &x, rhs, &r, &mut omega_scratch)
+        } else {
+            f64::INFINITY
+        };
 
         let improved = r_norm < best_r_norm;
         if improved {
             best_r_norm = r_norm;
+            best_omega = omega;
             x_out.copy_from_slice(&x);
             stagnant_count = 0;
             if with_diagnostics {
@@ -2765,6 +3053,7 @@ fn solve_sparse_refined_core(
         }
 
         if r_norm > best_r_norm * divergence_factor {
+            stop = RefineStop::Diverged;
             break;
         }
         // Plateau: `max_stagnant_steps` consecutive non-improving
@@ -2773,9 +3062,24 @@ fn solve_sparse_refined_core(
         // A single non-improving step is allowed because some KKT
         // matrices oscillate into a better basin on the next step.
         if stagnant_count >= max_stagnant_steps {
+            stop = RefineStop::Stagnated;
             break;
         }
     }
+
+    // Exhausting the budget on the step that *reached* the target is not
+    // the budget binding. Without this, `steps == max_steps` would be
+    // ambiguous and the "did it run to the cap?" question issue #190
+    // asks would still not be answerable.
+    if stop == RefineStop::MaxSteps && reached(best_r_norm, best_omega) {
+        stop = RefineStop::Converged;
+    }
+
+    let outcome = RefineOutcome {
+        steps: steps_taken,
+        relative_residual: rel_res(best_r_norm),
+        stop,
+    };
 
     let diag = if with_diagnostics {
         Some(RefinementDiagnostics {
@@ -2787,7 +3091,7 @@ fn solve_sparse_refined_core(
     } else {
         None
     };
-    Ok(diag)
+    Ok((outcome, diag))
 }
 
 /// Multi-RHS solve with per-column iterative refinement, batched through
@@ -2797,7 +3101,7 @@ fn solve_sparse_refined_core(
 /// refined solves reach the BLAS-3 panel kernel that fix #2 added.
 ///
 /// The per-column convergence logic mirrors `solve_sparse_refined_core`
-/// exactly (same `max_steps`, 2-strike plateau, `ε·√n` relative target,
+/// exactly (same `max_steps`, 2-strike plateau, `StopCriterion`,
 /// 100× divergence guard, and per-column best-iterate). Each step
 /// **compacts** the active (un-converged) columns into the batched
 /// solve, so the work never exceeds the per-column loop. `rhs` is
@@ -2842,7 +3146,7 @@ pub fn solve_sparse_many_refined_into(
     nrhs: usize,
     x_out: &mut [f64],
     opts: RefineOptions,
-) -> Result<(), FeralError> {
+) -> Result<RefineOutcome, FeralError> {
     let n = factors.n;
     if rhs.len() != n * nrhs {
         return Err(FeralError::DimensionMismatch {
@@ -2858,21 +3162,45 @@ pub fn solve_sparse_many_refined_into(
     }
     if nrhs == 0 || n == 0 {
         x_out.fill(0.0);
-        return Ok(());
+        return Ok(RefineOutcome {
+            steps: 0,
+            relative_residual: 0.0,
+            stop: RefineStop::Converged,
+        });
     }
 
     // Same constants as the single-RHS refiner (solve_sparse_refined_core),
-    // including the issue #178 per-call step cap.
+    // including the issue #178 per-call step cap and the issue #190
+    // per-call stopping criterion. The criterion is applied per column,
+    // exactly as the `ε·√n` target was.
     let max_steps = opts.max_steps;
     let max_stagnant_steps = 2;
     let threshold = f64::EPSILON * (n as f64).sqrt();
     let divergence_factor = 100.0;
-    let relative_reached = |r_norm: f64, b_norm: f64| -> bool {
-        if b_norm > 0.0 {
-            r_norm < threshold * b_norm
-        } else {
-            r_norm < threshold
+    let reached = |r_norm: f64, b_norm: f64, omega: f64| -> bool {
+        match opts.stop {
+            StopCriterion::EpsSqrtN => {
+                if b_norm > 0.0 {
+                    r_norm < threshold * b_norm
+                } else {
+                    r_norm < threshold
+                }
+            }
+            StopCriterion::RelativeResidual(t) => {
+                if b_norm > 0.0 {
+                    r_norm <= t * b_norm
+                } else {
+                    r_norm <= t
+                }
+            }
+            StopCriterion::BackwardError(t) => omega <= t,
         }
+    };
+    let wants_omega = matches!(opts.stop, StopCriterion::BackwardError(_));
+    let mut om_scratch = if wants_omega {
+        vec![0.0f64; n]
+    } else {
+        Vec::new()
     };
 
     // Initial batched solve, written straight into the caller's buffer:
@@ -2886,11 +3214,21 @@ pub fn solve_sparse_many_refined_into(
     // the same — return before the per-column residual sweep rather than
     // computing residuals nobody will act on.
     if max_steps == 0 {
-        return Ok(());
+        return Ok(RefineOutcome {
+            steps: 0,
+            // No residual formed; see `RefineOutcome::relative_residual`.
+            relative_residual: f64::NAN,
+            stop: RefineStop::MaxSteps,
+        });
     }
 
     let mut best_rn = vec![0.0f64; nrhs];
     let mut bnorm = vec![0.0f64; nrhs];
+    // ω of each column's best iterate; untouched unless it is the criterion.
+    let mut best_om = vec![f64::INFINITY; nrhs];
+    // Per-column exit and correction count, aggregated at the end.
+    let mut col_stop = vec![RefineStop::Converged; nrhs];
+    let mut col_steps = vec![0usize; nrhs];
 
     // Initial per-column residual r_c = b_c - A·x_c into a small reused
     // scratch; build the active set (columns not yet at the target). The
@@ -2909,12 +3247,24 @@ pub fn solve_sparse_many_refined_into(
         }
         bnorm[c] = norm2(&rhs[c * n..(c + 1) * n]);
         best_rn[c] = norm2(&rc);
-        if !relative_reached(best_rn[c], bnorm[c]) {
+        if wants_omega {
+            best_om[c] = backward_error(
+                matrix,
+                &x_out[c * n..(c + 1) * n],
+                &rhs[c * n..(c + 1) * n],
+                &rc,
+                &mut om_scratch,
+            );
+        }
+        if !reached(best_rn[c], bnorm[c], best_om[c]) {
+            // Every column starts out assuming the budget will bind; the
+            // per-column exits below overwrite it.
+            col_stop[c] = RefineStop::MaxSteps;
             active.push(c);
         }
     }
     if active.is_empty() {
-        return Ok(());
+        return Ok(aggregate_outcome(&col_stop, &col_steps, &best_rn, &bnorm));
     }
 
     // Refinement is needed for at least one column. `x_out` holds the
@@ -2954,9 +3304,22 @@ pub fn solve_sparse_many_refined_into(
                 rc[i] = rhs[c * n + i] - rc[i];
             }
             let rn = norm2(&rc);
+            col_steps[c] += 1;
+            let om = if wants_omega {
+                backward_error(
+                    matrix,
+                    &x[c * n..(c + 1) * n],
+                    &rhs[c * n..(c + 1) * n],
+                    &rc,
+                    &mut om_scratch,
+                )
+            } else {
+                f64::INFINITY
+            };
 
             if rn < best_rn[c] {
                 best_rn[c] = rn;
+                best_om[c] = om;
                 x_out[c * n..(c + 1) * n].copy_from_slice(&x[c * n..(c + 1) * n]);
                 stagnant[c] = 0;
             } else {
@@ -2964,18 +3327,59 @@ pub fn solve_sparse_many_refined_into(
             }
 
             // Stop this column on convergence, divergence, or plateau —
-            // identical predicates to the single-RHS refiner.
-            let done = relative_reached(best_rn[c], bnorm[c])
-                || rn > best_rn[c] * divergence_factor
-                || stagnant[c] >= max_stagnant_steps;
-            if !done {
+            // identical predicates to the single-RHS refiner, tested in
+            // the same order so the recorded reason matches which one
+            // actually fired first.
+            if reached(best_rn[c], bnorm[c], best_om[c]) {
+                col_stop[c] = RefineStop::Converged;
+            } else if rn > best_rn[c] * divergence_factor {
+                col_stop[c] = RefineStop::Diverged;
+            } else if stagnant[c] >= max_stagnant_steps {
+                col_stop[c] = RefineStop::Stagnated;
+            } else {
                 still.push(c);
             }
         }
         active = still;
     }
 
-    Ok(())
+    Ok(aggregate_outcome(&col_stop, &col_steps, &best_rn, &bnorm))
+}
+
+/// Collapse the per-column refinement record into one [`RefineOutcome`],
+/// as documented on its fields: `steps` and `relative_residual` are
+/// maxima, and `stop` is the worst exit by [`RefineStop::rank`].
+///
+/// Returning a maximum rather than a per-column `Vec` keeps the multi-RHS
+/// refiner allocation-free on this path — the wide buffers it does
+/// allocate are already the dominant cost, and a host asking "did the
+/// budget bind anywhere?" does not need the breakdown.
+fn aggregate_outcome(
+    col_stop: &[RefineStop],
+    col_steps: &[usize],
+    best_rn: &[f64],
+    bnorm: &[f64],
+) -> RefineOutcome {
+    let mut stop = RefineStop::Converged;
+    let mut steps = 0usize;
+    let mut worst_rel = 0.0f64;
+    for c in 0..col_stop.len() {
+        stop = stop.worst(col_stop[c]);
+        steps = steps.max(col_steps[c]);
+        let rel = if bnorm[c] > 0.0 {
+            best_rn[c] / bnorm[c]
+        } else {
+            best_rn[c]
+        };
+        if rel > worst_rel {
+            worst_rel = rel;
+        }
+    }
+    RefineOutcome {
+        steps,
+        relative_residual: worst_rel,
+        stop,
+    }
 }
 
 fn norm2(v: &[f64]) -> f64 {
@@ -3475,6 +3879,117 @@ mod tests {
             }
         }
         CscMatrix::from_triplets(n, &rows, &cols, &vals).unwrap()
+    }
+
+    // --- componentwise backward error ω (issue #190) -----------------
+    //
+    // Oracle: values produced independently in Python from the published
+    // LAPACK `dgerfs` BERR formula (see
+    // `dev/research/issue-190-refine-target.md`), not from this code.
+    // CLAUDE.md forbids writing the implementation and its oracle in the
+    // same session without an external source; the published formula is
+    // that source.
+
+    /// Residual `r = b - A·x`, formed exactly as the refiner forms it.
+    fn residual_of(m: &CscMatrix, x: &[f64], b: &[f64]) -> Vec<f64> {
+        let mut r = vec![0.0; m.n];
+        m.symv(x, &mut r);
+        for i in 0..m.n {
+            r[i] = b[i] - r[i];
+        }
+        r
+    }
+
+    fn omega_of(m: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+        let r = residual_of(m, x, b);
+        let mut scratch = vec![0.0; m.n];
+        backward_error(m, x, b, &r, &mut scratch)
+    }
+
+    fn assert_close(got: f64, want: f64, what: &str) {
+        if want == 0.0 {
+            assert_eq!(got, 0.0, "{what}: expected exactly 0, got {got:e}");
+            return;
+        }
+        let rel = ((got - want) / want).abs();
+        assert!(
+            rel <= 1e-15,
+            "{what}: got {got:e}, oracle {want:e}, relative difference {rel:e}"
+        );
+    }
+
+    #[test]
+    fn backward_error_matches_the_lapack_oracle_on_a_well_scaled_system() {
+        // A = [[4,1,0],[1,3,1],[0,1,2]], x = [1/2, 1/4, 1/8],
+        // b = A·x with 2⁻⁴⁰ added to row 1. All values exact in binary.
+        let m = CscMatrix::from_triplets(
+            3,
+            &[0, 1, 1, 2, 2],
+            &[0, 0, 1, 1, 2],
+            &[4.0, 1.0, 3.0, 1.0, 2.0],
+        )
+        .expect("m");
+        let x = [0.5, 0.25, 0.125];
+        let b = [2.25, 1.375 + f64::from_bits(0x3D70000000000000), 0.5];
+        assert_close(
+            omega_of(&m, &x, &b),
+            3.3072534609913724e-13,
+            "well-scaled ω",
+        );
+    }
+
+    #[test]
+    fn backward_error_sees_what_the_normwise_residual_misses() {
+        // The case the research note quotes: A = diag(1e12, 1e-12),
+        // x = [1,1], b perturbed by 1e-24 in the *small* row.
+        // ‖r‖₂/‖b‖₂ = 1.0e-36 — indistinguishable from a perfect solve —
+        // while ω = 5.0e-13, nowhere near machine precision. This is the
+        // whole argument for offering `StopCriterion::BackwardError`, so
+        // both numbers are asserted, not just ω.
+        let m = CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[1e12, 1e-12]).expect("m");
+        let x = [1.0, 1.0];
+        let b = [1e12, 1e-12 + 1e-24];
+
+        assert_close(
+            omega_of(&m, &x, &b),
+            5.000242179395196e-13,
+            "badly-scaled ω",
+        );
+
+        let r = residual_of(&m, &x, &b);
+        let rel = norm2(&r) / norm2(&b);
+        assert_close(rel, 1.0000484358795394e-36, "badly-scaled ‖r‖/‖b‖");
+        assert!(
+            rel < f64::EPSILON && omega_of(&m, &x, &b) > 1e3 * f64::EPSILON,
+            "the two measures must disagree here, or this test proves nothing"
+        );
+    }
+
+    #[test]
+    fn backward_error_treats_a_structurally_empty_row_as_satisfied() {
+        // LAPACK's guarded branch would return safe1/safe1 = 1 for row 1.
+        // FERAL returns 0: dᵢ == 0 forces rᵢ == 0, so the equation holds.
+        // Reporting 1 would make any `BackwardError` target unreachable
+        // on such a system — the defect #190 reports for `ε·√n`.
+        let m = CscMatrix::from_triplets(2, &[0], &[0], &[1.0]).expect("m");
+        let x = [1.0, 0.0];
+        let b = [1.0, 0.0];
+        assert_eq!(omega_of(&m, &x, &b), 0.0, "empty row must contribute 0");
+    }
+
+    #[test]
+    fn backward_error_takes_the_guarded_branch_below_safe2() {
+        // dᵢ ≈ 2e-300, under safe2 ≈ 3.0e-292 for n = 2, so the
+        // `(|rᵢ| + safe1)/(dᵢ + safe1)` form is what runs. An unguarded
+        // ratio here would report ~5e-11 instead.
+        let m = CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[1e-300, 1.0]).expect("m");
+        let x = [1.0, 0.0];
+        let b = [1e-300 + 1e-310, 0.0];
+        assert_close(
+            omega_of(&m, &x, &b),
+            3.342610678347075e-08,
+            "tiny-denominator ω",
+        );
     }
 
     #[test]

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2233,11 +2233,14 @@ impl RefineOptions {
 /// See `dev/research/issue-190-refine-target.md`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StopCriterion {
-    /// `‖r‖₂ < ε·√n·‖b‖₂` — FERAL's historical rule, and the default.
+    /// `‖r‖₂ < ε·√n·‖b‖₂` — FERAL's historical rule, and the default
+    /// through 0.17.0. As of 0.18.0 the default is
+    /// [`Self::EpsSqrtNAndBackwardError`]; this variant is what a caller
+    /// opts into to get the pre-0.18.0 behaviour back.
     ///
-    /// Kept bit-for-bit, including the strict `<`, so every call that
-    /// does not opt into a target performs exactly the arithmetic it
-    /// did before #190.
+    /// Kept bit-for-bit, including the strict `<`, so a call that opts
+    /// into this variant performs exactly the arithmetic it did before
+    /// #190.
     EpsSqrtN,
     /// `‖r‖₂/‖b‖₂ ≤ target` — normwise relative residual.
     ///

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2122,18 +2122,34 @@ pub struct RefineOptions {
     pub stop: StopCriterion,
 }
 
+/// The default componentwise target: MUMPS's `CNTL(2)`.
+///
+/// MUMPS sets `CNTL(2) = sqrt(epsilon)` (`ref/mumps/src/dini_defaults.F:1094`)
+/// and stops its `ICNTL(10)` refinement when the Arioli-Demmel-Duff
+/// backward error falls below it. FERAL uses the same number for the
+/// same purpose, so a default-configured `solve_refined` certifies at
+/// least what a default-configured MUMPS does.
+///
+/// `f64::EPSILON` itself -- LAPACK `dgerfs`'s target -- was measured and
+/// rejected: on the seven-matrix large corpus it stagnates or exhausts
+/// the step budget on five of seven under a badly scaled RHS (up to 10
+/// steps) while `sqrt(eps)` converges in at most one. See
+/// `dev/research/issue-190-refine-target.md`.
+pub const DEFAULT_BACKWARD_ERROR_TARGET: f64 = 1.4901161193847656e-8;
+
 impl Default for RefineOptions {
     fn default() -> Self {
         Self {
             max_steps: DEFAULT_REFINE_MAX_STEPS,
-            stop: StopCriterion::EpsSqrtN,
+            stop: StopCriterion::EpsSqrtNAndBackwardError(DEFAULT_BACKWARD_ERROR_TARGET),
         }
     }
 }
 
 impl RefineOptions {
     /// Options capping refinement at `max_steps` correction steps,
-    /// keeping the default [`StopCriterion::EpsSqrtN`].
+    /// keeping the default
+    /// [`StopCriterion::EpsSqrtNAndBackwardError`].
     ///
     /// `RefineOptions::with_max_steps(1)` is the interior-point host's
     /// case: one correction per call, leaving the convergence decision to
@@ -2233,6 +2249,26 @@ pub enum StopCriterion {
     /// ([`CscMatrix::abs_symv`]) and **no extra solves** — in contrast
     /// to [`RefinementDiagnostics::kappa_1_est`], which costs 3–5.
     BackwardError(f64),
+    /// Both at once: `‖r‖₂ < ε·√n·‖b‖₂` **and** `ω ≤ target`.
+    ///
+    /// This is the default, with `target = DEFAULT_BACKWARD_ERROR_TARGET`.
+    ///
+    /// Neither test alone is sufficient. [`Self::EpsSqrtN`] is normwise,
+    /// so it is dominated by the rows carrying the largest right-hand-side
+    /// entries: on a RHS whose entries span 1e-6..1e6 it passes on the
+    /// *raw* solve — `r05_kkt` reaches `‖r‖₂/‖b‖₂ = 2.7e-14` at step 0 —
+    /// while the rows carrying the small entries still sit at
+    /// `ω = 9.5e-5`, nine orders worse than MUMPS on the same system.
+    /// [`Self::BackwardError`] alone fixes that but, being satisfied at
+    /// `√ε`, can stop while `‖r‖₂/‖b‖₂` is still looser than the
+    /// historical rule delivered.
+    ///
+    /// Requiring both means the returned iterate is never worse than
+    /// what `EpsSqrtN` shipped, and additionally carries the
+    /// Arioli-Demmel-Duff certificate. Measured cost on the seven-matrix
+    /// large corpus, both RHS families: at most two correction steps,
+    /// the same bound `EpsSqrtN` already had.
+    EpsSqrtNAndBackwardError(f64),
 }
 
 /// Why a refinement call stopped, and how much it did.
@@ -2376,13 +2412,13 @@ fn backward_error(
 /// the returned `x` is no worse than the unrefined `solve_sparse()` output.
 ///
 /// Convergence test: whichever `StopCriterion` the caller selected, or
-/// after 10 steps. The default criterion is `EpsSqrtN` — stop when
-/// `||r||₂ / ||b||₂ < ε·√n`, i.e. we've reached machine precision.
-/// That test is normwise, so on a badly-scaled right-hand side it can
-/// stop at `||r||₂/||b||₂ ≈ 4e-16` while the componentwise backward
-/// error is `9e-6` (measured, bratu3d); `StopCriterion::BackwardError`
-/// is the one with a principled stopping value (issue #190). 10 comes
-/// from FERAL's corpus,
+/// after 10 steps. The default is `EpsSqrtNAndBackwardError(√ε)` — stop
+/// once `||r||₂ / ||b||₂ < ε·√n` *and* the componentwise backward error
+/// `ω ≤ √ε`. The normwise half alone is not enough: on a badly-scaled
+/// right-hand side it stops at `||r||₂/||b||₂ ≈ 4e-16` while `ω = 9e-6`
+/// (measured, bratu3d), because it is dominated by the rows carrying
+/// the largest RHS entries. `√ε` is MUMPS's `CNTL(2)`, the same number
+/// its `ICNTL(10)` refinement stops on. 10 comes from FERAL's corpus,
 /// not from MUMPS (whose `ICNTL(10)` default is `0` — no refinement at
 /// all; the comparison harness sets it to `2`): below 10 some
 /// near-rank-deficient KKT matrices
@@ -2957,6 +2993,14 @@ fn solve_sparse_refined_core(
                 }
             }
             StopCriterion::BackwardError(t) => omega <= t,
+            StopCriterion::EpsSqrtNAndBackwardError(t) => {
+                let normwise = if b_norm > 0.0 {
+                    r_norm < threshold * b_norm
+                } else {
+                    r_norm < threshold
+                };
+                normwise && omega <= t
+            }
         }
     };
 
@@ -2965,7 +3009,10 @@ fn solve_sparse_refined_core(
     // ω is only formed when it is the criterion; under the other two it
     // stays `INFINITY` and is never read. One `abs_symv` per step, no
     // extra solves.
-    let wants_omega = matches!(opts.stop, StopCriterion::BackwardError(_));
+    let wants_omega = matches!(
+        opts.stop,
+        StopCriterion::BackwardError(_) | StopCriterion::EpsSqrtNAndBackwardError(_)
+    );
     let mut omega_scratch = if wants_omega {
         vec![0.0; n]
     } else {
@@ -3195,9 +3242,20 @@ pub fn solve_sparse_many_refined_into(
                 }
             }
             StopCriterion::BackwardError(t) => omega <= t,
+            StopCriterion::EpsSqrtNAndBackwardError(t) => {
+                let normwise = if b_norm > 0.0 {
+                    r_norm < threshold * b_norm
+                } else {
+                    r_norm < threshold
+                };
+                normwise && omega <= t
+            }
         }
     };
-    let wants_omega = matches!(opts.stop, StopCriterion::BackwardError(_));
+    let wants_omega = matches!(
+        opts.stop,
+        StopCriterion::BackwardError(_) | StopCriterion::EpsSqrtNAndBackwardError(_)
+    );
     let mut om_scratch = if wants_omega {
         vec![0.0f64; n]
     } else {

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -1453,10 +1453,26 @@ impl SolveManyWorkspace {
         } else {
             n * nrhs
         };
-        // Allocate at the padded row stride unconditionally: the solve
-        // picks `ldw` per call, and under the `kernel-probe` feature the
-        // dispatch threshold can move between construction and use.
-        let ldw = padded_ldw(nrhs);
+        // Row stride to allocate at. This must match what
+        // `solve_sparse_core_many_into` computes, since that function
+        // slices these buffers at `n * ldw` / `nrow * ldw` / `ldw`: the
+        // panel path pads to a whole `NR` tile (see `padded_ldw`), the
+        // rank-1 path uses exactly `nrhs`.
+        //
+        // Sizing on the threshold rather than padding unconditionally
+        // matters at the `nrhs` an interior-point host actually uses:
+        // padding `nrhs = 1` allocates 8x the `y` and `w` it will touch,
+        // and `nrhs = 2` (Mehrotra predictor-corrector) 4x, on a
+        // workspace that refinement rebuilds per step.
+        //
+        // Under `kernel-probe` the threshold is a runtime override that
+        // can move between construction and use, so there — and only
+        // there — pad unconditionally.
+        let ldw = if cfg!(feature = "kernel-probe") || nrhs >= blas3_nrhs_threshold() {
+            padded_ldw(nrhs)
+        } else {
+            nrhs
+        };
         Self {
             y: vec![0.0; n * ldw],
             w: vec![0.0; max_nrow * ldw],

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2316,6 +2316,19 @@ pub struct RefineOutcome {
     /// formed and there is nothing honest to report. For a multi-RHS
     /// call this is the maximum over columns.
     pub relative_residual: f64,
+    /// The Arioli-Demmel-Duff componentwise backward error
+    /// `ω = maxᵢ |rᵢ| / (|A|·|x| + |b|)ᵢ` of the iterate that was
+    /// returned. For a multi-RHS call this is the maximum over columns.
+    ///
+    /// **`NaN` when the criterion did not require ω** — that is, under
+    /// [`StopCriterion::EpsSqrtN`] and [`StopCriterion::RelativeResidual`],
+    /// and under `max_steps == 0`. ω costs an extra `abs_symv` per step,
+    /// so the refiner only forms it when it is being tested against;
+    /// reporting a stale or defaulted number instead would be worse than
+    /// reporting none. Note that `NaN` here means *not measured* and is
+    /// distinct from `INFINITY`, which is a real measurement: a
+    /// non-finite iterate. Test with `is_nan()`, not against a bound.
+    pub backward_error: f64,
     /// Which exit fired. For a multi-RHS call, the worst over columns in
     /// the order `MaxSteps > Diverged > Stagnated > Converged` —
     /// `MaxSteps` ranks first because "did the budget bind?" is the
@@ -2956,6 +2969,7 @@ fn solve_sparse_refined_core(
                 // No residual was formed, so there is nothing honest to
                 // report. See `RefineOutcome::relative_residual`.
                 relative_residual: f64::NAN,
+                backward_error: f64::NAN,
                 stop: RefineStop::MaxSteps,
             },
             None,
@@ -3163,6 +3177,11 @@ fn solve_sparse_refined_core(
     let outcome = RefineOutcome {
         steps: steps_taken,
         relative_residual: rel_res(best_r_norm),
+        // Gate on `wants_omega`, not on `best_omega == INFINITY`: under
+        // the normwise criteria `best_omega` is the never-read `INFINITY`
+        // sentinel, but when ω *is* the criterion `INFINITY` is a real
+        // measurement (a non-finite iterate) and must be reported.
+        backward_error: if wants_omega { best_omega } else { f64::NAN },
         stop,
     };
 
@@ -3250,6 +3269,7 @@ pub fn solve_sparse_many_refined_into(
         return Ok(RefineOutcome {
             steps: 0,
             relative_residual: 0.0,
+            backward_error: 0.0,
             stop: RefineStop::Converged,
         });
     }
@@ -3314,6 +3334,7 @@ pub fn solve_sparse_many_refined_into(
             steps: 0,
             // No residual formed; see `RefineOutcome::relative_residual`.
             relative_residual: f64::NAN,
+            backward_error: f64::NAN,
             stop: RefineStop::MaxSteps,
         });
     }
@@ -3360,7 +3381,14 @@ pub fn solve_sparse_many_refined_into(
         }
     }
     if active.is_empty() {
-        return Ok(aggregate_outcome(&col_stop, &col_steps, &best_rn, &bnorm));
+        return Ok(aggregate_outcome(
+            &col_stop,
+            &col_steps,
+            &best_rn,
+            &bnorm,
+            &best_om,
+            wants_omega,
+        ));
     }
 
     // Refinement is needed for at least one column. `x_out` holds the
@@ -3439,7 +3467,14 @@ pub fn solve_sparse_many_refined_into(
         active = still;
     }
 
-    Ok(aggregate_outcome(&col_stop, &col_steps, &best_rn, &bnorm))
+    Ok(aggregate_outcome(
+        &col_stop,
+        &col_steps,
+        &best_rn,
+        &bnorm,
+        &best_om,
+        wants_omega,
+    ))
 }
 
 /// Collapse the per-column refinement record into one [`RefineOutcome`],
@@ -3455,10 +3490,13 @@ fn aggregate_outcome(
     col_steps: &[usize],
     best_rn: &[f64],
     bnorm: &[f64],
+    best_om: &[f64],
+    wants_omega: bool,
 ) -> RefineOutcome {
     let mut stop = RefineStop::Converged;
     let mut steps = 0usize;
     let mut worst_rel = 0.0f64;
+    let mut worst_om = 0.0f64;
     for c in 0..col_stop.len() {
         stop = stop.worst(col_stop[c]);
         steps = steps.max(col_steps[c]);
@@ -3470,10 +3508,17 @@ fn aggregate_outcome(
         if rel > worst_rel {
             worst_rel = rel;
         }
+        if best_om[c] > worst_om {
+            worst_om = best_om[c];
+        }
     }
     RefineOutcome {
         steps,
         relative_residual: worst_rel,
+        // `best_om` is the untouched `INFINITY` sentinel under the
+        // normwise criteria; report "not measured" rather than a fold
+        // over sentinels. See `RefineOutcome::backward_error`.
+        backward_error: if wants_omega { worst_om } else { f64::NAN },
         stop,
     }
 }

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -16,6 +16,47 @@ use crate::sparse::csc::CscMatrix;
 /// setup. See `dev/research/issue-57-blas3-panel.md`.
 const BLAS3_NRHS_THRESHOLD: usize = 32;
 
+/// In-process override for [`BLAS3_NRHS_THRESHOLD`], compiled in only under
+/// the `kernel-probe` feature. It exists so a probe can time the rank-1 and
+/// BLAS-3 multi-RHS kernels at the *same* `nrhs`, interleaved within one
+/// process.
+///
+/// The alternative — building two binaries and alternating runs — was tried
+/// and does not work here: a full sweep takes ~25 minutes, so "adjacent" runs
+/// are 25 minutes apart, and the control (the looped single-RHS path, which is
+/// byte-identical in both builds) drifted by up to 2x between them. The
+/// `nrhs >= 32` rows, where both builds run the *same* kernel and the ratio
+/// must be exactly 1.00, read 0.86-0.90 instead. See
+/// `dev/research/blas3-threshold-refit.md`.
+///
+/// `usize::MAX` means "no override"; the const applies.
+#[cfg(feature = "kernel-probe")]
+static BLAS3_NRHS_OVERRIDE: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(usize::MAX);
+
+/// Override the multi-RHS BLAS-3 dispatch threshold for this process.
+/// Measurement scaffolding only — not part of the supported API, and absent
+/// unless the `kernel-probe` feature is enabled.
+#[cfg(feature = "kernel-probe")]
+#[doc(hidden)]
+pub fn set_blas3_nrhs_threshold(threshold: usize) {
+    BLAS3_NRHS_OVERRIDE.store(threshold, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The active multi-RHS BLAS-3 dispatch threshold. With `kernel-probe` off
+/// this is the const, inlined — identical codegen to reading it directly.
+#[inline(always)]
+fn blas3_nrhs_threshold() -> usize {
+    #[cfg(feature = "kernel-probe")]
+    {
+        let overridden = BLAS3_NRHS_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed);
+        if overridden != usize::MAX {
+            return overridden;
+        }
+    }
+    BLAS3_NRHS_THRESHOLD
+}
+
 /// Multi-RHS refinement dispatch crossover (issue #58). At or above this
 /// `nrhs`, `Solver::solve_many_refined` refines through the batched
 /// `solve_sparse_many_refined` (one panel solve per refinement step over
@@ -1412,10 +1453,14 @@ impl SolveManyWorkspace {
         } else {
             n * nrhs
         };
+        // Allocate at the padded row stride unconditionally: the solve
+        // picks `ldw` per call, and under the `kernel-probe` feature the
+        // dispatch threshold can move between construction and use.
+        let ldw = padded_ldw(nrhs);
         Self {
-            y: vec![0.0; n * nrhs],
-            w: vec![0.0; max_nrow * nrhs],
-            acc: vec![0.0; nrhs],
+            y: vec![0.0; n * ldw],
+            w: vec![0.0; max_nrow * ldw],
+            acc: vec![0.0; ldw],
             scaled_rhs: vec![0.0; scaled_rhs_len],
             nrhs,
             n,
@@ -1561,11 +1606,17 @@ fn solve_sparse_core_many_into(
     acc_buf: &mut [f64],
 ) {
     let n = factors.n;
-    let y = &mut y_buf[..n * nrhs];
 
     // Route wide solves through the BLAS-3 panel kernels (issue #57
     // fix #2); narrow solves stay on the bit-identical rank-1 kernels.
-    let use_blas3 = nrhs >= BLAS3_NRHS_THRESHOLD;
+    let use_blas3 = nrhs >= blas3_nrhs_threshold();
+
+    // Row stride of the row-major buffers. Padded to a whole `NR` tile for
+    // the panel path so every row is cache-line aligned (see `padded_ldw`);
+    // left at `nrhs` for the rank-1 path, which gains nothing from the
+    // padding and would only pay for the extra columns.
+    let ldw = if use_blas3 { padded_ldw(nrhs) } else { nrhs };
+    let y = &mut y_buf[..n * ldw];
 
     // Permute the RHS into the **row-major** working layout
     // `y[new*nrhs + c] = rhs[c, perm[new]]`. The caller's `rhs` stays
@@ -1575,7 +1626,10 @@ fn solve_sparse_core_many_into(
     // hot per-supernode loops was the multi-RHS bottleneck, badly so
     // when `n` is a power of two and columns alias in cache).
     for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        let dst = new_idx * nrhs;
+        let dst = new_idx * ldw;
+        for c in nrhs..ldw {
+            y[dst + c] = 0.0;
+        }
         for c in 0..nrhs {
             y[dst + c] = rhs[c * n + old_idx];
         }
@@ -1593,10 +1647,10 @@ fn solve_sparse_core_many_into(
 
         // Gather the supernode's rows from `y` into `w` (both row-major):
         // w[i, :] = y[row_indices[perm[i]], :], a contiguous memcpy.
-        let w = &mut w_buf[..nrow * nrhs];
+        let w = &mut w_buf[..nrow * ldw];
         for i in 0..nrow {
-            let src = node.row_indices[ff.perm[i]] * nrhs;
-            w[i * nrhs..(i + 1) * nrhs].copy_from_slice(&y[src..src + nrhs]);
+            let src = node.row_indices[ff.perm[i]] * ldw;
+            w[i * ldw..(i + 1) * ldw].copy_from_slice(&y[src..src + ldw]);
         }
 
         // L-solve. At small `nrhs` the row-major rank-1 cascade runs
@@ -1604,9 +1658,9 @@ fn solve_sparse_core_many_into(
         // BLAS3_NRHS_THRESHOLD` the register-blocked panel kernel runs
         // (TRSM on L_11 + GEMM on L_21, issue #57 fix #2).
         if use_blas3 {
-            fwd_blas3(w, &ff.l, nrow, nelim, nrhs);
+            fwd_blas3(w, &ff.l, nrow, nelim, ldw);
         } else {
-            fwd_rank1(w, &ff.l, nrow, nelim, nrhs);
+            fwd_rank1(w, &ff.l, nrow, nelim, ldw);
         }
 
         // D-block solve, fused into the forward pass. A node's
@@ -1614,18 +1668,18 @@ fn solve_sparse_core_many_into(
         // completes — ancestors only ever touch its separator rows — so
         // D⁻¹ can be applied here instead of in a second postorder pass,
         // saving one gather/scatter round trip per supernode (issue #57).
-        dsolve_node(w, ff, nelim, nrhs);
+        dsolve_node(w, ff, nelim, ldw);
 
         // Scatter back into `y` (both row-major), undoing the BK
         // permutation: y[row_indices[perm[i]], :] = w[i, :].
         for i in 0..nrow {
-            let dst = node.row_indices[ff.perm[i]] * nrhs;
-            y[dst..dst + nrhs].copy_from_slice(&w[i * nrhs..(i + 1) * nrhs]);
+            let dst = node.row_indices[ff.perm[i]] * ldw;
+            y[dst..dst + ldw].copy_from_slice(&w[i * ldw..(i + 1) * ldw]);
         }
     }
 
     // Phase 3: Backward substitution (reverse postorder).
-    let acc = &mut acc_buf[..nrhs];
+    let acc = &mut acc_buf[..ldw];
     for node in factors.node_factors.iter().rev() {
         let ff = &node.frontal_factors;
         let nelim = ff.nelim;
@@ -1634,24 +1688,24 @@ fn solve_sparse_core_many_into(
             continue;
         }
 
-        let w = &mut w_buf[..nrow * nrhs];
+        let w = &mut w_buf[..nrow * ldw];
         for i in 0..nrow {
             // y is row-major (`y[node*nrhs + c]`), so each supernode row
             // gathers a contiguous run — a memcpy, not a stride-`n` walk.
-            let src = node.row_indices[ff.perm[i]] * nrhs;
-            w[i * nrhs..(i + 1) * nrhs].copy_from_slice(&y[src..src + nrhs]);
+            let src = node.row_indices[ff.perm[i]] * ldw;
+            w[i * ldw..(i + 1) * ldw].copy_from_slice(&y[src..src + ldw]);
         }
 
         // L^T-solve (mirror of the forward dispatch).
         if use_blas3 {
-            back_blas3(w, &ff.l, nrow, nelim, nrhs, acc);
+            back_blas3(w, &ff.l, nrow, nelim, ldw, acc);
         } else {
-            back_rank1(w, &ff.l, nrow, nelim, nrhs, acc);
+            back_rank1(w, &ff.l, nrow, nelim, ldw, acc);
         }
 
         for i in 0..nrow {
-            let dst = node.row_indices[ff.perm[i]] * nrhs;
-            y[dst..dst + nrhs].copy_from_slice(&w[i * nrhs..(i + 1) * nrhs]);
+            let dst = node.row_indices[ff.perm[i]] * ldw;
+            y[dst..dst + ldw].copy_from_slice(&w[i * ldw..(i + 1) * ldw]);
         }
     }
 
@@ -1659,7 +1713,7 @@ fn solve_sparse_core_many_into(
     // `x_out`: x[c, old] = y[new*nrhs + c]. One-time scatter (mirror of
     // the entry permute).
     for (new_idx, &old_idx) in factors.perm.iter().enumerate() {
-        let src = new_idx * nrhs;
+        let src = new_idx * ldw;
         for c in 0..nrhs {
             x_out[c * n + old_idx] = y[src + c];
         }
@@ -1841,6 +1895,31 @@ struct PanelBlock<'a> {
     col_stride: usize,
 }
 
+/// Register-tile height for the multi-RHS panel GEMM: 4 output rows held
+/// in registers at once.
+const MR: usize = 4;
+/// Register-tile width: 8 right-hand-side columns per tile.
+const NR: usize = 8;
+
+/// Row stride for the row-major multi-RHS work buffers, rounded up to a
+/// whole `NR`-column tile — i.e. to a multiple of 64 bytes.
+///
+/// The padding is what makes every row of `y`/`w` start on a cache-line
+/// boundary. Measured 2026-08-20 across seven KKT matrices: with the stride
+/// left at a raw `nrhs`, the BLAS-3 solve is ~1.5x slower at every `nrhs`
+/// that is not a multiple of 8. `nrhs = 33` costs 1.59x `nrhs = 32` on
+/// bratu3d (74.2 ms vs 46.6 ms) despite doing 3% *more* work, and it costs
+/// the same as `nrhs = 31` — which has seven tail columns to 33's one. The
+/// tail-column count does not predict the cost; the stride does.
+///
+/// The padded columns carry a zero right-hand side, so they are numerically
+/// inert: every real column's arithmetic, and its order, is untouched.
+/// See `dev/research/blas3-threshold-refit.md`.
+#[inline]
+fn padded_ldw(nrhs: usize) -> usize {
+    nrhs.div_ceil(NR) * NR
+}
+
 /// Register-blocked panel GEMM: `C[m, c] -= sum_k A[m, k] · B[k, c]`,
 /// `C` (`m_dim × nrhs`) and `B` (`k_dim × nrhs`) row-major with leading
 /// dimension `nrhs`, `A` an `m_dim × k_dim` view into the column-major
@@ -1857,8 +1936,6 @@ fn gemm_panel_minus(
     k_dim: usize,
     nrhs: usize,
 ) {
-    const MR: usize = 4;
-    const NR: usize = 8;
     let m_main = m_dim - m_dim % MR;
     let c_main = nrhs - nrhs % NR;
 
@@ -1910,37 +1987,79 @@ fn gemm_panel_minus(
         m0 += MR;
     }
 
-    // Column tail (nrhs % NR) for the MR-tiled rows.
-    gemm_scalar_block(c_rows, a, b_rows, 0, m_main, c_main, nrhs, k_dim, nrhs);
-    // Row tail (m_dim % MR), full column range.
-    gemm_scalar_block(c_rows, a, b_rows, m_main, m_dim, 0, nrhs, k_dim, nrhs);
+    // Column tail (nrhs % NR) for the MR-tiled rows: one padded full-width
+    // tile per row block, not a scalar sweep.
+    if c_main < nrhs {
+        let live = nrhs - c_main;
+        let mut m0 = 0;
+        while m0 < m_main {
+            gemm_tile::<MR>(c_rows, a, b_rows, m0, c_main, live, k_dim, nrhs);
+            m0 += MR;
+        }
+    }
+    // Row tail (m_dim % MR), full column range, one row at a time.
+    for m in m_main..m_dim {
+        let mut c0 = 0;
+        while c0 < nrhs {
+            let live = NR.min(nrhs - c0);
+            gemm_tile::<1>(c_rows, a, b_rows, m, c0, live, k_dim, nrhs);
+            c0 += NR;
+        }
+    }
 }
 
-/// Scalar fallback for the GEMM tails: `C[m, c] -= sum_k A[m, k]·B[k, c]`
-/// over `m ∈ [m_lo, m_hi)`, `c ∈ [c_lo, c_hi)`. Accumulates per `(m, c)`
-/// in increasing `k` (left fold), matching the core kernel's order.
+/// Register-blocked GEMM tile: `R` contiguous output rows starting at row
+/// `m0`, and the `live` columns starting at `c0`.
+///
+/// `live` may be shorter than `NR`. The lanes past it hold zero in both the
+/// accumulator and the `B` buffer, so they compute `0.0 - a·0.0 == 0.0` at
+/// every step and are never stored back. The stored elements are therefore
+/// bit-identical to computing only `live` lanes, and each remains a left
+/// fold over increasing `k` — matching the main kernel above and the rank-1
+/// cascade, so the panel path's parity with the scalar path is unchanged.
+///
+/// Running the tails at full register width is the point. The scalar tail
+/// this replaced re-walked all of `A`'s row and `B`'s column for *every*
+/// output element — strides `col_stride` and `nrhs`, no reuse — which made a
+/// tail column cost 2.0-5.1x a blocked column, measured across seven KKT
+/// matrices on 2026-08-20. That was enough to make `nrhs = 31` slower than
+/// `nrhs = 32` on every one of them despite 3% less work (bratu3d 85.3 ms vs
+/// 47.8 ms). See `dev/research/blas3-threshold-refit.md`.
+#[inline]
 #[allow(clippy::too_many_arguments)]
-fn gemm_scalar_block(
+fn gemm_tile<const R: usize>(
     c_rows: &mut [f64],
     a: &PanelBlock,
     b_rows: &[f64],
-    m_lo: usize,
-    m_hi: usize,
-    c_lo: usize,
-    c_hi: usize,
+    m0: usize,
+    c0: usize,
+    live: usize,
     k_dim: usize,
     nrhs: usize,
 ) {
-    for m in m_lo..m_hi {
-        let ab = a.base + m * a.row_stride;
-        let row = &mut c_rows[m * nrhs..(m + 1) * nrhs];
-        for c in c_lo..c_hi {
-            let mut sum = row[c];
-            for k in 0..k_dim {
-                sum -= a.l[ab + k * a.col_stride] * b_rows[k * nrhs + c];
+    debug_assert!(live > 0 && live <= NR);
+    let mut acc = [[0.0f64; NR]; R];
+    let mut ab = [0usize; R];
+    for r in 0..R {
+        ab[r] = a.base + (m0 + r) * a.row_stride;
+        let off = (m0 + r) * nrhs + c0;
+        acc[r][..live].copy_from_slice(&c_rows[off..off + live]);
+    }
+    let mut bb = [0.0f64; NR];
+    for k in 0..k_dim {
+        let boff = k * nrhs + c0;
+        bb[..live].copy_from_slice(&b_rows[boff..boff + live]);
+        let kc = k * a.col_stride;
+        for r in 0..R {
+            let av = a.l[ab[r] + kc];
+            for s in 0..NR {
+                acc[r][s] -= av * bb[s];
             }
-            row[c] = sum;
         }
+    }
+    for r in 0..R {
+        let off = (m0 + r) * nrhs + c0;
+        c_rows[off..off + live].copy_from_slice(&acc[r][..live]);
     }
 }
 
@@ -3859,6 +3978,94 @@ mod tests {
                 x_ser[i].to_bits(),
                 "gate-rejected factor: requesting parallel changed bit {i}"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod gemm_tail_tests {
+    use super::*;
+
+    /// Reference GEMM with the summation order the panel kernel documents:
+    /// each `C[m, c]` accumulates over increasing `k` as a left fold. This is
+    /// the specification `gemm_panel_minus` has always claimed to implement
+    /// (see its doc comment and the rank-1 cascade it must stay parity with),
+    /// so equality here is equality with the pre-tail-rewrite kernel too.
+    fn reference(
+        c_rows: &mut [f64],
+        a: &PanelBlock,
+        b_rows: &[f64],
+        m_dim: usize,
+        k_dim: usize,
+        nrhs: usize,
+    ) {
+        for m in 0..m_dim {
+            let ab = a.base + m * a.row_stride;
+            for c in 0..nrhs {
+                let mut sum = c_rows[m * nrhs + c];
+                for k in 0..k_dim {
+                    sum -= a.l[ab + k * a.col_stride] * b_rows[k * nrhs + c];
+                }
+                c_rows[m * nrhs + c] = sum;
+            }
+        }
+    }
+
+    /// Deterministic, sign-varying, non-dyadic values, so a reassociation
+    /// would change the low bits rather than cancel out.
+    fn fill(v: &mut [f64], seed: u64) {
+        let mut x = seed | 1;
+        for e in v.iter_mut() {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            let u = ((x >> 11) as f64) / ((1u64 << 53) as f64);
+            *e = (u - 0.5) * 3.7;
+        }
+    }
+
+    /// Every `nrhs % NR` and `m_dim % MR` residue, including the shapes that
+    /// exercise the column tail, the row tail, and both at once.
+    #[test]
+    fn panel_gemm_is_bit_identical_to_the_reference_on_every_tail_shape() {
+        for &nrhs in &[1, 2, 3, 5, 7, 8, 9, 12, 14, 16, 20, 24, 31, 32, 33, 40] {
+            for &m_dim in &[1, 2, 3, 4, 5, 7, 8, 11, 16, 19] {
+                for &k_dim in &[1, 2, 5, 13, 32] {
+                    // `A` is a strided view, exactly as the solve builds it:
+                    // `row_stride = 1`, `col_stride = nrow`, offset `base`.
+                    let nrow = m_dim + 6;
+                    let base = 3;
+                    let mut lbuf = vec![0.0f64; base + nrow * k_dim + nrow];
+                    fill(&mut lbuf, 0x9E37_79B9_7F4A_7C15 ^ (nrhs as u64) << 8);
+                    let a = PanelBlock {
+                        l: &lbuf,
+                        base,
+                        row_stride: 1,
+                        col_stride: nrow,
+                    };
+
+                    let mut b = vec![0.0f64; k_dim * nrhs];
+                    fill(&mut b, 0xD1B5_4A32_D192_ED03 ^ (m_dim as u64) << 8);
+                    let mut c0 = vec![0.0f64; m_dim * nrhs];
+                    fill(&mut c0, 0xA24B_AED4_963E_E407 ^ (k_dim as u64) << 8);
+
+                    let mut got = c0.clone();
+                    gemm_panel_minus(&mut got, &a, &b, m_dim, k_dim, nrhs);
+                    let mut want = c0;
+                    reference(&mut want, &a, &b, m_dim, k_dim, nrhs);
+
+                    for i in 0..m_dim * nrhs {
+                        assert_eq!(
+                            got[i].to_bits(),
+                            want[i].to_bits(),
+                            "bit mismatch at {i} for nrhs={nrhs} m_dim={m_dim} k_dim={k_dim}: \
+                             {} vs {}",
+                            got[i],
+                            want[i]
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/src/numeric/solve.rs
+++ b/src/numeric/solve.rs
@@ -2378,8 +2378,9 @@ fn backward_error(
 /// Convergence test: whichever `StopCriterion` the caller selected, or
 /// after 10 steps. The default criterion is `EpsSqrtN` — stop when
 /// `||r||₂ / ||b||₂ < ε·√n`, i.e. we've reached machine precision.
-/// On a large ill-conditioned system that target is not reachable and
-/// the loop always runs the full budget; `StopCriterion::BackwardError`
+/// That test is normwise, so on a badly-scaled right-hand side it can
+/// stop at `||r||₂/||b||₂ ≈ 4e-16` while the componentwise backward
+/// error is `9e-6` (measured, bratu3d); `StopCriterion::BackwardError`
 /// is the one with a principled stopping value (issue #190). 10 comes
 /// from FERAL's corpus,
 /// not from MUMPS (whose `ICNTL(10)` default is `0` — no refinement at

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -19,8 +19,8 @@ use crate::numeric::factorize::{
 };
 use crate::numeric::solve::{
     solve_sparse, solve_sparse_into, solve_sparse_many, solve_sparse_many_into,
-    solve_sparse_many_refined_into, solve_sparse_refined_auto_into, RefineOptions,
-    SolveManyWorkspace, BLAS3_REFINE_THRESHOLD,
+    solve_sparse_many_refined_into, solve_sparse_refined_auto_into, RefineOptions, RefineOutcome,
+    RefineStop, SolveManyWorkspace, BLAS3_REFINE_THRESHOLD,
 };
 use crate::scaling::{
     mc64_value_bound_passes, pick_scaling_strategy, precompute_mc64_validity, Mc64CacheValidity,
@@ -1679,7 +1679,7 @@ impl Solver {
         rhs: &[f64],
         x_out: &mut [f64],
         opts: RefineOptions,
-    ) -> Result<(), FeralError> {
+    ) -> Result<RefineOutcome, FeralError> {
         let f = match &self.last_factors {
             Some(f) => f,
             None => return Err(FeralError::NoFactor),
@@ -1696,7 +1696,7 @@ impl Solver {
         rhs: &[f64],
         x_out: &mut [f64],
         opts: RefineOptions,
-    ) -> Result<(), FeralError> {
+    ) -> Result<RefineOutcome, FeralError> {
         // Issue #131 Gap A: when parallelism is on, refine through the
         // contribution-block solve core (pooled across the initial +
         // correction solves). Install on this solver's pool (built during
@@ -1828,7 +1828,7 @@ impl Solver {
         nrhs: usize,
         x_out: &mut [f64],
         opts: RefineOptions,
-    ) -> Result<(), FeralError> {
+    ) -> Result<RefineOutcome, FeralError> {
         let factors = match &self.last_factors {
             Some(f) => f,
             None => return Err(FeralError::NoFactor),
@@ -1841,7 +1841,11 @@ impl Solver {
             });
         }
         if nrhs == 0 {
-            return Ok(());
+            return Ok(RefineOutcome {
+                steps: 0,
+                relative_residual: 0.0,
+                stop: RefineStop::Converged,
+            });
         }
         if rhs.len() != n * nrhs {
             return Err(FeralError::DimensionMismatch {
@@ -1855,12 +1859,33 @@ impl Solver {
         if nrhs >= BLAS3_REFINE_THRESHOLD {
             return solve_sparse_many_refined_into(matrix, factors, rhs, nrhs, x_out, opts);
         }
+        // Aggregate the per-column outcomes the same way the batched
+        // refiner does, so the two dispatch paths report identically
+        // (issue #190). `relative_residual` is NaN under `max_steps = 0`,
+        // and `NaN > x` is false, so the max fold leaves it at 0.0 —
+        // handled explicitly rather than silently.
+        let mut agg = RefineOutcome {
+            steps: 0,
+            relative_residual: 0.0,
+            stop: RefineStop::Converged,
+        };
+        let mut any_nan = false;
         for c in 0..nrhs {
             let src = &rhs[c * n..(c + 1) * n];
             let dst = &mut x_out[c * n..(c + 1) * n];
-            self.refine_into(matrix, factors, src, dst, opts)?;
+            let o = self.refine_into(matrix, factors, src, dst, opts)?;
+            agg.steps = agg.steps.max(o.steps);
+            agg.stop = agg.stop.worst(o.stop);
+            if o.relative_residual.is_nan() {
+                any_nan = true;
+            } else if o.relative_residual > agg.relative_residual {
+                agg.relative_residual = o.relative_residual;
+            }
         }
-        Ok(())
+        if any_nan {
+            agg.relative_residual = f64::NAN;
+        }
+        Ok(agg)
     }
 
     /// Estimate `kappa_1(A) = ||A||_1 * ||A^{-1}||_1` via the

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -1844,6 +1844,7 @@ impl Solver {
             return Ok(RefineOutcome {
                 steps: 0,
                 relative_residual: 0.0,
+                backward_error: 0.0,
                 stop: RefineStop::Converged,
             });
         }
@@ -1861,15 +1862,20 @@ impl Solver {
         }
         // Aggregate the per-column outcomes the same way the batched
         // refiner does, so the two dispatch paths report identically
-        // (issue #190). `relative_residual` is NaN under `max_steps = 0`,
-        // and `NaN > x` is false, so the max fold leaves it at 0.0 —
-        // handled explicitly rather than silently.
+        // (issue #190). `relative_residual` and `backward_error` are NaN
+        // under `max_steps = 0`, and `NaN > x` is false, so the max fold
+        // leaves them at 0.0 — handled explicitly rather than silently.
+        // `backward_error` is additionally NaN whenever ω is not the
+        // criterion, which is a per-*call* property, so in practice
+        // either every column reports NaN or none does.
         let mut agg = RefineOutcome {
             steps: 0,
             relative_residual: 0.0,
+            backward_error: 0.0,
             stop: RefineStop::Converged,
         };
         let mut any_nan = false;
+        let mut any_om_nan = false;
         for c in 0..nrhs {
             let src = &rhs[c * n..(c + 1) * n];
             let dst = &mut x_out[c * n..(c + 1) * n];
@@ -1881,9 +1887,17 @@ impl Solver {
             } else if o.relative_residual > agg.relative_residual {
                 agg.relative_residual = o.relative_residual;
             }
+            if o.backward_error.is_nan() {
+                any_om_nan = true;
+            } else if o.backward_error > agg.backward_error {
+                agg.backward_error = o.backward_error;
+            }
         }
         if any_nan {
             agg.relative_residual = f64::NAN;
+        }
+        if any_om_nan {
+            agg.backward_error = f64::NAN;
         }
         Ok(agg)
     }

--- a/src/sparse/csc.rs
+++ b/src/sparse/csc.rs
@@ -340,6 +340,34 @@ impl CscMatrix {
         }
     }
 
+    /// Absolute symmetric matrix-vector product: `y = |A| * |x|`.
+    ///
+    /// Same traversal as [`symv`](Self::symv) — stored lower triangle,
+    /// symmetry applied implicitly — with `abs` on both factors, so no
+    /// cancellation can occur and every partial sum is non-negative.
+    ///
+    /// This is the denominator of the componentwise backward error
+    /// `ω = maxᵢ |rᵢ| / (|A|·|x| + |b|)ᵢ` used by
+    /// [`StopCriterion::BackwardError`](crate::numeric::solve::StopCriterion::BackwardError).
+    /// It costs one pass over the stored entries and, unlike anything
+    /// derived from a condition-number estimate, **no extra solves**.
+    pub fn abs_symv(&self, x: &[f64], y: &mut [f64]) {
+        for yi in y.iter_mut().take(self.n) {
+            *yi = 0.0;
+        }
+        for j in 0..self.n {
+            let axj = x[j].abs();
+            for k in self.col_ptr[j]..self.col_ptr[j + 1] {
+                let i = self.row_idx[k];
+                let v = self.values[k].abs();
+                y[i] += v * axj;
+                if i != j {
+                    y[j] += v * x[i].abs();
+                }
+            }
+        }
+    }
+
     /// Convert to dense symmetric matrix.
     pub fn to_dense(&self) -> crate::dense::matrix::SymmetricMatrix {
         self.to_dense_into(Vec::new())
@@ -377,7 +405,79 @@ impl CscMatrix {
 
 #[cfg(test)]
 mod tests {
+    // --- `abs_symv` (issue #190) -------------------------------------
+    //
+    // `abs_symv` is the denominator of the componentwise backward error.
+    // Two properties pin it down: it agrees with `symv` whenever no sign
+    // can differ, and it does not agree when a sign can — the second is
+    // what would fail if `abs_symv` were accidentally aliased to `symv`.
+
     use super::*;
+
+    /// Lower triangle of [[4, 1, 0], [1, 3, 1], [0, 1, 2]].
+    fn sym3_positive() -> CscMatrix {
+        CscMatrix::from_triplets(
+            3,
+            &[0, 1, 1, 2, 2],
+            &[0, 0, 1, 1, 2],
+            &[4.0, 1.0, 3.0, 1.0, 2.0],
+        )
+        .expect("sym3")
+    }
+
+    #[test]
+    fn abs_symv_equals_symv_when_nothing_can_change_sign() {
+        let m = sym3_positive();
+        let x = [0.5, 0.25, 0.125];
+        let (mut a, mut b) = (vec![0.0; 3], vec![0.0; 3]);
+        m.symv(&x, &mut a);
+        m.abs_symv(&x, &mut b);
+        assert_eq!(a, b, "non-negative A and x: |A||x| must equal Ax");
+    }
+
+    #[test]
+    fn abs_symv_differs_from_symv_when_signs_cancel() {
+        // Same matrix, but x straddles zero so `symv` cancels and
+        // `abs_symv` cannot. This is the assertion that fails if
+        // `abs_symv` forgets either `abs`.
+        let m = sym3_positive();
+        let x = [1.0, -1.0, 1.0];
+        let (mut a, mut b) = (vec![0.0; 3], vec![0.0; 3]);
+        m.symv(&x, &mut a);
+        m.abs_symv(&x, &mut b);
+        // Row 0:  4*1 + 1*(-1) = 3   vs   4*1 + 1*1 = 5
+        assert_eq!(a[0], 3.0);
+        assert_eq!(b[0], 5.0);
+        // Row 1:  1*1 + 3*(-1) + 1*1 = -1  vs  1 + 3 + 1 = 5
+        assert_eq!(a[1], -1.0);
+        assert_eq!(b[1], 5.0);
+        // Row 2:  1*(-1) + 2*1 = 1   vs   1*1 + 2*1 = 3
+        assert_eq!(a[2], 1.0);
+        assert_eq!(b[2], 3.0);
+    }
+
+    #[test]
+    fn abs_symv_negates_both_factors_not_just_one() {
+        // A with negative entries, x non-negative: catches an
+        // implementation that took |x| but not |A|.
+        let m =
+            CscMatrix::from_triplets(2, &[0, 1, 1], &[0, 0, 1], &[-2.0, -3.0, -4.0]).expect("neg");
+        let x = [1.0, 1.0];
+        let mut y = vec![0.0; 2];
+        m.abs_symv(&x, &mut y);
+        assert_eq!(y, vec![5.0, 7.0]);
+    }
+
+    #[test]
+    fn abs_symv_handles_an_empty_column() {
+        // Structurally empty row/column 1 — the `d_i == 0` case that
+        // `backward_error` treats specially.
+        let m = CscMatrix::from_triplets(2, &[0], &[0], &[1.0]).expect("empty col");
+        let x = [1.0, 0.0];
+        let mut y = vec![0.0; 2];
+        m.abs_symv(&x, &mut y);
+        assert_eq!(y, vec![1.0, 0.0]);
+    }
 
     fn sample_3x3() -> CscMatrix {
         // [ 2 -1  0 ]

--- a/tests/issue190_componentwise_default.rs
+++ b/tests/issue190_componentwise_default.rs
@@ -180,11 +180,13 @@ fn normwise_criterion_alone_is_not_enough() {
         ("degenlpa", "DEGENLPA_0065", 1.89e-6),
         ("acopp14", "ACOPP14_0003", 6.42e-7),
     ];
+    let mut ran = 0usize;
     for (fam, stem, _measured) in cases {
         let p = PathBuf::from(format!("tests/data/parity/{fam}/{stem}.mtx"));
         if !p.exists() {
             continue;
         }
+        ran += 1;
         let (om_eps, om_default) = omegas(&p).unwrap_or_else(|| panic!("{stem}: solve failed"));
         assert!(
             om_eps > 10.0 * target,
@@ -198,11 +200,37 @@ fn normwise_criterion_alone_is_not_enough() {
              (EpsSqrtN gave {om_eps:.3e})"
         );
     }
+    // Without this the test passes vacuously if the `tests/data/parity`
+    // layout moves: every fixture would `continue` and nothing would be
+    // pinned. Its sibling guards the same way with `checked >= 60`.
+    assert_eq!(
+        ran,
+        cases.len(),
+        "only {ran} of {} pinned fixtures were found under tests/data/parity; \
+         this test pins the #190 regression and must not pass vacuously",
+        cases.len()
+    );
 }
 
-/// The default is the conjunction, so it can only ever refine *more* than
-/// the historical rule -- never less. This is what lets it ship without
-/// loosening any residual gate.
+/// The default is the conjunction, so it can only ever run *more* steps
+/// than the historical rule -- never fewer. This is what lets it ship
+/// without loosening any residual gate.
+///
+/// **This is an empirical corpus check, not an invariant the code
+/// guarantees.** More steps does not imply a smaller `ω`: best-iterate
+/// selection is still `min ‖r‖₂` (`solve.rs`, `if improved { best_omega
+/// = omega; ... }`), so a step that lowers the residual is free to raise
+/// the componentwise error. What the conjunction *does* guarantee is
+/// that the returned iterate is never worse **normwise** -- the
+/// `EpsSqrtN` half of the test still has to pass. The `ω` comparison
+/// below is the stronger statement, and it holds on every matrix in the
+/// tracked corpus today.
+///
+/// So a failure here is a finding to investigate, not necessarily a
+/// regression: it would mean a real matrix on which the extra
+/// componentwise steps land on a worse-`ω` iterate, which is the case
+/// for revisiting best-iterate selection. Do not silence it by
+/// weakening the comparison.
 #[test]
 fn default_is_never_weaker_than_the_historical_rule() {
     let paths = parity_matrices();

--- a/tests/issue190_componentwise_default.rs
+++ b/tests/issue190_componentwise_default.rs
@@ -1,0 +1,230 @@
+//! The default refinement criterion must certify *componentwise* accuracy.
+//!
+//! Before 2026-08-21 `RefineOptions::default()` stopped on
+//! `‖r‖₂ < ε·√n·‖b‖₂` alone. That test is normwise, so it is dominated by
+//! the rows carrying the largest right-hand-side entries. On a RHS whose
+//! entries span twelve orders of magnitude — the shape an interior-point
+//! method produces near convergence, where the dual, primal and
+//! complementarity blocks differ by many orders — it passes on the *raw*
+//! solve and refinement never runs, while the rows carrying the small
+//! entries are componentwise garbage.
+//!
+//! The oracle is canonical MUMPS 5.8.2 (`external_benchmarks/mumps_oracle`,
+//! `ICNTL(10)=2`, `ICNTL(11)=1`), run on identical systems with identical
+//! right-hand sides. It returns `ω` at machine precision where FERAL
+//! returned as much as `9.5e-5`:
+//!
+//! | matrix | FERAL ω, old default | MUMPS ω1 |
+//! |---|---:|---:|
+//! | `r05_kkt` | 9.520e-5 | 3.608e-16 |
+//! | `bratu3d` | 8.953e-6 | 2.844e-16 |
+//! | `cont-201` | 3.860e-7 | 2.728e-16 |
+//!
+//! So `ω ≤ √ε` is attainable on these systems and FERAL was simply not
+//! trying. Those three fixtures are gitignored (`tests/data/large/*`), so
+//! this test runs the same experiment on the tracked parity corpus, where
+//! the defect reproduces on 13 of 63 matrices.
+//!
+//! See `dev/research/issue-190-refine-target.md`, addendum 2026-08-21.
+
+use feral::numeric::solve::{RefineOptions, StopCriterion};
+use feral::{read_mtx, CscMatrix, FactorStatus, Solver};
+use std::path::{Path, PathBuf};
+
+/// Arioli-Demmel-Duff componentwise backward error, LAPACK `dgerfs`'s
+/// guarded form. `ω ≤ u` certifies that `x` solves `(A+δA)x = b+δb`
+/// exactly with `|δA| ≤ ω|A|` and `|δb| ≤ ω|b|`, entry by entry.
+fn omega(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    a.symv(x, &mut ax);
+    let r: Vec<f64> = (0..n).map(|i| b[i] - ax[i]).collect();
+    let mut d = vec![0.0f64; n];
+    a.abs_symv(x, &mut d);
+    let safe1 = ((n + 1) as f64) * f64::MIN_POSITIVE;
+    let safe2 = safe1 / f64::EPSILON;
+    let mut om = 0.0f64;
+    for i in 0..n {
+        let den = d[i] + b[i].abs();
+        if den == 0.0 {
+            continue;
+        }
+        let v = if den > safe2 {
+            r[i].abs() / den
+        } else {
+            (r[i].abs() + safe1) / (den + safe1)
+        };
+        if v > om {
+            om = v;
+        }
+    }
+    om
+}
+
+/// `b = A·v` with `v[i] = ±10^((i%13)-6)` — entries spanning `1e-6..1e6`.
+fn badly_scaled_rhs(a: &CscMatrix) -> Vec<f64> {
+    let n = a.n;
+    let v: Vec<f64> = (0..n)
+        .map(|i| {
+            let mag = 10f64.powi(((i % 13) as i32) - 6);
+            if i % 2 == 0 {
+                mag
+            } else {
+                -mag
+            }
+        })
+        .collect();
+    let mut b = vec![0.0f64; n];
+    a.symv(&v, &mut b);
+    b
+}
+
+fn parity_matrices() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(fams) = std::fs::read_dir(Path::new("tests/data/parity")) else {
+        return out;
+    };
+    for fam in fams.flatten() {
+        let Ok(files) = std::fs::read_dir(fam.path()) else {
+            continue;
+        };
+        for f in files.flatten() {
+            let p = f.path();
+            if p.extension().map(|e| e == "mtx").unwrap_or(false) {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// `(ω under EpsSqrtN, ω under the shipped default)`.
+fn omegas(path: &Path) -> Option<(f64, f64)> {
+    let csc = read_mtx(path).ok()?.to_csc().ok()?;
+    let n = csc.n;
+    let b = badly_scaled_rhs(&csc);
+    let mut s = Solver::new();
+    if !matches!(
+        s.factor(&csc, None),
+        FactorStatus::Success | FactorStatus::WrongInertia { .. }
+    ) {
+        return None;
+    }
+    let mut xe = vec![0.0f64; n];
+    s.solve_refined_into(
+        &csc,
+        &b,
+        &mut xe,
+        RefineOptions::default().and_stop(StopCriterion::EpsSqrtN),
+    )
+    .ok()?;
+    let mut xd = vec![0.0f64; n];
+    s.solve_refined_into(&csc, &b, &mut xd, RefineOptions::default())
+        .ok()?;
+    Some((omega(&csc, &xe, &b), omega(&csc, &xd, &b)))
+}
+
+/// Every matrix the corpus can factor must come back backward stable
+/// under the shipped default, on a right-hand side the old normwise rule
+/// declared converged at once.
+#[test]
+fn default_certifies_backward_stability_on_badly_scaled_rhs() {
+    let target = f64::EPSILON.sqrt();
+    let paths = parity_matrices();
+    assert!(
+        paths.len() >= 60,
+        "parity corpus missing: found {} matrices",
+        paths.len()
+    );
+    let mut bad: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+    for p in &paths {
+        let Some((_, om_default)) = omegas(p) else {
+            continue;
+        };
+        checked += 1;
+        if om_default > target {
+            bad.push(format!(
+                "{}: omega = {:.3e} > sqrt(eps) = {:.3e}",
+                p.display(),
+                om_default,
+                target
+            ));
+        }
+    }
+    assert!(checked >= 60, "only {checked} matrices factored");
+    assert!(
+        bad.is_empty(),
+        "RefineOptions::default() left omega above sqrt(eps) on {} matrix/matrices:\n  {}",
+        bad.len(),
+        bad.join("\n  ")
+    );
+}
+
+/// The defect this default exists to fix, pinned so it cannot silently
+/// return: on these matrices the normwise rule stops at step 0 with a
+/// componentwise error orders of magnitude above `√ε`, and the shipped
+/// default drives it to machine precision.
+///
+/// Values are the `EpsSqrtN` omegas measured 2026-08-21; the assertions
+/// are one-sided (`> 10·√ε`) so ordinary numerical drift cannot flip them.
+#[test]
+fn normwise_criterion_alone_is_not_enough() {
+    let target = f64::EPSILON.sqrt();
+    // (family, stem, omega under EpsSqrtN as measured)
+    let cases = [
+        ("degenlpb", "DEGENLPB_0046", 5.35e-6),
+        ("degenlpb", "DEGENLPB_0045", 4.48e-6),
+        ("degenlpb", "DEGENLPB_0047", 2.69e-6),
+        ("degenlpa", "DEGENLPA_0065", 1.89e-6),
+        ("acopp14", "ACOPP14_0003", 6.42e-7),
+    ];
+    for (fam, stem, _measured) in cases {
+        let p = PathBuf::from(format!("tests/data/parity/{fam}/{stem}.mtx"));
+        if !p.exists() {
+            continue;
+        }
+        let (om_eps, om_default) = omegas(&p).unwrap_or_else(|| panic!("{stem}: solve failed"));
+        assert!(
+            om_eps > 10.0 * target,
+            "{stem}: EpsSqrtN omega = {om_eps:.3e} is no longer above 10*sqrt(eps) = {:.3e}; \
+             the fixture no longer exercises the defect this default fixes",
+            10.0 * target
+        );
+        assert!(
+            om_default <= target,
+            "{stem}: default omega = {om_default:.3e} > sqrt(eps) = {target:.3e} \
+             (EpsSqrtN gave {om_eps:.3e})"
+        );
+    }
+}
+
+/// The default is the conjunction, so it can only ever refine *more* than
+/// the historical rule -- never less. This is what lets it ship without
+/// loosening any residual gate.
+#[test]
+fn default_is_never_weaker_than_the_historical_rule() {
+    let paths = parity_matrices();
+    let mut worse: Vec<String> = Vec::new();
+    for p in &paths {
+        let Some((om_eps, om_default)) = omegas(p) else {
+            continue;
+        };
+        // Allow exact equality (the common case: the normwise rule was
+        // already sufficient and no extra step ran).
+        if om_default > om_eps {
+            worse.push(format!(
+                "{}: default {:.3e} > EpsSqrtN {:.3e}",
+                p.display(),
+                om_default,
+                om_eps
+            ));
+        }
+    }
+    assert!(
+        worse.is_empty(),
+        "default produced a worse componentwise error than EpsSqrtN on:\n  {}",
+        worse.join("\n  ")
+    );
+}

--- a/tests/issue190_refine_target.rs
+++ b/tests/issue190_refine_target.rs
@@ -1,0 +1,382 @@
+//! Issue #190 — a caller-settable *target* for iterative refinement, and
+//! a report of what the refinement actually did.
+//!
+//! #178 made the step budget per-call. #190's finding is that the budget
+//! is the wrong knob: on a large near-singular KKT the hardwired `ε·√n`
+//! target is unreachable, so the loop runs to the cap on every call and
+//! the cap becomes the de-facto stopping rule — one that was not monotone
+//! in outcome across a 118-problem corpus.
+//!
+//! Two asks, tested here:
+//!   1. `RefineOptions::stop` — `EpsSqrtN` (unchanged default),
+//!      `RelativeResidual(t)`, `BackwardError(t)`.
+//!   2. The `*_into` entry points return a `RefineOutcome` saying how
+//!      many corrections ran, how good the returned iterate is, and
+//!      **which exit fired** — the last being what back-solve wall time
+//!      cannot tell a host.
+//!
+//! Design note: `dev/research/issue-190-refine-target.md`.
+//!
+//! **Where the target constants come from.** They are not round numbers
+//! picked to look tidy — a target below what the fixture can reach tests
+//! the cap, not the criterion. Measured ladder for `full_budget_case()`,
+//! single RHS, one row per correction step:
+//!
+//! ```text
+//!   k:      1        2        3        4        5
+//!   rel: 2.37e-3  7.74e-4  2.55e-4  8.38e-5  2.76e-5
+//!   ome: 1.21e-3  4.85e-4  1.66e-4  5.53e-5  1.82e-5
+//!   k:      6        7        8        9       10
+//!   rel: 9.07e-6  2.99e-6  9.82e-7  3.23e-7  1.06e-7
+//!   ome: 6.01e-6  1.98e-6  6.51e-7  2.14e-7  7.05e-8
+//! ```
+//!
+//! So `1e-4` costs 4 steps, `1e-6` costs 8, and anything below ~`1e-7`
+//! is unreachable and runs to the cap. Tests that want a *reachable*
+//! target use the first two; `the_cap_still_wins_over_an_unreachable_target`
+//! deliberately uses the third case.
+
+use feral::numeric::factorize::{factorize_multifrontal, NumericParams, SparseFactors};
+use feral::numeric::solve::{
+    solve_sparse_many_refined_into, solve_sparse_refined, solve_sparse_refined_into, RefineOptions,
+    RefineStop, StopCriterion, DEFAULT_REFINE_MAX_STEPS,
+};
+use feral::symbolic::{symbolic_factorize, SupernodeParams};
+use feral::{BunchKaufmanParams, CscMatrix, FactorStatus, Solver, ZeroPivotAction};
+
+fn ldlt_params() -> NumericParams {
+    NumericParams::with_bk(BunchKaufmanParams {
+        on_zero_pivot: ZeroPivotAction::ForceAccept,
+        ..BunchKaufmanParams::default()
+    })
+}
+
+fn tridiag(n: usize, diag: impl Fn(usize) -> f64) -> CscMatrix {
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for j in 0..n {
+        rows.push(j);
+        cols.push(j);
+        vals.push(diag(j));
+        if j + 1 < n {
+            rows.push(j + 1);
+            cols.push(j);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiag")
+}
+
+fn factorize(m: &CscMatrix) -> SparseFactors {
+    let sym = symbolic_factorize(m, &SupernodeParams::default()).expect("symbolic");
+    let (f, _) = factorize_multifrontal(m, &sym, &ldlt_params()).expect("numeric");
+    f
+}
+
+const N: usize = 20;
+
+/// Same construction as `tests/issue178_refine_cap.rs`: factor `A + ΔA`
+/// and refine against `A`, so the correction is a genuinely approximate
+/// inverse and refinement converges *linearly* instead of bottoming out
+/// on roundoff. With a 1 % diagonal perturbation the residual falls ~3.3×
+/// per step and never reaches `ε·√n`, so the default run uses all ten
+/// corrections. That is exactly the situation #190 describes.
+fn full_budget_case() -> (CscMatrix, SparseFactors, Vec<f64>) {
+    let a = tridiag(N, |_| 2.0);
+    let perturbed = tridiag(N, |j| 2.0 + 1e-2 * (1.0 + (j as f64) * 0.01));
+    let factors = factorize(&perturbed);
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    (a, factors, rhs)
+}
+
+/// 100× smaller perturbation: refinement reaches `ε·√n` on its own, well
+/// inside the budget.
+fn early_exit_case() -> (CscMatrix, SparseFactors, Vec<f64>) {
+    let a = tridiag(N, |_| 2.0);
+    let perturbed = tridiag(N, |j| 2.0 + 1e-4 * (1.0 + (j as f64) * 0.01));
+    let factors = factorize(&perturbed);
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    (a, factors, rhs)
+}
+
+fn refine(
+    a: &CscMatrix,
+    f: &SparseFactors,
+    rhs: &[f64],
+    opts: RefineOptions,
+) -> (Vec<f64>, feral::RefineOutcome) {
+    let mut x = vec![0.0; a.n];
+    let o = solve_sparse_refined_into(a, f, rhs, &mut x, opts).expect("refine");
+    (x, o)
+}
+
+// --- guard: the fixtures still do what the tests assume ---------------
+
+#[test]
+fn the_full_budget_case_really_does_run_to_the_cap() {
+    // If this stops holding, every "stops earlier than the default" test
+    // below becomes vacuous, so it is asserted separately and loudly.
+    let (a, f, rhs) = full_budget_case();
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::default());
+    assert_eq!(o.steps, DEFAULT_REFINE_MAX_STEPS, "outcome: {o:?}");
+    assert_eq!(o.stop, RefineStop::MaxSteps, "outcome: {o:?}");
+}
+
+#[test]
+fn the_early_exit_case_really_does_converge_on_its_own() {
+    let (a, f, rhs) = early_exit_case();
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::default());
+    assert_eq!(o.stop, RefineStop::Converged, "outcome: {o:?}");
+    assert!(o.steps < DEFAULT_REFINE_MAX_STEPS, "outcome: {o:?}");
+}
+
+// --- ask 1: the target is settable -----------------------------------
+
+#[test]
+fn the_default_criterion_is_bit_for_bit_the_historical_behavior() {
+    // The no-regression gate. `EpsSqrtN` keeps the strict `<` the old
+    // code had, so a caller that does not opt in runs the same
+    // arithmetic — not merely a close answer.
+    for (a, f, rhs) in [full_budget_case(), early_exit_case()] {
+        let before = solve_sparse_refined(&a, &f, &rhs).expect("refine");
+        let (after, _) = refine(&a, &f, &rhs, RefineOptions::default());
+        let lhs: Vec<u64> = before.iter().map(|v| v.to_bits()).collect();
+        let rhs_bits: Vec<u64> = after.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(lhs, rhs_bits, "default options must not change any bit");
+    }
+}
+
+#[test]
+fn a_loose_relative_target_stops_where_the_default_runs_to_the_cap() {
+    let (a, f, rhs) = full_budget_case();
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::with_target(1e-6));
+    assert_eq!(o.stop, RefineStop::Converged, "outcome: {o:?}");
+    assert!(
+        o.steps < DEFAULT_REFINE_MAX_STEPS,
+        "a reachable target must cost fewer steps than the cap: {o:?}"
+    );
+    assert!(
+        o.relative_residual <= 1e-6,
+        "reported Converged, so the target must actually be met: {o:?}"
+    );
+}
+
+#[test]
+fn a_tighter_relative_target_costs_more_steps_than_a_looser_one() {
+    // Monotonicity in the *target* is the property the step cap did not
+    // have (#190's corpus table). Assert it directly.
+    //
+    // Targets come from the fixture's measured ladder (see the module
+    // comment): it contracts ~3.0x per step from 2.4e-3, so 1e-4 lands at
+    // 4 corrections and 1e-6 at 8. Both are above the 10-step floor of
+    // 1.06e-7, so both are genuinely reachable and this test is about
+    // monotonicity, not about the cap.
+    let (a, f, rhs) = full_budget_case();
+    let (_, loose) = refine(&a, &f, &rhs, RefineOptions::with_target(1e-4));
+    let (_, tight) = refine(&a, &f, &rhs, RefineOptions::with_target(1e-6));
+    assert_eq!(loose.stop, RefineStop::Converged, "loose: {loose:?}");
+    assert_eq!(tight.stop, RefineStop::Converged, "tight: {tight:?}");
+    assert!(
+        loose.steps < tight.steps,
+        "loose {loose:?} should be cheaper than tight {tight:?}"
+    );
+    assert!(loose.relative_residual <= 1e-4);
+    assert!(tight.relative_residual <= 1e-6);
+}
+
+#[test]
+fn a_backward_error_target_stops_early_too() {
+    let (a, f, rhs) = full_budget_case();
+    // 1e-6 is reachable here; the fixture's omega floor at the cap is
+    // 7.05e-8, so anything tighter than ~1e-7 would test the cap instead.
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::with_backward_error(1e-6));
+    assert_eq!(o.stop, RefineStop::Converged, "outcome: {o:?}");
+    assert!(o.steps < DEFAULT_REFINE_MAX_STEPS, "outcome: {o:?}");
+}
+
+#[test]
+fn a_tighter_backward_error_target_costs_more_steps() {
+    let (a, f, rhs) = full_budget_case();
+    let (_, loose) = refine(&a, &f, &rhs, RefineOptions::with_backward_error(1e-4));
+    let (_, tight) = refine(&a, &f, &rhs, RefineOptions::with_backward_error(1e-6));
+    assert_eq!(loose.stop, RefineStop::Converged, "loose: {loose:?}");
+    assert_eq!(tight.stop, RefineStop::Converged, "tight: {tight:?}");
+    assert!(
+        loose.steps < tight.steps,
+        "loose {loose:?} should be cheaper than tight {tight:?}"
+    );
+}
+
+#[test]
+fn the_cap_still_wins_over_an_unreachable_target() {
+    // #178's invariant, re-asserted under the new criteria: a target
+    // never *extends* the run past the budget.
+    let (a, f, rhs) = full_budget_case();
+    let opts = RefineOptions::with_target(0.0).and_max_steps(3);
+    let (_, o) = refine(&a, &f, &rhs, opts);
+    assert_eq!(o.steps, 3, "outcome: {o:?}");
+    assert_eq!(o.stop, RefineStop::MaxSteps, "outcome: {o:?}");
+}
+
+#[test]
+fn a_met_target_never_adds_work_when_the_cap_is_raised() {
+    // The other half of #178's invariant: raising `max_steps` cannot add
+    // work to a run that has already reached its target. Checked under
+    // all three criteria, since each has its own exit test.
+    let (a, f, rhs) = early_exit_case();
+    for stop in [
+        StopCriterion::EpsSqrtN,
+        StopCriterion::RelativeResidual(1e-6),
+        StopCriterion::BackwardError(1e-6),
+    ] {
+        let ten = refine(&a, &f, &rhs, RefineOptions::default().and_stop(stop)).1;
+        let hundred = refine(
+            &a,
+            &f,
+            &rhs,
+            RefineOptions::default().and_stop(stop).and_max_steps(100),
+        )
+        .1;
+        assert_eq!(ten.steps, hundred.steps, "{stop:?}: {ten:?} vs {hundred:?}");
+        assert_eq!(ten.stop, RefineStop::Converged, "{stop:?}: {ten:?}");
+    }
+}
+
+#[test]
+fn builders_compose_in_either_order() {
+    let a = RefineOptions::with_target(1e-7).and_max_steps(4);
+    let b = RefineOptions::with_max_steps(4).and_stop(StopCriterion::RelativeResidual(1e-7));
+    assert_eq!(a, b);
+    assert_eq!(a.max_steps, 4);
+    assert_eq!(a.stop, StopCriterion::RelativeResidual(1e-7));
+}
+
+// --- ask 2: the outcome is surfaced ----------------------------------
+
+#[test]
+fn max_steps_zero_reports_max_steps_and_a_nan_residual() {
+    // #178 requires `k = 0` to cost exactly what an unrefined solve
+    // costs, so no residual is formed and there is nothing honest to
+    // report. NaN says "not computed" rather than inventing a 0.0 that
+    // would read as a perfect solve.
+    let (a, f, rhs) = full_budget_case();
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::with_max_steps(0));
+    assert_eq!(o.steps, 0, "outcome: {o:?}");
+    assert_eq!(o.stop, RefineStop::MaxSteps, "outcome: {o:?}");
+    assert!(o.relative_residual.is_nan(), "outcome: {o:?}");
+}
+
+#[test]
+fn a_stagnating_run_is_reported_as_stagnated_not_as_the_cap() {
+    // Refining an *exact* factor bottoms out on roundoff in two or three
+    // steps. Distinguishing that from "the budget bound" is the whole
+    // point of `RefineStop` — back-solve wall time cannot.
+    let a = tridiag(N, |_| 2.0);
+    let f = factorize(&a);
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    let (_, o) = refine(&a, &f, &rhs, RefineOptions::with_target(0.0));
+    assert_eq!(
+        o.stop,
+        RefineStop::Stagnated,
+        "an exactly-factored system under an unreachable target must \
+         bottom out, not exhaust the budget: {o:?}"
+    );
+    assert!(o.steps < DEFAULT_REFINE_MAX_STEPS, "outcome: {o:?}");
+}
+
+#[test]
+fn the_solver_entry_point_surfaces_the_same_outcome() {
+    // #190's actual ask: a host calls `Solver`, not the free functions.
+    let a = tridiag(N, |_| 2.0);
+    let perturbed = tridiag(N, |j| 2.0 + 1e-2 * (1.0 + (j as f64) * 0.01));
+    let mut s = Solver::new();
+    let st = s.factor(&perturbed, None);
+    assert!(
+        matches!(st, FactorStatus::Success),
+        "factor must succeed for this test to mean anything, got {st:?}"
+    );
+    let rhs: Vec<f64> = (0..N).map(|i| ((i % 7) as f64) - 3.0).collect();
+    let mut x = vec![0.0; N];
+    let o = s
+        .solve_refined_into(&a, &rhs, &mut x, RefineOptions::default())
+        .expect("solve_refined_into");
+    assert_eq!(o.steps, DEFAULT_REFINE_MAX_STEPS, "outcome: {o:?}");
+    assert_eq!(o.stop, RefineStop::MaxSteps, "outcome: {o:?}");
+}
+
+// --- multi-RHS -------------------------------------------------------
+
+/// Three columns whose per-column difficulty differs, so the aggregation
+/// has something to aggregate.
+fn many_rhs(n: usize, nrhs: usize) -> Vec<f64> {
+    let mut b = vec![0.0; n * nrhs];
+    for c in 0..nrhs {
+        for i in 0..n {
+            b[c * n + i] = ((i % 7) as f64) - 3.0 + (c as f64) * 0.5;
+        }
+    }
+    b
+}
+
+#[test]
+fn the_multi_rhs_outcome_is_the_max_over_columns() {
+    for &nrhs in &[3usize, 20] {
+        let (a, f, _) = full_budget_case();
+        let b = many_rhs(N, nrhs);
+        let mut x = vec![0.0; N * nrhs];
+        let opts = RefineOptions::with_target(1e-6);
+        let agg =
+            solve_sparse_many_refined_into(&a, &f, &b, nrhs, &mut x, opts).expect("many refined");
+
+        let mut want_steps = 0usize;
+        let mut want_rel = 0.0f64;
+        for c in 0..nrhs {
+            let (_, o) = refine(&a, &f, &b[c * N..(c + 1) * N], opts);
+            want_steps = want_steps.max(o.steps);
+            want_rel = want_rel.max(o.relative_residual);
+        }
+        assert_eq!(agg.steps, want_steps, "nrhs = {nrhs}: {agg:?}");
+        assert!(
+            (agg.relative_residual - want_rel).abs() <= 1e-15 * want_rel.max(1e-300),
+            "nrhs = {nrhs}: aggregated {:e} vs per-column max {want_rel:e}",
+            agg.relative_residual
+        );
+    }
+}
+
+#[test]
+fn the_multi_rhs_path_honors_each_criterion_per_column() {
+    let (a, f, _) = full_budget_case();
+    let nrhs = 20;
+    let b = many_rhs(N, nrhs);
+    // The relative target has to be looser than the single-RHS one: the
+    // worst column's 10-step floor is 4.46e-6, 42x the best column's
+    // 1.06e-7, because ||b|| varies across columns. omega does not spread
+    // that way (2.86e-8 to 7.05e-8 across the same 20 columns), which is
+    // the scale-awareness the criterion exists for.
+    for (opts, name) in [
+        (RefineOptions::with_target(1e-4), "relative"),
+        (RefineOptions::with_backward_error(1e-6), "backward"),
+    ] {
+        let mut x = vec![0.0; N * nrhs];
+        let o =
+            solve_sparse_many_refined_into(&a, &f, &b, nrhs, &mut x, opts).expect("many refined");
+        assert_eq!(o.stop, RefineStop::Converged, "{name}: {o:?}");
+        assert!(o.steps < DEFAULT_REFINE_MAX_STEPS, "{name}: {o:?}");
+
+        // Every column must independently satisfy the criterion, not
+        // merely the aggregate.
+        for c in 0..nrhs {
+            let (single, so) = refine(&a, &f, &b[c * N..(c + 1) * N], opts);
+            let batched = &x[c * N..(c + 1) * N];
+            assert_eq!(so.stop, RefineStop::Converged, "{name} col {c}: {so:?}");
+            let bits_a: Vec<u64> = single.iter().map(|v| v.to_bits()).collect();
+            let bits_b: Vec<u64> = batched.iter().map(|v| v.to_bits()).collect();
+            assert_eq!(
+                bits_a, bits_b,
+                "{name} col {c}: batched and per-column refiners must agree bit-for-bit"
+            );
+        }
+    }
+}

--- a/tests/issue190_refine_target.rs
+++ b/tests/issue190_refine_target.rs
@@ -380,3 +380,236 @@ fn the_multi_rhs_path_honors_each_criterion_per_column() {
         }
     }
 }
+
+// --- ask 2b: the outcome reports ω, not just the normwise residual ----
+//
+// The downstream question on PR #191 was whether `RefineOutcome` carries
+// the achieved backward error as well as the step count. It does, and
+// these tests pin what the number means. The point of the field is that
+// 0.18.0 makes ω *the thing being certified* by the default criterion —
+// a host that gets `Converged` back and wants to log or threshold on the
+// certificate should not have to recompute it with a second `abs_symv`.
+
+/// ω computed straight from the Arioli-Demmel-Duff definition
+/// `ω = maxᵢ |rᵢ| / (|A|·|x| + |b|)ᵢ`, with its own residual and its own
+/// traversal of the stored lower triangle. Deliberately does **not** call
+/// `CscMatrix::abs_symv` or anything in `numeric::solve`, so it is an
+/// independent oracle for what the refiner reports.
+///
+/// The production version carries LAPACK `dgerfs`'s `safe1`/`safe2`
+/// guard for denominators near underflow. These fixtures are the
+/// `tridiag(20, 2.0)` family with an O(1) right-hand side, so every
+/// denominator is O(1) — some twenty orders above the guard's cutoff —
+/// and the guarded and unguarded forms agree to the last bit.
+fn omega_by_definition(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut ax = vec![0.0f64; n];
+    let mut den = vec![0.0f64; n];
+    for j in 0..n {
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let i = a.row_idx[k];
+            let v = a.values[k];
+            ax[i] += v * x[j];
+            den[i] += v.abs() * x[j].abs();
+            if i != j {
+                ax[j] += v * x[i];
+                den[j] += v.abs() * x[i].abs();
+            }
+        }
+    }
+    let mut om = 0.0f64;
+    for i in 0..n {
+        let d = den[i] + b[i].abs();
+        assert!(d > 1e-8, "fixture denominator {d:e} is near the guard");
+        let t = (b[i] - ax[i]).abs() / d;
+        if t > om {
+            om = t;
+        }
+    }
+    om
+}
+
+#[test]
+fn the_reported_omega_is_the_omega_of_the_returned_iterate() {
+    let (a, f, rhs) = full_budget_case();
+    // Every criterion that actually forms ω. `full_budget_case` cannot
+    // reach `√ε`, so these run to the cap and the returned iterate is
+    // the best one seen -- exactly the case where a host wants to know
+    // how close refinement got.
+    let criteria = [
+        StopCriterion::BackwardError(1e-4),
+        StopCriterion::BackwardError(f64::EPSILON.sqrt()),
+        StopCriterion::EpsSqrtNAndBackwardError(f64::EPSILON.sqrt()),
+    ];
+    for stop in criteria {
+        let (x, o) = refine(
+            &a,
+            &f,
+            &rhs,
+            RefineOptions {
+                stop,
+                ..RefineOptions::default()
+            },
+        );
+        let expect = omega_by_definition(&a, &x, &rhs);
+        assert!(
+            o.backward_error.is_finite(),
+            "{stop:?}: reported ω must be a measurement, got {:e}",
+            o.backward_error
+        );
+        let rel = (o.backward_error - expect).abs() / expect;
+        assert!(
+            rel < 1e-12,
+            "{stop:?}: reported ω {:e} != recomputed {expect:e} (rel {rel:e})",
+            o.backward_error
+        );
+    }
+}
+
+#[test]
+fn omega_is_reported_as_not_measured_under_the_normwise_criteria() {
+    // `NaN` means "not formed", and is deliberately distinct from
+    // `INFINITY`, which the refiner reports for a non-finite iterate.
+    // Leaking the internal `INFINITY` sentinel here would read as a
+    // catastrophically bad solve on a run that converged fine.
+    let (a, f, rhs) = early_exit_case();
+    for stop in [
+        StopCriterion::EpsSqrtN,
+        StopCriterion::RelativeResidual(1e-4),
+    ] {
+        let (_, o) = refine(
+            &a,
+            &f,
+            &rhs,
+            RefineOptions {
+                stop,
+                ..RefineOptions::default()
+            },
+        );
+        assert_eq!(o.stop, RefineStop::Converged, "{stop:?}: {o:?}");
+        assert!(
+            o.backward_error.is_nan(),
+            "{stop:?}: ω was never formed, must report NaN, got {:e}",
+            o.backward_error
+        );
+    }
+}
+
+#[test]
+fn omega_is_reported_as_not_measured_when_the_budget_is_zero() {
+    // Issue #178 requires `max_steps = 0` to cost exactly an unrefined
+    // solve, so no residual and no ω are formed -- same reasoning as
+    // `relative_residual` being NaN on this path.
+    let (a, f, rhs) = early_exit_case();
+    let (_, o) = refine(
+        &a,
+        &f,
+        &rhs,
+        RefineOptions {
+            max_steps: 0,
+            ..RefineOptions::default()
+        },
+    );
+    assert!(o.relative_residual.is_nan(), "{o:?}");
+    assert!(o.backward_error.is_nan(), "{o:?}");
+}
+
+#[test]
+fn the_multi_rhs_outcome_reports_the_worst_column_omega() {
+    // Two aggregations, written independently and both checked here:
+    // the batched refiner's own fold over `best_om`, and the fold in
+    // `Solver::solve_many_refined_into`, which for `nrhs` below
+    // BLAS3_REFINE_THRESHOLD loops per column and combines the
+    // single-RHS outcomes itself. #190 requires the two dispatch paths
+    // report identically, so `nrhs = 2` (the IPM width, narrow path) and
+    // `nrhs = 40` (batched path) are both run through the `Solver` as
+    // well as through the free function.
+    let (a, f, _rhs1) = full_budget_case();
+    let perturbed = tridiag(N, |j| 2.0 + 1e-2 * (1.0 + (j as f64) * 0.01));
+    let mut solver = Solver::new();
+    let st = solver.factor(&perturbed, None);
+    assert!(matches!(st, FactorStatus::Success), "factor: {st:?}");
+    let opts = RefineOptions {
+        stop: StopCriterion::BackwardError(1e-4),
+        ..RefineOptions::default()
+    };
+    for nrhs in [2usize, 40] {
+        // Each column rotates the base RHS pattern and rescales by an
+        // O(1) factor, so the columns have genuinely different ω and the
+        // max fold is exercised. Deliberately *not* a 10^-c ladder: that
+        // pushes the small columns' denominators toward the `dgerfs`
+        // underflow guard, where the oracle's unguarded formula stops
+        // agreeing with the production one for reasons that have nothing
+        // to do with what this test is asserting.
+        let mut rhs = vec![0.0; N * nrhs];
+        for c in 0..nrhs {
+            let s = 1.0 + 0.25 * (c as f64);
+            for i in 0..N {
+                rhs[c * N + i] = (((i + 2 * c) % 7) as f64 - 3.0) * s;
+            }
+        }
+        let mut x = vec![0.0; N * nrhs];
+        let o = solve_sparse_many_refined_into(&a, &f, &rhs, nrhs, &mut x, opts).expect("many");
+        let worst = (0..nrhs)
+            .map(|c| omega_by_definition(&a, &x[c * N..(c + 1) * N], &rhs[c * N..(c + 1) * N]))
+            .fold(0.0f64, f64::max);
+        assert!(
+            o.backward_error.is_finite(),
+            "nrhs={nrhs}: {:e}",
+            o.backward_error
+        );
+        let rel = (o.backward_error - worst).abs() / worst;
+        assert!(
+            rel < 1e-12,
+            "nrhs={nrhs}: reported ω {:e} != worst column {worst:e} (rel {rel:e})",
+            o.backward_error
+        );
+
+        // Same problem through the `Solver`, which at nrhs = 2 takes the
+        // per-column loop and its separately written fold.
+        let mut xs = vec![0.0; N * nrhs];
+        let os = solver
+            .solve_many_refined_into(&a, &rhs, nrhs, &mut xs, opts)
+            .expect("solver many");
+        let rel = (os.backward_error - worst).abs() / worst;
+        assert!(
+            rel < 1e-12,
+            "nrhs={nrhs}: Solver reported ω {:e} != worst column {worst:e} (rel {rel:e})",
+            os.backward_error
+        );
+    }
+}
+
+#[test]
+fn the_solver_multi_rhs_path_also_reports_omega_as_not_measured() {
+    // The narrow path's fold is written separately from the batched
+    // one, so its "not measured" case needs its own check: a max fold
+    // over NaN silently yields 0.0, which would read as a *perfect*
+    // backward error on a run that never formed ω at all.
+    let perturbed = tridiag(N, |j| 2.0 + 1e-4 * (1.0 + (j as f64) * 0.01));
+    let a = tridiag(N, |_| 2.0);
+    let mut solver = Solver::new();
+    let st = solver.factor(&perturbed, None);
+    assert!(matches!(st, FactorStatus::Success), "factor: {st:?}");
+    for nrhs in [2usize, 40] {
+        let rhs = many_rhs(N, nrhs);
+        let mut x = vec![0.0; N * nrhs];
+        let o = solver
+            .solve_many_refined_into(
+                &a,
+                &rhs,
+                nrhs,
+                &mut x,
+                RefineOptions {
+                    stop: StopCriterion::EpsSqrtN,
+                    ..RefineOptions::default()
+                },
+            )
+            .expect("solver many");
+        assert!(
+            o.backward_error.is_nan(),
+            "nrhs={nrhs}: ω never formed, must be NaN, got {:e}",
+            o.backward_error
+        );
+    }
+}


### PR DESCRIPTION
## Read this first: breaking API change, and a measured cost

**Breaking.** Three `Solver` methods now return `Result<RefineOutcome, FeralError>`
where 0.17.0 returned `Result<(), FeralError>`:

- `Solver::solve_refined_into`
- `Solver::solve_many_refined_into`
- the parallel refined entry point reached from `solve_refined_into`

Any caller using the result in *expression* position — a `match` arm, a tail
expression in a function returning `Result<(), _>`, a `let () =` binding — fails
with `E0308`. pounce does not compile against this branch until its call sites
add `.map(|_| ())`. Adding `stop` to `RefineOptions` is source-compatible, so the
return type is the only break. Under 0.x semver **this makes the next release
0.18.0, not 0.17.1.**

The CHANGELOG previously claimed "existing callers compile unchanged — the new
return value is not `#[must_use]`." That was wrong: `#[must_use]` governs whether
*discarding* a value warns, not the value's type. Corrected in this branch.

**The componentwise default costs latency.** A controlled A/B over the corpus —
same binary, only the `RefineOptions::default()` stop criterion differing:

| ratio | control (`EpsSqrtN`) | shipped default | delta |
|---|---:|---:|---:|
| factor/MUMPS p90 | 1.54 | 1.56 | +1.3% (noise) |
| solve/MUMPS geomean | 0.08 | 0.08 | none |
| solve/MUMPS p50 | 0.08 | 0.08 | none |
| solve/MUMPS p90 | 0.15 | 0.20 | **+33%** |
| solve/MUMPS p99 | 0.71 | 1.08 | **+52%** |
| solve/SSIDS geomean | 0.94 | 1.06 | **+13%** |
| solve/SSIDS p90 | 2.50 | 3.60 | **+44%** |
| solve/SSIDS p99 | 8.33 | 13.00 | **+56%** |

**And on at least one real workload it is not a tail effect — it is the whole
run.** Measured downstream in pounce on `laptime` (58,014 variables, L-BFGS,
126,028-dimension KKT, 60 IPM iterations), one binary, arms differing only in the
`StopCriterion`:

| stop criterion | overall | factor | back-solve | vs `EpsSqrtN` |
|---|---:|---:|---:|---:|
| `EpsSqrtN` (0.17.0's default) | 58.6 s | 9.27 s | 46.7 s | — |
| refinement off | 13.9 s | 5.85 s | 5.44 s | -76% |
| `RelativeResidual(1e-10)` | 22.8 s | 6.48 s | 13.77 s | -61% |
| **this PR's default** | 69.4 s | 10.39 s | 56.4 s | **+18%** |

+18% overall and +21% on back-solve, on every iteration. `dirichlet120` (exact
Hessian) is factorization-dominated and does not discriminate — all four arms
reach `Optimal` in 56 iterations at the same objective.

Whether the conjunctive default is right is a reviewer decision. The alternative
is to keep `EpsSqrtN` as the default and let callers opt in — `f547bc5` makes
that work either way, and it is a one-line change to the `Default` impl at
`src/numeric/solve.rs:2140`.

---

## What the deficiency was

pounce reported that feral works on the vast majority of problems but fails on a
class of them where MA57/MUMPS succeed. Four hypotheses were ruled out by
measurement — `ForceAccept`, the pivot threshold, the escalation ladder, and
inertia. None of them was the gap.

The gap is the **stopping criterion**. Iterative refinement stopped on the
normwise residual `‖r‖₂/‖b‖₂`, which is dominated by the rows with the largest
`|bᵢ|`. When an interior-point method drives components of the RHS across many
orders of magnitude — the shape a KKT system takes near convergence — a solution
can satisfy the normwise test while individual components are badly wrong.
MUMPS stops on the componentwise backward error instead
(`CNTL(2) = sqrt(eps)`, `ref/mumps/src/dini_defaults.F:1094`), reached through
`ICNTL(10)`.

feral had no way to ask for that. Now it does, and it is the default:

```rust
StopCriterion::EpsSqrtNAndBackwardError(DEFAULT_BACKWARD_ERROR_TARGET)
```

The conjunction, not a replacement — `BackwardError(√ε)` alone regresses
`tests/parity.rs` (`ROSZMAN1_0241 residual: feral=4.805e-14 > max(K*mumps=2.077e-14, floor=1.000e-14)`),
and `BackwardError(f64::EPSILON)` stagnates or exhausts the step budget on 5 of
7 large matrices. Both are recorded in `dev/tried-and-rejected.md`.

## Evidence

`tests/issue190_componentwise_default.rs`, three tests against tracked fixtures:

- **`default_certifies_backward_stability_on_badly_scaled_rhs`** — all 63
  factorable parity matrices return `ω ≤ √ε` under a RHS built as `b = A·v` with
  `v[i] = ±10^((i%13)-6)`.
- **`normwise_criterion_alone_is_not_enough`** — pins 5 named fixtures where the
  historical rule leaves `ω > 10·√ε`: `DEGENLPB_0046` (5.35e-6), `DEGENLPB_0045`
  (4.48e-6), `DEGENLPB_0047` (2.69e-6), `DEGENLPA_0065` (1.89e-6), `ACOPP14_0003`
  (6.42e-7). Assertions are one-sided so drift cannot flip them.
- **`default_is_never_weaker_than_the_historical_rule`** — the conjunction never
  yields a worse `ω` than `EpsSqrtN` on any corpus matrix.

`ω` is computed with LAPACK `dgerfs`'s guarded formula (Arioli–Demmel–Duff 1989),
so the oracle is external to this implementation.

**Full suite:** 956 tests pass. **Inertia gate:** 154531/154590 = 100.0%.
**Phase 2.8.1 partitions:** all four PASS, at the bottom of the observed band
(sparse 1.56/1.56, dense 1.58/2.00 against the 08-19-05 baseline of
1.58/1.58/1.58/2.00).

## Also in this branch

Two independent threads that were already sitting unpushed on local `main`:

- **`a0b4d64` — multi-RHS cache-line stride.** The row-major multi-RHS work
  buffers used a leading dimension of exactly `nrhs`, so any `nrhs` not a
  multiple of 8 straddled a cache line on every panel row. `t(31)/t(32)` — where
  `nrhs = 31` is 3% *less* work — read 1.41–1.80 on seven matrices. Padding the
  panel path's row stride to `nrhs.div_ceil(8) * 8` brings it to 0.73–1.38.
  Measured gain in the regime that actually ships (`nrhs >= 32`, not a multiple
  of 8): **geomean 1.36x**. Bit-for-bit identical output, verified three ways
  including an 800-shape `to_bits()` sweep against a scalar reference.
  **This does not reach pounce**, which caps `nrhs` at 16 deliberately to stay
  under `BLAS3_NRHS_THRESHOLD` and keep the blocked solve bit-identical to
  looping (pounce gh#729). The 1.36x is real but downstream-invisible for that
  caller.
- **`f547bc5` — `StopCriterion`.** `EpsSqrtN` / `RelativeResidual(f64)` /
  `BackwardError(f64)` / `EpsSqrtNAndBackwardError(f64)`. Lets a caller state
  what convergence means instead of inheriting one hardcoded rule. This is also
  what retires pounce's `FeralConfig::refine_target` placeholder and the wasted
  unrefined pre-solve it guarded.

Plus four diagnostic probes (`001a7db`) that located the gap, and a docs commit
(`f5bc004`) removing unverifiable provenance numbers from `849caea`'s growth-flag
comments.

## Correction to an earlier claim

`crates/feral-diagnostics/src/bin/probe_vs_mumps_residual.rs` used to carry a
comment claiming feral fell "nine orders short" of MUMPS on residual. That was
wrong — it compared feral *unrefined* against MUMPS *with* refinement enabled.
Refined, feral matches or beats MUMPS on all seven large matrices under that RHS,
and inertia agrees exactly on all seven. The comment now says so.

## Open items, not addressed here

- `qap15_kkt` returns `ω = 1.229e-10` where MUMPS reaches 1.023e-12. Below the
  target, so it passes, but the gap is unexplained.
- The `residual_improvement_factor` plateau heuristic deserves its own issue.
- The `BLAS3_NRHS_THRESHOLD` doc comment still cites `multi-rhs.md` D3 as if it
  were a measurement; it is a pre-implementation rule of thumb.
- The six-file version bump to 0.18.0 (`scripts/release-checklist.sh bump
  0.18.0`) belongs to the release ritual, not this PR; the CHANGELOG now names
  0.18.0 as the target.

Closes #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAxgLjVsYe4oB2XRURmKG
