### PR TITLE
feat: cooperative cancellation for Solver::factor (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,35 @@ All notable changes to FERAL will be documented in this file.
   returned at 25.5 ms. A paired A/B against the previous release found no
   measurable cost when unarmed — every poll site short-circuits on an
   `Option::is_some` branch and touches no atomic.
-- **Additive.** An unarmed `Solver` is unaffected in behaviour and in
-  performance. `FactorStatus` and `FeralError` each gain one variant, so
-  exhaustive `match`es over them need a new arm. The C ABI defines
-  `FERAL_INTERRUPTED = 4` and the Python bindings define
-  `FactorStatus.INTERRUPTED`; neither surface can arm the flag yet, so on both
-  the code is reserved rather than reachable.
+- **BREAKING for exhaustive `match`es; additive at runtime.** An unarmed
+  `Solver` is unaffected in behaviour and in performance — nothing that
+  already worked changes what it does. But `FactorStatus` and `FeralError`
+  each gain one variant and neither is `#[non_exhaustive]`, so every
+  downstream `match` over them that lists all arms stops compiling until a
+  new arm is added. In-tree this broke 4 integration tests, 10
+  `feral-diagnostics` probe binaries, and the Python bindings; a downstream
+  crate will see the same. Each was given an explicit arm rather than a
+  wildcard, deliberately: the next variant should break the same builds
+  rather than be silently absorbed. The C ABI defines `FERAL_INTERRUPTED = 4`
+  and the Python bindings define `FactorStatus.INTERRUPTED`; neither surface
+  can arm the flag yet, so on both the code is reserved rather than
+  reachable.
+- **One defect found in review and fixed before merge.** The issue-#65 MC64
+  rescue re-factors with `Mc64Symmetric` when the first factorization reports
+  the singular signature, and its non-adoption arm was a bare `_` that also
+  caught `Err(_)`. An interrupt observed during that *retry* was therefore
+  swallowed: `factor` returned `Success` rather than `Interrupted`, and
+  `mc64_retry_not_adopted` latched. Because that latch is keyed on the
+  pattern and cleared only on a pattern change, a single cancellation would
+  have suppressed the MC64 rescue for every later factor of the same pattern
+  — for an interior-point host, the rest of the solve — reporting unrescued
+  inertia where it would otherwise have recovered. The window was not narrow:
+  it was the entire duration of a second full factorization. Fixed by
+  propagating `Err(FeralError::Interrupted)` explicitly and leaving the latch
+  disarmed, since a cancellation is not evidence about MC64 — the retry never
+  finished. Regression test: `tests/issue194_interrupt_during_mc64_retry.rs`,
+  verified to fail before the fix (observed `Success` on a cancelled call).
+
 ### Added - iterative refinement can be told what "converged" means (issue #190)
 
 - **The problem.** The refinement loop's only convergence test was a hardwired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to FERAL will be documented in this file.
 
+## [Unreleased]
+
+### Added — `Solver::factor` can now be cancelled (issue #194)
+
+- **What changed.** A caller-owned `Arc<AtomicBool>` can be armed on a
+  `Solver` with `with_interrupt(flag)` (builder) or `set_interrupt(Some(flag))`
+  (through a `&mut` borrow; `None` disarms), and read back with `interrupt()`.
+  While armed, `factor` polls the flag and, on the first observation of `true`,
+  stops and returns the new `FactorStatus::Interrupted`. The underlying
+  free-function drivers surface it as the new `FeralError::Interrupted`, and
+  the flag itself is `BunchKaufmanParams::interrupt`, so direct users of
+  `factorize_multifrontal*` and of the dense frontal factor get the same
+  mechanism.
+- **Why.** `factor` could not be cancelled once running and offered no surface
+  through which to ask, so a host enforcing a wall-clock budget could not
+  enforce it whenever a single factorization was larger than the whole budget —
+  it never regained control to check its own deadline. Measured in pounce on
+  `emfl050_5_5` (5675 variables, 5625 constraints): a `max_wall_time=5` solve
+  returned `TIME_LIMIT` after **48.8 s**, because the between-operation check
+  passed while under budget and one factorization then ran ~44 s uninterrupted.
+  A watchdog on the caller's side cannot fix this: `Solver` holds workspace,
+  symbolic and permute caches across calls, so abandoning a factorization
+  mid-flight either orphans mutable state or forces a fresh `Solver` per call
+  and destroys the symbolic reuse an interior-point host depends on.
+- **Contract.** On `Interrupted` the factors are left invalid exactly as after
+  any failed factor — `inertia()` is `None`, `solve()` returns `NoFactor` — and
+  a subsequent `factor` re-runs cleanly once the caller clears the flag. No
+  partial results are promised. Polling happens at supernode boundaries and, in
+  a supernode, at dense panel boundaries; there is no guarantee about *when*
+  within a panel the check fires. Only the numeric factorization is covered:
+  the symbolic analysis on the first factor of a new pattern is not
+  interruptible.
+- **Caller-owned, and no clock.** feral only ever *reads* the flag, so
+  re-arming after an interrupt is the caller's `store(false)`. Taking a flag
+  rather than a deadline keeps feral clock-agnostic and leaves
+  wall-vs-CPU-vs-budget policy where it belongs.
+- **Measured.** In `--release` on a warm solver (symbolic cached, the
+  interior-point case), 5-point Laplacian `n = 122500`: sequential driver,
+  263.2 ms un-interrupted, flag set at 26.3 ms, `Interrupted` returned at
+  34.8 ms; parallel driver, 153.5 ms un-interrupted, flag set at 15.3 ms,
+  returned at 25.5 ms. A paired A/B against the previous release found no
+  measurable cost when unarmed — every poll site short-circuits on an
+  `Option::is_some` branch and touches no atomic.
+- **Additive.** An unarmed `Solver` is unaffected in behaviour and in
+  performance. `FactorStatus` and `FeralError` each gain one variant, so
+  exhaustive `match`es over them need a new arm. The C ABI defines
+  `FERAL_INTERRUPTED = 4` and the Python bindings define
+  `FactorStatus.INTERRUPTED`; neither surface can arm the flag yet, so on both
+  the code is reserved rather than reachable.
+
 ## [0.17.0] - 2026-08-19
 
 ### Fixed — the tree-parallel solve no longer runs on trees too thin to pay for it (issue #175)

--- a/crates/feral-diagnostics/src/bin/diag_issue50_auto_validate.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_auto_validate.rs
@@ -127,6 +127,10 @@ fn run_auto(matrix: &CscMatrix) -> (Option<usize>, Option<u64>, String, String) 
         FactorStatus::Singular => "singular",
         FactorStatus::WrongInertia { .. } => "wrong_inertia",
         FactorStatus::FatalError(_) => "fatal",
+        // Issue #194: unreachable here (this probe never arms an
+        // interrupt flag), but labelled rather than wildcarded so a
+        // future variant cannot be silently folded into another.
+        FactorStatus::Interrupted => "interrupted",
     };
     let (resolved, nnz_l) = match solver.factors() {
         Some(f) => (format!("{:?}", f.resolved_method), Some(f.factor_nnz())),

--- a/crates/feral-diagnostics/src/bin/diag_issue50_numeric_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_issue50_numeric_inventory.rs
@@ -207,6 +207,7 @@ fn run_one(matrix: &CscMatrix, method: OrderingMethod) -> (Option<usize>, Option
         FactorStatus::Singular => "singular",
         FactorStatus::WrongInertia { .. } => "wrong_inertia",
         FactorStatus::FatalError(_) => "fatal",
+        FactorStatus::Interrupted => "interrupted",
     };
     let nnz_l = solver.factors().map(|f| f.factor_nnz());
     let factor_us = if matches!(status, FactorStatus::Success) {

--- a/crates/feral-diagnostics/src/bin/diag_near_singular_sweep.rs
+++ b/crates/feral-diagnostics/src/bin/diag_near_singular_sweep.rs
@@ -112,6 +112,7 @@ fn main() {
             FactorStatus::Singular => "Singular",
             FactorStatus::WrongInertia { .. } => "WrongInertia",
             FactorStatus::FatalError(_) => "FatalError",
+            FactorStatus::Interrupted => "Interrupted",
         };
 
         let inertia = solver.inertia().cloned().unwrap_or(feral::Inertia {
@@ -201,6 +202,7 @@ fn main() {
             FactorStatus::Singular => "Singular",
             FactorStatus::WrongInertia { .. } => "WrongInertia",
             FactorStatus::FatalError(_) => "FatalError",
+            FactorStatus::Interrupted => "Interrupted",
         };
         let inertia = solver.inertia().cloned().unwrap_or(feral::Inertia {
             positive: 0,

--- a/crates/feral-diagnostics/src/bin/diag_small_sparse_inventory.rs
+++ b/crates/feral-diagnostics/src/bin/diag_small_sparse_inventory.rs
@@ -160,6 +160,7 @@ fn run_one(matrix: &CscMatrix, method: OrderingMethod) -> (Option<usize>, Option
         FactorStatus::Singular => "singular",
         FactorStatus::WrongInertia { .. } => "wrong_inertia",
         FactorStatus::FatalError(_) => "fatal",
+        FactorStatus::Interrupted => "interrupted",
     };
     let nnz_l = solver.factors().map(|f| f.factor_nnz());
     let factor_us = if matches!(status, FactorStatus::Success) {

--- a/crates/feral-diagnostics/src/bin/phase0_cb_on_revalidation.rs
+++ b/crates/feral-diagnostics/src/bin/phase0_cb_on_revalidation.rs
@@ -130,6 +130,10 @@ fn run_case(case: &Case) -> Outcome {
             pass: false,
             detail: format!("FAIL FatalError({e:?})  factor={dt:.3}s"),
         },
+        FactorStatus::Interrupted => Outcome {
+            pass: false,
+            detail: format!("FAIL Interrupted  factor={dt:.3}s"),
+        },
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/probe_issue63_nearsingular.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue63_nearsingular.rs
@@ -116,6 +116,7 @@ fn status_short(s: &FactorStatus) -> &'static str {
         FactorStatus::Singular => "Singular",
         FactorStatus::WrongInertia { .. } => "WrongInertia",
         FactorStatus::FatalError(_) => "FatalError",
+        FactorStatus::Interrupted => "Interrupted",
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/probe_issue65_scaling.rs
+++ b/crates/feral-diagnostics/src/bin/probe_issue65_scaling.rs
@@ -46,6 +46,7 @@ fn status_short(s: &FactorStatus) -> String {
             format!("WrongInertia(act {actual:?} exp {expected:?})")
         }
         FactorStatus::FatalError(e) => format!("FatalError({e:?})"),
+        FactorStatus::Interrupted => "Interrupted".to_string(),
     }
 }
 

--- a/crates/feral-diagnostics/src/bin/probe_kkt_replay.rs
+++ b/crates/feral-diagnostics/src/bin/probe_kkt_replay.rs
@@ -143,6 +143,7 @@ fn main() {
             ),
             FactorStatus::Singular => "Singular".to_string(),
             FactorStatus::FatalError(e) => format!("Fatal: {e:?}"),
+            FactorStatus::Interrupted => "Interrupted".to_string(),
         };
         println!("{i:>4}  {elapsed:>10.3}  {p:>10}  {n:>10}  {z:>10}  {label}");
     }

--- a/crates/feral-diagnostics/src/bin/probe_pinene_issue38_fix.rs
+++ b/crates/feral-diagnostics/src/bin/probe_pinene_issue38_fix.rs
@@ -75,6 +75,7 @@ fn main() {
             ),
             FactorStatus::Singular => "Singular".to_string(),
             FactorStatus::FatalError(e) => format!("Fatal: {e:?}"),
+            FactorStatus::Interrupted => "Interrupted".to_string(),
         };
 
         println!("{i:>4}  {elapsed:>10.3}  {p:>10}  {n:>10}  {z:>10}  {label}");

--- a/crates/feral-diagnostics/src/bin/probe_warm_cascade.rs
+++ b/crates/feral-diagnostics/src/bin/probe_warm_cascade.rs
@@ -80,6 +80,7 @@ fn factor_one(
         FactorStatus::WrongInertia { .. } => "WrongInertia",
         FactorStatus::Singular => "Singular",
         FactorStatus::FatalError(_) => "Fatal",
+        FactorStatus::Interrupted => "Interrupted",
     };
     println!("  {label:<8} {secs:>10.3} s  {tag}");
     secs

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,70 +1,335 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-20T02:05:49Z
+Generated: 2026-08-30T00:31:02Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-04.md
+File: dev/sessions/2026-08-19-05.md
 ```
-# Session 2026-08-19-04
-
-## BENCHMARK NUMBERS ARE NOT COMPARABLE TO LAST SESSION
-
-Reported first, per the hard rule in CLAUDE.md — and for the same reason
-as 2026-08-19-02: `cargo run --bin bench --release` in this container
-finds only the 8 synthetic matrices. The external corpus and the
-MUMPS/SPRAL oracle timings are absent, so both Phase 2.8.1 exit
-partitions report `N/A` and **no comparison against 2026-08-15-02's
-1.61 / 2.00 / 1.67 / 1.67 is possible from this run**. I am not claiming
-those numbers held; they were not measured.
-
-What the run does confirm, identical to last session: inertia 2/2 vs
-MUMPS, residual 2/2, worst residual 1.26e-16.
-
-It is also the wrong benchmark for this change, which touches solve
-*scheduling* and not the factor path. The measurements that matter are
-in "Benchmark Results" below.
+# Session 2026-08-19-05
 
 ## Goal
 
-Fix issue #175 — the tree-parallel solve added for #131 Gap A is a net
-15% loss on the wide-sparse Mittelmann KKT `NARX_CFy`, and
-`CbTaskPlan::worthwhile` has no per-call-overhead term.
+Close out issue #153 item 2, review the six PRs merged since v0.16.0 for
+mistakes before shipping, and cut release 0.17.0 (which unblocks
+pounce#710's second blocker).
+
+## Benchmark Results
+
+No regression. Both exit partitions PASS, and the small-frontal p90
+improved slightly against the run earlier in this session (1.60/1.61 ->
+1.58); the change is within run-to-run noise on this container and is not
+claimed as an improvement.
+
+```
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.58     <= 2.0     PASS
+medium (<500)            153560     1.58     <= 3.0     PASS
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.45       0.32       1.58       3.45      10.58
+solve/MUMPS        153560       0.08       0.08       0.15       0.79       2.71
+factor/SSIDS       154500       0.04       0.03       0.33       1.02       2.30
+solve/SSIDS        154500       0.95       1.00       2.50       9.00      35.25
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+```
 
 ## Accomplished
 
-### The report is real, and it is purely a scheduling bug
+### Issue #153 item 2 — both hypotheses falsified (PR #184, merged)
 
-The reporter serialized the tree-parallel solve with `FERAL_CB_THRESH`
-and recovered 7.35 s of 49.41 s (15%) plus ~3.0M involuntary context
-switches, on 14 cores over 100 IPM iterations. Two things follow that
-the issue does not state:
+Rescoped #153 to item 2 and measured rather than assumed. Both standing
+hypotheses for the dtoc1nd dense-front gap — a packed-SIMD work gate, and
+`block_size` — were falsified by measurement. Research note written; two
+diagnostic probes landed.
 
-1. `FERAL_CB_THRESH` does not choose the solve *core* — since #177 that
-   is `cb_core_profitable`, which reads neither the worker count nor the
-   environment. A huge threshold collapses the plan to one task, so the
-   **same** CB core runs serially. The whole 7.35 s is scheduling
-   overhead, and fixing it cannot move a bit of any solve.
-2. Rows 3 and 4 of the reporter's table are within noise, so the CB core
-   running serially already matches switching parallelism off entirely
-   on this problem. Nothing in the report argues for changing which core
-   runs.
+### Pre-release review of six PRs (PR #185, merged)
 
-### Mechanism: the overhead is per front, not per task
-
-`cb_run_parallel` takes the shared `contribs` mutex inside its per-front
-loop — once per child drained, once to store the front's own block. That
-cost scales with the supernode count; `MIN_TOTAL_COST` is a floor on
-*total* work. `NARX_CFy` has 45,736 supernodes and a Lagrangian Hessian
+Reviewed #174, #179, #180, #181, #182, #183 with agents, then verified
+every reported finding by hand against git before acting on it. One
+behavioural regression, one guard-test gap, and a set of unsupported
 ```
 
 ## Git Status
 ```
+9b9e882 Merge pull request #188 from jkitchin/ci/codecov-coverage
+1292984 ci: measure coverage with cargo-llvm-cov and report it to Codecov
+ad0d96d Merge pull request #187 from jkitchin/docs/session-2026-08-19-05
+b224ed1 docs: session checkpoint 2026-08-19-05 (pre-release review, 0.17.0 tagged)
 2fbf9b7 Merge pull request #186 from jkitchin/release/0.17.0
-5082eff release: 0.17.0
-a91082b Merge pull request #185 from jkitchin/fix/pre-release-0.17.0
-d758cd8 docs(journal): session 2026-08-19-05 pre-release review entries
-8b97b21 docs: correct pre-release claims across CHANGELOG, README and rustdoc
 ```
 
 ## Test Status
+```
+test symbolic::tests::schur_symbolic_tail_invariant_reversed_user_order ... ok
+test symbolic::tests::schur_symbolic_tail_invariant_user_order ... ok
+test symbolic::tests::symbolic_factorize_amf_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_auto_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_default_uses_amf_for_small_matrices ... ok
+test symbolic::tests::symbolic_factorize_external_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_metis_produces_valid_perm ... ok
+test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
+test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
+test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
+
+test result: ok. 442 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 2.84s
+
+```
+
+## Benchmark
+```
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-05.md)
+
+
+No regression. Both exit partitions PASS, and the small-frontal p90
+improved slightly against the run earlier in this session (1.60/1.61 ->
+1.58); the change is within run-to-run noise on this container and is not
+claimed as an improvement.
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     147982     1.58     <= 2.0     PASS
+medium (<500)            152145     2.00     <= 3.0     PASS
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.58     <= 2.0     PASS
+medium (<500)            153560     1.58     <= 3.0     PASS
+
+=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
+ratio               count    geomean        p50        p90        p99        max
+factor/MUMPS       153560       0.45       0.32       1.58       3.45      10.58
+solve/MUMPS        153560       0.08       0.08       0.15       0.79       2.71
+factor/SSIDS       154500       0.04       0.03       0.33       1.02       2.30
+solve/SSIDS        154500       0.95       1.00       2.50       9.00      35.25
+nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
+nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+
+```
+
+## Recent Decisions
+guard. Under `cargo llvm-cov` the build is unoptimized *and* carries
+per-region counters, and the factor misses the budget:
+
+    test dirichlet120_parallel_factor_does_not_deadlock ... FAILED
+    panicked at tests/issue102_intrafront_deadlock.rs:72:13:
+    issue #102 regression: ... did not finish in 120 s
+    test result: FAILED. 0 passed; 1 failed; finished in 123.25s
+    real 3m4.912s   user 11m14.718s
+
+The same test passes under `cargo test` and under `cargo test --release`
+in the same tree. So this is instrumentation overhead, and had the
+workflow shipped without the skip the coverage job would have been red
+from its first run in a way that reads like issue #102 came back.
+
+The alternative — raising the 120 s budget so it survives instrumentation
+— is loosening a tolerance, which needs human approval, and it would
+weaken the guard everywhere to accommodate one job. Skipping in the
+coverage job only leaves the assertion at 120 s in ci.yml's `check` job,
+which runs on every push and PR. The guard keeps its teeth; coverage
+just does not measure that path. An audit found no other test that needs
+the same treatment: `large_matrix_smoke` and `rook_rescue_kkt` time
+themselves but assert nothing about the elapsed time, so
+`issue102_intrafront_deadlock` is the tree's only wall-clock assertion.
+
+**How to read the number.** Fixture-gated tests SKIP-and-pass when their
+gitignored fixtures are absent, so on CI every path they guard reads as
+uncovered while being covered locally. The coverage job prints the skip
+list to the run summary — the same step ci.yml has — so a low number in
+those modules can be checked against it before being treated as a real
+gap.
+
+## Recent Tried-and-Rejected
+total factor time** on a matrix whose paying bucket is 91% of that time. Moving
+three quarters of the panel share into BLAS-3 buys 1.3%: the two kernels cost
+nearly the same per flop at this front shape, so the 53.5% panel share is not
+recoverable time.
+
+It also does not generalize. `bs = 48` and `bs = 64` are identical for any front
+with `ncol ≤ 48`, and that is every other matrix sampled — `ncol` p90 is 1-19
+across clnlbeam, dtoc2, marine_1600, rocket, steering, gasoil_3200, pinene_3200,
+robot_1600, svanberg, nql180, qcqp1500-1c, cont5_2_4_l; only dtoc1nd is at 63. On
+the two with any wide fronts at all the paired sweep finds nothing: nql180 0.990
+(5/12 wins, tied with the default), qcqp1500-1c 0.994 (3/12). A 1.3% win on one
+corpus matrix and a no-op elsewhere is below the bar for changing a global default.
+
+**Kept from this attempt:** `block_size` is bit-neutral on all three matrices
+swept — identical inertia, zero delayed pivots, identical residual, and an
+identical hash over every `L`/`D` bit in storage order across
+`bs ∈ {8,16,24,32,48,62,64}` (`dtoc1nd_0010` 9cb93f568423e6c0, `nql180_0000`
+4f588093d6bac8c7, `qcqp1500-1c_0000` cfec17df1a4f8d38). So future retuning of it
+is a performance-only change. Not yet established on a matrix that actually
+delays a pivot — all three report `d0`.
+
+## Source Files
+```
+src/bin/bench.rs
+src/bin/perf_probe.rs
+src/bin/probe_ft_eta.rs
+src/bin/probe_lu_phases.rs
+src/bin/probe_panel_frag.rs
+src/capi.rs
+src/dense/block_ldlt32.rs
+src/dense/equilibrate.rs
+src/dense/factor.rs
+src/dense/matrix.rs
+src/dense/mod.rs
+src/dense/rook.rs
+src/dense/schur_kernel.rs
+src/dense/solve.rs
+src/env.rs
+src/error.rs
+src/inertia.rs
+src/io/mod.rs
+src/io/mtx.rs
+src/io/sidecar.rs
+src/lib.rs
+src/lu/condition.rs
+src/lu/dense_factor.rs
+src/lu/dense_matrix.rs
+src/lu/dense_solve.rs
+src/lu/dense_update.rs
+src/lu/markowitz.rs
+src/lu/mod.rs
+src/lu/scaling.rs
+src/lu/sparse_factor.rs
+src/lu/sparse_hyper.rs
+src/lu/sparse_matrix.rs
+src/lu/sparse_solve.rs
+src/lu/sparse_symbolic.rs
+src/lu/sparse_triangular.rs
+src/lu/sparse_update.rs
+src/numeric/condition.rs
+src/numeric/factorize.rs
+src/numeric/mod.rs
+src/numeric/solve.rs
+src/numeric/solver.rs
+src/ordering/amd.rs
+src/ordering/elimination_tree.rs
+src/ordering/mod.rs
+src/ordering/postorder.rs
+src/ordering/schur.rs
+src/scaling/hungarian.rs
+src/scaling/infnorm.rs
+src/scaling/mc64.rs
+src/scaling/mod.rs
+src/scaling/value_bound.rs
+src/sparse/csc.rs
+src/sparse/mod.rs
+src/symbolic/column_counts.rs
+src/symbolic/ldlt_compress.rs
+src/symbolic/mod.rs
+src/symbolic/profiler.rs
+src/symbolic/small_leaf.rs
+src/symbolic/supernode.rs
+```
+
+## Test Files
+```
+tests/amf_corpus_oracle.rs
+tests/auto_strategy.rs
+tests/blocked_ldlt.rs
+tests/build_row_indices_trailing_invariant.rs
+tests/cb_core_choice_ignores_env.rs
+tests/cb_solve_parity.rs
+tests/column_renumbering.rs
+tests/column_renumbering_parity.rs
+tests/d4_solve_2x2_gate.rs
+tests/d6_contrib_uninit.rs
+tests/d7_block32_dispatch_pooled.rs
+tests/delayed_pivoting.rs
+tests/dense_fast_path.rs
+tests/dense_ldlt.rs
+tests/env_knob_parsing.rs
+tests/env_knob_scan.rs
+tests/factor_scratch_parity.rs
+tests/factor_workspace_parity.rs
+tests/factors_ld_export.rs
+tests/fine_grained_delay.rs
+tests/fma_opt_in_roundtrip.rs
+tests/golden_bits.rs
+tests/growth_flag.rs
+tests/issue102_intrafront_deadlock.rs
+tests/issue102_ordering_escalation.rs
+tests/issue107_external_ordering.rs
+tests/issue112_bg_update.rs
+tests/issue127_pipeline_split.rs
+tests/issue128_supernode_nrow.rs
+tests/issue177_parallel_entry_point_core.rs
+tests/issue178_refine_cap.rs
+tests/issue178_solve_into.rs
+tests/issue52_stats.rs
+tests/issue64_arrow_ordering.rs
+tests/issue65_mc64_fallback.rs
+tests/issue67_thin_ordering.rs
+tests/issue91_preprocess_misfire.rs
+tests/issue99_fma_front_gate.rs
+tests/issue_15_cascade_arm_gate.rs
+tests/issue_17_robot_1600_cascade_off.rs
+tests/issue_18_narx_cfy_cascade_off.rs
+tests/issue_2_kkt_ls_init.rs
+tests/issue_38_static_pivot.rs
+tests/issue_46_saddle_kkt_cascade.rs
+tests/issue_55_delay_budget.rs
+tests/issue_55_n_tiny_counter.rs
+tests/kkt_hardening.rs
+tests/kkt_matrices.rs
+tests/large_matrix_smoke.rs
+tests/ldlt_compress.rs
+tests/lu_adversarial_inputs.rs
+tests/lu_default_ordering.rs
+tests/lu_dense.rs
+tests/lu_dense_bump.rs
+tests/lu_dense_update_bg.rs
+tests/lu_ft_widebump.rs
+tests/lu_hyper_sparse.rs
+tests/lu_markowitz.rs
+tests/lu_real_bases.rs
+tests/lu_scaling.rs
+tests/lu_sparse.rs
+tests/lu_sparse_rhs.rs
+tests/lu_update_alloc_probe.rs
+tests/lu_update_casctanks.rs
+tests/maxfromm_parity.rs
+tests/mc64_end_to_end.rs
+tests/mc64_scaling.rs
+tests/multi_rhs.rs
+tests/n2_static_pivot_scaling.rs
+tests/n3_parallel_profiler.rs
+tests/n4_mc64_retry_latch.rs
+tests/parallel_parity.rs
+tests/parity.rs
+tests/pivot_rejection.rs
+tests/pounce710_refine_cap_nrhs2.rs
+tests/pounce_interface.rs
+tests/profiler_smoke.rs
+tests/property_tests.rs
+tests/refined_solve_core_stability.rs
+tests/rook_rescue.rs
+tests/rook_rescue_kkt.rs
+tests/small_leaf_parity.rs
+tests/solver_with_ordering.rs
+tests/sparse_postorder.rs
+tests/sparse_refined.rs
+tests/sqd_fast_path.rs
+tests/static_assembly_maps.rs
+tests/stress_tests.rs
+tests/symbolic_profiler.rs
+tests/task_plan_parity.rs
+tests/threshold_consistency.rs
+tests/tiny_fast_path.rs
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,69 +1,69 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-08-30T00:31:02Z
+Generated: 2026-08-30T00:59:34Z
 
 ## Latest Session
-File: dev/sessions/2026-08-19-05.md
+File: dev/sessions/2026-08-30-01.md
 ```
-# Session 2026-08-19-05
+# Session 2026-08-30-01
 
 ## Goal
 
-Close out issue #153 item 2, review the six PRs merged since v0.16.0 for
-mistakes before shipping, and cut release 0.17.0 (which unblocks
-pounce#710's second blocker).
+Fix issue #194: `Solver::factor` cannot be cancelled once running, and
+offers no surface through which a caller could ask, which makes a host's
+wall-clock budget unenforceable whenever a single factorization is larger
+than the whole budget.
 
 ## Benchmark Results
 
-No regression. Both exit partitions PASS, and the small-frontal p90
-improved slightly against the run earlier in this session (1.60/1.61 ->
-1.58); the change is within run-to-run noise on this container and is not
-claimed as an improvement.
+**No comparison against the previous session's numbers is possible in
+this container, and that is a gap in this checkpoint rather than a pass.**
+The corpus (154k matrices with oracle timings) is not present here, so
+`cargo run --bin bench --release` ran only the 8 synthetic matrices and
+both exit-partition tables read `N/A`:
 
 ```
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
+
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.58     <= 2.0     PASS
-medium (<500)            153560     1.58     <= 3.0     PASS
-
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.45       0.32       1.58       3.45      10.58
-solve/MUMPS        153560       0.08       0.08       0.15       0.79       2.71
-factor/SSIDS       154500       0.04       0.03       0.33       1.02       2.30
-solve/SSIDS        154500       0.95       1.00       2.50       9.00      35.25
-nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
-nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 ```
 
-## Accomplished
+Session 2026-08-19-05's p90s (dense 1.58 / 2.00, sparse 1.58 / 1.58)
+therefore stand unchallenged and unconfirmed. A session with the corpus
+mounted should re-run before this is treated as regression-free on the
+corpus.
 
-### Issue #153 item 2 — both hypotheses falsified (PR #184, merged)
-
-Rescoped #153 to item 2 and measured rather than assumed. Both standing
-hypotheses for the dtoc1nd dense-front gap — a packed-SIMD work gate, and
-`block_size` — were falsified by measurement. Research note written; two
-diagnostic probes landed.
-
-### Pre-release review of six PRs (PR #185, merged)
-
-Reviewed #174, #179, #180, #181, #182, #183 with agents, then verified
-every reported finding by hand against git before acting on it. One
-behavioural regression, one guard-test gap, and a set of unsupported
+In place of that, the poll overhead was measured directly: a paired A/B
+probe (same source, built against this branch and against a worktree at
+`origin/main`, best-of-10 warm refactors), alternated to control for
+container drift.
 ```
 
 ## Git Status
 ```
+4c7691a feat: cooperative cancellation for Solver::factor (#194)
+9edce95 docs: research note for issue #194 cooperative factor cancellation
 9b9e882 Merge pull request #188 from jkitchin/ci/codecov-coverage
 1292984 ci: measure coverage with cargo-llvm-cov and report it to Codecov
 ad0d96d Merge pull request #187 from jkitchin/docs/session-2026-08-19-05
-b224ed1 docs: session checkpoint 2026-08-19-05 (pre-release review, 0.17.0 tagged)
-2fbf9b7 Merge pull request #186 from jkitchin/release/0.17.0
 ```
 
 ## Test Status
@@ -86,72 +86,99 @@ test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 442 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 2.84s
+test result: ok. 442 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 2.79s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-19-05.md)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-08-30-01.md)
 
 
-No regression. Both exit partitions PASS, and the small-frontal p90
-improved slightly against the run earlier in this session (1.60/1.61 ->
-1.58); the change is within run-to-run noise on this container and is not
-claimed as an improvement.
+**No comparison against the previous session's numbers is possible in
+this container, and that is a gap in this checkpoint rather than a pass.**
+The corpus (154k matrices with oracle timings) is not present here, so
+`cargo run --bin bench --release` ran only the 8 synthetic matrices and
+both exit-partition tables read `N/A`:
+
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
 
 --- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
-small-frontal (<200)     153455     1.58     <= 2.0     PASS
-medium (<500)            153560     1.58     <= 3.0     PASS
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
 
-=== Sparse perf vs canonical oracles (154588 matrices with oracle timings) ===
-ratio               count    geomean        p50        p90        p99        max
-factor/MUMPS       153560       0.45       0.32       1.58       3.45      10.58
-solve/MUMPS        153560       0.08       0.08       0.15       0.79       2.71
-factor/SSIDS       154500       0.04       0.03       0.33       1.02       2.30
-solve/SSIDS        154500       0.95       1.00       2.50       9.00      35.25
-nnzL/MUMPS         153560       0.61       0.58       0.75       4.50      23.11
-nnzL/SSIDS         154500       0.88       1.00       1.00       4.50       5.00
+Session 2026-08-19-05's p90s (dense 1.58 / 2.00, sparse 1.58 / 1.58)
+therefore stand unchallenged and unconfirmed. A session with the corpus
+mounted should re-run before this is treated as regression-free on the
+corpus.
+
+In place of that, the poll overhead was measured directly: a paired A/B
+probe (same source, built against this branch and against a worktree at
+`origin/main`, best-of-10 warm refactors), alternated to control for
+container drift.
+
+                     branch (this PR)      main (9b9e882)
+grid_laplacian_350   203.8 / 197.8 ms      222.8 / 203.5 ms   sequential
+grid_laplacian_350    94.2 /  92.3 ms       94.4 /  92.2 ms   parallel
+tridiag_200k          57.7 /  57.3 ms       59.4 /  59.2 ms   sequential
+tridiag_200k          56.3 /  56.9 ms       56.8 /  54.6 ms   parallel
+
+No measurable overhead; every difference is inside this host's noise
+floor. That floor is wide — see the artifact recorded under *Abandoned*
+below — so the honest claim is "no regression detectable here", not "zero
+cost proven". A regression would in any case be surprising: every poll
+site short-circuits on an `Option::is_some` branch and touches no atomic
+when unarmed.
 
 ```
 
 ## Recent Decisions
-guard. Under `cargo llvm-cov` the build is unoptimized *and* carries
-per-region counters, and the factor misses the budget:
 
-    test dirichlet120_parallel_factor_does_not_deadlock ... FAILED
-    panicked at tests/issue102_intrafront_deadlock.rs:72:13:
-    issue #102 regression: ... did not finish in 120 s
-    test result: FAILED. 0 passed; 1 failed; finished in 123.25s
-    real 3m4.912s   user 11m14.718s
+**The flag lives on `BunchKaufmanParams`, not `NumericParams`.** It is
+not a Bunch-Kaufman parameter in spirit, and `NumericParams` is where a
+reader would look first. But the multifrontal drivers hold
+`params.bk` and the dense frontal factor is handed *only*
+`&BunchKaufmanParams`, so one field there is readable from every poll
+site with no sync step, while a field on `NumericParams` would need
+copying into `bk` — exactly the shape that left `NumericParams::fma` a
+silent no-op until finding N1 (`dev/research/repo-review-2026-06-09.md`).
+`BunchKaufmanParams` already carries execution knobs of this kind
+(`intrafront_parallel`, `fma`), so this is consistent with what the
+struct had become. Cost of the choice: discoverability, mitigated by
+`Solver::with_interrupt` / `set_interrupt` / `interrupt` being the
+documented entry points.
 
-The same test passes under `cargo test` and under `cargo test --release`
-in the same tree. So this is instrumentation overhead, and had the
-workflow shipped without the skip the coverage job would have been red
-from its first run in a way that reads like issue #102 came back.
+**`Interrupted` is a `FeralError` variant, so both drivers cancel for
+free.** The sequential driver already propagates errors out of its
+supernode loop with `?`; the parallel driver already funnels them into
+`first_error`, whose fast-exit at the top of `run_parallel_task` drains
+the scope without starting further work. Raising the interrupt as an
+ordinary error reuses both, so cancellation added no new control flow to
+either driver — including the several-tasks-in-flight case. The
+alternative, a distinct early-return channel, would have duplicated the
+parallel driver's unwind for no benefit.
 
-The alternative — raising the 120 s budget so it survives instrumentation
-— is loosening a tolerance, which needs human approval, and it would
-weaken the guard everywhere to accommodate one job. Skipping in the
-coverage job only leaves the assertion at 120 s in ci.yml's `check` job,
-which runs on every push and PR. The guard keeps its teeth; coverage
-just does not measure that path. An audit found no other test that needs
-the same treatment: `large_matrix_smoke` and `rook_rescue_kkt` time
-themselves but assert nothing about the elapsed time, so
-`issue102_intrafront_deadlock` is the tree's only wall-clock assertion.
-
-**How to read the number.** Fixture-gated tests SKIP-and-pass when their
-gitignored fixtures are absent, so on CI every path they guard reads as
-uncovered while being covered locally. The coverage job prints the skip
-list to the run summary — the same step ci.yml has — so a low number in
-those modules can be checked against it before being treated as a real
-gap.
+**Consequence for the API.** `FactorStatus` and `FeralError` each gain a
+variant, so every exhaustive `match` over them in the tree, in
+`feral-diagnostics` and in the Python bindings needed a new arm. All were
+given explicit arms rather than wildcards, deliberately: the next variant
+should break the same builds rather than be silently absorbed.
 
 ## Recent Tried-and-Rejected
 total factor time** on a matrix whose paying bucket is 91% of that time. Moving
@@ -272,6 +299,7 @@ tests/issue128_supernode_nrow.rs
 tests/issue177_parallel_entry_point_core.rs
 tests/issue178_refine_cap.rs
 tests/issue178_solve_into.rs
+tests/issue194_factor_interrupt.rs
 tests/issue52_stats.rs
 tests/issue64_arrow_ordering.rs
 tests/issue65_mc64_fallback.rs
@@ -320,16 +348,5 @@ tests/profiler_smoke.rs
 tests/property_tests.rs
 tests/refined_solve_core_stability.rs
 tests/rook_rescue.rs
-tests/rook_rescue_kkt.rs
-tests/small_leaf_parity.rs
-tests/solver_with_ordering.rs
-tests/sparse_postorder.rs
-tests/sparse_refined.rs
-tests/sqd_fast_path.rs
-tests/static_assembly_maps.rs
-tests/stress_tests.rs
-tests/symbolic_profiler.rs
-tests/task_plan_parity.rs
-tests/threshold_consistency.rs
-tests/tiny_fast_path.rs
-```
+
+(truncated from 363 lines to 350 line budget)

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7096,3 +7096,62 @@ uncovered while being covered locally. The coverage job prints the skip
 list to the run summary — the same step ci.yml has — so a low number in
 those modules can be checked against it before being treated as a real
 gap.
+
+## 2026-08-30 — cancellation is a caller-owned flag polled at two granularities, not a deadline (#194)
+
+`Solver::factor` gains cooperative cancellation. Four choices are worth
+recording, because each had a plausible alternative.
+
+**A flag, not a deadline.** feral takes an `Arc<AtomicBool>` the caller
+owns and feral only ever reads. It does not take an `Instant`, a
+`Duration`, or a callback. Holding a clock would force feral to choose
+between wall time, CPU time and a host's own budget accounting — a policy
+question that belongs to the host, which is also the only party that
+knows what its remaining budget is. Polling `Ordering::Relaxed` is
+sufficient: the flag carries no data dependency, and a missed observation
+costs one more panel before the next poll. feral never writes the flag,
+so re-arming after an interrupt is the caller's `store(false)`.
+
+**Two poll granularities, because one is not enough.** The issue asked
+for supernode boundaries. That alone would not have fixed the case that
+motivated it. Issue #8 measured a delayed-pivot cascade concentrating
+118k delayed pivots into three ~14k-column expanded root fronts, so an
+87 s factorization is dominated by a handful of *individual fronts*; a
+check that fires only between supernodes returns "budget plus one 44 s
+supernode", which is the reported bug again. So the dense frontal factor
+polls at its panel-loop boundaries too (blocked and unblocked paths).
+That loop is still one level out from the hot kernels — every iteration
+guards at least `O(nrow)` of work — so this is not a kernel-level check.
+The *published* contract stays the weaker of the two: supernode
+boundaries, and within a supernode dense panel boundaries, with no
+promise about when within a panel.
+
+**The flag lives on `BunchKaufmanParams`, not `NumericParams`.** It is
+not a Bunch-Kaufman parameter in spirit, and `NumericParams` is where a
+reader would look first. But the multifrontal drivers hold
+`params.bk` and the dense frontal factor is handed *only*
+`&BunchKaufmanParams`, so one field there is readable from every poll
+site with no sync step, while a field on `NumericParams` would need
+copying into `bk` — exactly the shape that left `NumericParams::fma` a
+silent no-op until finding N1 (`dev/research/repo-review-2026-06-09.md`).
+`BunchKaufmanParams` already carries execution knobs of this kind
+(`intrafront_parallel`, `fma`), so this is consistent with what the
+struct had become. Cost of the choice: discoverability, mitigated by
+`Solver::with_interrupt` / `set_interrupt` / `interrupt` being the
+documented entry points.
+
+**`Interrupted` is a `FeralError` variant, so both drivers cancel for
+free.** The sequential driver already propagates errors out of its
+supernode loop with `?`; the parallel driver already funnels them into
+`first_error`, whose fast-exit at the top of `run_parallel_task` drains
+the scope without starting further work. Raising the interrupt as an
+ordinary error reuses both, so cancellation added no new control flow to
+either driver — including the several-tasks-in-flight case. The
+alternative, a distinct early-return channel, would have duplicated the
+parallel driver's unwind for no benefit.
+
+**Consequence for the API.** `FactorStatus` and `FeralError` each gain a
+variant, so every exhaustive `match` over them in the tree, in
+`feral-diagnostics` and in the Python bindings needed a new arm. All were
+given explicit arms rather than wildcards, deliberately: the next variant
+should break the same builds rather than be silently absorbed.

--- a/dev/journal/2026-08-30-01.org
+++ b/dev/journal/2026-08-30-01.org
@@ -1,0 +1,46 @@
+#+TITLE: Session 2026-08-30-01 journal
+#+STARTUP: showall
+
+* 00:35 :issue-194:orientation:
+Goal: fix issue #194 — `Solver::factor` cannot be cancelled, so a host
+enforcing a wall-clock budget cannot enforce it across one factorization.
+Reported measurement (pounce, `emfl050_5_5`, 5675 vars / 5625 cons):
+`max_wall_time=5` returned TIME_LIMIT after 48.8 s, one factorization
+having run ~44 s uninterrupted.
+
+Verified the issue's claims against this tree before designing:
+- `Solver::factor(&mut self, &CscMatrix, Option<Inertia>) -> FactorStatus`
+  (src/numeric/solver.rs:929) takes no interrupt/deadline/callback.
+- `FactorStatus` (solver.rs:87) is `Success | Singular | WrongInertia |
+  FatalError` — no early-return variant.
+- `NumericParams` (factorize.rs:56) has no equivalent field; none of the
+  16 `with_*` builders exposes one.
+- `FeralError::DelayBudgetExceeded` (error.rs) is a symbolic-time
+  *column-count* budget, not wall-clock. Confirmed as reported.
+- `Solver` holds `workspace`, `last_symbolic`, `permute_cache`,
+  `parallel_pool` across calls, so the reporter's "a watchdog thread on
+  our side would orphan mutable state" is correct.
+
+`grep -rin "interrupt|cancel|deadline|watchdog"` over dev/tried-and-rejected.md
+and dev/decisions.md found no prior attempt at this feature (all hits are
+about numerical *cancellation* in 2x2 determinants). Nothing to avoid
+repeating.
+
+Research note written: dev/research/issue-194-cooperative-interrupt.md.
+
+* 00:40 :issue-194:design:
+Key design finding, not in the issue: supernode-boundary polling alone
+would NOT fix the reported case. Issue #8 records that a delayed-pivot
+cascade concentrates 118k delayed pivots into three ~14k-column expanded
+root fronts — the 87 s factor is dominated by individual *fronts*, so a
+between-supernodes check returns "5 s plus one 44 s supernode".
+
+So poll at two places:
+  1. supernode boundaries, in both drivers;
+  2. the `while k < ncol_eff` panel loop in the dense frontal factor,
+     which is one level out from the hot kernels (loop body is >= O(nrow)).
+
+Mechanism `Option<Arc<AtomicBool>>` on `NumericParams` + a new
+`FeralError::Interrupted`, so both drivers' existing error unwind
+(sequential `?`, parallel `first_error` + task fast-exit) carries the
+cancellation with no new control flow.

--- a/dev/journal/2026-08-30-01.org
+++ b/dev/journal/2026-08-30-01.org
@@ -44,3 +44,72 @@ Mechanism `Option<Arc<AtomicBool>>` on `NumericParams` + a new
 `FeralError::Interrupted`, so both drivers' existing error unwind
 (sequential `?`, parallel `first_error` + task fast-exit) carries the
 cancellation with no new control flow.
+
+* 01:20 :issue-194:implementation:tests:
+Implemented and tested. Poll sites: `Solver::factor` entry; the supernode
+loop in both multifrontal drivers; the `while k < ncol_eff` panel loop in
+both the blocked and the unblocked dense frontal factor.
+
+Mechanism: `BunchKaufmanParams::interrupt: Option<Arc<AtomicBool>>` plus
+`interrupt_requested()`; `FeralError::Interrupted`;
+`FactorStatus::Interrupted`. Putting the field on `BunchKaufmanParams`
+rather than `NumericParams` means one field is visible to *both* the
+driver loops (which hold `params.bk`) and the dense frontal factor (which
+is handed only `&BunchKaufmanParams`) — no cross-struct sync step of the
+kind that made `fma` a silent no-op until finding N1.
+
+`tests/issue194_factor_interrupt.rs`, 8 tests, all pass. Measured in
+`--release`, warm solver (symbolic cached — the IPM case), 5-point
+Laplacian n = 122500:
+
+: sequential: baseline 263.2 ms; flag set at 26.3 ms; Interrupted at 34.8 ms
+: parallel:   baseline 153.5 ms; flag set at 15.3 ms; Interrupted at 25.5 ms
+
+Overshoot past the request ~9-10 ms, most of it the un-polled prologue
+(scaling + permute), against a factorization that would otherwise have
+run to completion. That is the issue's "~5 s plus one supernode" outcome.
+
+Full suite: 100 test binaries, 0 failures. fmt/clippy clean for `feral`
+and `feral-diagnostics`; `cargo check` clean for the python bindings.
+
+* 01:35 :issue-194:api-surface:
+Adding a `FactorStatus` variant broke exhaustive matches in four in-tree
+integration tests, ten `feral-diagnostics` probe binaries (built by CI
+with `-D warnings`, outside the root workspace default set), and the
+python bindings (`FactorStatus` *and* `FeralError`, both matched
+exhaustively in `python/src/`). All patched with explicit arms rather
+than wildcards, so the next variant is caught the same way.
+
+C ABI gets `FERAL_INTERRUPTED = 4` (also in `feral_capi.h`); Python gets
+`FactorStatus.INTERRUPTED`. Neither surface can arm the flag today, so
+both are defined for exhaustiveness, not reachable. Noted in the
+checkpoint as an obvious follow-up if a C or Python consumer wants this.
+
+* 01:50 :issue-194:benchmark:measurement-artifact:
+The corpus (154k matrices with oracle timings) is not present in this
+container, so `cargo run --bin bench --release` produced only the 8
+synthetic matrices and both exit-partition tables read N/A. No comparison
+against session 2026-08-19-05's p90 numbers is possible here; that is a
+gap in this checkpoint, not a pass.
+
+Measured the poll overhead directly instead: a paired A/B probe (same
+source, built against this branch and against a worktree at origin/main,
+best-of-10 warm refactors).
+
+**A measurement artifact worth recording.** The first main run read
+283-291 ms on `grid_laplacian_350` sequential against 202-205 ms for the
+branch — a 40% "regression on main", which is impossible for a change
+that only adds branches. Re-running interleaved immediately afterwards
+gave main 200-203 ms. The first main block simply landed in a slow patch
+of container time (it ran right after `git worktree add`). Interleaved
+best-of-10, two alternations:
+
+: grid seq   branch 203.8 / 197.8   main 222.8 / 203.5
+: grid par   branch  94.2 /  92.3   main  94.4 /  92.2
+: tridiag seq branch 57.7 /  57.3   main  59.4 /  59.2
+: tridiag par branch 56.3 /  56.9   main  56.8 /  54.6
+
+No measurable overhead; every difference is inside a noise floor that the
+discarded block shows to be tens of percent on this host. Lesson for
+future sessions: on this container a single un-interleaved A/B block can
+manufacture a 40% effect. Alternate the arms.

--- a/dev/research/issue-194-cooperative-interrupt.md
+++ b/dev/research/issue-194-cooperative-interrupt.md
@@ -1,0 +1,158 @@
+# Issue #194 — cooperative cancellation for `Solver::factor`
+
+Research note. Written before implementation, per CLAUDE.md §Work.
+
+## The reported problem
+
+A host (pounce) enforcing a wall-clock budget cannot enforce it across a
+single `Solver::factor` call. Measured on `emfl050_5_5` (5675 vars, 5625
+constraints): a `max_wall_time=5` solve returned `TIME_LIMIT` after
+**48.8 s**. The between-operation deadline check passed while under
+budget, one factorization then ran ~44 s with no way for the host to
+regain control, and only the *next* check tripped.
+
+`factor` takes no interrupt, deadline, cancel flag or progress callback;
+`FactorStatus` has no variant that could carry an early return. The
+existing `DelayBudgetExceeded` is a *symbolic-time column-count* budget
+on the delayed-pivot cascade, not a wall-clock one, and it is armed by
+default — it did not save this case.
+
+## Why the host cannot fix this on its own side
+
+Confirmed by reading the issue's account against this tree: `Solver`
+holds `workspace: FactorWorkspace`, `last_symbolic`, `permute_cache` and
+`parallel_pool` — mutable state reused across `factor` calls, which is
+exactly the symbolic-cache reuse an IPM depends on. A thread-based
+watchdog that abandons a factorization mid-flight either leaves those
+buffers being mutated by an orphaned thread, or forces a fresh `Solver`
+per factorization and destroys the reuse. Cancellation has to be
+cooperative and inside feral.
+
+## Where the time goes, and therefore where to poll
+
+Two granularities matter, and only the coarser one is what the issue
+asks for:
+
+1. **Supernode boundaries.** Both drivers have a natural per-supernode
+   loop: `factorize_multifrontal_supernodal_with_workspace`'s
+   `while snode_idx < n_snodes`, and `run_parallel_task`'s
+   `for &snode_idx in plan.owned[task_idx].iter().chain(once(&task_idx))`.
+
+2. **Dense panel boundaries inside one supernode.** Supernode boundaries
+   alone are *not* sufficient for the motivating case. Issue #8 records
+   the mechanism the reporter cites: a delayed-pivot cascade concentrates
+   118k delayed pivots into three ~14k-column expanded root fronts, so
+   the 87 s factor is dominated by a handful of *individual fronts*. A
+   check that only fires between supernodes would return "~5 s plus one
+   44 s supernode", which is the bug again with extra steps.
+
+   `factor_frontal_blocked_in_place_with_scratch` has one `while k <
+   ncol_eff` loop that covers both the panel path (>= `PANEL_MIN_NCOL`
+   columns of work per iteration) and the scalar tail (O(nrow) per
+   pivot). The unblocked `factor_frontal_in_place_with_scratch_impl` has
+   the same loop shape. Polling at the top of those loops is off the
+   inner kernels — the loop body is at minimum O(nrow) work — and bounds
+   the overshoot at one panel rather than one front.
+
+So: poll at supernode boundaries *and* at dense panel boundaries. The
+published contract stays the weaker of the two ("checks at supernode
+boundaries, and within a supernode at dense panel boundaries; no
+guarantee about when within a panel").
+
+## Mechanism: `AtomicBool`, not a clock
+
+Polling a caller-owned `Arc<AtomicBool>` rather than a deadline keeps
+feral clock-agnostic and leaves wall-vs-CPU-vs-budget policy with the
+caller. `Ordering::Relaxed` is the right load: the flag carries no data
+dependency — we are not reading anything the setter wrote besides the
+flag itself — and a missed observation only costs one more panel before
+the next poll. Cost when unarmed is an `Option::is_some` branch that
+predicts perfectly; when armed, a relaxed load of an uncontended cache
+line.
+
+feral only ever *reads* the flag. It never clears it — the caller owns
+arming and disarming, so a re-arm after an interrupt is the caller's
+`store(false)`.
+
+## Plumbing: a new `FeralError` variant
+
+The drivers already return `Result<(SparseFactors, Inertia), FeralError>`
+and both already have an error path that unwinds correctly:
+
+- sequential: `?` out of the supernode loop;
+- parallel: the `first_error` mutex plus the fast-exit check at task
+  entry, which drains the scope without doing further work.
+
+So `FeralError::Interrupted` gets cancellation for free on both drivers,
+including the "several tasks in flight" case, with no new control flow.
+`Solver::factor` then maps it to a new `FactorStatus::Interrupted`.
+
+`Solver::factor`'s existing `Err(e) => { last_factors = None; ... }` arm
+already clears the stored factor and inertia, which *is* the contract the
+issue asks for ("factors are left invalid; a subsequent factor re-runs
+cleanly"). The new arm is a copy of it that returns `Interrupted`
+instead of `FatalError`.
+
+## API surface
+
+Per the issue, matching the existing builder convention:
+
+```rust
+pub fn with_interrupt(self, flag: Arc<AtomicBool>) -> Self;
+```
+
+Adding two more, both cheap and both needed by the stated consumer:
+
+- `set_interrupt(&mut self, Option<Arc<AtomicBool>>)` — the pounce
+  wiring in the issue is `SparseSymLinearSolverInterface::set_interrupt(
+  &mut self, ...)`, and a consuming builder cannot be called through the
+  `&mut Solver` a backend handle holds. It is also the only way to
+  *disarm*.
+- `interrupt(&self) -> Option<&Arc<AtomicBool>>` — lets a test assert the
+  arming without factoring.
+
+The flag lives on `NumericParams::interrupt` (`Option<Arc<AtomicBool>>`,
+default `None`), which is the single funnel `Solver::factor` already
+clones into `effective_params` and hands to both drivers. Direct users of
+the free-function `factorize_multifrontal*` API get it too.
+
+C ABI: a new `FERAL_INTERRUPTED = 4` status code. There is no C-side way
+to arm the flag in this change — the C ABI owns its `Solver` internally —
+so the code is defined and mapped, but unreachable from C until a future
+`feral_set_interrupt` is added. Mapping it now keeps the `match` in
+`capi.rs` exhaustive and honest rather than folding an interrupt into
+`FERAL_FATAL`.
+
+## Oracle for the tests
+
+No external numerical oracle is needed: this is a control-flow feature,
+not a numerical one. The properties under test are
+
+1. unarmed ⇒ byte-identical behaviour (same status, same inertia);
+2. armed-and-set-before-`factor` ⇒ `Interrupted`, no factor stored,
+   `solve` fails with `NoFactor`;
+3. after clearing the flag, a subsequent `factor` succeeds and produces
+   the same inertia as an un-interrupted run — the "re-runs cleanly"
+   half of the contract;
+4. armed-but-clear ⇒ `Success` (the flag is polled, not merely present);
+5. both drivers (`with_parallel(true)` / `(false)`) honour it;
+6. a flag set from another thread *during* a long factorization stops it
+   early — the actual reported scenario.
+
+(3) is the one that matters most: it is the property the reporter says
+they will rely on, and the one a naive implementation (leaving a
+half-written `workspace` or a stale `contrib_blocks`) would break.
+
+## Rejected alternatives
+
+- **A deadline (`Instant`) inside feral.** Explicitly not asked for, and
+  it forces a clock choice (wall vs CPU) that belongs to the caller.
+- **A progress callback.** Strictly more API surface for the same
+  outcome, and a `dyn FnMut` in the supernode loop is harder to make
+  zero-overhead than an `Option<Arc<AtomicBool>>`.
+- **Returning `Ok` with a partial factor.** The issue explicitly does not
+  want partial results, and a partial `SparseFactors` would be a
+  correctness trap for `solve`.
+- **Polling inside the dense kernels** (`apply_schur_panel_range` and
+  friends). That is the hot inner loop; the panel loop above it is one
+  level out and already coarse enough.

--- a/dev/sessions/2026-08-30-01.md
+++ b/dev/sessions/2026-08-30-01.md
@@ -1,0 +1,189 @@
+# Session 2026-08-30-01
+
+## Goal
+
+Fix issue #194: `Solver::factor` cannot be cancelled once running, and
+offers no surface through which a caller could ask, which makes a host's
+wall-clock budget unenforceable whenever a single factorization is larger
+than the whole budget.
+
+## Benchmark Results
+
+**No comparison against the previous session's numbers is possible in
+this container, and that is a gap in this checkpoint rather than a pass.**
+The corpus (154k matrices with oracle timings) is not present here, so
+`cargo run --bin bench --release` ran only the 8 synthetic matrices and
+both exit-partition tables read `N/A`:
+
+```
+--- Sparse solver validation ---
+Sparse solver: 2/2 total
+  Inertia match vs MUMPS: 2/2 (100.0%)
+  Residual pass: 2/2 (100.0%)
+  Worst residual: 1.26e-16 (densecol_kkt_300_0000)
+
+Dense failure analysis: no failures
+Sparse failure analysis: no failures
+
+--- Dense perf vs oracles: no matrices have oracle timings ---
+--- Sparse perf vs oracles: no matrices have oracle timings ---
+
+--- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)          0        -     <= 2.0      N/A
+medium (<500)                 0        -     <= 3.0      N/A
+```
+
+Session 2026-08-19-05's p90s (dense 1.58 / 2.00, sparse 1.58 / 1.58)
+therefore stand unchallenged and unconfirmed. A session with the corpus
+mounted should re-run before this is treated as regression-free on the
+corpus.
+
+In place of that, the poll overhead was measured directly: a paired A/B
+probe (same source, built against this branch and against a worktree at
+`origin/main`, best-of-10 warm refactors), alternated to control for
+container drift.
+
+```
+                     branch (this PR)      main (9b9e882)
+grid_laplacian_350   203.8 / 197.8 ms      222.8 / 203.5 ms   sequential
+grid_laplacian_350    94.2 /  92.3 ms       94.4 /  92.2 ms   parallel
+tridiag_200k          57.7 /  57.3 ms       59.4 /  59.2 ms   sequential
+tridiag_200k          56.3 /  56.9 ms       56.8 /  54.6 ms   parallel
+```
+
+No measurable overhead; every difference is inside this host's noise
+floor. That floor is wide — see the artifact recorded under *Abandoned*
+below — so the honest claim is "no regression detectable here", not "zero
+cost proven". A regression would in any case be surprising: every poll
+site short-circuits on an `Option::is_some` branch and touches no atomic
+when unarmed.
+
+## Accomplished
+
+### Cooperative cancellation for `Solver::factor` (#194)
+
+Commit `4c7691a`, research note
+`dev/research/issue-194-cooperative-interrupt.md`.
+
+Every claim in the issue was verified against this tree before designing:
+`factor`'s signature, `FactorStatus`' variants, `NumericParams`' fields,
+`DelayBudgetExceeded`'s actual semantics (a symbolic-time column-count
+budget, not wall-clock — as reported), and the cross-call mutable state
+(`workspace`, `last_symbolic`, `permute_cache`, `parallel_pool`) that
+makes a caller-side watchdog unsound. `dev/tried-and-rejected.md` has no
+prior attempt at this feature.
+
+**API.** `Solver::with_interrupt(Arc<AtomicBool>)` (builder, as the issue
+proposed), plus `set_interrupt(Option<..>)` — the stated consumer holds
+its `Solver` behind `&mut self`, where a consuming builder cannot be
+called, and it is also the only way to disarm — and `interrupt()`.
+`FactorStatus::Interrupted` and `FeralError::Interrupted`.
+
+**Design finding not in the issue.** Supernode-boundary polling alone,
+which is what #194 asked for, would *not* have fixed the case that
+motivated it. Issue #8 measured a delayed-pivot cascade concentrating
+118k delayed pivots into three ~14k-column expanded root fronts, so an
+87 s factorization is dominated by individual fronts and a
+between-supernodes check returns "budget plus one 44 s supernode". So the
+dense frontal factor polls at its panel-loop boundaries too — still one
+level out from the hot kernels, since each polled iteration guards at
+least `O(nrow)` of work.
+
+**Evidence.** `tests/issue194_factor_interrupt.rs`, 8 tests, all passing.
+In `--release`, warm solver (symbolic cached, the IPM case), 5-point
+Laplacian `n = 122500`:
+
+```
+sequential: baseline 263.2 ms; flag set at 26.3 ms; Interrupted at 34.8 ms
+parallel:   baseline 153.5 ms; flag set at 15.3 ms; Interrupted at 25.5 ms
+```
+
+Overshoot past the request is ~9–10 ms, most of it the un-polled prologue
+(scaling and permute), against a factorization that would otherwise have
+run to completion. That is the issue's "budget plus one supernode"
+outcome.
+
+The tests also pin the rest of the contract: an unarmed `Solver` is
+unaffected; an armed-but-clear flag still succeeds with the baseline
+inertia (so the flag is polled, not merely present); an interrupted
+factor stores no factor and `solve` returns `NoFactor`; clearing the flag
+lets the next `factor` re-run cleanly and reproduce the un-interrupted
+inertia — including after a *mid-flight* abort, which is the case a naive
+implementation (poisoned workspace, stale contribution blocks) would
+break; and feral never writes the caller's flag.
+
+Full suite: 100 test binaries, 0 failures. `cargo fmt --check` clean;
+`cargo clippy --all-targets -- -D warnings` clean for `feral` and for
+`feral-diagnostics`; `cargo check` clean for the Python bindings.
+
+### Blast radius of a new enum variant
+
+Adding `FactorStatus::Interrupted` and `FeralError::Interrupted` broke
+exhaustive matches in 4 in-tree integration tests, 10 `feral-diagnostics`
+probe binaries (built by CI with `-D warnings`, and *outside* the root
+workspace default set, so the root `cargo clippy --all-targets` does not
+see them), and the Python bindings (both enums). All were given explicit
+arms rather than wildcards, so the next variant breaks the same builds
+instead of being silently absorbed.
+
+C ABI gained `FERAL_INTERRUPTED = 4` (`src/capi.rs` and
+`feral-ipopt-shim/include/feral_capi.h`); Python gained
+`FactorStatus.INTERRUPTED`. Neither surface can arm the flag today —
+there is no `feral_set_interrupt` and no Python flag object — so on both
+the code is reserved for exhaustiveness, not reachable. The shim's
+`switch` has a `default:`, so it maps to `SYMSOLVER_FATAL_ERROR` and did
+not need editing.
+
+## Decisions Made
+
+Appended to `dev/decisions.md` (2026-08-30 entry): a flag rather than a
+deadline (feral holds no clock; wall-vs-CPU-vs-budget policy stays with
+the caller); two poll granularities because supernode boundaries alone do
+not cover the motivating case; the flag on `BunchKaufmanParams` rather
+than `NumericParams`, so one field is readable from both the driver loops
+and the dense frontal factor with no sync step of the kind that left
+`NumericParams::fma` a silent no-op until finding N1; and `Interrupted`
+as a `FeralError` variant, so both drivers' existing unwind (`?` and
+`first_error` + task fast-exit) carries the cancellation with no new
+control flow.
+
+## Abandoned Approaches
+
+Nothing was implemented and abandoned. One *measurement* was made and
+discarded, recorded here because it was nearly reported as a result:
+
+The first A/B block read `main` at 283–291 ms on `grid_laplacian_350`
+sequential against 202–205 ms for this branch — a 40% "regression on
+main", which is impossible for a change that only adds branches. That
+block ran immediately after `git worktree add`; re-running the two arms
+interleaved gave `main` 200–203 ms, matching the branch. The first block
+landed in a slow patch of container time. Recorded in the journal: on
+this container a single un-interleaved A/B block can manufacture a 40%
+effect, so alternate the arms.
+
+## Next Session Should
+
+1. Re-run `cargo run --bin bench --release` with the corpus mounted and
+   confirm the exit-partition p90s against session 2026-08-19-05
+   (dense 1.58 / 2.00, sparse 1.58 / 1.58). This session could not.
+2. Decide whether the C ABI and the Python bindings should be able to
+   *arm* the interrupt flag, rather than only name the status. For C that
+   is a `feral_set_interrupt(FeralSolver*, ...)` plus an ownership story
+   for the flag; for Python a small `feral.InterruptFlag` wrapping the
+   `Arc<AtomicBool>` (`factor` already runs under `py.allow_threads`, so
+   a Python watchdog thread could set it). Neither is needed by #194's
+   consumer, which is Rust.
+3. Consider whether the *symbolic* phase should be interruptible. It is
+   not, and the doc says so. For an IPM refactoring a fixed pattern it is
+   a cache hit and costs nothing, but the first factor of a new pattern
+   runs an ordering (METIS/KaHIP/SCOTCH) that a budget cannot preempt.
+4. Reduce the ~9–10 ms overshoot if a consumer asks: it is dominated by
+   the un-polled prologue (scaling, permute), not by the poll spacing, so
+   the fix would be a poll between prologue phases rather than a finer
+   one inside the panel loop.

--- a/feral-ipopt-shim/include/feral_capi.h
+++ b/feral-ipopt-shim/include/feral_capi.h
@@ -31,6 +31,14 @@ extern "C" {
 #define FERAL_SINGULAR       1
 #define FERAL_WRONG_INERTIA  2
 #define FERAL_FATAL          3
+/* Issue #194: the factorization stopped because a cooperative interrupt
+ * flag was set. Not reachable through this ABI today -- there is no
+ * feral_set_interrupt entry point, so the Solver behind the handle is
+ * always unarmed -- but defined so a shim can switch on it exhaustively
+ * rather than treating an unknown code as fatal. Like FERAL_FATAL this is
+ * NOT an Ipopt ESymSolverStatus value: 4 is SYMSOLVER_FATAL_ERROR there,
+ * so a shim must translate, never cast. */
+#define FERAL_INTERRUPTED    4
 
 /* Opaque handle. */
 typedef struct FeralSolver FeralSolver;

--- a/python/feral/__init__.py
+++ b/python/feral/__init__.py
@@ -79,6 +79,10 @@ class FactorStatus(IntEnum):
     SINGULAR = _feral._STATUS_CODES["SINGULAR"]
     WRONG_INERTIA = _feral._STATUS_CODES["WRONG_INERTIA"]
     NUMERIC_FAILURE = _feral._STATUS_CODES["NUMERIC_FAILURE"]
+    #: Issue #194. Reserved: the Rust core can stop a factorization on a
+    #: caller-armed interrupt flag, but these bindings expose no way to arm
+    #: one, so :meth:`Solver.factor` never returns this today.
+    INTERRUPTED = _feral._STATUS_CODES["INTERRUPTED"]
 
 
 class QualityLevel(IntEnum):

--- a/python/src/common.rs
+++ b/python/src/common.rs
@@ -39,6 +39,12 @@ pub(crate) const STATUS_SUCCESS: i32 = 0;
 pub(crate) const STATUS_SINGULAR: i32 = 1;
 pub(crate) const STATUS_WRONG_INERTIA: i32 = 2;
 pub(crate) const STATUS_NUMERIC_FAILURE: i32 = 3;
+/// Issue #194: the Rust `FactorStatus::Interrupted`. Mirrored here so the
+/// Rust-side match stays exhaustive and a cancellation is never reported
+/// as a numeric failure. Not observable from Python today — these
+/// bindings expose no way to arm `Solver::with_interrupt`, so the Rust
+/// solver underneath is always unarmed.
+pub(crate) const STATUS_INTERRUPTED: i32 = 4;
 
 // ----------------------------------------------------------------------
 // QualityLevel codes (matching the Python IntEnum).

--- a/python/src/errors.rs
+++ b/python/src/errors.rs
@@ -64,6 +64,14 @@ pub(crate) fn map_feral_err(e: RustFeralError) -> PyErr {
         RustFeralError::NeedsRefactor => NeedsRefactorError::new_err(
             "LU basis update requires a refactor (update or stability budget reached)",
         ),
+        // Issue #194: unreachable from Python — these bindings expose no
+        // way to arm the Rust core's cooperative interrupt flag, so no
+        // factorization started here can be cancelled. Mapped to the
+        // FactorError root rather than wildcarded so the exhaustiveness
+        // check keeps guarding this function.
+        RustFeralError::Interrupted => {
+            FactorError::new_err("factorization interrupted by the caller's interrupt flag")
+        }
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -30,7 +30,8 @@ use pyo3::wrap_pyfunction;
 
 use common::{
     Inertia, QUALITY_BASELINE, QUALITY_EXHAUSTED, QUALITY_PIVOT_RAISED, QUALITY_SCALING_ENABLED,
-    STATUS_NUMERIC_FAILURE, STATUS_SINGULAR, STATUS_SUCCESS, STATUS_WRONG_INERTIA,
+    STATUS_INTERRUPTED, STATUS_NUMERIC_FAILURE, STATUS_SINGULAR, STATUS_SUCCESS,
+    STATUS_WRONG_INERTIA,
 };
 use factors::Factors;
 use introspect::{
@@ -71,6 +72,7 @@ fn _feral(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     status.set_item("SINGULAR", STATUS_SINGULAR)?;
     status.set_item("WRONG_INERTIA", STATUS_WRONG_INERTIA)?;
     status.set_item("NUMERIC_FAILURE", STATUS_NUMERIC_FAILURE)?;
+    status.set_item("INTERRUPTED", STATUS_INTERRUPTED)?;
     m.add("_STATUS_CODES", status)?;
 
     let quality = PyDict::new_bound(py);

--- a/python/src/solver.rs
+++ b/python/src/solver.rs
@@ -14,8 +14,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::common::{
-    array1_to_vec, ordering_from_str, ordering_to_str, quality_to_int, Inertia, STATUS_SINGULAR,
-    STATUS_SUCCESS, STATUS_WRONG_INERTIA,
+    array1_to_vec, ordering_from_str, ordering_to_str, quality_to_int, Inertia,
+    STATUS_INTERRUPTED, STATUS_SINGULAR, STATUS_SUCCESS, STATUS_WRONG_INERTIA,
 };
 use crate::errors::{
     map_feral_err, DelayBudgetExceeded, NumericFailure, PatternMismatch, SingularError,
@@ -200,6 +200,11 @@ impl Solver {
                 actual,
                 expected: _,
             } => Ok((STATUS_WRONG_INERTIA, Some(actual.into()))),
+            // Issue #194: unreachable from Python — these bindings expose
+            // no way to arm the interrupt flag — but returned as its own
+            // code rather than folded into NUMERIC_FAILURE, so if an
+            // arming API is added later nothing here has to change.
+            RustFactorStatus::Interrupted => Ok((STATUS_INTERRUPTED, None)),
             RustFactorStatus::FatalError(e) => Err(match e {
                 RustFeralError::NumericallyRankDeficient => SingularError::new_err(format!("{e}")),
                 RustFeralError::InvalidInput(s) => PyValueError::new_err(s),

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -33,6 +33,14 @@ pub const FERAL_SUCCESS: i32 = 0;
 pub const FERAL_SINGULAR: i32 = 1;
 pub const FERAL_WRONG_INERTIA: i32 = 2;
 pub const FERAL_FATAL: i32 = 3;
+/// Issue #194: the factorization stopped because the caller's
+/// cooperative interrupt flag was set. No factor is stored.
+///
+/// Unreachable through this ABI today — the C surface owns its `Solver`
+/// internally and has no way to arm the flag — but defined and mapped so
+/// the Rust-side `FactorStatus` match stays exhaustive and an interrupt
+/// is never silently reported as `FERAL_FATAL`.
+pub const FERAL_INTERRUPTED: i32 = 4;
 
 /// Opaque handle.
 pub struct FeralSolver {
@@ -408,6 +416,11 @@ pub unsafe extern "C" fn feral_factor(
                 // No valid inertia — invalidate (see Singular branch, X1).
                 s.neg_evals = -1;
                 FERAL_FATAL
+            }
+            FactorStatus::Interrupted => {
+                // No valid inertia — invalidate (see Singular branch, X1).
+                s.neg_evals = -1;
+                FERAL_INTERRUPTED
             }
         }
     }))

--- a/src/dense/factor.rs
+++ b/src/dense/factor.rs
@@ -691,6 +691,58 @@ pub struct BunchKaufmanParams {
     /// fronts (the FMA path is one ULP per accumulate off nofma; see
     /// `schur_kernel::fma_vs_nofma_panel_kernels_within_n_elim_ulps`).
     pub fma_min_front_rows: Option<usize>,
+
+    /// Cooperative cancellation flag (issue #194). `None` (default) is
+    /// the uninterruptible path: every poll site short-circuits on an
+    /// `Option::is_some` branch and no atomic is ever touched.
+    ///
+    /// When `Some(flag)`, the factorization polls `flag` with
+    /// [`Ordering::Relaxed`](std::sync::atomic::Ordering::Relaxed) and
+    /// aborts with [`FeralError::Interrupted`] the first time it reads
+    /// `true`. Polling happens at supernode boundaries in both
+    /// multifrontal drivers and, within a supernode, at dense panel
+    /// boundaries in the frontal factor — coarse enough to stay off the
+    /// inner kernels (each poll guards at least `O(nrow)` of work),
+    /// frequent enough that the overshoot is one panel rather than one
+    /// front. Supernode boundaries alone would not be enough: a
+    /// delayed-pivot cascade concentrates the cost of a whole
+    /// factorization into a handful of very wide fronts (issue #8
+    /// measured 118k delayed pivots landing in three ~14k-column
+    /// expanded fronts).
+    ///
+    /// Relaxed is the right ordering: the flag carries no data
+    /// dependency — nothing else the setter wrote is read here — and a
+    /// missed observation costs one more panel before the next poll.
+    ///
+    /// The flag is **caller-owned and read-only to feral**: feral never
+    /// sets or clears it, so re-arming after an interrupt is the
+    /// caller's `store(false)`. On interrupt no factors are produced and
+    /// no partial result is promised. Arm it on a `Solver` with
+    /// [`Solver::with_interrupt`](crate::Solver::with_interrupt) or
+    /// [`Solver::set_interrupt`](crate::Solver::set_interrupt).
+    ///
+    /// This lives on `BunchKaufmanParams` rather than on
+    /// [`NumericParams`](crate::NumericParams) so that the one field is
+    /// visible to *both* the multifrontal driver loops (which read
+    /// `params.bk`) and the dense frontal factor (which is handed only
+    /// `&BunchKaufmanParams`), with no cross-struct sync step of the
+    /// kind that made [`fma`](Self::fma) a silent no-op before finding
+    /// N1. Deadline policy — wall vs CPU vs budget — stays with the
+    /// caller; feral holds no clock.
+    pub interrupt: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+}
+
+impl BunchKaufmanParams {
+    /// Has the caller requested cancellation? `false` — via a
+    /// perfectly-predicted branch, with no atomic access — whenever
+    /// [`interrupt`](Self::interrupt) is unarmed. Issue #194.
+    #[inline]
+    pub fn interrupt_requested(&self) -> bool {
+        match &self.interrupt {
+            Some(flag) => flag.load(std::sync::atomic::Ordering::Relaxed),
+            None => false,
+        }
+    }
 }
 
 /// Minimum trailing-update area `(nrow - j_start) * n_elim` below which
@@ -885,6 +937,8 @@ impl Default for BunchKaufmanParams {
             static_pivot_floor: 0.0,
             intrafront_parallel: false,
             fma_min_front_rows: None,
+            // Issue #194: uninterruptible by default. See the field doc.
+            interrupt: None,
         }
     }
 }
@@ -1818,6 +1872,14 @@ fn factor_frontal_in_place_with_scratch_impl(
     // Factor only the first ncol columns. Pivot search is restricted to
     // [k, ncol_eff); `ncol_eff` shrinks as stuck columns are delayed.
     while k < ncol_eff {
+        // Issue #194: cooperative cancellation poll. One perfectly-
+        // predicted branch when unarmed; one relaxed load when armed.
+        // Guards at least `O(nrow)` of work (`scalar_pivot_step` scans
+        // and updates the trailing columns), so this is well off the
+        // inner kernels.
+        if params.interrupt_requested() {
+            return Err(FeralError::Interrupted);
+        }
         match scalar_pivot_step(
             a,
             nrow,
@@ -2223,6 +2285,18 @@ pub fn factor_frontal_blocked_in_place_with_scratch(
     // delays, so `ncol_eff` then stays `== ncol`.
     let mut ncol_eff = ncol;
     while k < ncol_eff {
+        // Issue #194: cooperative cancellation poll, once per panel (or
+        // once per scalar-tail pivot). Each iteration below performs at
+        // least `O(nrow)` work — a panel factor plus its deferred Schur
+        // update is far more — so the poll is one level out from the hot
+        // kernels, which is what makes a ~14k-column cascade front
+        // (issue #8) interruptible at all. `pack_pool` was moved out of
+        // `scratch` above; returning here drops it, and the next call
+        // re-allocates once, exactly as the other early error returns in
+        // this function do.
+        if params.interrupt_requested() {
+            return Err(FeralError::Interrupted);
+        }
         let remaining = ncol_eff - k;
         // Scalar tail engages when too few columns are left to amortize
         // the deferred-Schur dispatch. With W-1 the first panel may

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,22 @@ pub enum FeralError {
     /// `dev/research/sqd-fast-path.md` and issue #34.
     SqdContractViolated { column: usize, pivot: f64 },
 
+    /// A cooperative interrupt was requested: the caller-armed
+    /// `Arc<AtomicBool>` on
+    /// [`BunchKaufmanParams::interrupt`](crate::BunchKaufmanParams::interrupt)
+    /// was observed set at a supernode boundary, or at a dense panel
+    /// boundary within a supernode. The factorization stopped where it
+    /// stood; no factors are produced and no partial result is promised.
+    ///
+    /// Raised only when the caller armed the flag — an unarmed
+    /// factorization can never return this. `Solver::factor` maps it to
+    /// [`FactorStatus::Interrupted`](crate::FactorStatus::Interrupted),
+    /// clears any stored factor, and a subsequent `factor()` (once the
+    /// caller clears the flag) re-runs cleanly. feral only ever *reads*
+    /// the flag: clearing and re-arming belong to the caller. See issue
+    /// #194 and `dev/research/issue-194-cooperative-interrupt.md`.
+    Interrupted,
+
     /// A supernode received more delayed pivots from its children at
     /// numeric time than the symbolic-analysis phase budgeted for.
     /// Mirrors MUMPS's `INFO(2)` workspace-overflow path: a predictable,
@@ -111,6 +127,12 @@ impl std::fmt::Display for FeralError {
                     "delayed-pivot budget exceeded at supernode {}: \
                      required {} delayed columns, capacity {} (issue #55)",
                     supernode, required, capacity
+                )
+            }
+            FeralError::Interrupted => {
+                write!(
+                    f,
+                    "factorization interrupted by the caller's interrupt flag"
                 )
             }
             FeralError::SingularBasis { column } => {

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -2219,6 +2219,20 @@ pub fn factorize_multifrontal_supernodal_with_workspace(
     let prologue_us = t_prologue.map(|t| t.elapsed().as_micros() as u64);
 
     while snode_idx < n_snodes {
+        // Issue #194: cooperative cancellation poll at the supernode
+        // boundary. Unarmed, this is an `Option::is_some` branch that
+        // predicts perfectly; armed, a relaxed load of an uncontended
+        // cache line, once per supernode. The dense frontal factor polls
+        // again at its panel boundaries so a single very wide front
+        // (issue #8's delayed-pivot cascade) is interruptible too.
+        //
+        // Returning here leaves `contrib_blocks` and the partial
+        // `node_factors` to drop, and `ws` in the same state any other
+        // `?` exit from this loop leaves it: the next call's prologue
+        // re-establishes the `row_map` invariant unconditionally.
+        if params.bk.interrupt_requested() {
+            return Err(FeralError::Interrupted);
+        }
         if use_small_leaf {
             if let Some(gid) = symbolic.snode_group[snode_idx] {
                 let group = &symbolic.small_leaf_groups[gid];
@@ -3760,6 +3774,17 @@ fn run_parallel_task<'a>(
                 .iter()
                 .chain(std::iter::once(&task_idx))
             {
+                // Issue #194: cooperative cancellation poll at the
+                // supernode boundary, mirroring the sequential driver.
+                // Raising `Interrupted` as an ordinary task error reuses
+                // the existing unwind: it lands in `first_error`, and
+                // every task still queued takes the fast-exit at the top
+                // of `run_parallel_task`, so the scope drains without
+                // starting further work.
+                if params.bk.interrupt_requested() {
+                    task_res = Err(FeralError::Interrupted);
+                    break;
+                }
                 let snode = &symbolic.supernodes[snode_idx];
                 // Stage child contributions: shared lock held only for
                 // the drain, not across the factor body.

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -1460,6 +1460,25 @@ impl Solver {
                         mc64_fallback_adopted = true;
                         Ok((rf, ri))
                     }
+                    // Issue #194: a cancellation is not evidence about
+                    // MC64. The retry never got to finish, so nothing was
+                    // learned about whether the Hungarian matching would
+                    // have improved the zero count. Propagate the
+                    // interrupt (the caller asked to stop, and the
+                    // published contract says the first observation of the
+                    // flag aborts the factorization) and leave
+                    // `mc64_retry_not_adopted` DISARMED.
+                    //
+                    // Arming it here would be a correctness bug, not just
+                    // a lost optimization: the latch is keyed on the
+                    // pattern and cleared only on a pattern change, so in
+                    // an IPM — fixed pattern for the whole solve — one
+                    // cancellation would suppress the issue-#65 rescue for
+                    // every remaining iterate, reporting unrescued inertia
+                    // where it would otherwise have recovered. See the
+                    // `mc64_retry_not_adopted` field doc on exactly that
+                    // interaction with the inertia hard rule.
+                    Err(FeralError::Interrupted) => Err(FeralError::Interrupted),
                     // MC64 did not improve the zero count (e.g. the matrix
                     // is genuinely singular) or it errored — keep the
                     // original factor. N4: latch so subsequent same-pattern

--- a/src/numeric/solver.rs
+++ b/src/numeric/solver.rs
@@ -32,6 +32,7 @@ use crate::symbolic::{
     symbolic_factorize_with_method, OrderingMethod, SymbolicFactorization, SymbolicProfileReport,
     SymbolicProfiler,
 };
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 /// Snapshot of per-`factor()` diagnostic state for issue #52
@@ -97,6 +98,20 @@ pub enum FactorStatus {
     /// Unrecoverable error (dimension mismatch, alloc failure,
     /// symbolic-analysis failure).
     FatalError(FeralError),
+    /// The caller-armed interrupt flag was observed set, and the
+    /// factorization stopped where it stood (issue #194).
+    ///
+    /// Contract: the `Solver`'s factors are left invalid, exactly as
+    /// after any failed factor — `inertia()` is `None` and `solve()`
+    /// returns [`FeralError::NoFactor`]. No partial result is promised,
+    /// and there is no guarantee about *when* within a dense panel the
+    /// check fires. Once the caller clears its flag, a subsequent
+    /// `factor()` re-runs cleanly.
+    ///
+    /// Only reachable when the caller armed a flag via
+    /// [`Solver::with_interrupt`] / [`Solver::set_interrupt`]; an
+    /// unarmed `Solver` never returns this.
+    Interrupted,
 }
 
 /// Quality-escalation state. Mirrors Ipopt's two-stage
@@ -573,6 +588,78 @@ impl Solver {
         self
     }
 
+    /// Arm cooperative cancellation for subsequent [`factor`](Self::factor)
+    /// calls (issue #194).
+    ///
+    /// A host enforcing a wall-clock budget cannot enforce it across a
+    /// single `factor` call: it never regains control to check its own
+    /// deadline. Arming a shared `AtomicBool` gives it a way to ask.
+    /// While armed, `factor` polls the flag at supernode boundaries and,
+    /// within a supernode, at dense panel boundaries; the first
+    /// observation of `true` aborts the factorization and `factor`
+    /// returns [`FactorStatus::Interrupted`].
+    ///
+    /// **Contract.** On `Interrupted` the `Solver`'s factors are left
+    /// invalid, exactly as after any failed factor: [`inertia`](Self::inertia)
+    /// is `None` and [`solve`](Self::solve) returns
+    /// [`FeralError::NoFactor`]. No partial results are promised, and
+    /// there is no guarantee about *when* within a panel the check
+    /// fires. Once the caller clears the flag, a subsequent `factor`
+    /// re-runs cleanly — the reused symbolic cache, permute cache and
+    /// numeric workspace all survive an interrupt.
+    ///
+    /// The flag is caller-owned: feral only ever *reads* it, never sets
+    /// or clears it, so re-arming after an interrupt is the caller's
+    /// `store(false, Relaxed)`.
+    ///
+    /// **Not covered.** Only the numeric factorization is polled. The
+    /// symbolic analysis on the first `factor` of a new pattern (and any
+    /// ordering escalation that re-runs it) is not interruptible; for an
+    /// IPM refactoring a fixed pattern this is a cache hit and costs
+    /// nothing, which is the case the flag exists for.
+    ///
+    /// feral holds no clock. Wall-vs-CPU-vs-budget policy stays with the
+    /// caller — this deliberately takes a flag, not a deadline.
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use std::sync::Arc;
+    /// use feral::{FactorStatus, Solver};
+    ///
+    /// let cancel = Arc::new(AtomicBool::new(false));
+    /// let mut solver = Solver::new().with_interrupt(Arc::clone(&cancel));
+    /// // ... a watchdog elsewhere: cancel.store(true, Ordering::Relaxed);
+    /// # let a = feral::CscMatrix::from_triplets(2, &[0, 1], &[0, 1], &[2.0, 3.0]).unwrap();
+    /// if let FactorStatus::Interrupted = solver.factor(&a, None) {
+    ///     cancel.store(false, Ordering::Relaxed); // caller re-arms
+    /// }
+    /// ```
+    ///
+    /// See also [`set_interrupt`](Self::set_interrupt), which arms
+    /// through a `&mut` borrow and can disarm.
+    pub fn with_interrupt(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.numeric_params.bk.interrupt = Some(flag);
+        self
+    }
+
+    /// Arm or disarm cooperative cancellation through a `&mut` borrow
+    /// (issue #194). `None` disarms, restoring the zero-overhead
+    /// uninterruptible path.
+    ///
+    /// Same contract as [`with_interrupt`](Self::with_interrupt), which
+    /// this is the non-consuming form of. A backend that owns its
+    /// `Solver` behind `&mut self` cannot call a consuming builder, and
+    /// nothing else can take the flag back off.
+    pub fn set_interrupt(&mut self, flag: Option<Arc<AtomicBool>>) {
+        self.numeric_params.bk.interrupt = flag;
+    }
+
+    /// The interrupt flag this `Solver` is armed with, if any (issue
+    /// #194). `None` on a fresh `Solver`.
+    pub fn interrupt(&self) -> Option<&Arc<AtomicBool>> {
+        self.numeric_params.bk.interrupt.as_ref()
+    }
+
     /// Toggle the FMA opt-in dispatch on dense trailing-update and
     /// panel-update kernels. Default `false` keeps the bit-exact
     /// `*_nofma` path; pass `true` to dispatch through the FMA
@@ -927,6 +1014,17 @@ impl Solver {
     /// without invalidating the stored factor (caller may still
     /// `solve` against it). See plan §`factor()` flow.
     pub fn factor(&mut self, matrix: &CscMatrix, check_inertia: Option<Inertia>) -> FactorStatus {
+        // Issue #194: if the caller has already asked to stop, say so
+        // before doing any work at all — including the O(nnz) finite
+        // scan below and the (uninterruptible) symbolic analysis. A
+        // no-op when unarmed.
+        if self.numeric_params.bk.interrupt_requested() {
+            self.last_factors = None;
+            self.last_inertia = None;
+            self.last_nnz_a = None;
+            self.last_pattern_reused = None;
+            return FactorStatus::Interrupted;
+        }
         // Step 0: reject non-finite input. A single +∞ / -∞ / NaN
         // entry sends the BK pivot-search loop into pathological
         // behavior (every threshold test fails against the inf
@@ -1571,6 +1669,18 @@ impl Solver {
                 self.last_nnz_a = None;
                 self.last_pattern_reused = None;
                 FactorStatus::Singular
+            }
+            // Issue #194: the caller asked to stop. Same invalidation as
+            // any other failed factor — that *is* the published contract
+            // ("factors are left invalid, exactly as after any failed
+            // factor") — but reported distinctly so a host can tell its
+            // own cancellation apart from a real failure.
+            Err(FeralError::Interrupted) => {
+                self.last_factors = None;
+                self.last_inertia = None;
+                self.last_nnz_a = None;
+                self.last_pattern_reused = None;
+                FactorStatus::Interrupted
             }
             Err(e) => {
                 self.last_factors = None;

--- a/tests/issue194_factor_interrupt.rs
+++ b/tests/issue194_factor_interrupt.rs
@@ -1,0 +1,370 @@
+//! Issue #194: `Solver::factor` must be cooperatively cancellable.
+//!
+//! A host enforcing a wall-clock budget cannot enforce it across a single
+//! `factor` call: it never regains control to check its deadline. Measured in
+//! pounce on `emfl050_5_5`, a `max_wall_time=5` solve returned `TIME_LIMIT`
+//! after 48.8 s because one factorization ran ~44 s uninterrupted.
+//!
+//! The fix is a caller-owned `Arc<AtomicBool>` polled at supernode boundaries
+//! and, within a supernode, at dense panel boundaries. These tests pin the
+//! contract the reporter said they would rely on:
+//!
+//! * unarmed → byte-identical behaviour;
+//! * armed and set → `FactorStatus::Interrupted`, no factor stored;
+//! * clearing the flag → the next `factor` re-runs cleanly, same inertia;
+//! * armed and clear → `Success` (the flag is polled, not merely present);
+//! * both the sequential and parallel drivers honour it;
+//! * a flag set from another thread mid-factorization stops it early.
+
+use feral::{CscMatrix, FactorStatus, FeralError, Inertia, Solver};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Symmetric tridiagonal SPD matrix, lower triangle. Cheap to factor —
+/// used for the contract tests, where the point is the control flow.
+fn tridiag_spd(n: usize) -> CscMatrix {
+    let mut rows = Vec::with_capacity(2 * n);
+    let mut cols = Vec::with_capacity(2 * n);
+    let mut vals = Vec::with_capacity(2 * n);
+    for c in 0..n {
+        rows.push(c);
+        cols.push(c);
+        vals.push(4.0);
+        if c + 1 < n {
+            rows.push(c + 1);
+            cols.push(c);
+            vals.push(-1.0);
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("tridiagonal triplets")
+}
+
+/// 5-point Laplacian on a `g x g` grid, lower triangle. `n = g^2`. Chosen
+/// for the mid-flight test because its elimination tree is genuinely
+/// two-dimensional: fill grows like `n log n` and the factor is dominated
+/// by wide separator fronts, so it takes long enough to interrupt.
+fn grid_laplacian(g: usize) -> CscMatrix {
+    let n = g * g;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    let at = |i: usize, j: usize| i * g + j;
+    for i in 0..g {
+        for j in 0..g {
+            let c = at(i, j);
+            rows.push(c);
+            cols.push(c);
+            vals.push(4.0);
+            if i + 1 < g {
+                rows.push(at(i + 1, j));
+                cols.push(c);
+                vals.push(-1.0);
+            }
+            if j + 1 < g {
+                rows.push(at(i, j + 1));
+                cols.push(c);
+                vals.push(-1.0);
+            }
+        }
+    }
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("grid laplacian triplets")
+}
+
+fn baseline_inertia(a: &CscMatrix, parallel: bool) -> Inertia {
+    let mut s = Solver::new().with_parallel(parallel);
+    let status = s.factor(a, None);
+    assert!(
+        matches!(status, FactorStatus::Success),
+        "baseline factor must succeed, got {status:?}"
+    );
+    s.inertia().cloned().expect("baseline inertia")
+}
+
+#[test]
+fn unarmed_solver_is_unaffected() {
+    let a = tridiag_spd(500);
+    for parallel in [false, true] {
+        let mut s = Solver::new().with_parallel(parallel);
+        assert!(
+            s.interrupt().is_none(),
+            "a fresh Solver must not be armed (parallel={parallel})"
+        );
+        let status = s.factor(&a, None);
+        assert!(
+            matches!(status, FactorStatus::Success),
+            "unarmed factor must succeed (parallel={parallel}), got {status:?}"
+        );
+        assert_eq!(
+            s.inertia().cloned(),
+            Some(baseline_inertia(&a, parallel)),
+            "unarmed factor must report the baseline inertia (parallel={parallel})"
+        );
+    }
+}
+
+#[test]
+fn armed_but_clear_flag_factors_normally() {
+    let a = tridiag_spd(500);
+    for parallel in [false, true] {
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut s = Solver::new()
+            .with_parallel(parallel)
+            .with_interrupt(Arc::clone(&flag));
+        assert!(
+            s.interrupt().is_some(),
+            "with_interrupt must arm the Solver (parallel={parallel})"
+        );
+        let status = s.factor(&a, None);
+        assert!(
+            matches!(status, FactorStatus::Success),
+            "a clear flag must not interrupt (parallel={parallel}), got {status:?}"
+        );
+        assert_eq!(
+            s.inertia().cloned(),
+            Some(baseline_inertia(&a, parallel)),
+            "arming with a clear flag must not perturb the factor (parallel={parallel})"
+        );
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "feral must never write the caller's flag (parallel={parallel})"
+        );
+    }
+}
+
+#[test]
+fn set_flag_interrupts_and_leaves_no_factor() {
+    let a = tridiag_spd(500);
+    for parallel in [false, true] {
+        let flag = Arc::new(AtomicBool::new(true));
+        let mut s = Solver::new()
+            .with_parallel(parallel)
+            .with_interrupt(Arc::clone(&flag));
+        let status = s.factor(&a, None);
+        assert!(
+            matches!(status, FactorStatus::Interrupted),
+            "a set flag must interrupt (parallel={parallel}), got {status:?}"
+        );
+        // Contract: factors are left invalid, exactly as after any failed
+        // factor. The caller must not solve against them.
+        assert!(
+            s.inertia().is_none(),
+            "interrupted factor must not leave an inertia (parallel={parallel})"
+        );
+        match s.solve(&vec![1.0; a.n]) {
+            Err(FeralError::NoFactor) => {}
+            other => panic!(
+                "solve after an interrupted factor must fail with NoFactor \
+                 (parallel={parallel}), got {:?}",
+                other.map(|v| v.len())
+            ),
+        }
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "feral must not clear the caller's flag (parallel={parallel})"
+        );
+    }
+}
+
+#[test]
+fn clearing_the_flag_lets_the_next_factor_run_clean() {
+    let a = tridiag_spd(500);
+    for parallel in [false, true] {
+        let expected = baseline_inertia(&a, parallel);
+        let flag = Arc::new(AtomicBool::new(true));
+        let mut s = Solver::new()
+            .with_parallel(parallel)
+            .with_interrupt(Arc::clone(&flag));
+
+        let status = s.factor(&a, None);
+        assert!(
+            matches!(status, FactorStatus::Interrupted),
+            "setup: expected Interrupted (parallel={parallel}), got {status:?}"
+        );
+
+        // The half of the contract that a naive implementation breaks: an
+        // interrupted factorization must not poison the reused workspace,
+        // symbolic cache or permute cache.
+        flag.store(false, Ordering::Relaxed);
+        let status = s.factor(&a, None);
+        assert!(
+            matches!(status, FactorStatus::Success),
+            "re-factor after clearing the flag must succeed (parallel={parallel}), \
+             got {status:?}"
+        );
+        assert_eq!(
+            s.inertia().cloned(),
+            Some(expected),
+            "re-factor must reproduce the un-interrupted inertia (parallel={parallel})"
+        );
+
+        // And a solve against the recovered factor must work.
+        let rhs = vec![1.0; a.n];
+        let x = s.solve(&rhs).expect("solve after clean re-factor");
+        assert_eq!(x.len(), a.n);
+        assert!(
+            x.iter().all(|v| v.is_finite()),
+            "re-factor solve produced non-finite values (parallel={parallel})"
+        );
+    }
+}
+
+#[test]
+fn set_interrupt_arms_and_disarms_through_a_mut_borrow() {
+    // The consumer in issue #194 holds the Solver behind `&mut self`
+    // (`SparseSymLinearSolverInterface::set_interrupt`), where a consuming
+    // builder cannot be called. `set_interrupt` is that path, and is also
+    // the only way to disarm.
+    let a = tridiag_spd(200);
+    let flag = Arc::new(AtomicBool::new(true));
+    let mut s = Solver::new().with_parallel(false);
+
+    s.set_interrupt(Some(Arc::clone(&flag)));
+    assert!(s.interrupt().is_some(), "set_interrupt(Some) must arm");
+    assert!(
+        matches!(s.factor(&a, None), FactorStatus::Interrupted),
+        "armed + set flag must interrupt"
+    );
+
+    s.set_interrupt(None);
+    assert!(s.interrupt().is_none(), "set_interrupt(None) must disarm");
+    assert!(
+        matches!(s.factor(&a, None), FactorStatus::Success),
+        "a disarmed Solver must ignore a still-set flag"
+    );
+    assert!(
+        flag.load(Ordering::Relaxed),
+        "disarming must not touch the caller's flag"
+    );
+}
+
+/// The reported scenario: the flag is clear when `factor` starts and is set
+/// by a watchdog while the factorization is running. This is what proves the
+/// poll fires *inside* the factorization rather than only at entry.
+///
+/// Shaped like the IPM case in the issue: the solver is warm (symbolic
+/// analysis already cached from a prior factor on the same pattern), so what
+/// is being timed and interrupted is the numeric phase alone — which is the
+/// only phase the flag covers.
+fn mid_factorization_interrupt(parallel: bool) {
+    // 5-point Laplacian, n = 122_500. Big enough that the numeric factor is
+    // comfortably longer than a thread wake-up even in `--release`.
+    let a = grid_laplacian(350);
+    let flag = Arc::new(AtomicBool::new(false));
+    let mut s = Solver::new()
+        .with_parallel(parallel)
+        .with_interrupt(Arc::clone(&flag));
+
+    // First factor: warms the symbolic + permute caches.
+    assert!(
+        matches!(s.factor(&a, None), FactorStatus::Success),
+        "warm-up factor must succeed (parallel={parallel})"
+    );
+    let expected = s.inertia().cloned().expect("warm-up inertia");
+
+    // Second factor, un-interrupted: this is the cost the watchdog below is
+    // calibrated against, measured on *this* machine rather than assumed.
+    let t0 = Instant::now();
+    assert!(matches!(s.factor(&a, None), FactorStatus::Success));
+    let baseline = t0.elapsed();
+    eprintln!(
+        "warm baseline factor (parallel={parallel}): {baseline:?} (n = {})",
+        a.n
+    );
+
+    // If the baseline is short enough that a watchdog cannot reliably fire
+    // inside it, this test cannot distinguish "interrupted mid-flight" from
+    // "finished first". Report and pass rather than flake.
+    if baseline < Duration::from_millis(100) {
+        eprintln!(
+            "SKIP: warm baseline {baseline:?} is too short to interrupt reliably; \
+             the mid-flight assertion needs >= 100 ms."
+        );
+        return;
+    }
+
+    let delay = baseline / 10;
+    let watchdog_flag = Arc::clone(&flag);
+    let watchdog = std::thread::spawn(move || {
+        std::thread::sleep(delay);
+        watchdog_flag.store(true, Ordering::Relaxed);
+    });
+
+    let t0 = Instant::now();
+    let status = s.factor(&a, None);
+    let interrupted_in = t0.elapsed();
+    watchdog.join().expect("watchdog thread panicked");
+
+    eprintln!(
+        "parallel={parallel}: watchdog fired at {delay:?}; factor returned \
+         {status:?} after {interrupted_in:?}"
+    );
+    assert!(
+        matches!(status, FactorStatus::Interrupted),
+        "a flag set {delay:?} into a {baseline:?} factorization must interrupt it \
+         (parallel={parallel}), got {status:?}"
+    );
+    // The whole point of the issue: the overshoot is bounded, not "the
+    // factorization runs to completion and the caller finds out afterwards".
+    assert!(
+        interrupted_in < baseline,
+        "interrupted factor took {interrupted_in:?}, which is not shorter than the \
+         un-interrupted baseline {baseline:?} (parallel={parallel}) — the poll is \
+         not bounding the overshoot"
+    );
+
+    // And the contract still holds after a mid-flight abort: no factor left
+    // behind, and clearing the flag gives a clean re-factor with the same
+    // inertia as before the interrupt.
+    assert!(
+        s.inertia().is_none(),
+        "mid-flight interrupt must leave no inertia (parallel={parallel})"
+    );
+    flag.store(false, Ordering::Relaxed);
+    assert!(
+        matches!(s.factor(&a, None), FactorStatus::Success),
+        "re-factor after a mid-flight interrupt must succeed (parallel={parallel})"
+    );
+    assert_eq!(
+        s.inertia().cloned(),
+        Some(expected),
+        "re-factor after a mid-flight interrupt must reproduce the inertia \
+         (parallel={parallel})"
+    );
+}
+
+#[test]
+fn sequential_driver_interrupts_mid_factorization() {
+    mid_factorization_interrupt(false);
+}
+
+#[test]
+fn parallel_driver_interrupts_mid_factorization() {
+    mid_factorization_interrupt(true);
+}
+
+/// The free-function driver surface gets the same mechanism, since the flag
+/// rides on the params struct rather than on `Solver`.
+#[test]
+fn free_function_driver_reports_interrupted_error() {
+    use feral::dense::factor::BunchKaufmanParams;
+    use feral::numeric::factorize::factorize_multifrontal;
+    use feral::symbolic::{symbolic_factorize, SupernodeParams};
+    use feral::NumericParams;
+
+    let a = tridiag_spd(300);
+    let sym = symbolic_factorize(&a, &SupernodeParams::default()).expect("symbolic");
+    let flag = Arc::new(AtomicBool::new(true));
+    let params = NumericParams {
+        bk: BunchKaufmanParams {
+            interrupt: Some(Arc::clone(&flag)),
+            ..NumericParams::default().bk
+        },
+        ..NumericParams::default()
+    };
+    match factorize_multifrontal(&a, &sym, &params) {
+        Err(FeralError::Interrupted) => {}
+        Ok(_) => panic!("a set flag must abort the free-function driver"),
+        Err(e) => panic!("expected FeralError::Interrupted, got {e:?}"),
+    }
+}

--- a/tests/issue194_interrupt_during_mc64_retry.rs
+++ b/tests/issue194_interrupt_during_mc64_retry.rs
@@ -1,0 +1,252 @@
+//! Issue #194 x issue #65: an interrupt observed during the MC64 *retry*
+//! factorization must be reported as `Interrupted`, and must not arm the
+//! per-pattern non-adoption latch.
+//!
+//! `Solver::factor` can run *two* factorizations. When the first one
+//! reports the singular signature (`inertia.zero > 0`) under a non-MC64
+//! `Auto` scaling, the issue-#65 rescue re-factors the whole matrix with
+//! `Mc64Symmetric` and adopts the result iff it strictly reduces the zero
+//! count (`src/numeric/solver.rs`, the `mc64_fallback_adopted` block).
+//!
+//! The non-adoption arm was written as a bare `_`, so it also caught
+//! `Err(_)` -- including the `Err(FeralError::Interrupted)` that issue
+//! #194's polling now produces. Two things went wrong:
+//!
+//!   1. `factor` returned `Success`/`Singular` rather than `Interrupted`,
+//!      contradicting the published contract that the first observation of
+//!      the flag aborts the factorization.
+//!   2. `mc64_retry_not_adopted` latched. That latch is keyed on the
+//!      *pattern* and cleared only on a pattern change, so an
+//!      interior-point host -- fixed pattern for a whole solve -- would
+//!      have the issue-#65 rescue suppressed for every remaining iterate
+//!      by a single unrelated cancellation, reporting unrescued inertia
+//!      where it would otherwise have recovered. The field's own doc
+//!      flags exactly that interaction with the inertia hard rule.
+//!
+//! This is not a narrow race: the vulnerable window is the entire duration
+//! of the retry, which is a second *full* factorization of the same
+//! matrix. It is precisely the long-factorization case issue #194 exists
+//! for.
+//!
+//! RED (bare `_` arm): the interrupted call returns non-`Interrupted`, and
+//! the follow-up call finds the retry suppressed (count stays 1).
+//! GREEN (explicit `Err(Interrupted)` arm): the call returns `Interrupted`
+//! and the follow-up call re-runs the retry (count reaches 2).
+
+use feral::{CscMatrix, FactorStatus, Solver};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// A 2D 5-point grid Laplacian on `k x k`, block-diagonal with a rank-1
+/// `[[1,1],[1,1]]` tail.
+///
+/// The grid block supplies enough work that one factorization is
+/// milliseconds rather than microseconds, which is what makes the retry
+/// window wide enough to aim at. The 2x2 tail is the same genuinely
+/// rank-deficient construction `tests/n4_mc64_retry_latch.rs` uses: pivot
+/// on the leading 1, and the Schur complement is `1 - 1 = 0`, so BK
+/// force-accepts exactly one zero pivot and `inertia.zero == 1` fires the
+/// issue-#65 gate. MC64 cannot change rank, so the retry never adopts --
+/// which is the non-adoption arm this test is about.
+fn grid_plus_rank_deficient_tail(k: usize) -> CscMatrix {
+    let g = k * k;
+    let n = g + 2;
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    // Lower triangle of the grid Laplacian.
+    for j in 0..k {
+        for i in 0..k {
+            let idx = j * k + i;
+            rows.push(idx);
+            cols.push(idx);
+            vals.push(4.0);
+            if i + 1 < k {
+                rows.push(idx + 1);
+                cols.push(idx);
+                vals.push(-1.0);
+            }
+            if j + 1 < k {
+                rows.push(idx + k);
+                cols.push(idx);
+                vals.push(-1.0);
+            }
+        }
+    }
+    // Rank-deficient 2x2 tail: [[1,1],[1,1]].
+    rows.push(g);
+    cols.push(g);
+    vals.push(1.0);
+    rows.push(g + 1);
+    cols.push(g);
+    vals.push(1.0);
+    rows.push(g + 1);
+    cols.push(g + 1);
+    vals.push(1.0);
+    CscMatrix::from_triplets(n, &rows, &cols, &vals).expect("grid triplets")
+}
+
+#[test]
+fn an_interrupt_during_the_mc64_retry_is_reported_and_does_not_latch() {
+    let a = grid_plus_rank_deficient_tail(90);
+
+    // Calibrate on a fresh Solver, timing the *first* factor() -- symbolic
+    // analysis plus factorization #1 plus the retry -- so the fractions
+    // below are relative to the same shape of work the armed run does.
+    // A fresh Solver is required: this call leaves `mc64_retry_not_adopted`
+    // armed, which would suppress the retry on any reuse.
+    let mut cal = Solver::new();
+    let t0 = Instant::now();
+    let cal_status = cal.factor(&a, None);
+    let t_total = t0.elapsed();
+
+    assert_eq!(
+        cal.mc64_retry_attempt_count(),
+        1,
+        "the fixture must actually drive the issue-#65 retry, otherwise \
+         this test exercises nothing; got status {cal_status:?}",
+    );
+
+    // Aim the watchdog inside the retry, and sweep the back half of the
+    // call at fine resolution.
+    //
+    // The watchdog spins rather than sleeping. `thread::sleep` has ~1 ms
+    // granularity and overshoots, which on a call this short is coarser
+    // than the whole window -- the first version of this test used sleep
+    // and never landed, failing its own vacuity guard.
+    //
+    // The "did this attempt land inside the retry?" test is deliberately
+    // independent of the behaviour under test, so that it reports the same
+    // answer before and after the fix. Two observables together pin it:
+    //
+    //   * `mc64_retry_attempt_count() == 1` proves factorization #1
+    //     returned `Ok(..)` and the issue-#65 gate was entered -- had the
+    //     flag been seen during factorization #1, that call would have
+    //     returned `Err`, the gate (which keys on `Ok(..)`) would never
+    //     have been entered, and the count would be 0. So the flag was set
+    //     *after* factorization #1 finished.
+    //   * `delay < call_elapsed` proves the watchdog fired before `factor`
+    //     returned. So the flag was set *before* the call ended.
+    //
+    // Together: set after factorization #1 and before the call returned,
+    // i.e. during the retry. Note this says nothing about what `factor`
+    // returned, which is the thing being asserted -- an earlier version
+    // keyed the detector on `status == Interrupted` and could therefore
+    // never land pre-fix, reporting the bug as "never exercised".
+    let mut landed = false;
+    let mut attempts = 0usize;
+    for step in 0..=60u32 {
+        let frac = 0.40 + f64::from(step) * 0.01;
+        attempts += 1;
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut s = Solver::new().with_interrupt(Arc::clone(&flag));
+        let delay = t_total.mul_f64(frac);
+
+        let watchdog = {
+            let flag = Arc::clone(&flag);
+            std::thread::spawn(move || {
+                let t = Instant::now();
+                while t.elapsed() < delay {
+                    std::hint::spin_loop();
+                }
+                flag.store(true, Ordering::Relaxed);
+            })
+        };
+
+        let t_call = Instant::now();
+        let status = s.factor(&a, None);
+        let call_elapsed = t_call.elapsed();
+        watchdog.join().expect("watchdog thread");
+
+        if s.mc64_retry_attempt_count() != 1 || delay >= call_elapsed {
+            // Too early (the flag was seen by the uninterruptible symbolic
+            // phase or by factorization #1), or too late (the call had
+            // already finished). Try the next offset.
+            continue;
+        }
+        landed = true;
+        eprintln!(
+            "landed inside the retry at frac={frac:.2} (delay {delay:?} of \
+             call {call_elapsed:?}) after {attempts} attempts; status {status:?}"
+        );
+
+        // 1. The cancellation must be reported. Pre-fix the bare `_` arm
+        //    mapped Err(Interrupted) to Ok(original factor), so `factor`
+        //    returned Success/Singular and the host's cancellation
+        //    silently did not take effect.
+        assert!(
+            matches!(status, FactorStatus::Interrupted),
+            "an interrupt observed during the MC64 retry must be reported \
+             as Interrupted, not swallowed into the original factor's \
+             status; got {status:?}",
+        );
+
+        // 2. And the latch must be left disarmed, so once the caller
+        //    clears its flag the issue-#65 rescue is still available on
+        //    this pattern.
+        flag.store(false, Ordering::Relaxed);
+        let after = s.factor(&a, None);
+        assert_eq!(
+            s.mc64_retry_attempt_count(),
+            2,
+            "the MC64 rescue must still be available after a cancellation. \
+             A cancellation is not evidence that MC64 does not help -- the \
+             retry never finished -- so `mc64_retry_not_adopted` must stay \
+             disarmed. Pre-fix the bare `_` arm armed it, and being keyed \
+             on the pattern and cleared only on a pattern change, that \
+             suppressed the rescue for every later factor of this pattern. \
+             Follow-up status: {after:?}",
+        );
+        assert!(
+            !matches!(after, FactorStatus::Interrupted),
+            "with the flag cleared the follow-up factor must run to \
+             completion; got {after:?}",
+        );
+        break;
+    }
+
+    assert!(
+        landed,
+        "none of {attempts} attempts landed inside the retry window, so the \
+         regression this test guards was never exercised. Calibrated full \
+         call = {t_total:?}. Fail rather than pass vacuously.",
+    );
+}
+
+#[test]
+fn an_interrupt_during_the_first_factorization_still_reports_interrupted() {
+    // The companion case, and the one that was already correct: when the
+    // flag is seen by factorization #1 the issue-#65 gate is never
+    // entered (it keys on `Ok(..)`), so no retry is counted and the error
+    // reaches the caller through the ordinary path. Pinned so that a
+    // future edit to the gate cannot start swallowing this one too.
+    let a = grid_plus_rank_deficient_tail(90);
+    let flag = Arc::new(AtomicBool::new(false));
+    let mut s = Solver::new().with_interrupt(Arc::clone(&flag));
+
+    let watchdog = {
+        let flag = Arc::clone(&flag);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_micros(200));
+            flag.store(true, Ordering::Relaxed);
+        })
+    };
+    let status = s.factor(&a, None);
+    watchdog.join().expect("watchdog thread");
+
+    assert!(
+        matches!(status, FactorStatus::Interrupted),
+        "a flag set during the first factorization must abort it; got {status:?}",
+    );
+    assert_eq!(
+        s.mc64_retry_attempt_count(),
+        0,
+        "the issue-#65 gate keys on Ok(..), so an aborted factorization \
+         #1 must never reach the retry",
+    );
+    assert!(
+        s.inertia().is_none(),
+        "an interrupted factor stores no factor",
+    );
+}

--- a/tests/issue_17_robot_1600_cascade_off.rs
+++ b/tests/issue_17_robot_1600_cascade_off.rs
@@ -112,5 +112,8 @@ fn robot_1600_iter_3_matches_mumps_inertia_with_defaults() {
         }
         FactorStatus::Singular => panic!("robot_1600_0003 reported Singular under defaults"),
         FactorStatus::FatalError(e) => panic!("robot_1600_0003 fatal error: {e:?}"),
+        // Issue #194: unreachable — this Solver is never armed with an
+        // interrupt flag. Matched explicitly rather than by wildcard.
+        FactorStatus::Interrupted => panic!("unexpected Interrupted on an unarmed Solver"),
     }
 }

--- a/tests/issue_18_narx_cfy_cascade_off.rs
+++ b/tests/issue_18_narx_cfy_cascade_off.rs
@@ -86,6 +86,11 @@ fn check_iter(iter: usize) {
         }
         FactorStatus::Singular => panic!("iter {iter}: factor Singular"),
         FactorStatus::FatalError(e) => panic!("iter {iter}: factor FatalError: {e:?}"),
+        // Issue #194: unreachable — this Solver is never armed with an
+        // interrupt flag. Matched explicitly rather than by wildcard.
+        FactorStatus::Interrupted => {
+            panic!("iter {iter}: unexpected Interrupted on an unarmed Solver")
+        }
     }
 }
 

--- a/tests/large_matrix_smoke.rs
+++ b/tests/large_matrix_smoke.rs
@@ -239,6 +239,13 @@ fn smoke_one(
             failures.push(format!("{name}: factor fatal: {e}"));
             return SmokeOutcome::Failed;
         }
+        // Issue #194: unreachable — the smoke harness never arms an
+        // interrupt flag — but a silent wildcard here would hide it if
+        // that ever changed.
+        FactorStatus::Interrupted => {
+            failures.push(format!("{name}: factor interrupted on an unarmed Solver"));
+            return SmokeOutcome::Failed;
+        }
     }
 
     let t = Instant::now();

--- a/tests/pounce_interface.rs
+++ b/tests/pounce_interface.rs
@@ -390,6 +390,10 @@ fn i7_quality_escalation_loop_terminates_with_correct_inertia() {
             }
             FactorStatus::Singular => panic!("unexpected Singular on a non-singular bordered KKT"),
             FactorStatus::FatalError(e) => panic!("fatal: {}", e),
+            // Issue #194: unreachable here — this Solver is never armed
+            // with an interrupt flag — but matched explicitly so a future
+            // status variant cannot be swallowed by a wildcard.
+            FactorStatus::Interrupted => panic!("unexpected Interrupted on an unarmed Solver"),
         }
     };
     assert!(matches!(final_status, FactorStatus::Success));


### PR DESCRIPTION
Closes #194.

## What

`Solver::factor` can now be cancelled by a caller-owned `Arc<AtomicBool>`.

- `Solver::with_interrupt(flag)` — the builder the issue proposed.
- `Solver::set_interrupt(Option<flag>)` — the stated consumer holds its `Solver` behind `&mut self` (`SparseSymLinearSolverInterface::set_interrupt`), where a consuming builder cannot be called; it is also the only way to disarm.
- `Solver::interrupt()` — read back what is armed.
- `FactorStatus::Interrupted` and `FeralError::Interrupted`.

The flag itself is `BunchKaufmanParams::interrupt`, so direct users of `factorize_multifrontal*` and of the dense frontal factor get the same mechanism.

## Why

`factor` could not be cancelled once running and offered no surface through which a caller could ask, so a host enforcing a wall-clock budget could not enforce it whenever a single factorization was larger than the whole budget — it never regained control to check its own deadline. Measured in pounce on `emfl050_5_5` (5675 variables, 5625 constraints): a `max_wall_time=5` solve returned `TIME_LIMIT` after **48.8 s**, because the between-operation check passed while under budget and one factorization then ran ~44 s uninterrupted.

Every claim in the issue was checked against this tree before designing, rather than taken at face value: `factor`'s signature, `FactorStatus`' variants, `NumericParams`' fields, `DelayBudgetExceeded`'s actual semantics (a symbolic-time column-count budget, not wall-clock — as reported), and the cross-call mutable state (`workspace`, `last_symbolic`, `permute_cache`, `parallel_pool`) that makes a caller-side watchdog unsound. `dev/tried-and-rejected.md` has no prior attempt at this feature.

## One thing the issue asked for would not have fixed the issue

Supernode-boundary polling alone leaves the reported case intact. feral's own #8 measured a delayed-pivot cascade concentrating 118k delayed pivots into three ~14k-column expanded root fronts, so an 87 s factorization is dominated by a handful of *individual fronts*; a check that fires only between supernodes returns "budget plus one 44 s supernode", which is the reported bug again.

So there are two poll granularities: supernode boundaries in both multifrontal drivers, **and** the `while k < ncol_eff` panel loop in the dense frontal factor (blocked and unblocked paths). That loop is still one level out from the hot kernels — every polled iteration guards at least `O(nrow)` of work. The published contract stays the weaker of the two: supernode boundaries, and within a supernode dense panel boundaries, with no promise about when within a panel.

## Design notes

- **A flag, not a deadline.** feral holds no clock; wall-vs-CPU-vs-budget policy stays with the caller. `Ordering::Relaxed` is sufficient — the flag carries no data dependency, and a missed observation costs one more panel.
- **feral only ever reads the flag.** Re-arming after an interrupt is the caller's `store(false)`.
- **`Interrupted` is a `FeralError` variant**, so both drivers' existing unwind carries the cancellation with no new control flow: the sequential `?` out of the supernode loop, and the parallel `first_error` plus the fast-exit at the top of `run_parallel_task`, which drains the scope without starting further work.
- **The flag lives on `BunchKaufmanParams`, not `NumericParams`.** The drivers hold `params.bk` and the dense frontal factor is handed *only* `&BunchKaufmanParams`, so one field is readable from every poll site with no sync step — exactly the shape that left `NumericParams::fma` a silent no-op until finding N1.

Full rationale in `dev/research/issue-194-cooperative-interrupt.md` and the 2026-08-30 entry in `dev/decisions.md`.

## Contract

On `Interrupted` the factors are left invalid exactly as after any failed factor — `inertia()` is `None`, `solve()` returns `NoFactor` — and a subsequent `factor` re-runs cleanly once the caller clears the flag. No partial results are promised. Only the numeric factorization is covered: the symbolic analysis on the first factor of a new pattern is not interruptible (for an IPM refactoring a fixed pattern that is a cache hit, which is the case the flag exists for).

## Evidence

`tests/issue194_factor_interrupt.rs`, 8 tests, all passing. In `--release`, warm solver (symbolic cached, the IPM case), 5-point Laplacian `n = 122500`:

| driver | un-interrupted | flag set at | returned `Interrupted` |
|---|---|---|---|
| sequential | 263.2 ms | 26.3 ms | 34.8 ms |
| parallel | 153.5 ms | 15.3 ms | 25.5 ms |

Overshoot past the request is ~9–10 ms, most of it the un-polled prologue (scaling and permute), against a factorization that would otherwise have run to completion.

The tests also pin the rest of the contract: an unarmed `Solver` is unaffected; an armed-but-clear flag still succeeds with the baseline inertia (so the flag is polled, not merely present); an interrupted factor stores no factor and `solve` returns `NoFactor`; clearing the flag lets the next `factor` re-run cleanly and reproduce the un-interrupted inertia — including after a *mid-flight* abort, which is the case a naive implementation (poisoned workspace, stale contribution blocks) would break; and feral never writes the caller's flag.

Full suite: 100 test binaries, 0 failures. `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean for `feral` and for `feral-diagnostics`; `cargo check` clean for the Python bindings.

## Two things to flag for review

**1. The benchmark gate is unmet, and this PR does not claim otherwise.** The corpus is not present in the container this was developed in, so `cargo run --bin bench --release` ran only the 8 synthetic matrices and both exit-partition tables read `N/A`. Session 2026-08-19-05's p90s (dense 1.58 / 2.00, sparse 1.58 / 1.58) stand unconfirmed. In its place, the poll overhead was measured directly with a paired A/B against `origin/main` (same probe source, best-of-10 warm refactors, arms alternated):

```
                     branch                main (9b9e882)
grid_laplacian_350   203.8 / 197.8 ms      222.8 / 203.5 ms   sequential
grid_laplacian_350    94.2 /  92.3 ms       94.4 /  92.2 ms   parallel
tridiag_200k          57.7 /  57.3 ms       59.4 /  59.2 ms   sequential
tridiag_200k          56.3 /  56.9 ms       56.8 /  54.6 ms   parallel
```

No measurable overhead — every poll site short-circuits on an `Option::is_some` branch and touches no atomic when unarmed. But the honest claim is "no regression detectable on this host", not "zero cost proven": the *first*, un-alternated A/B block read `main` at 283–291 ms on `grid_laplacian_350` sequential, an apparent 40% regression that turned out to be container drift and disappeared on re-running interleaved. Someone should re-run `bench` with the corpus mounted.

**2. C and Python can name the status but cannot arm the flag.** `FERAL_INTERRUPTED = 4` (`src/capi.rs`, `feral-ipopt-shim/include/feral_capi.h`) and `FactorStatus.INTERRUPTED` are defined so the exhaustive matches stay honest, but neither surface has an arming API — #194's consumer is Rust. Whether to add one (`feral_set_interrupt`, or a small `feral.InterruptFlag`; `factor` already runs under `py.allow_threads`) is recorded as a follow-up in the session checkpoint.

## Blast radius

Adding a variant to each of `FactorStatus` and `FeralError` broke exhaustive matches in 4 in-tree integration tests, 10 `feral-diagnostics` probe binaries (built by CI with `-D warnings`, and outside the root workspace default set, so the root `cargo clippy --all-targets` does not see them), and the Python bindings. All were given **explicit arms rather than wildcards**, deliberately: the next variant should break the same builds rather than be silently absorbed. An unarmed `Solver` is unaffected in behaviour and in performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jy5x8pZLRm8GDaSNXMokLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy5x8pZLRm8GDaSNXMokLP)_