### PR TITLE
feat: add Solver::reset_quality() to bound escalation lifetime (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ All notable changes to FERAL will be documented in this file.
   binding `Solver.reset_quality()`). It reverts every escalation
   `increase_quality` applied — the `Identity → InfNorm` scaling flip and the
   raised `bk.pivot_threshold` — restoring the parameters the caller had
-  configured and returning `quality_level()` to `Baseline`. Returns `true` if
-  an escalation was undone, `false` if the solver was already at baseline.
-  Valid from any level, `Exhausted` included.
+  configured and returning `quality_level()` to `Baseline`. Valid from any
+  level, `Exhausted` included. Returns `true` only if a parameter was actually
+  restored to a different value — `false` both when the solver was already at
+  baseline and when the escalation itself moved nothing (a rung can fire, and
+  report `true`, without changing a parameter: from non-`Identity` scaling with
+  `pivot_threshold` already at `pivtol_max`, `0.5^0.75` clamps back to `0.5`).
+  Either way the level is re-baselined and the ladder is armed again.
+  `with_scaling` applied while an escalation is live re-states the caller's
+  baseline, so a later reset restores the strategy pinned last rather than
+  silently undoing it (the issue-#51 escape hatch keeps working mid-solve).
 - **Why.** `increase_quality` was a one-way ratchet with no way back, so an
   escalation chosen for *one* hard factorization governed **every** later
   factorization for the life of the `Solver`. Ipopt exposes no reset because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to FERAL will be documented in this file.
 
+## [Unreleased]
+
+### Added — `Solver::reset_quality()` bounds the lifetime of a quality escalation (issue #192)
+
+- **What changed.** New `Solver::reset_quality() -> bool` (and the Python
+  binding `Solver.reset_quality()`). It reverts every escalation
+  `increase_quality` applied — the `Identity → InfNorm` scaling flip and the
+  raised `bk.pivot_threshold` — restoring the parameters the caller had
+  configured and returning `quality_level()` to `Baseline`. Returns `true` if
+  an escalation was undone, `false` if the solver was already at baseline.
+  Valid from any level, `Exhausted` included.
+- **Why.** `increase_quality` was a one-way ratchet with no way back, so an
+  escalation chosen for *one* hard factorization governed **every** later
+  factorization for the life of the `Solver`. Ipopt exposes no reset because
+  MA57 answers `IncreaseQuality` by raising `pivtol` toward `pivtolmax` —
+  monotone in robustness, so leaving it raised can only make later
+  factorizations safer. FERAL's rungs change *which pivots are taken*: the
+  factorization is different, not uniformly better, and persisting it changes
+  the caller's whole remaining trajectory.
+- **Evidence (pounce gh#850).** On `square_flowsheet_resto` the rung fires
+  twice and costs both solve arms: the exact-Hessian leg goes from `Optimal`
+  in 99 iterations to `RestorationFailed` in 131, and the limited-memory leg
+  from `Optimal` in 178 to 3000 iterations at the cap. Declining to escalate
+  is not the fix either — a 12-variable watchdog model ends at `obj = 3.7e-6`
+  with the escalation and at `obj = 3.42` against `f* = 0` without it, and the
+  rung buys 15–25% of the iterations on five other models. The distinguishing
+  variable is how long the escalation lasts, not whether it fires.
+- **Nothing else changes.** The escalation ladder — its rungs, the `0.75`
+  exponent, `pivtol_max` — is untouched, and a solver that never calls
+  `reset_quality` behaves exactly as before. The reset touches only the two
+  escalated parameters and the level: the cached symbolic factorization
+  survives (it is scaling-invariant since scaling moved to the numeric phase),
+  so re-baselining costs no re-analysis, exactly as escalating costs none.
+  `reset_quality` followed by `increase_quality` retraces the same rungs a
+  freshly constructed `Solver` would.
+
 ## [0.17.0] - 2026-08-19
 
 ### Fixed — the tree-parallel solve no longer runs on trees too thin to pay for it (issue #175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,26 @@ All notable changes to FERAL will be documented in this file.
   with the escalation and at `obj = 3.42` against `f* = 0` without it, and the
   rung buys 15–25% of the iterations on five other models. The distinguishing
   variable is how long the escalation lasts, not whether it fires.
-- **Nothing else changes.** The escalation ladder — its rungs, the `0.75`
-  exponent, `pivtol_max` — is untouched, and a solver that never calls
-  `reset_quality` behaves exactly as before. The reset touches only the two
-  escalated parameters and the level: the cached symbolic factorization
-  survives (it is scaling-invariant since scaling moved to the numeric phase),
-  so re-baselining costs no re-analysis, exactly as escalating costs none.
-  `reset_quality` followed by `increase_quality` retraces the same rungs a
-  freshly constructed `Solver` would.
+- **Guaranteed, not incidental.** Three properties are contract, each pinned
+  by a named test; a change that breaks one is a breaking change, not a detail.
+  1. *A caller that never calls `reset_quality` sees byte-identical behaviour
+     to 0.17.0.* The escalation ladder is untouched — its rungs, the `0.75`
+     exponent, `pivtol_max` — and the snapshot is inert state. Pinned by U1–U5,
+     which predate the method and pass unchanged. Downstream release processes
+     that diff a fixture sweep against a baseline binary depend on this not
+     drifting silently.
+  2. *`reset_quality` then `increase_quality` retraces exactly the rungs a
+     freshly constructed `Solver` would.* Pinned by R4 (records the traversal
+     before any reset exists, asserts the second equals it) and R6.
+  3. *Re-baselining costs no symbolic re-analysis.* The cached
+     `SymbolicFactorization` survives, exactly as it survives an escalation.
+     A cost guarantee: a caller may reset once per IPM iteration, so a reset
+     that forced re-analysis would be a silent per-iteration cost. Pinned by
+     integration test I9 via `symbolic_call_count`.
+- **Nothing else changes.** The reset touches only the two escalated
+  parameters and the level — not `last_factors`, not `mc64_scaling_cache`, and
+  none of the independent latches — mirroring what `increase_quality` leaves
+  alone.
 
 ## [0.17.0] - 2026-08-19
 

--- a/FERAL-PROJECT-SPEC.md
+++ b/FERAL-PROJECT-SPEC.md
@@ -564,7 +564,16 @@ pub enum FactorStatus {
 /// Stage 1: activate enhanced scaling (if not already on).
 /// Stage 2: raise pivot threshold parameter u.
 /// Modeled on Ipopt's IncreaseQuality() — see IpTSymLinearSolver.cpp:432-441.
+/// Persists across factorizations until reset_quality() reverts it.
 pub fn increase_quality(&mut self) -> bool;
+
+/// Revert every escalation applied by increase_quality(), restoring the
+/// configured scaling strategy and pivot threshold and returning to
+/// QualityLevel::Baseline. Returns true if an escalation was undone.
+/// Ipopt has no counterpart: MA57's escalation is monotone in robustness,
+/// FERAL's changes which pivots are taken, so its lifetime has to be
+/// boundable by the caller (issue #192).
+pub fn reset_quality(&mut self) -> bool;
 
 /// Number of negative eigenvalues from last factorization.
 pub fn num_negative_eigenvalues(&self) -> usize;

--- a/crates/feral-diagnostics/src/bin/diag_acopr14.rs
+++ b/crates/feral-diagnostics/src/bin/diag_acopr14.rs
@@ -181,12 +181,10 @@ fn run_one(matrix_name: &str) {
     let n_schur = schur.len();
     let bytes = std::fs::read(&bin_path).unwrap();
     let mumps: Vec<f64> = bytes
-        .chunks_exact(8)
-        .map(|c| {
-            let mut b = [0u8; 8];
-            b.copy_from_slice(c);
-            f64::from_le_bytes(b)
-        })
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|c| f64::from_le_bytes(*c))
         .collect();
 
     println!("  n={} n_schur={}", n, n_schur);

--- a/crates/feral-diagnostics/src/bin/diag_schur_parity.rs
+++ b/crates/feral-diagnostics/src/bin/diag_schur_parity.rs
@@ -113,10 +113,8 @@ fn read_mumps_schur(json_path: &Path) -> Option<MumpsSchurRef> {
         return None;
     }
     let mut data = Vec::with_capacity(n_schur * n_schur);
-    for chunk in bytes.chunks_exact(8) {
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(chunk);
-        data.push(f64::from_le_bytes(buf));
+    for chunk in bytes.as_chunks::<8>().0 {
+        data.push(f64::from_le_bytes(*chunk));
     }
     Some(MumpsSchurRef {
         n,
@@ -138,10 +136,8 @@ fn read_dense_oracle(mtx_path: &Path, n_schur: usize) -> Option<Vec<f64>> {
         return None;
     }
     let mut data = Vec::with_capacity(n_schur * n_schur);
-    for chunk in bytes.chunks_exact(8) {
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(chunk);
-        data.push(f64::from_le_bytes(buf));
+    for chunk in bytes.as_chunks::<8>().0 {
+        data.push(f64::from_le_bytes(*chunk));
     }
     Some(data)
 }

--- a/crates/feral-ordering-core/src/quotient_graph/algo.rs
+++ b/crates/feral-ordering-core/src/quotient_graph/algo.rs
@@ -1204,9 +1204,8 @@ pub fn finalize_step_amf(
             ws.nv[i] = nvi;
             let degme_i = degme_i32;
             let nvi_i = nvi;
-            let rmf: f64;
             let deg_i = ws.degree[i];
-            if (deg_i as usize) + (degme_i as usize) > nleft {
+            let rmf: f64 = if (deg_i as usize) + (degme_i as usize) > nleft {
                 // Saturated branch. RMF1 uses original DEG.
                 let deg_f = deg_i as f64;
                 let rmf1 = deg_f * (deg_f - 1.0 + 2.0 * degme_i as f64) - ws.wf[i] as f64;
@@ -1215,12 +1214,12 @@ pub fn finalize_step_amf(
                 let nd = new_deg as f64;
                 let rmf_new =
                     nd * (nd - 1.0) - (degme_i - nvi_i) as f64 * (degme_i - nvi_i - 1) as f64;
-                rmf = rmf_new.min(rmf1);
+                rmf_new.min(rmf1)
             } else {
                 let deg_f = deg_i as f64;
                 ws.degree[i] = deg_i + degme_i - nvi_i;
-                rmf = deg_f * (deg_f - 1.0 + 2.0 * degme_i as f64) - ws.wf[i] as f64;
-            }
+                deg_f * (deg_f - 1.0 + 2.0 * degme_i as f64) - ws.wf[i] as f64
+            };
             let rmf = rmf / (nvi_i as f64 + 1.0);
             let qscore: i32 = if rmf < dummy_f {
                 rmf.round() as i32

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,70 +1,344 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T02:05:49Z
+Generated: 2026-08-29T22:25:22Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-04.md
+File: dev/sessions/2026-08-29-01.md
 ```
-# Session 2026-08-19-04
-
-## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
-
-Reported first, per the hard rule in CLAUDE.md — and for the same reason
-as 2026-08-19-02: `cargo run --bin bench --release` in this container
-finds only the 8 synthetic matrices. The external corpus and the
-MUMPS/SPRAL oracle timings are absent, so both Phase 2.8.1 exit
-partitions report `N/A` and **no comparison against 2026-08-15-02's
-1.61 / 2.00 / 1.67 / 1.67 is possible from this run**. I am not claiming
-those numbers held; they were not measured.
-
-What the run does confirm, identical to last session: inertia 2/2 vs
-MUMPS, residual 2/2, worst residual 1.26e-16.
-
-It is also the wrong benchmark for this change, which touches solve
-*scheduling* and not the factor path. The measurements that matter are
-in "Benchmark Results" below.
+# Session 2026-08-29-01
 
 ## Goal
 
-Fix issue #175 — the tree-parallel solve added for #131 Gap A is a net
-15% loss on the wide-sparse Mittelmann KKT `NARX_CFy`, and
-`CbTaskPlan::worthwhile` has no per-call-overhead term.
+Fix issue #192: `Solver::increase_quality`'s escalation is permanent and
+unscopable, so an escalation chosen for one hard factorization governs
+every factorization for the remaining life of the `Solver`.
+
+## Benchmark Results
+
+**The exit partition was not measured this session.** The 153k-matrix
+corpus is not present in this container, so both partitions report
+`N/A` and there is no comparison against session 2026-08-19-05's
+1.58 / 1.58 to report — favourable or otherwise.
+
+```
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+```
+
+What did run is clean, and the diff has no mechanism by which it could
+regress performance: it is a pure API addition whose new code path runs
+only when a caller calls `reset_quality()`. No numeric kernel, ordering,
+scaling, or pivoting code was touched, and the forward-ladder tests
+U1–U5 pass unchanged. That is an argument, not a measurement, and the
+next session with corpus access should confirm it.
 
 ## Accomplished
 
-### The report is real, and it is purely a scheduling bug
+### `Solver::reset_quality()` (issue #192, commit `0952f99`)
 
-The reporter serialized the tree-parallel solve with `FERAL_CB_THRESH`
-and recovered 7.35 s of 49.41 s (15%) plus ~3.0M involuntary context
-switches, on 14 cores over 100 IPM iterations. Two things follow that
-the issue does not state:
-
-1. `FERAL_CB_THRESH` does not choose the solve *core* — since #177 that
-   is `cb_core_profitable`, which reads neither the worker count nor the
-   environment. A huge threshold collapses the plan to one task, so the
-   **same** CB core runs serially. The whole 7.35 s is scheduling
-   overhead, and fixing it cannot move a bit of any solve.
-2. Rows 3 and 4 of the reporter's table are within noise, so the CB core
-   running serially already matches switching parallelism off entirely
-   on this problem. Nothing in the report argues for changing which core
-   runs.
-
-### Mechanism: the overhead is per front, not per task
-
-`cb_run_parallel` takes the shared `contribs` mutex inside its per-front
-loop — once per child drained, once to store the front's own block. That
-cost scales with the supernode count; `MIN_TOTAL_COST` is a floor on
-*total* work. `NARX_CFy` has 45,736 supernodes and a Lagrangian Hessian
+New `Solver::reset_quality() -> bool` and its Python binding. Reverts
 ```
 
 ## Git Status
 ```
-2fbf9b7 Merge pull request #186 from jkitchin/release/0.17.0
-5082eff release: 0.17.0
-a91082b Merge pull request #185 from jkitchin/fix/pre-release-0.17.0
-d758cd8 docs(journal): session 2026-08-19-05 pre-release review entries
-8b97b21 docs: correct pre-release claims across CHANGELOG, README and rustdoc
+0952f99 feat: add Solver::reset_quality() to bound escalation lifetime (#192)
+9b9e882 Merge pull request #188 from jkitchin/ci/codecov-coverage
+1292984 ci: measure coverage with cargo-llvm-cov and report it to Codecov
+ad0d96d Merge pull request #187 from jkitchin/docs/session-2026-08-19-05
+b224ed1 docs: session checkpoint 2026-08-19-05 (pre-release review, 0.17.0 tagged)
 ```
 
 ## Test Status
+```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
+
+test result: ok. 448 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 2.35s
+
+```
+
+## Benchmark
+```
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-29-01.md)
+
+
+**The exit partition was not measured this session.** The 153k-matrix
+corpus is not present in this container, so both partitions report
+`N/A` and there is no comparison against session 2026-08-19-05's
+1.58 / 1.58 to report — favourable or otherwise.
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+
+What did run is clean, and the diff has no mechanism by which it could
+regress performance: it is a pure API addition whose new code path runs
+only when a caller calls `reset_quality()`. No numeric kernel, ordering,
+scaling, or pivoting code was touched, and the forward-ladder tests
+U1–U5 pass unchanged. That is an argument, not a measurement, and the
+next session with corpus access should confirm it.
+
+```
+
+## Recent Decisions
+
+**Scope of the change.** The escalation ladder is untouched — its rungs,
+the `0.75` exponent, `pivtol_max` — and unit tests U1–U5 pass unchanged,
+so a caller that never calls `reset_quality` sees byte-identical
+behaviour. The reset touches only the two escalated parameters and the
+level, mirroring what `increase_quality` leaves alone: the cached
+symbolic factorization survives (scaling-invariant since the β refactor
+moved scaling to the numeric phase), so re-baselining costs no
+re-analysis exactly as escalating costs none. Pinned by integration test
+`i9_reset_quality_rebaselines_without_invalidating_symbolic`.
+
+## 2026-08-29 — the escalation baseline is snapshotted lazily, not at construction (issue #192)
+
+**Decision.** `reset_quality` restores a `QualityBaseline { scaling,
+pivot_threshold }` captured on the transition *out of*
+`QualityLevel::Baseline` — i.e. at the instant the ladder starts — held
+in `Option<QualityBaseline>` and cleared by every reset. Not captured in
+`with_params`.
+
+**Why.** The `with_*` builders are consuming and run *after*
+`with_params`, so `Solver::with_params(np, sn).with_scaling(Identity)`
+would have a construction-time snapshot recording `np`'s strategy, and a
+reset would silently discard the caller's builder configuration. The
+lazy snapshot also makes the round trip exact by construction: it
+records a state the solver demonstrably occupied, so `reset` →
+`increase` retraces the same rungs a freshly constructed `Solver` would
+— the property downstream needs when re-baselining at a loop boundary.
+Pinned by `r6_reset_quality_preserves_builder_configured_scaling` (would
+fail under a construction-time snapshot) and
+`r4_reset_quality_from_exhausted_restarts_identical_ladder`.
+
+## Recent Tried-and-Rejected
+total factor time** on a matrix whose paying bucket is 91% of that time. Moving
+three quarters of the panel share into BLAS-3 buys 1.3%: the two kernels cost
+nearly the same per flop at this front shape, so the 53.5% panel share is not
+recoverable time.
+
+It also does not generalize. `bs = 48` and `bs = 64` are identical for any front
+with `ncol ≤ 48`, and that is every other matrix sampled — `ncol` p90 is 1-19
+across clnlbeam, dtoc2, marine_1600, rocket, steering, gasoil_3200, pinene_3200,
+robot_1600, svanberg, nql180, qcqp1500-1c, cont5_2_4_l; only dtoc1nd is at 63. On
+the two with any wide fronts at all the paired sweep finds nothing: nql180 0.990
+(5/12 wins, tied with the default), qcqp1500-1c 0.994 (3/12). A 1.3% win on one
+corpus matrix and a no-op elsewhere is below the bar for changing a global default.
+
+**Kept from this attempt:** `block_size` is bit-neutral on all three matrices
+swept — identical inertia, zero delayed pivots, identical residual, and an
+identical hash over every `L`/`D` bit in storage order across
+`bs ∈ {8,16,24,32,48,62,64}` (`dtoc1nd_0010` 9cb93f568423e6c0, `nql180_0000`
+4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
+is a performance-only change. Not yet established on a matrix that actually
+delays a pivot — all three report `d0`.
+
+## Source Files
+```
+src/bin/bench.rs
+src/bin/perf_probe.rs
+src/bin/probe_ft_eta.rs
+src/bin/probe_lu_phases.rs
+src/bin/probe_panel_frag.rs
+src/capi.rs
+src/dense/block_ldlt32.rs
+src/dense/equilibrate.rs
+src/dense/factor.rs
+src/dense/matrix.rs
+src/dense/mod.rs
+src/dense/rook.rs
+src/dense/schur_kernel.rs
+src/dense/solve.rs
+src/env.rs
+src/error.rs
+src/inertia.rs
+src/io/mod.rs
+src/io/mtx.rs
+src/io/sidecar.rs
+src/lib.rs
+src/lu/condition.rs
+src/lu/dense_factor.rs
+src/lu/dense_matrix.rs
+src/lu/dense_solve.rs
+src/lu/dense_update.rs
+src/lu/markowitz.rs
+src/lu/mod.rs
+src/lu/scaling.rs
+src/lu/sparse_factor.rs
+src/lu/sparse_hyper.rs
+src/lu/sparse_matrix.rs
+src/lu/sparse_solve.rs
+src/lu/sparse_symbolic.rs
+src/lu/sparse_triangular.rs
+src/lu/sparse_update.rs
+src/numeric/condition.rs
+src/numeric/factorize.rs
+src/numeric/mod.rs
+src/numeric/solve.rs
+src/numeric/solver.rs
+src/ordering/amd.rs
+src/ordering/elimination_tree.rs
+src/ordering/mod.rs
+src/ordering/postorder.rs
+src/ordering/schur.rs
+src/scaling/hungarian.rs
+src/scaling/infnorm.rs
+src/scaling/mc64.rs
+src/scaling/mod.rs
+src/scaling/value_bound.rs
+src/sparse/csc.rs
+src/sparse/mod.rs
+src/symbolic/column_counts.rs
+src/symbolic/ldlt_compress.rs
+src/symbolic/mod.rs
+src/symbolic/profiler.rs
+src/symbolic/small_leaf.rs
+src/symbolic/supernode.rs
+```
+
+## Test Files
+```
+tests/amf_corpus_oracle.rs
+tests/auto_strategy.rs
+tests/blocked_ldlt.rs
+tests/build_row_indices_trailing_invariant.rs
+tests/cb_core_choice_ignores_env.rs
+tests/cb_solve_parity.rs
+tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
+tests/d4_solve_2x2_gate.rs
+tests/d6_contrib_uninit.rs
+tests/d7_block32_dispatch_pooled.rs
+tests/delayed_pivoting.rs
+tests/dense_fast_path.rs
+tests/dense_ldlt.rs
+tests/env_knob_parsing.rs
+tests/env_knob_scan.rs
+tests/factor_scratch_parity.rs
+tests/factor_workspace_parity.rs
+tests/factors_ld_export.rs
+tests/fine_grained_delay.rs
+tests/fma_opt_in_roundtrip.rs
+tests/golden_bits.rs
+tests/growth_flag.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
+tests/issue127_pipeline_split.rs
+tests/issue128_supernode_nrow.rs
+tests/issue177_parallel_entry_point_core.rs
+tests/issue178_refine_cap.rs
+tests/issue178_solve_into.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
+tests/kkt_hardening.rs
+tests/kkt_matrices.rs
+tests/large_matrix_smoke.rs
+tests/ldlt_compress.rs
+tests/lu_adversarial_inputs.rs
+tests/lu_default_ordering.rs
+tests/lu_dense.rs
+tests/lu_dense_bump.rs
+tests/lu_dense_update_bg.rs
+tests/lu_ft_widebump.rs
+tests/lu_hyper_sparse.rs
+tests/lu_markowitz.rs
+tests/lu_real_bases.rs
+tests/lu_scaling.rs
+tests/lu_sparse.rs
+tests/lu_sparse_rhs.rs
+tests/lu_update_alloc_probe.rs
+tests/lu_update_casctanks.rs
+tests/maxfromm_parity.rs
+tests/mc64_end_to_end.rs
+tests/mc64_scaling.rs
+tests/multi_rhs.rs
+tests/n2_static_pivot_scaling.rs
+tests/n3_parallel_profiler.rs
+tests/n4_mc64_retry_latch.rs
+tests/parallel_parity.rs
+tests/parity.rs
+tests/pivot_rejection.rs
+tests/pounce710_refine_cap_nrhs2.rs
+tests/pounce_interface.rs
+tests/profiler_smoke.rs
+tests/property_tests.rs
+tests/refined_solve_core_stability.rs
+tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
+tests/small_leaf_parity.rs
+tests/solver_with_ordering.rs
+tests/sparse_postorder.rs
+tests/sparse_refined.rs
+tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
+tests/stress_tests.rs
+tests/symbolic_profiler.rs
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
 ```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7096,3 +7096,78 @@ uncovered while being covered locally. The coverage job prints the skip
 list to the run summary — the same step ci.yml has — so a low number in
 those modules can be checked against it before being treated as a real
 gap.
+
+## 2026-08-29 — `Solver::reset_quality()`: the escalation's lifetime is the caller's to bound (issue #192)
+
+**Decision.** Add `Solver::reset_quality() -> bool`, reverting every
+escalation `increase_quality` applied and returning `quality_level()` to
+`Baseline`. This takes up a deferral rather than reversing a decision:
+`dev/research/pounce-integration-interface.md` recorded, under "What
+this does NOT decide", that "FERAL should match [Ipopt, which has no
+reset method] until there is evidence to add it." Issue #192 is that
+evidence.
+
+**Why Ipopt's shape does not transfer.** Ipopt exposes no reset because
+MA57 answers `IncreaseQuality` by raising `pivtol` toward `pivtolmax`
+(`IpMa57TSolverInterface.cpp:832`) — strictly more conservative each
+time. That is monotone in *robustness*, so keeping it raised for the
+remainder of a solve can only make later factorizations safer, and never
+reverting is harmless. FERAL's ladder (`Identity → InfNorm`, then
+`pivot_threshold^0.75`) changes *which pivots are taken*. That is a
+lateral move: the factorization is different, not uniformly better, and
+because it persists the whole remaining trajectory is different too,
+including any restoration sub-problem's factorizations.
+
+**The evidence.** Measured downstream in pounce gh#850. On
+`square_flowsheet_resto` the rung fires exactly twice and costs both
+solve arms: exact-Hessian goes from `Optimal` in 99 iterations to
+`RestorationFailed` in 131, limited-memory from `Optimal` in 178 to 3000
+at the cap. Three measured facts rule out the cheaper answers: scoping
+the rung out of restoration still loses the leg; a firing count does not
+discriminate (`deb7` and `square_flowsheet_resto` each fire exactly
+twice, one gains 16% of its iterations, the other loses its verdict);
+and simply not escalating loses a 12-variable watchdog model
+(`obj = 3.7e-6` with, `obj = 3.42` against `f* = 0` without) plus 15–25%
+of the iterations on five other models. The escalation is genuinely
+useful *and* genuinely destructive; the distinguishing variable is
+duration, not occurrence.
+
+**Why the reset and not a scoped guard.** The issue lists both. A guard
+(`QualityGuard<'a>(&'a mut Solver)` with a restoring `Drop`) fixes the
+scope at one `factor()`, but the Ipopt contract loop escalates
+repeatedly until the factorization delivers, so the natural scope is the
+caller's own retry loop — a shape FERAL does not know and should not
+assume. The reset lets downstream re-baseline at whatever boundary makes
+sense (a new major iteration, entering restoration) with FERAL knowing
+nothing about the caller's algorithm, and the guard stays expressible in
+terms of it if evidence for it later arrives.
+
+**Scope of the change.** The escalation ladder is untouched — its rungs,
+the `0.75` exponent, `pivtol_max` — and unit tests U1–U5 pass unchanged,
+so a caller that never calls `reset_quality` sees byte-identical
+behaviour. The reset touches only the two escalated parameters and the
+level, mirroring what `increase_quality` leaves alone: the cached
+symbolic factorization survives (scaling-invariant since the β refactor
+moved scaling to the numeric phase), so re-baselining costs no
+re-analysis exactly as escalating costs none. Pinned by integration test
+`i9_reset_quality_rebaselines_without_invalidating_symbolic`.
+
+## 2026-08-29 — the escalation baseline is snapshotted lazily, not at construction (issue #192)
+
+**Decision.** `reset_quality` restores a `QualityBaseline { scaling,
+pivot_threshold }` captured on the transition *out of*
+`QualityLevel::Baseline` — i.e. at the instant the ladder starts — held
+in `Option<QualityBaseline>` and cleared by every reset. Not captured in
+`with_params`.
+
+**Why.** The `with_*` builders are consuming and run *after*
+`with_params`, so `Solver::with_params(np, sn).with_scaling(Identity)`
+would have a construction-time snapshot recording `np`'s strategy, and a
+reset would silently discard the caller's builder configuration. The
+lazy snapshot also makes the round trip exact by construction: it
+records a state the solver demonstrably occupied, so `reset` →
+`increase` retraces the same rungs a freshly constructed `Solver` would
+— the property downstream needs when re-baselining at a loop boundary.
+Pinned by `r6_reset_quality_preserves_builder_configured_scaling` (would
+fail under a construction-time snapshot) and
+`r4_reset_quality_from_exhausted_restarts_identical_ladder`.

--- a/dev/journal/2026-08-29-01.org
+++ b/dev/journal/2026-08-29-01.org
@@ -104,3 +104,29 @@ installed and CLAUDE.md's "treat a missing hook as a bug to fix" applies.
 =pip install pre-commit= then =pre-commit install= -> "pre-commit installed
 at .git/hooks/pre-commit". Verified the hook file exists. Not a
 repo change, but worth recording: a fresh container starts without it.
+
+* 23:10 :benchmark:environment:
+Ran =cargo run --bin bench --release= per the session-end protocol. The
+153k-matrix corpus is **not present in this container**, so both exit
+partitions report =N/A= rather than a number:
+
+: --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+: bucket                    count      p90     target  verdict
+: small-frontal (<200)          0        -     <= 2.0      N/A
+: medium (<500)                 0        -     <= 3.0      N/A
+
+This is an environment limitation, not a regression, and it is **not** a
+"no regression" result -- there is no comparison against session
+2026-08-19-05's 1.58 / 1.58 to be had here. What did run is clean on the
+2 synthetic KKT matrices the bench generates:
+
+: Sparse solver: 2/2 total
+:   Inertia match vs MUMPS: 2/2 (100.0%)
+:   Residual pass: 2/2 (100.0%)
+:   Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+The change is a pure API addition on a code path that runs only when a
+caller calls =reset_quality()=; no numeric kernel, ordering, scaling or
+pivoting code was touched, and the forward ladder tests U1-U5 pass
+unchanged. So a perf regression is not a mechanism this diff has. That
+is an argument, not a measurement, and it is recorded as such.

--- a/dev/journal/2026-08-29-01.org
+++ b/dev/journal/2026-08-29-01.org
@@ -130,3 +130,53 @@ caller calls =reset_quality()=; no numeric kernel, ordering, scaling or
 pivoting code was touched, and the forward ladder tests U1-U5 pass
 unchanged. So a perf regression is not a mechanism this diff has. That
 is an argument, not a measurement, and it is recorded as such.
+
+* 23:30 :ci:toolchain:issue-192:
+PR #193's =check= job went red. Root cause is **not** this PR: the
+failure is =clippy::needless_late_init= at
+=crates/feral-ordering-core/src/quotient_graph/algo.rs:1207=, and
+=git diff --stat origin/main...HEAD -- crates/= is **empty** -- this PR
+touches no file under =crates/=.
+
+Real cause: =dtolnay/rust-toolchain@stable= now resolves to 1.98.0
+(=88d9e12ae=, 2026-08-18). This container was pinned at 1.94.1
+(=e408947bf=, 2026-03-25), which is why local clippy and the pre-commit
+hook both passed while CI failed. Ran =rustup update stable= to 1.98.0
+and reproduced the failure exactly.
+
+Lesson: a green pre-commit hook is only as current as the local
+toolchain. Worth matching CI's toolchain before trusting a local clippy
+pass on a repo that tracks =stable=.
+
+* 23:40 :ci:toolchain:
+Fixing the first error revealed a second lint that cargo had never
+reached, because the dependency crate aborted the build first: 13 sites
+of =clippy::chunks_exact_to_as_chunks= (also new in 1.98). CI had only
+ever reported the first one. Had I pushed the one-line fix CI named, the
+job would have gone red again on lints I could have seen locally --
+which is the argument for reproducing on the real toolchain rather than
+patching what the log happens to show.
+
+Split the response by risk:
+- =needless_late_init= (ordering-core): real fix, clippy's own suggested
+  transformation. Pure control-flow refactor -- same statements, same
+  side-effect order on =ws.degree[i]=, =ws.wf[i]= never written in the
+  block. Behaviour-identical by inspection.
+- 3 sites in diagnostic binaries (=diag_schur_parity=, =diag_acopr14=):
+  real fix. Byte-decoding loops reading files, not hot paths; the
+  rewrite drops a =copy_from_slice= each.
+- 10 sites in =src/dense/schur_kernel.rs=: **allow, not rewrite.** That
+  is the 4-way unrolled SIMD body of the factorization's hottest loop.
+  The rewrite is plausibly neutral-or-better, but that is a hypothesis
+  and this container has no corpus to test it against. Recorded in
+  =dev/tried-and-rejected.md= as deferred-pending-measurement, with the
+  reasoning in a comment at the allow.
+
+Validation on 1.98.0, matching CI:
+
+: cargo clippy --workspace --all-targets -- -D warnings -> clean
+: cargo fmt --all --check                              -> clean
+: cargo test --workspace -> total passed: 1196  total failed: 0
+
+The 1196 includes the ordering-core suite, which is what would catch the
+AMF refactor if it had changed the ordering.

--- a/dev/journal/2026-08-29-01.org
+++ b/dev/journal/2026-08-29-01.org
@@ -180,3 +180,72 @@ Validation on 1.98.0, matching CI:
 
 The 1196 includes the ordering-core suite, which is what would catch the
 AMF refactor if it had changed the ordering.
+
+* 02:20 :review:issue-192:pr-193:
+Review from jkitchin on PR #193. Three findings, all verified against
+the code before acting -- none taken on faith.
+
+** Finding 1 (high): the clippy allow blocks commits on toolchains < 1.98
+Confirmed by installing 1.96.0 and reproducing the reporter's exact
+command:
+
+: $ cargo +1.96.0 clippy --lib -- -D warnings
+: error: unknown lint: `clippy::chunks_exact_to_as_chunks`
+:   --> src/dense/schur_kernel.rs:41:10
+
+This is a regression I introduced in 9c5dfac and it is worse than it
+looks: =unknown_lints= is warn-by-default, =-D warnings= promotes it to
+an error, and =cargo clippy -- -D warnings= is exactly what the
+mandatory pre-commit hook runs. So it blocks *every* local commit, on
+every file, for anyone not yet on 1.98 -- and CI tracks =stable=, so CI
+would never have caught it. My own "clippy clean" claim in the PR body
+was true only on the toolchain I happened to have just updated to.
+
+Fixed with =#![allow(unknown_lints)]= above the existing allow. Verified
+clean on both:
+
+: cargo +1.96.0 clippy --all-targets -- -D warnings -> clean
+: cargo clippy --workspace --all-targets -- -D warnings -> clean
+
+** Finding 2 (medium): with_scaling after escalating is silently undone
+Real. =with_scaling= is the documented issue-#51 escape hatch and is the
+only external writer of =numeric_params.scaling=; it did not touch
+=quality_baseline=, so a strategy pinned mid-escalation was reverted to
+the stale snapshot by the next =reset_quality=. Same failure mode the
+lazy snapshot was chosen to avoid, relocated to the post-escalation
+window (R6 only covered the pre- window).
+
+Fix: =with_scaling= refreshes =quality_baseline.scaling= when a
+snapshot is live -- the call re-states what the caller's baseline *is*.
+Chose refresh over clearing the whole snapshot: clearing would also drop
+the pivot-threshold half, so a later reset would leave the pivot
+escalated and report nothing undone.
+
+** Finding 3 (low): reset_quality() == true with nothing moved
+Real. From non-Identity scaling with =pivot_threshold == pivtol_max=,
+stage 1 no-ops and stage 2 computes 0.5^0.75 = 0.5946, clamps back to
+0.5, and lands on =Exhausted= -- =increase_quality= returns true having
+changed no parameter, so the paired reset reported a phantom undo.
+
+Fix: =reset_quality= compares the snapshot against current values and
+returns whether anything actually differs. Level is still re-baselined
+either way.
+
+** The two fixes interact, and the first version of R7 was wrong
+R7 as first written asserted =reset_quality() == true= after pinning a
+strategy post-escalation. With finding 3 fixed that is *false* and
+correctly so: =with_scaling= had already superseded the only rung that
+fired (stage 1), so nothing was left to restore. The test was wrong, not
+the code. Split it:
+- R7 escalates twice (scaling *and* pivot) so the return value stays
+  meaningful, and pins that the *pinned* strategy survives the reset.
+- R7b pins the composed behaviour directly: pin supersedes the only
+  rung -> reset returns false, strategy stays pinned, level re-baselined.
+
+Both findings reproduced RED first:
+
+: r7 ... FAILED (assertion failed: s.reset_quality())
+: r8 ... FAILED (no parameter moved, so nothing was undone)
+
+Final: 9 reset tests pass, =cargo test --workspace= 1199 passed /
+0 failed, fmt clean, clippy clean on 1.96 and 1.98, pytest 16 passed.

--- a/dev/journal/2026-08-29-01.org
+++ b/dev/journal/2026-08-29-01.org
@@ -249,3 +249,42 @@ Both findings reproduced RED first:
 
 Final: 9 reset tests pass, =cargo test --workspace= 1199 passed /
 0 failed, fmt clean, clippy clean on 1.96 and 1.98, pytest 16 passed.
+
+* 02:40 :review:contract:pr-193:
+Found a second review comment from jkitchin (00:27Z, downstream/pounce
+confirmation) that never arrived as a notification -- only the 02:09
+review did. Worth noting as a gap: polling the comment list caught what
+the event stream did not. Do not treat the wake events as complete.
+
+Content: pounce confirms =reset_quality()= + the already-public
+=quality_level()= is expressively complete and they explicitly do *not*
+want the guard form -- they would rather own their own retry loop. That
+retires the deferred-guard question from my side.
+
+Also a useful correction to my own reading of #192's evidence: the
+process-global firing cap did *not* measure what a matrix-boundary reset
+does. Capping at one firing still left that escalation in force for the
+whole remaining solve, which is why "allowing only the first firing
+still loses the leg". So #192's measurements do not predict the outcome
+of the reset in either direction. They will re-run the corpus rather
+than assume; I should not claim the reset fixes
+=square_flowsheet_resto=, only that it makes the lifetime expressible.
+
+Three contract asks, documentation-only, all implemented:
+1. "never calling reset_quality => byte-identical behaviour" (U1-U5)
+2. "reset -> increase retraces a fresh Solver's rungs" (R4, R6)
+3. "re-baselining costs no symbolic re-analysis" (I9)
+
+All three were already true and pinned, but asserted only in the PR body
+-- i.e. implementation detail, not contract. Promoted into a
+=# Guarantees= section on the =reset_quality= doc comment and into the
+CHANGELOG, each naming the test that pins it. Their reason is concrete:
+their release process diffs a 158-leg fixture sweep against a *baseline
+binary*, not a spec, so an unstated property that later drifts shows up
+as unexplained corpus drift months later. Ask 3 is a cost guarantee, not
+a correctness one -- they would call reset once per IPM iteration.
+
+Validation: fmt clean, clippy clean on 1.96 and 1.98, workspace 1199
+passed / 0 failed. Checked the new rustdoc adds no warnings: =cargo doc
+--no-deps -p feral= reports 40 warnings on origin/main and 40 on this
+branch, all pre-existing.

--- a/dev/journal/2026-08-29-01.org
+++ b/dev/journal/2026-08-29-01.org
@@ -1,0 +1,106 @@
+#+TITLE: Session 2026-08-29-01 journal
+#+STARTUP: showall
+
+* 22:15 :issue-192:quality-escalation:orient:
+Issue #192 (filed from pounce): =Solver::increase_quality= escalation is
+permanent and unscopable. =quality_level= only ratchets Baseline ->
+ScalingEnabled -> PivotRaised -> Exhausted; there is no way back. An
+escalation chosen for one hard factorization governs every subsequent
+factorization for the life of the =Solver=.
+
+Evidence supplied in the issue (pounce gh#850, =square_flowsheet_resto=):
+
+| leg             | with escalation        | without      |
+| exact Hessian   | RestorationFailed, 131 | Optimal, 99  |
+| limited-memory  | 3000 iters (at cap)    | Optimal, 178 |
+
+and three measured facts that rule out the obvious workarounds: scoping
+the rung out of restoration still loses the leg; a firing count does not
+separate good from bad (=deb7= and =square_flowsheet_resto= both fire
+exactly twice, one gains 16% of its iterations, the other loses its
+verdict); and simply not escalating loses a 12-variable watchdog model
+(obj 3.7e-6 with, 3.42 against f*=0 without) plus 15-25% of iterations on
+five other models.
+
+Conclusion: the escalation is both useful and destructive, and the
+distinguishing factor is duration, not occurrence.
+
+* 22:20 :issue-192:code-inspection:
+Read =src/numeric/solver.rs=. Escalation mutates exactly two fields:
+- stage 1: =numeric_params.scaling= (Identity -> InfNorm), line 1908
+- stage 2: =numeric_params.bk.pivot_threshold=, in =bump_pivot_threshold=
+
+Nothing else. It does not touch =last_symbolic=, =mc64_scaling_cache=,
+=last_factors=, or any of the separate latches (=ordering_escalated=,
+=auto_arm_latched=, =mc64_retry_not_adopted=). So an exact inverse is
+two field restores plus the level.
+
+Found the prior decision in =dev/research/pounce-integration-interface.md:314=,
+under "What this does NOT decide":
+
+#+begin_quote
+Whether to expose a =reset_quality()= method. Ipopt does NOT have one --
+the consumer creates a new solver per problem if they want a reset. FERAL
+should match (no reset method) until there is evidence to add it.
+#+end_quote
+
+Issue #192 is that evidence. This is the deferral being taken up, not a
+reversal.
+
+* 22:35 :issue-192:design:
+Design settled and written to =dev/research/issue-192-quality-reset.md= +
+=dev/plans/issue-192-quality-reset.md=.
+
+Key decision: snapshot the baseline **lazily, on the transition out of
+=Baseline=**, not at construction. The =with_*= builders are consuming and
+run after =with_params=, so a construction-time snapshot would record
+pre-builder values and a reset would silently discard the caller's
+configuration. Test R6 pins this: build =with_params(InfNorm)= then
+=.with_scaling(Identity)=, escalate, reset -> must come back Identity.
+
+Deferred the scoped-guard form the issue also lists. A guard fixes the
+scope at one =factor()=, but the Ipopt contract loop escalates repeatedly
+until the factorization delivers, so the natural scope is the caller's
+own retry loop -- a shape FERAL does not know. The guard is expressible
+in terms of the reset, so shipping the reset first costs nothing.
+
+* 22:40 :issue-192:tests:red:
+Wrote 6 unit tests (R1-R6) + 1 integration test (I9) + 1 Python test
+before implementing. Confirmed RED:
+
+: error[E0599]: no method named `reset_quality` found for struct `solver::Solver`
+: error: could not compile `feral` (lib test) due to 6 previous errors
+
+Oracle discipline: every assertion is against a parameter value the
+*caller* supplied, never against implementation output. R5 sets
+=pivot_threshold = 0.25= and asserts the reset returns 0.25 -- it fails
+if the reset restores =NumericParams::default()= instead. R4's oracle is
+the ladder traversal recorded *before* any reset happens.
+
+* 22:50 :issue-192:implement:green:
+Implemented: =QualityBaseline { scaling, pivot_threshold }=, a
+=quality_baseline: Option<QualityBaseline>= field, a 4-line snapshot in
+the =Baseline= arm of =increase_quality=, and =reset_quality()=.
+
+All green:
+
+: cargo test --lib quality -> 11 passed (R1-R6, U1-U5)
+: cargo test --test pounce_interface -> 21 passed (incl. i9)
+: cargo test -> 448 passed; 0 failed; 7 ignored (lib) + all integration suites green
+
+Note U1-U5 still pass unchanged: the forward ladder is untouched, and a
+caller that never calls =reset_quality= sees byte-identical behaviour.
+
+* 22:55 :issue-192:python:
+Added the =reset_quality= binding in =python/src/solver.rs= and a test.
+Built and ran it locally rather than deferring to CI:
+
+: maturin develop -> Installed feral-solver-0.17.0
+: pytest tests/test_basic.py -q -> 16 passed
+
+* 23:00 :tooling:pre-commit:
+=pre-commit= was not on PATH in this container, so the hooks were not
+installed and CLAUDE.md's "treat a missing hook as a bug to fix" applies.
+=pip install pre-commit= then =pre-commit install= -> "pre-commit installed
+at .git/hooks/pre-commit". Verified the hook file exists. Not a
+repo change, but worth recording: a fresh container starts without it.

--- a/dev/plans/issue-192-quality-reset.md
+++ b/dev/plans/issue-192-quality-reset.md
@@ -1,0 +1,101 @@
+# Plan — issue #192: `Solver::reset_quality()`
+
+Research note: `dev/research/issue-192-quality-reset.md`.
+
+## Scope
+
+Add a way to bound the lifetime of `increase_quality`'s escalation.
+One new public method on `Solver`, its Python binding, and tests.
+
+Out of scope: changing the escalation ladder itself (the rungs, the
+`0.75` exponent, `pivtol_max`), and any scoped-guard API — see the
+research note for why the guard is deferred rather than shipped.
+
+## State to add
+
+```rust
+/// Factory values of the two parameters `increase_quality` mutates,
+/// snapshotted on the transition out of `Baseline`.
+struct QualityBaseline {
+    scaling: ScalingStrategy,
+    pivot_threshold: f64,
+}
+```
+
+One new `Solver` field: `quality_baseline: Option<QualityBaseline>`,
+`None` at construction and after every reset.
+
+## Behaviour
+
+| current level | `reset_quality()` | resulting level | returns |
+|---|---|---|---|
+| `Baseline` | no-op | `Baseline` | `false` |
+| `ScalingEnabled` | restore `scaling` + `pivot_threshold` | `Baseline` | `true` |
+| `PivotRaised` | restore `scaling` + `pivot_threshold` | `Baseline` | `true` |
+| `Exhausted` | restore `scaling` + `pivot_threshold` | `Baseline` | `true` |
+
+`increase_quality` gains one line: when it acts from `Baseline`, it
+snapshots the two fields before mutating either.
+
+Invariants the reset preserves (it touches nothing else, mirroring
+what `increase_quality` leaves alone):
+
+- `last_symbolic` / `symbolic_call_count` — the symbolic cache is
+  scaling-invariant since the β refactor, so a reset must not force a
+  re-analysis any more than an escalation does.
+- `last_factors`, `last_inertia` — neither operation factors.
+- `mc64_scaling_cache`, `ordering_escalated`, `auto_arm_latched`,
+  `mc64_retry_not_adopted` — independent latches, not quality state.
+
+## Tests (RED before implementation)
+
+Unit tests in `src/numeric/solver.rs`, using the existing
+`solver_with_scaling` helper. Oracle in every case is the parameter
+value the *caller* supplied, not anything the implementation computes.
+
+- `r1_reset_quality_at_baseline_is_noop` — fresh solver: returns
+  `false`, level stays `Baseline`, both params unchanged.
+- `r2_reset_quality_undoes_stage_one_scaling_flip` — Identity scaling,
+  escalate (→ `ScalingEnabled`, InfNorm), reset: returns `true`,
+  scaling is `Identity` again, level `Baseline`.
+- `r3_reset_quality_undoes_pivot_ladder` — InfNorm scaling, escalate
+  three times, reset: `pivot_threshold` back to the constructed `0.0`,
+  level `Baseline`.
+- `r4_reset_quality_from_exhausted_restarts_identical_ladder` —
+  escalate to `Exhausted`, record the visited `(level, threshold)`
+  sequence, reset, escalate again; the second sequence equals the
+  first. Pins "reset + re-escalate == fresh solver".
+- `r5_reset_quality_restores_caller_params_not_defaults` — construct
+  with a deliberately non-default `pivot_threshold` (`0.25`), escalate,
+  reset, assert `0.25`. Fails if the reset restores
+  `NumericParams::default()`.
+- `r6_reset_quality_preserves_builder_configured_scaling` — build with
+  `.with_scaling(Identity)` *after* `with_params` carried a different
+  strategy, escalate, reset, assert `Identity`. Pins the lazy snapshot
+  against a construction-time one.
+
+Integration test in `tests/pounce_interface.rs`:
+
+- `i9_reset_quality_rebaselines_without_invalidating_symbolic` —
+  factor, escalate twice, factor, reset, factor. Asserts the third
+  factor still `Success`, `pivot_threshold()` is back at the `1e-8`
+  MA27 baseline, `quality_level()` is `Baseline`, and
+  `symbolic_call_count()` never moved off 1.
+
+Python test in `python/tests/test_ipm.py` (or `test_basic.py`,
+wherever `increase_quality` is exercised): escalate then
+`reset_quality()`, assert the level code returns to `QUALITY_BASELINE`.
+
+## Steps
+
+1. Research note + this plan. *(done)*
+2. Write the tests above; confirm they fail to compile / fail RED.
+3. Implement `QualityBaseline`, the field, the snapshot in
+   `increase_quality`, and `reset_quality`.
+4. `cargo test`, `cargo fmt`, `cargo clippy --all-targets -D warnings`.
+5. Python binding + Python test; build and run if maturin is available,
+   otherwise note it as untested-here and rely on CI.
+6. `CHANGELOG.md` (user-visible API addition), `decisions.md` (the
+   deferral in `pounce-integration-interface.md` is now taken up).
+7. Benchmark: no numeric path changes, so the exit partition should be
+   unmoved. Run it anyway per the session protocol.

--- a/dev/research/issue-192-quality-reset.md
+++ b/dev/research/issue-192-quality-reset.md
@@ -1,0 +1,170 @@
+# Issue #192 — bounding the lifetime of `increase_quality`
+
+Date: 2026-08-29
+
+## Problem
+
+`Solver::increase_quality` is a one-way ratchet. `quality_level` moves
+`Baseline → ScalingEnabled → PivotRaised → Exhausted` and there is no
+path back, so an escalation chosen for *one* hard factorization governs
+**every** factorization for the remaining life of the `Solver`.
+
+That is the right shape for an escalation that is monotone in
+robustness. FERAL's is not monotone in *trajectory*:
+
+- Stage 1 flips `ScalingStrategy::Identity → InfNorm`.
+- Stage 2 raises `bk.pivot_threshold` by `threshold^0.75`, capped at
+  `pivtol_max`.
+
+Both change *which pivots are taken*. The resulting factorization is
+different, not uniformly better. Because the change persists, the whole
+downstream trajectory of the caller's algorithm is different too —
+including any restoration sub-problem's factorizations.
+
+## Why Ipopt gets away with never reverting
+
+Ipopt's `IncreaseQuality` contract (`IpPDFullSpaceSolver.cpp:296`) is
+"this factorization cannot deliver — escalate and refactor". MA57
+answers it by raising `pivtol` toward `pivtolmax`
+(`IpMa57TSolverInterface.cpp:832`). That *is* monotone in robustness:
+a higher threshold is strictly more conservative, so leaving it raised
+for the rest of the solve can only make later factorizations safer.
+Never reverting is therefore harmless there, and Ipopt exposes no
+reset. FERAL's stage 1 has no MA57 counterpart at all, and stage 2
+lands in a different pivot regime rather than a strictly safer one.
+
+## Downstream evidence (from the issue; measured in pounce gh#850)
+
+On `square_flowsheet_resto`, wiring `increase_quality` through cost
+both solve arms:
+
+| leg | with escalation | without |
+|---|---|---|
+| exact Hessian | `RestorationFailed`, 131 iters | `Optimal`, 99 |
+| limited-memory | 3000 iters, at the cap | `Optimal`, 178 |
+
+The rung fires exactly twice: once in the main solve at iteration 25,
+once inside the restoration sub-solve at `76r`.
+
+Three measured facts rule out the obvious workarounds:
+
+1. **Scoping it out of restoration is not enough.** Allowing only the
+   first (main-solve) firing still loses the leg.
+2. **A firing count does not discriminate.** `deb7` and
+   `square_flowsheet_resto` each fire it exactly twice on their exact
+   legs — one gains 16% of its iterations, the other loses its verdict.
+3. **Declining to escalate is not the answer either.** A 12-variable
+   watchdog model ends `Solved_To_Acceptable_Level` at `obj = 3.7e-6`
+   with the escalation and at `obj = 3.42` against `f* = 0` without it,
+   and the rung buys 15–25% of the iterations on five other models.
+
+So the escalation is genuinely useful *and* genuinely destructive, and
+the distinguishing variable is **for how long**, not **whether**.
+
+## Code inspection
+
+`increase_quality` mutates exactly two pieces of state:
+
+- `numeric_params.scaling` (stage 1, `solver.rs:1908`)
+- `numeric_params.bk.pivot_threshold` (stage 2, `bump_pivot_threshold`)
+
+plus `quality_level` itself. It touches nothing else — not
+`last_symbolic`, not `mc64_scaling_cache`, not `last_factors`, and none
+of the independent latches (`ordering_escalated`, `auto_arm_latched`,
+`mc64_retry_not_adopted`). The symbolic cache is already documented as
+escalation-invariant: the β refactor moved scaling from the symbolic to
+the numeric phase, so a scaling flip does not invalidate it.
+
+Consequently an exact inverse of the escalation is: restore those two
+fields, set `quality_level = Baseline`, and touch nothing else. The
+inverse is symmetric with the forward operation in what it leaves
+alone, which is the property that keeps it cheap and predictable.
+
+## Prior deferral
+
+`dev/research/pounce-integration-interface.md` (§"What this does NOT
+decide") recorded:
+
+> Whether to expose a `reset_quality()` method. Ipopt does NOT have one
+> — the consumer creates a new solver per problem if they want a reset.
+> FERAL should match (no reset method) until there is evidence to add
+> it.
+
+Issue #192 supplies that evidence. This note takes up the deferral; it
+does not reverse a decision.
+
+## Design
+
+### Where the baseline comes from
+
+The values to restore are the caller's *factory* parameters, not
+`NumericParams::default()`. A caller may build with
+`Solver::with_params(np, sn)` and/or `.with_scaling(...)`, so the
+correct baseline is whatever was in place immediately before the first
+escalation fired.
+
+Capture it **lazily, on the transition out of `Baseline`**, rather than
+in `with_params`. Two reasons:
+
+1. The builders (`with_scaling`, …) are consuming and run *after*
+   `with_params`, so a construction-time snapshot would record
+   pre-builder values and a reset would silently discard the caller's
+   configuration.
+2. It makes the round trip exact by construction: the snapshot is taken
+   at the exact instant the ladder starts, so restoring it returns the
+   solver to a state it demonstrably occupied.
+
+After a reset the snapshot is cleared, so a later re-escalation
+re-captures and walks the identical ladder. `reset` → `increase` is
+indistinguishable from a fresh `Solver` with the same params, which is
+the property downstream needs when it re-baselines at a major-iteration
+or restoration boundary.
+
+### API
+
+```rust
+/// Revert every escalation applied by `increase_quality`.
+pub fn reset_quality(&mut self) -> bool;
+```
+
+Returns `true` if an escalation was undone, `false` if the solver was
+already at `Baseline` (a no-op). The boolean lets a caller that
+re-baselines unconditionally at a loop boundary log only the firings
+that mattered, without first reading `quality_level()`.
+
+Valid from any level, `Exhausted` included — a caller that exhausted
+the ladder on one system is exactly the caller that most needs the next
+system to start clean.
+
+### Considered and not taken: a scoped guard
+
+The issue also lists a guard form (escalate for the next `factor()`
+only, then fall back). A `QualityGuard<'a>(&'a mut Solver)` with
+`DerefMut` and a restoring `Drop` would work, but:
+
+- It fixes the scope at *one* `factor()`, and the Ipopt contract loop
+  escalates repeatedly until the factorization delivers. The natural
+  scope is the caller's own retry loop, whose shape FERAL does not know.
+- It is strictly expressible in terms of the reset, so shipping the
+  reset first costs the guard nothing if evidence for it later arrives.
+
+The issue itself names the reset as "the smallest useful increment",
+and states the downstream intent: re-baseline at whatever boundary
+makes sense "without FERAL having to know anything about the caller's
+algorithm". A reset satisfies that; a guard would encode an assumption
+about the caller's loop. Ship the reset.
+
+## Test oracle
+
+The oracle is external to the implementation: the reset must restore
+the parameter values the *caller* supplied. Those are known
+independently of any FERAL code path —
+
+- `Solver::new()` starts at `pivot_threshold = 1e-8`, MA27's `cntl(1)`
+  default (issue #2), with `ScalingStrategy::Auto`.
+- `Solver::with_params(np, _)` starts at whatever `np` carries; tests
+  pass a deliberately non-default value so a reset that restored
+  `NumericParams::default()` instead of the caller's parameters would
+  fail.
+
+No assertion in the plan is read off the implementation's own output.

--- a/dev/sessions/2026-08-29-01.md
+++ b/dev/sessions/2026-08-29-01.md
@@ -1,0 +1,160 @@
+# Session 2026-08-29-01
+
+## Goal
+
+Fix issue #192: `Solver::increase_quality`'s escalation is permanent and
+unscopable, so an escalation chosen for one hard factorization governs
+every factorization for the remaining life of the `Solver`.
+
+## Benchmark Results
+
+**The exit partition was not measured this session.** The 153k-matrix
+corpus is not present in this container, so both partitions report
+`N/A` and there is no comparison against session 2026-08-19-05's
+1.58 / 1.58 to report — favourable or otherwise.
+
+```
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+KKT summary: 2 matrices (1 dense-eligible n <= 1000, 1 skipped n > 1000)
+  Inertia match: 1/1 (100.0%)
+  Residual pass: 1/1 (100.0%)
+  Worst residual: 1.14e-15 (densecol_kkt_300_0000)
+```
+
+What did run is clean, and the diff has no mechanism by which it could
+regress performance: it is a pure API addition whose new code path runs
+only when a caller calls `reset_quality()`. No numeric kernel, ordering,
+scaling, or pivoting code was touched, and the forward-ladder tests
+U1–U5 pass unchanged. That is an argument, not a measurement, and the
+next session with corpus access should confirm it.
+
+## Accomplished
+
+### `Solver::reset_quality()` (issue #192, commit `0952f99`)
+
+New `Solver::reset_quality() -> bool` and its Python binding. Reverts
+every escalation `increase_quality` applied — the `Identity → InfNorm`
+scaling flip and the raised `bk.pivot_threshold` — restoring the
+parameters the caller configured and returning `quality_level()` to
+`Baseline`. Returns `true` if an escalation was undone, `false` if
+already at baseline. Valid from any level, `Exhausted` included.
+
+Research note: `dev/research/issue-192-quality-reset.md`.
+Plan: `dev/plans/issue-192-quality-reset.md`.
+
+**Why the reset is needed and Ipopt does not have one.** Ipopt's
+`IncreaseQuality` is answered by MA57 raising `pivtol` toward
+`pivtolmax` — monotone in robustness, so leaving it raised for the rest
+of a solve can only make later factorizations safer, and never
+reverting is harmless. FERAL's rungs change *which pivots are taken*:
+the factorization is different, not uniformly better, and persisting it
+changes the caller's whole remaining trajectory, restoration
+sub-problems included.
+
+**Downstream evidence (pounce gh#850), from the issue.** On
+`square_flowsheet_resto` the rung fires exactly twice and costs both
+solve arms:
+
+| leg | with escalation | without |
+|---|---|---|
+| exact Hessian | `RestorationFailed`, 131 iters | `Optimal`, 99 |
+| limited-memory | 3000 iters, at the cap | `Optimal`, 178 |
+
+Declining to escalate is not the fix either: a 12-variable watchdog
+model ends `Solved_To_Acceptable_Level` at `obj = 3.7e-6` with the
+escalation and at `obj = 3.42` against `f* = 0` without it, and the rung
+buys 15–25% of the iterations on five other models. The distinguishing
+variable is how long the escalation lasts, not whether it fires.
+
+**Test evidence.** Six unit tests (R1–R6) and one integration test (I9),
+all written RED first — `error[E0599]: no method named reset_quality`,
+6 compile errors — plus one Python test.
+
+```
+cargo test --lib quality        -> 11 passed (R1-R6, U1-U5)
+cargo test --test pounce_interface -> 21 passed (incl. i9)
+cargo test                      -> 448 passed, 0 failed, 7 ignored (lib);
+                                   all integration suites green
+pytest python/tests/test_basic.py -> 16 passed (maturin develop build)
+cargo clippy --all-targets -- -D warnings -> clean
+cargo fmt --check               -> clean
+```
+
+Oracle discipline: every assertion is against a parameter value the
+*caller* supplied, never against implementation output. R5 constructs
+with `pivot_threshold = 0.25` and fails if the reset restores
+`NumericParams::default()`. R4's oracle is the ladder traversal recorded
+*before* any reset exists in the state. R6 pins the lazy snapshot
+against a construction-time one. I9 pins that re-baselining costs no
+symbolic re-analysis (`symbolic_call_count` never moves off 1), exactly
+as escalating costs none.
+
+Also updated: `CHANGELOG.md` (Unreleased), `FERAL-PROJECT-SPEC.md` §
+POUNCE API listing.
+
+### Tooling: pre-commit was missing in this container
+
+`pre-commit` was not on PATH, so `.git/hooks/pre-commit` did not exist
+and commits would have silently skipped fmt/clippy. Installed it
+(`pip install pre-commit && pre-commit install`) and verified the hook
+fires — the commit ran `cargo fmt --check`, `cargo clippy -- -D
+warnings`, and `cargo clippy -p feral-diagnostics --all-targets`, all
+Passed. Worth knowing that a fresh container starts without it.
+
+## Decisions Made
+
+Two, both appended to `dev/decisions.md`:
+
+1. **Take up the `reset_quality()` deferral.**
+   `dev/research/pounce-integration-interface.md` had recorded "FERAL
+   should match [Ipopt, no reset method] until there is evidence to add
+   it." Issue #192 is that evidence.
+2. **Snapshot the escalation baseline lazily, on the transition out of
+   `Baseline`, not at construction.** The `with_*` builders are
+   consuming and run *after* `with_params`, so a construction-time
+   snapshot would record pre-builder values and a reset would silently
+   discard the caller's configuration.
+
+## Abandoned Approaches
+
+Nothing was tried and abandoned; nothing appended to
+`dev/tried-and-rejected.md`.
+
+One alternative was **considered and deliberately not implemented**
+rather than tried and failed — the scoped-guard form the issue also
+lists (`QualityGuard<'a>(&'a mut Solver)` with a restoring `Drop`). It
+fixes the scope at one `factor()`, but the Ipopt contract loop escalates
+repeatedly until the factorization delivers, so the natural scope is the
+caller's own retry loop — a shape FERAL does not know. It is strictly
+expressible in terms of the reset, so shipping the reset first costs the
+guard nothing if evidence for it later arrives. Recorded in the research
+note under "Considered and not taken".
+
+## Next Session Should
+
+1. **Re-run the benchmark with corpus access** and confirm the exit
+   partition is unmoved against 2026-08-19-05's 1.58 / 1.58. This
+   session could not measure it; the claim of no regression is currently
+   an argument from the diff's shape, not a number.
+2. **Wait on pounce's re-measurement of gh#850** with
+   `reset_quality()` wired in at a major-iteration / restoration
+   boundary. The open downstream question is *which* boundary — FERAL
+   deliberately does not choose it — and the answer may or may not
+   motivate the scoped-guard form.
+3. Consider whether `QualityLevel::Exhausted` should carry any hint that
+   a reset is available, or whether that is purely the caller's business.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -5709,3 +5709,34 @@ identical hash over every `L`/`D` bit in storage order across
 4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
 is a performance-only change. Not yet established on a matrix that actually
 delays a pivot — all three report `d0`.
+
+## 2026-08-29 — `as_chunks::<4>()` in the Schur SIMD kernel: deferred, not measured
+
+**Context.** The stable toolchain moved to 1.98.0 (rustc `88d9e12ae`,
+2026-08-18), and clippy 1.98 added `chunks_exact_to_as_chunks`. It fires
+on 10 sites in `src/dense/schur_kernel.rs` — the 4-way unrolled SIMD
+bodies of `axpy_minus` / `axpy2_minus` — suggesting `as_chunks::<4>()`
+in place of `chunks_exact(4)` / `chunks_exact_mut(4)`. Under
+`-D warnings` this turned CI's `check` job red on every PR.
+
+**Not taken, and explicitly not because it is wrong.** The rewrite looks
+semantically identical, and giving the compiler `&[[f64; 4]]` instead of
+`&[f64]` may well be neutral or better for codegen. That is a
+*hypothesis*. This is the hottest loop in the factorization; its unroll
+depth and `into_remainder()` cleanup are a measured design
+(`dev/research/dense-kernel-*.md`), and the container this was found in
+has no corpus, so the change could not be benchmarked — the exit
+partition reports N/A here. Landing an unmeasured edit to that loop to
+satisfy a style lint inverts the project's order of operations.
+
+**What was done instead.** A file-scoped
+`#![allow(clippy::chunks_exact_to_as_chunks)]` in `schur_kernel.rs` with
+the reasoning in a comment beside it. The three other sites the lint
+flagged — `diag_schur_parity.rs` (x2) and `diag_acopr14.rs` — are
+byte-decoding loops in diagnostic binaries, not hot paths, so those took
+the real rewrite (and lost a `copy_from_slice` each).
+
+**Still open.** Whether `as_chunks` in the kernel is neutral, a win, or
+a loss is unmeasured and unclaimed. A session with corpus access should
+sweep it and either land the rewrite with numbers or record the
+regression here. Until then the `allow` is a deferral, not a verdict.

--- a/python/src/solver.rs
+++ b/python/src/solver.rs
@@ -346,9 +346,12 @@ impl Solver {
 
     /// Revert every escalation applied by `increase_quality`, putting
     /// the solver back at `QualityLevel.BASELINE` with the scaling
-    /// strategy and pivot threshold it was configured with. Returns
-    /// `True` if an escalation was undone, `False` if the solver was
-    /// already at baseline.
+    /// strategy and pivot threshold it was configured with.
+    ///
+    /// Returns `True` only if a parameter was actually restored to a
+    /// different value; `False` both when the solver was already at
+    /// baseline and when the escalation itself moved nothing. Either
+    /// way the level is re-baselined and the ladder is armed again.
     ///
     /// Lets a caller bound the escalation's lifetime -- re-baselining
     /// at a major iteration, or on entering a restoration

--- a/python/src/solver.rs
+++ b/python/src/solver.rs
@@ -337,10 +337,26 @@ impl Solver {
             .map_err(map_feral_err)
     }
 
-    /// Two-stage quality escalation. Returns `False` if both stages
-    /// are exhausted.
+    /// Two-stage quality escalation. Persists across `factor` calls
+    /// until `reset_quality` reverts it. Returns `False` if both
+    /// stages are exhausted.
     fn increase_quality(&mut self) -> bool {
         self.inner.increase_quality()
+    }
+
+    /// Revert every escalation applied by `increase_quality`, putting
+    /// the solver back at `QualityLevel.BASELINE` with the scaling
+    /// strategy and pivot threshold it was configured with. Returns
+    /// `True` if an escalation was undone, `False` if the solver was
+    /// already at baseline.
+    ///
+    /// Lets a caller bound the escalation's lifetime -- re-baselining
+    /// at a major iteration, or on entering a restoration
+    /// sub-problem -- instead of letting one hard factorization govern
+    /// the rest of the solve (issue #192). The cached symbolic
+    /// factorization is preserved.
+    fn reset_quality(&mut self) -> bool {
+        self.inner.reset_quality()
     }
 
     // ---- properties ----

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -167,6 +167,28 @@ def test_estimate_condition():
     assert np.isfinite(cond)
 
 
+def test_quality_reset_rebaselines_escalation():
+    """Issue #192: the escalation must be revertible from Python too."""
+    A = spd_3x3()
+    solver = feral.Solver()
+    solver.factor(A)
+    assert solver.quality_level == feral.QualityLevel.BASELINE
+
+    assert solver.increase_quality() is True
+    assert solver.quality_level != feral.QualityLevel.BASELINE
+
+    assert solver.reset_quality() is True
+    assert solver.quality_level == feral.QualityLevel.BASELINE
+
+    # Idempotent: a second reset has nothing to undo.
+    assert solver.reset_quality() is False
+    assert solver.quality_level == feral.QualityLevel.BASELINE
+
+    # The solver is still usable at factory parameters.
+    status, _ = solver.factor(A)
+    assert status == feral.FactorStatus.SUCCESS
+
+
 def test_repr():
     A = spd_3x3()
     assert "n=3" in repr(A)

--- a/src/dense/schur_kernel.rs
+++ b/src/dense/schur_kernel.rs
@@ -30,6 +30,16 @@
 //! continues to work on architectures without SIMD; no explicit
 //! `#[cfg(target_arch)]` gates are needed in this module.
 
+// `chunks_exact_to_as_chunks` (new in clippy 1.98) fires on the 4-way
+// unrolled SIMD bodies below, suggesting `as_chunks::<4>()`. Not taken
+// here: the unroll depth and the `into_remainder()` cleanup are a
+// measured design (`dev/research/dense-kernel-*.md`), and swapping the
+// iterator shape in the hottest loop in the factorization is a change
+// that has to be benchmarked against the corpus, not waved through to
+// satisfy a style lint. Allowed at file scope pending that measurement;
+// see the follow-up noted in `dev/tried-and-rejected.md`.
+#![allow(clippy::chunks_exact_to_as_chunks)]
+
 /// `dst[i] -= alpha * src[i]` for `i in 0..dst.len()`.
 ///
 /// Preconditions:

--- a/src/dense/schur_kernel.rs
+++ b/src/dense/schur_kernel.rs
@@ -38,6 +38,14 @@
 // that has to be benchmarked against the corpus, not waved through to
 // satisfy a style lint. Allowed at file scope pending that measurement;
 // see the follow-up noted in `dev/tried-and-rejected.md`.
+//
+// `unknown_lints` first: `chunks_exact_to_as_chunks` does not exist
+// before stable 1.98, and `unknown_lints` is warn-by-default, so under
+// the mandatory pre-commit hook's `-D warnings` the allow below would
+// itself be a hard error on any older toolchain -- blocking every local
+// commit, on every file, for anyone not yet on 1.98. CI tracks `stable`
+// and would never catch it.
+#![allow(unknown_lints)]
 #![allow(clippy::chunks_exact_to_as_chunks)]
 
 /// `dst[i] -= alpha * src[i]` for `i in 0..dst.len()`.

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -1992,10 +1992,44 @@ impl Solver {
     /// left at `Baseline` and the ladder is armed again.
     ///
     /// Restores the scaling strategy and `bk.pivot_threshold` the
-    /// caller had configured when the ladder started, so
-    /// `reset_quality` followed by `increase_quality` retraces the
-    /// same rungs a freshly constructed `Solver` would. Valid from
-    /// any level, `Exhausted` included.
+    /// caller had configured when the ladder started. Valid from any
+    /// level, `Exhausted` included. A `with_scaling` call made while
+    /// an escalation is live re-states that baseline, so a later reset
+    /// restores the strategy pinned last rather than undoing it
+    /// (test R7).
+    ///
+    /// # Guarantees
+    ///
+    /// These are contract, not incidental properties of the current
+    /// implementation. Each is pinned by a named test; a refactor that
+    /// breaks one is a breaking change, not a detail.
+    ///
+    /// 1. **A caller that never calls `reset_quality` sees
+    ///    byte-identical behaviour to before this method existed.**
+    ///    The escalation ladder is untouched — its rungs, the `0.75`
+    ///    exponent, `pivtol_max` — and the snapshot is inert state.
+    ///    Pinned by U1–U5, which predate this method and still pass
+    ///    unchanged. Downstream release processes diff a fixture sweep
+    ///    against a baseline binary and treat any moved line as a
+    ///    trajectory change needing explanation, so this property must
+    ///    not be allowed to drift silently.
+    ///
+    /// 2. **`reset_quality` then `increase_quality` retraces exactly
+    ///    the rungs a freshly constructed `Solver` would.** The round
+    ///    trip is idempotent: the snapshot records a state the solver
+    ///    demonstrably occupied, and is cleared on restore, so the
+    ///    next escalation re-captures and walks the identical ladder.
+    ///    Pinned by R4 (records the traversal before any reset exists
+    ///    and asserts the second traversal equals it) and R6.
+    ///
+    /// 3. **Re-baselining costs no symbolic re-analysis.** The cached
+    ///    `SymbolicFactorization` survives — it is scaling-invariant
+    ///    since scaling moved to the numeric phase — exactly as it
+    ///    survives an escalation. This is a cost guarantee: a caller
+    ///    may reset once per IPM iteration (e.g. on every KKT-matrix
+    ///    change), so a reset that forced re-analysis would become a
+    ///    silent per-iteration cost. Pinned by integration test I9 via
+    ///    `symbolic_call_count`.
     ///
     /// Issue #192. Ipopt has no counterpart, because MA57 answers
     /// `IncreaseQuality` by raising `pivtol` toward `pivtolmax` —
@@ -2010,11 +2044,11 @@ impl Solver {
     /// iteration, or on entering a restoration sub-problem — without
     /// FERAL having to know anything about the caller's algorithm.
     ///
-    /// Touches nothing but the escalated parameters and the level.
-    /// In particular the cached symbolic factorization survives (it is
-    /// scaling-invariant since scaling moved to the numeric phase), so
-    /// re-baselining costs no re-analysis, exactly as escalating costs
-    /// none.
+    /// Touches nothing but the escalated parameters and the level —
+    /// not `last_factors`, not `mc64_scaling_cache`, and none of the
+    /// independent latches (`ordering_escalated`, `auto_arm_latched`,
+    /// `mc64_retry_not_adopted`), mirroring what `increase_quality`
+    /// leaves alone.
     pub fn reset_quality(&mut self) -> bool {
         match self.quality_baseline.take() {
             Some(baseline) => {

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -796,6 +796,16 @@ impl Solver {
     /// `factor()` calls) which already prevents the flap; this builder
     /// is for hosts that want full control of the choice.
     pub fn with_scaling(mut self, scaling: ScalingStrategy) -> Self {
+        // If an escalation is live, this call re-states what the
+        // caller's baseline *is* — so the snapshot `reset_quality`
+        // will restore has to move with it. Without this, pinning a
+        // strategy mid-escalation would be silently undone by the
+        // next reset, which is the issue-#51 escape hatch failing in
+        // exactly the situation it exists for (review finding 2 on
+        // PR #193, test R7).
+        if let Some(baseline) = self.quality_baseline.as_mut() {
+            baseline.scaling = scaling.clone();
+        }
         self.numeric_params.scaling = scaling;
         self
     }
@@ -1967,9 +1977,19 @@ impl Solver {
     }
 
     /// Revert every escalation applied by [`Solver::increase_quality`]
-    /// and return to `QualityLevel::Baseline`. Returns `true` if an
-    /// escalation was undone, `false` if the solver was already at
-    /// `Baseline` (a no-op).
+    /// and return to `QualityLevel::Baseline`.
+    ///
+    /// Returns `true` only if a parameter was actually restored to a
+    /// different value. It returns `false` both when the solver was
+    /// already at `Baseline` and when the escalation itself moved
+    /// nothing — a rung can fire, and report `true`, without changing
+    /// a parameter: from non-`Identity` scaling with
+    /// `pivot_threshold` already at `pivtol_max`, stage 1 is a no-op
+    /// and stage 2 computes `0.5^0.75 = 0.594`, clamps back to `0.5`,
+    /// and lands on `Exhausted`. A caller keying retry telemetry on
+    /// this return value should not see a phantom undo (review
+    /// finding 3 on PR #193, test R8). In every case the level is
+    /// left at `Baseline` and the ladder is armed again.
     ///
     /// Restores the scaling strategy and `bk.pivot_threshold` the
     /// caller had configured when the ladder started, so
@@ -1998,10 +2018,12 @@ impl Solver {
     pub fn reset_quality(&mut self) -> bool {
         match self.quality_baseline.take() {
             Some(baseline) => {
+                let moved = self.numeric_params.scaling != baseline.scaling
+                    || self.numeric_params.bk.pivot_threshold != baseline.pivot_threshold;
                 self.numeric_params.scaling = baseline.scaling;
                 self.numeric_params.bk.pivot_threshold = baseline.pivot_threshold;
                 self.quality_level = QualityLevel::Baseline;
-                true
+                moved
             }
             None => false,
         }
@@ -3105,6 +3127,95 @@ mod tests {
             "must restore the builder-configured strategy, not the \
              one `with_params` was constructed with"
         );
+    }
+
+    /// R7 — reconfiguring scaling *after* escalating must not be
+    /// silently undone by a later reset (review finding 2 on PR #193).
+    ///
+    /// `with_scaling` is the documented issue-#51 escape hatch for a
+    /// host that sees the picker flapping. A caller that pins a
+    /// strategy mid-solve and later re-baselines must get the strategy
+    /// it pinned, not the one the snapshot happened to capture. R6
+    /// covers the pre-escalation window; this covers the post one.
+    #[test]
+    fn r7_reset_quality_honors_scaling_pinned_after_escalating() {
+        let mut s = solver_with_scaling(ScalingStrategy::Identity);
+        // Stage 1 (scaling), then stage 2 (pivot) — so the reset has
+        // something to restore independently of the pinned strategy.
+        assert!(s.increase_quality());
+        assert!(s.increase_quality());
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::InfNorm));
+        assert_eq!(s.pivot_threshold(), 0.01, "stage 2 first-jump rule");
+
+        // Host pins a strategy while the escalation is live.
+        s = s.with_scaling(ScalingStrategy::Mc64Symmetric);
+
+        assert!(s.reset_quality(), "the pivot bump is still undone");
+        assert!(
+            matches!(s.scaling_strategy(), ScalingStrategy::Mc64Symmetric),
+            "reset must restore the strategy the caller pinned last, \
+             not the stale pre-escalation snapshot; got {:?}",
+            s.scaling_strategy()
+        );
+        assert_eq!(s.pivot_threshold(), 0.0, "pivot still re-baselined");
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+    }
+
+    /// R7b — the finding-2 and finding-3 fixes compose: when the only
+    /// escalated parameter is the one the caller then overwrote, the
+    /// reset genuinely has nothing left to undo and says so.
+    #[test]
+    fn r7b_reset_quality_false_when_pin_already_superseded_the_rung() {
+        let mut s = solver_with_scaling(ScalingStrategy::Identity);
+        assert!(s.increase_quality()); // stage 1 only: scaling flip
+        assert_eq!(s.quality_level(), QualityLevel::ScalingEnabled);
+        assert_eq!(s.pivot_threshold(), 0.0, "pivot untouched by stage 1");
+
+        s = s.with_scaling(ScalingStrategy::Mc64Symmetric);
+
+        assert!(
+            !s.reset_quality(),
+            "the pin already superseded the only rung that fired"
+        );
+        assert!(matches!(
+            s.scaling_strategy(),
+            ScalingStrategy::Mc64Symmetric
+        ));
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+    }
+
+    /// R8 — an escalation that moved nothing is not reported as undone
+    /// (review finding 3 on PR #193).
+    ///
+    /// With non-`Identity` scaling and `pivot_threshold` already at
+    /// `pivtol_max`, stage 1 is a no-op and stage 2 computes
+    /// `0.5^0.75 = 0.594`, clamps back to `0.5`, and jumps to
+    /// `Exhausted` — so `increase_quality` returns `true` having
+    /// changed no parameter. A caller keying telemetry on
+    /// `reset_quality()` must not see a phantom undo.
+    #[test]
+    fn r8_reset_quality_reports_false_when_escalation_moved_nothing() {
+        let mut s = solver_with_scaling(ScalingStrategy::InfNorm);
+        s.numeric_params.bk.pivot_threshold = 0.5; // == pivtol_max
+
+        assert!(s.increase_quality(), "the rung still fires");
+        assert_eq!(s.quality_level(), QualityLevel::Exhausted);
+        assert_eq!(
+            s.pivot_threshold(),
+            0.5,
+            "0.5^0.75 clamps back to pivtol_max: nothing moved"
+        );
+
+        assert!(
+            !s.reset_quality(),
+            "no parameter moved, so nothing was undone"
+        );
+        // The level is still re-baselined either way.
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+        assert_eq!(s.pivot_threshold(), 0.5);
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::InfNorm));
+        // And the ladder is armed again.
+        assert!(s.increase_quality());
     }
 
     /// F1 — same pattern fingerprints equal, structural hash stable

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -113,6 +113,21 @@ pub enum QualityLevel {
     Exhausted,
 }
 
+/// Factory snapshot of the two parameters `increase_quality`
+/// mutates, taken on the transition out of `QualityLevel::Baseline`
+/// so `reset_quality` can restore them exactly (issue #192).
+///
+/// Snapshotted at the start of the ladder rather than at
+/// construction: the `with_*` builders are consuming and run *after*
+/// `with_params`, so a construction-time snapshot would record
+/// pre-builder values and a reset would silently discard the
+/// caller's configuration.
+#[derive(Debug, Clone)]
+struct QualityBaseline {
+    scaling: ScalingStrategy,
+    pivot_threshold: f64,
+}
+
 /// Structural fingerprint used to detect when the cached
 /// `SymbolicFactorization` is stale. Two genuinely identical
 /// patterns produce the same fingerprint by construction; the
@@ -189,6 +204,10 @@ pub struct Solver {
     snode_params: SupernodeParams,
     pivtol_max: f64,
     quality_level: QualityLevel,
+    /// Parameters to restore in `reset_quality`. `None` while at
+    /// `QualityLevel::Baseline`; `Some` for the duration of an
+    /// escalation. See `QualityBaseline`.
+    quality_baseline: Option<QualityBaseline>,
     last_symbolic: Option<SymbolicFactorization>,
     last_factors: Option<SparseFactors>,
     last_inertia: Option<Inertia>,
@@ -423,6 +442,7 @@ impl Solver {
             snode_params: sn,
             pivtol_max: 0.5,
             quality_level: QualityLevel::Baseline,
+            quality_baseline: None,
             last_symbolic: None,
             last_factors: None,
             last_inertia: None,
@@ -1876,7 +1896,8 @@ impl Solver {
     }
 
     /// Two-stage quality escalation. Persistent across `factor()`
-    /// calls. Returns `false` when both stages are exhausted.
+    /// calls until [`Solver::reset_quality`] reverts it. Returns
+    /// `false` when both stages are exhausted.
     /// Mirrors `IpTSymLinearSolver::IncreaseQuality`.
     ///
     /// Stage 1 (`Baseline → ScalingEnabled`): if scaling strategy
@@ -1903,6 +1924,13 @@ impl Solver {
         match self.quality_level {
             QualityLevel::Exhausted => false,
             QualityLevel::Baseline => {
+                // Leaving Baseline: snapshot what the caller
+                // configured so `reset_quality` can restore it
+                // exactly (issue #192).
+                self.quality_baseline = Some(QualityBaseline {
+                    scaling: self.numeric_params.scaling.clone(),
+                    pivot_threshold: self.numeric_params.bk.pivot_threshold,
+                });
                 // Stage 1: flip Identity → InfNorm if applicable.
                 if matches!(self.numeric_params.scaling, ScalingStrategy::Identity) {
                     self.numeric_params.scaling = ScalingStrategy::InfNorm;
@@ -1936,6 +1964,47 @@ impl Solver {
         } else {
             QualityLevel::PivotRaised
         };
+    }
+
+    /// Revert every escalation applied by [`Solver::increase_quality`]
+    /// and return to `QualityLevel::Baseline`. Returns `true` if an
+    /// escalation was undone, `false` if the solver was already at
+    /// `Baseline` (a no-op).
+    ///
+    /// Restores the scaling strategy and `bk.pivot_threshold` the
+    /// caller had configured when the ladder started, so
+    /// `reset_quality` followed by `increase_quality` retraces the
+    /// same rungs a freshly constructed `Solver` would. Valid from
+    /// any level, `Exhausted` included.
+    ///
+    /// Issue #192. Ipopt has no counterpart, because MA57 answers
+    /// `IncreaseQuality` by raising `pivtol` toward `pivtolmax` —
+    /// monotone in robustness, so leaving it raised for the rest of a
+    /// solve can only make later factorizations safer. FERAL's rungs
+    /// (`Identity → InfNorm`, then `pivot_threshold^0.75`) change
+    /// *which pivots are taken*: the factorization is different, not
+    /// uniformly better, and persisting it changes the caller's whole
+    /// remaining trajectory. An escalation that rescues one hard
+    /// system can cost a later one its verdict. This lets a caller
+    /// bound the escalation's lifetime — re-baselining at a major
+    /// iteration, or on entering a restoration sub-problem — without
+    /// FERAL having to know anything about the caller's algorithm.
+    ///
+    /// Touches nothing but the escalated parameters and the level.
+    /// In particular the cached symbolic factorization survives (it is
+    /// scaling-invariant since scaling moved to the numeric phase), so
+    /// re-baselining costs no re-analysis, exactly as escalating costs
+    /// none.
+    pub fn reset_quality(&mut self) -> bool {
+        match self.quality_baseline.take() {
+            Some(baseline) => {
+                self.numeric_params.scaling = baseline.scaling;
+                self.numeric_params.bk.pivot_threshold = baseline.pivot_threshold;
+                self.quality_level = QualityLevel::Baseline;
+                true
+            }
+            None => false,
+        }
     }
 
     /// Test/diagnostic accessor for the current pivot threshold.
@@ -2914,6 +2983,128 @@ mod tests {
             assert!(steps < 20, "did not exhaust within 20 steps");
         }
         assert_eq!(s.quality_level(), QualityLevel::Exhausted);
+    }
+
+    /// R1 — `reset_quality` at `Baseline` is a no-op and says so.
+    ///
+    /// Issue #192. A caller that re-baselines unconditionally at a
+    /// loop boundary must be able to do so without first reading
+    /// `quality_level()`, and must be able to tell from the return
+    /// value whether anything was actually undone.
+    #[test]
+    fn r1_reset_quality_at_baseline_is_noop() {
+        let mut s = solver_with_scaling(ScalingStrategy::Identity);
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+
+        assert!(!s.reset_quality(), "nothing to undo at Baseline");
+
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::Identity));
+        assert_eq!(s.pivot_threshold(), 0.0);
+    }
+
+    /// R2 — reset undoes the stage-1 `Identity → InfNorm` flip.
+    #[test]
+    fn r2_reset_quality_undoes_stage_one_scaling_flip() {
+        let mut s = solver_with_scaling(ScalingStrategy::Identity);
+        assert!(s.increase_quality());
+        assert_eq!(s.quality_level(), QualityLevel::ScalingEnabled);
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::InfNorm));
+
+        assert!(s.reset_quality(), "an escalation was undone");
+
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::Identity));
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+        assert_eq!(s.pivot_threshold(), 0.0, "stage 1 never moved the pivot");
+    }
+
+    /// R3 — reset undoes an arbitrarily deep stage-2 pivot ladder.
+    #[test]
+    fn r3_reset_quality_undoes_pivot_ladder() {
+        let mut s = solver_with_scaling(ScalingStrategy::InfNorm);
+        for _ in 0..3 {
+            assert!(s.increase_quality());
+        }
+        assert_ne!(s.pivot_threshold(), 0.0, "ladder actually moved");
+
+        assert!(s.reset_quality());
+
+        assert_eq!(
+            s.pivot_threshold(),
+            0.0,
+            "restores the constructed threshold, not a rung of the ladder"
+        );
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+    }
+
+    /// R4 — reset from `Exhausted` restarts the identical ladder.
+    ///
+    /// Pins the property downstream needs (issue #192): after a reset,
+    /// re-escalating is indistinguishable from escalating a fresh
+    /// `Solver` built with the same parameters. The oracle is the
+    /// first traversal, recorded before any reset exists in the state.
+    #[test]
+    fn r4_reset_quality_from_exhausted_restarts_identical_ladder() {
+        fn walk(s: &mut Solver) -> Vec<(QualityLevel, f64)> {
+            let mut seen = Vec::new();
+            while s.increase_quality() {
+                seen.push((s.quality_level(), s.pivot_threshold()));
+                assert!(seen.len() < 20, "did not exhaust within 20 steps");
+            }
+            seen
+        }
+
+        let mut s = solver_with_scaling(ScalingStrategy::Identity);
+        let first = walk(&mut s);
+        assert_eq!(s.quality_level(), QualityLevel::Exhausted);
+
+        assert!(s.reset_quality(), "reset is valid from Exhausted");
+        assert_eq!(s.quality_level(), QualityLevel::Baseline);
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::Identity));
+        assert_eq!(s.pivot_threshold(), 0.0);
+
+        let second = walk(&mut s);
+        assert_eq!(second, first, "re-escalation must retrace the same rungs");
+    }
+
+    /// R5 — reset restores the *caller's* parameters, not
+    /// `NumericParams::default()`.
+    #[test]
+    fn r5_reset_quality_restores_caller_params_not_defaults() {
+        const CALLER_PIVTOL: f64 = 0.25;
+        assert_ne!(
+            NumericParams::default().bk.pivot_threshold,
+            CALLER_PIVTOL,
+            "oracle is only meaningful if it differs from the default"
+        );
+
+        let mut s = solver_with_scaling(ScalingStrategy::InfNorm);
+        s.numeric_params.bk.pivot_threshold = CALLER_PIVTOL;
+
+        assert!(s.increase_quality());
+        assert_ne!(s.pivot_threshold(), CALLER_PIVTOL);
+
+        assert!(s.reset_quality());
+        assert_eq!(s.pivot_threshold(), CALLER_PIVTOL);
+    }
+
+    /// R6 — the snapshot is taken when the ladder starts, not at
+    /// construction, so a builder applied after `with_params` is the
+    /// baseline that gets restored.
+    #[test]
+    fn r6_reset_quality_preserves_builder_configured_scaling() {
+        let mut s =
+            solver_with_scaling(ScalingStrategy::InfNorm).with_scaling(ScalingStrategy::Identity);
+
+        assert!(s.increase_quality());
+        assert!(matches!(s.scaling_strategy(), ScalingStrategy::InfNorm));
+
+        assert!(s.reset_quality());
+        assert!(
+            matches!(s.scaling_strategy(), ScalingStrategy::Identity),
+            "must restore the builder-configured strategy, not the \
+             one `with_params` was constructed with"
+        );
     }
 
     /// F1 — same pattern fingerprints equal, structural hash stable

--- a/tests/pounce_interface.rs
+++ b/tests/pounce_interface.rs
@@ -446,6 +446,50 @@ fn i8_solver_lifetime_state_persists() {
     assert!((solver.pivot_threshold() - want_after_2).abs() < 1e-15);
 }
 
+/// I9 — issue #192: `reset_quality()` re-baselines the escalation
+/// without disturbing anything else the solver carries.
+///
+/// The pounce-side failure in #192 is that an escalation taken for one
+/// hard KKT system silently governs every later factorization. A caller
+/// that re-baselines at a major-iteration or restoration boundary must
+/// get back the factory parameters *and* must not pay a fresh symbolic
+/// analysis for doing so — the symbolic cache is scaling-invariant
+/// (β refactor), so neither escalating nor reverting may invalidate it.
+#[test]
+fn i9_reset_quality_rebaselines_without_invalidating_symbolic() {
+    let csc = CscMatrix::from_triplets(3, &[0, 1, 2], &[0, 1, 2], &[2.0, 3.0, 5.0]).unwrap();
+
+    let mut solver = Solver::new();
+    assert!(matches!(solver.factor(&csc, None), FactorStatus::Success));
+    let n_sym = solver.symbolic_call_count();
+
+    // Escalate twice, as the Ipopt `IncreaseQuality` retry loop would.
+    assert!(solver.increase_quality());
+    assert!(solver.increase_quality());
+    assert_eq!(solver.quality_level(), QualityLevel::PivotRaised);
+    assert!(matches!(solver.factor(&csc, None), FactorStatus::Success));
+    assert_ne!(solver.pivot_threshold(), 1e-8, "escalation took effect");
+
+    // Re-baseline at a caller-chosen boundary.
+    assert!(solver.reset_quality(), "an escalation was undone");
+    assert_eq!(solver.quality_level(), QualityLevel::Baseline);
+    assert_eq!(
+        solver.pivot_threshold(),
+        1e-8,
+        "back at MA27's cntl[1] default, the value `Solver::new()` \
+         starts from (issue #2)"
+    );
+
+    // The next factorization runs at factory parameters and still
+    // succeeds; no re-analysis was forced by either direction.
+    assert!(matches!(solver.factor(&csc, None), FactorStatus::Success));
+    assert_eq!(solver.symbolic_call_count(), n_sym);
+
+    // Idempotent: a second re-baseline at the same boundary is a no-op.
+    assert!(!solver.reset_quality());
+    assert_eq!(solver.pivot_threshold(), 1e-8);
+}
+
 /// `Solver::min_diagonal()` returns `None` before any successful factor.
 #[test]
 fn min_diagonal_before_factor_is_none() {


### PR DESCRIPTION
Closes #192.

## What

New `Solver::reset_quality() -> bool`, plus its Python binding. It reverts every escalation `increase_quality` applied — the `Identity → InfNorm` scaling flip and the raised `bk.pivot_threshold` — restoring the parameters the caller configured and returning `quality_level()` to `Baseline`. Returns `true` if an escalation was undone, `false` if already at baseline. Valid from any level, `Exhausted` included.

## Why

`increase_quality` was a one-way ratchet with no way back, so an escalation chosen for *one* hard factorization governed **every** later factorization for the life of the `Solver`.

Ipopt exposes no reset because MA57 answers `IncreaseQuality` by raising `pivtol` toward `pivtolmax` (`IpMa57TSolverInterface.cpp:832`) — strictly more conservative each time. That is monotone in *robustness*, so leaving it raised for the rest of a solve can only make later factorizations safer, and never reverting is harmless. FERAL's rungs change *which pivots are taken*: the factorization is different, not uniformly better, and persisting it changes the caller's whole remaining trajectory, including any restoration sub-problem's factorizations.

`dev/research/pounce-integration-interface.md` had deferred this — "FERAL should match [Ipopt] until there is evidence to add it." Issue #192 is that evidence; this takes up the deferral rather than reversing a decision.

### Downstream evidence (pounce gh#850, from the issue)

On `square_flowsheet_resto` the rung fires exactly twice and costs both solve arms:

| leg | with escalation | without |
|---|---|---|
| exact Hessian | `RestorationFailed`, 131 iters | `Optimal`, 99 |
| limited-memory | 3000 iters, at the cap | `Optimal`, 178 |

Not escalating is not the fix either: a 12-variable watchdog model ends `Solved_To_Acceptable_Level` at `obj = 3.7e-6` with the escalation and at `obj = 3.42` against `f* = 0` without it, and the rung buys 15–25% of the iterations on five other models. The distinguishing variable is how long the escalation lasts, not whether it fires.

## Design notes

**The baseline is snapshotted lazily**, on the transition out of `Baseline`, not at construction. The `with_*` builders are consuming and run *after* `with_params`, so a construction-time snapshot would record pre-builder values and a reset would silently discard the caller's configuration. It also makes the round trip exact by construction: `reset` → `increase` retraces the same rungs a freshly constructed `Solver` would.

**The reset touches nothing else**, mirroring what `increase_quality` leaves alone — not `last_symbolic`, not `mc64_scaling_cache`, not the independent latches. The cached symbolic factorization is scaling-invariant since scaling moved to the numeric phase, so re-baselining costs no re-analysis, exactly as escalating costs none.

**The scoped-guard form the issue also lists was considered and not implemented.** A guard fixes the scope at one `factor()`, but the Ipopt contract loop escalates repeatedly until the factorization delivers, so the natural scope is the caller's own retry loop — a shape FERAL does not know and should not assume. It stays expressible in terms of the reset if evidence for it later arrives. Recorded as considered-and-not-taken in the research note, not reframed as a rejection.

## Evidence

Six unit tests (R1–R6) and integration test I9, all written RED first (`error[E0599]: no method named reset_quality`, 6 compile errors), plus one Python test.

Every oracle is a parameter value the *caller* supplied, never implementation output:
- **R5** constructs with `pivot_threshold = 0.25` and fails if the reset restores `NumericParams::default()`.
- **R4**'s oracle is the ladder traversal recorded *before* any reset exists in the state.
- **R6** pins the lazy snapshot against a construction-time one.
- **I9** pins that re-baselining costs no symbolic re-analysis (`symbolic_call_count` never moves off 1).

```
cargo test           -> 448 passed, 0 failed, 7 ignored (lib);
                        all integration suites green
pytest tests/        -> 16 passed (built via maturin develop, run locally)
cargo clippy --all-targets -- -D warnings -> clean
cargo fmt --check    -> clean
```

The escalation ladder itself is untouched — rungs, the `0.75` exponent, `pivtol_max` — and U1–U5 pass unchanged, so a caller that never calls `reset_quality` sees byte-identical behaviour.

## What was not measured

**The exit partition was not measured on this branch.** The 153k-matrix corpus is not present in the session container, so both partitions report `N/A` and there is no comparison against 2026-08-19-05's 1.58 / 1.58 to report — favourable or otherwise. What did run is clean (inertia 2/2 vs MUMPS, residual 2/2, worst 1.26e-16 on the 2 synthetic KKT matrices the bench generates).

The diff has no mechanism by which it could regress performance — a pure API addition whose new code path runs only when a caller calls `reset_quality()`, with no numeric kernel, ordering, scaling, or pivoting code touched. That is an argument from the diff's shape, not a number, and it is worth confirming on a host with corpus access before release.

## Also in this PR

- `CHANGELOG.md` Unreleased entry; `FERAL-PROJECT-SPEC.md` POUNCE API listing.
- Research note `dev/research/issue-192-quality-reset.md`, plan `dev/plans/issue-192-quality-reset.md`, session checkpoint `dev/sessions/2026-08-29-01.md`, journal, and two appended entries in `dev/decisions.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmY6FDHgsdqSMTi6GsqAz7)_