### PR TITLE
diag(#200): front-size attribution, and retraction of the per-supernode-overhead finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to FERAL will be documented in this file.
 
+## [Unreleased]
+
+### Changed — faster extend-add on matrices with large contribution blocks (issue #153)
+
+- **What changed.** `extend_add`, which scatters a child's contribution
+  block into its parent frontal matrix, no longer re-resolves each child
+  row's parent index once per column. It resolved
+  `parent_row_map[contrib.row_indices[ci]]` — two dependent gathers —
+  inside the inner loop, doing `cdim*(cdim+1)/2` double-gathers where
+  `cdim` suffice. The map is now built once into a pooled workspace
+  buffer, with a fast path for the common case of strictly-increasing
+  parent indices and a bypass to the original loop for blocks of four
+  rows or fewer, where the setup costs more than the gathers it removes.
+- **Effect.** Sequential factorization, 9-round interleaved A/B,
+  per-round paired medians: ex4_2_160 1.063x, arki0009 1.062x, optmass
+  1.012x, robot_1600 0.998x, steering_12800 0.992x. The gain scales with
+  contribution-block size (mean `cdim` 9.7 and 10.0 on the two matrices
+  that gain, 2.2 on optmass); steering_12800's ~1% regression is
+  consistent across campaigns and unexplained.
+- **Nothing numerical changes.** The iteration order, the unmapped-row
+  and zero-value skips, and the accumulation order into every cell are
+  unchanged. Verified bit-identical across separately-built binaries by
+  hashing the exported global L and D bitwise on all 30 factorizable
+  matrices of the Mittelmann KKT corpus.
+
 ## [0.17.0] - 2026-08-19
 
 ### Fixed — the tree-parallel solve no longer runs on trees too thin to pay for it (issue #175)

--- a/crates/feral-diagnostics/src/bin/diag_153_assembly_split.rs
+++ b/crates/feral-diagnostics/src/bin/diag_153_assembly_split.rs
@@ -1,0 +1,172 @@
+//! Issue #153 — which passes over the frontal matrix make up the
+//! non-kernel part of the supernode loop?
+//!
+//! `diag_153_kernel_headroom` shows the loop runs 1.3-1.9x slower than
+//! feral's own dense kernel on the identical shape sequence, and that
+//! the excess is proportional to **front area** (a flat ~0.5 ns per
+//! `nrow^2` element on the large-front matrices, 2-3 ns on the 17-32
+//! row fronts) rather than to the front *count*. Area-proportional
+//! means passes over the frontal matrix. This binary names them.
+//!
+//! It reports the assembly phase counters in **absolute ns per front
+//! and per front element**, never as a percentage of the driver wall.
+//! That distinction is the whole point: `PHASE_TIMING_ENABLED` costs
+//! 350-430 ns per front (`diag_200_probe_tax`), which inflates the
+//! *denominator* badly enough that `diag_factor_phases`' percentage
+//! columns cannot be compared against a probe-free measurement. Each
+//! individual counter, though, is inflated only by its own
+//! `Instant::now()` pair — tens of ns — so the absolute per-front
+//! numbers here are usable, and the per-counter floor is printed
+//! alongside so the reader can see how much of a small number is probe.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin diag_153_assembly_split \
+//!     -- [--reps N] <matrix.mtx>...
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
+use feral::numeric::factorize::{
+    factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, Profiler,
+};
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use feral::{read_mtx, NumericParams};
+use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+/// Cost of one `Instant::now()` pair on this machine, in ns — the floor
+/// under every per-front counter below.
+fn probe_floor() -> f64 {
+    let n = 200_000;
+    let t0 = Instant::now();
+    let mut acc = 0u64;
+    for _ in 0..n {
+        let a = Instant::now();
+        acc = acc.wrapping_add(a.elapsed().as_nanos() as u64);
+    }
+    std::hint::black_box(acc);
+    t0.elapsed().as_nanos() as f64 / n as f64
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 5usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--reps" {
+            if let Some(v) = it.next() {
+                reps = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+    println!(
+        "probe floor = {:.0} ns per Instant::now() pair",
+        probe_floor()
+    );
+    println!(
+        "{:<22}{:>8}{:>12}{:>10}{:>10}{:>10}{:>10}{:>10}",
+        "matrix", "snodes", "sum nrow^2", "buildrow", "scatter", "extendadd", "zerofill", "cbextr"
+    );
+    println!("{:<22}{:>8}{:>12}{:>50}", "", "", "", "-- ns per front --");
+
+    for p in &paths {
+        let csc = match read_mtx(Path::new(p)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {p}: {e:?}");
+                continue;
+            }
+        };
+        let label = Path::new(p)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let sp = SupernodeParams::default();
+        let symbolic = match symbolic_factorize_with_method(&csc, &sp, OrderingMethod::Auto) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{label}: symbolic failed: {e:?}");
+                continue;
+            }
+        };
+        let nparams = NumericParams::default();
+        let mut ws = FactorWorkspace::new();
+        if factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &nparams, &mut ws)
+            .is_err()
+        {
+            eprintln!("{label}: warm-up failed");
+            continue;
+        }
+
+        let mut best = u64::MAX;
+        let mut keep = [0f64; 6];
+        let mut nsn = 0usize;
+        let mut area = 0f64;
+        for _ in 0..reps {
+            PHASE_TIMING_ENABLED.store(true, Relaxed);
+            phase_timing::reset();
+            let prof = Arc::new(Mutex::new(Profiler::new()));
+            let mut np = nparams.clone();
+            np.profiler = Some(prof.clone());
+            np.pattern_reused_hint = true;
+            let t0 = Instant::now();
+            let res =
+                factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &np, &mut ws);
+            let wall = t0.elapsed().as_nanos() as u64;
+            PHASE_TIMING_ENABLED.store(false, Relaxed);
+            if res.is_err() {
+                eprintln!("{label}: timed factorization failed");
+                break;
+            }
+            let (br, sc, xa, _lex, cbex) = phase_timing::snapshot_detail();
+            let zf = phase_timing::snapshot_contrib_zerofill();
+            let guard = match prof.lock() {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("{label}: profiler poisoned: {e}");
+                    break;
+                }
+            };
+            if wall < best {
+                best = wall;
+                nsn = guard.len();
+                area = guard
+                    .timings()
+                    .iter()
+                    .map(|t| (t.nrow * t.nrow) as f64)
+                    .sum();
+                keep = [br as f64, sc as f64, xa as f64, zf as f64, cbex as f64, 0.0];
+            }
+        }
+        if best == u64::MAX || nsn == 0 {
+            continue;
+        }
+        let f = nsn as f64;
+        println!(
+            "{:<22}{:>8}{:>12.3e}{:>10.0}{:>10.0}{:>10.0}{:>10.0}{:>10.0}",
+            label,
+            nsn,
+            area,
+            keep[0] / f,
+            keep[1] / f,
+            keep[2] / f,
+            keep[3] / f,
+            keep[4] / f
+        );
+        println!(
+            "{:<22}{:>8}{:>12}{:>10.3}{:>10.3}{:>10.3}{:>10.3}{:>10.3}   ns/element",
+            "",
+            "",
+            "",
+            keep[0] / area,
+            keep[1] / area,
+            keep[2] / area,
+            keep[3] / area,
+            keep[4] / area
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_153_dense_peak.rs
+++ b/crates/feral-diagnostics/src/bin/diag_153_dense_peak.rs
@@ -1,0 +1,120 @@
+//! Issue #153 — what is feral's dense frontal-factor throughput, and how
+//! far is it from what the machine can do?
+//!
+//! The #200 measurements say feral runs 1.5-3.2x fewer flops per second
+//! than MA57 at every front size, on 0.44-1.20x the work. MA57's speed
+//! comes from OpenBLAS: its trailing updates are `dgemm`. feral is pure
+//! Rust by constraint (CLAUDE.md), so the honest question for #153 is
+//! not "why are we slower than MA57" but "how much of the machine does
+//! our kernel get, and how much does a tuned `dgemm` get on the same
+//! shapes on the same core?"
+//!
+//! This measures the first half: `factor_frontal` on a dense, diagonally
+//! dominant `n x n` front with every column eliminated, at the front
+//! sizes the corpus actually produces. Flops are counted with the same
+//! `sum_{k<ncol}(nrow-k)^2` multiply-add model used by
+//! `diag_200_work_vs_ma57`, so "MFlop/s" here means millions of
+//! multiply-adds per second and is directly comparable to that binary's
+//! column. The `dgemm` side is measured separately by
+//! `dev/scripts/dgemm_peak.f` and `dev/scripts/dsytrf_peak.f` against the
+//! same OpenBLAS MA57 links to; see `dev/scripts/README-blas-reference.md`.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin diag_153_dense_peak
+//!     [-- --reps N --sizes 32,64,128,256,512]
+use feral::dense::factor::factor_frontal;
+use feral::{BunchKaufmanParams, SymmetricMatrix};
+use std::time::Instant;
+
+/// Deterministic xorshift so runs are comparable.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        // Uniform in [-1, 1).
+        ((self.0 >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+    }
+}
+
+/// A symmetric front with a strong diagonal, so the factorization takes
+/// the ordinary 1x1-pivot path and measures kernel throughput rather
+/// than pivot-search pathology.
+fn make_front(n: usize, seed: u64) -> SymmetricMatrix {
+    let mut rng = Rng(seed);
+    let mut m = SymmetricMatrix::zeros(n);
+    for j in 0..n {
+        for i in j..n {
+            let v = if i == j {
+                n as f64 + 1.0
+            } else {
+                rng.next_f64()
+            };
+            m.set(i, j, v);
+        }
+    }
+    m
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 0usize;
+    let mut sizes: Vec<usize> = vec![16, 32, 48, 64, 96, 128, 192, 256, 384, 512];
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--reps" => {
+                if let Some(v) = it.next() {
+                    reps = v.parse()?;
+                }
+            }
+            "--sizes" => {
+                if let Some(v) = it.next() {
+                    sizes = v.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let params = BunchKaufmanParams::default();
+    println!(
+        "{:>6}{:>14}{:>12}{:>12}{:>12}",
+        "n", "macs", "min_us", "MMac/s", "% of n=512"
+    );
+    let mut peak = 0.0f64;
+    let mut rows: Vec<(usize, f64)> = Vec::new();
+    for &n in &sizes {
+        let front = make_front(n, 0x243F_6A88_85A3_08D3);
+        // sum_{k<n} (n-k)^2 multiply-adds.
+        let macs: f64 = (0..n).map(|k| ((n - k) * (n - k)) as f64).sum();
+        // Scale rep count so every size does comparable total work.
+        let r = if reps > 0 {
+            reps
+        } else {
+            (2.0e8 / macs).ceil().clamp(5.0, 20000.0) as usize
+        };
+        // Warm.
+        for _ in 0..3 {
+            let _ = factor_frontal(&front, n, false, &params)?;
+        }
+        let mut best = f64::INFINITY;
+        for _ in 0..r {
+            let t0 = Instant::now();
+            let f = factor_frontal(&front, n, false, &params)?;
+            let us = t0.elapsed().as_nanos() as f64 / 1000.0;
+            std::hint::black_box(&f);
+            best = best.min(us);
+        }
+        let rate = macs / best; // MMac/s == macs per microsecond
+        peak = peak.max(rate);
+        rows.push((n, rate));
+        println!("{:>6}{:>14.0}{:>12.2}{:>12.0}", n, macs, best, rate);
+    }
+    println!("\npeak = {peak:.0} MMac/s over the swept sizes");
+    if let Some(&(_, top)) = rows.last() {
+        println!("largest size = {top:.0} MMac/s");
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_153_kernel_headroom.rs
+++ b/crates/feral-diagnostics/src/bin/diag_153_kernel_headroom.rs
@@ -9,9 +9,11 @@
 //!
 //! This binary closes that gap *shape-exactly*. It profiles a real
 //! factorization to get the multiset of `(nrow, ncol)` fronts and the
-//! measured wallclock of each supernode, then re-times `factor_frontal`
-//! standalone on every distinct shape that occurred and reconstitutes
-//! the total:
+//! measured wallclock of each supernode, then re-times the *same entry
+//! point the driver calls* — `factor_frontal_blocked_in_place_with_scratch`,
+//! not the `factor_frontal` wrapper, which adds a `validate()` NaN scan
+//! and an `nrow^2` alloc-and-copy the driver does not pay — standalone on
+//! every distinct shape that occurred, and reconstitutes the total:
 //!
 //!   kernel_ns = sum over distinct shapes of count * isolated_kernel_ns
 //!   loop_ns   = measured per-supernode wallclock, same run
@@ -23,6 +25,11 @@
 //! traffic) can possibly be worth, and it is measured on *this* corpus
 //! rather than assumed. Whatever is left after that is a kernel problem
 //! and has to be compared against `dgemm`/`dsytrf`, not against MA57.
+//!
+//! The kernel is destructive, so each timed repetition must restore the
+//! front first. A restore-only loop of the same length is timed and
+//! subtracted, exactly as `dev/scripts/blas_front.f` does on the BLAS
+//! side, so the memcpy is not charged to the kernel.
 //!
 //! Caveat, stated rather than hidden: the standalone fronts are
 //! diagonally dominant and run with `may_delay = false`, so they take
@@ -36,7 +43,7 @@
 //! Usage:
 //!   cargo run --release -p feral-diagnostics --bin diag_153_kernel_headroom \
 //!     -- [--reps N] [--max-shapes K] <matrix.mtx>...
-use feral::dense::factor::factor_frontal;
+use feral::dense::factor::{factor_frontal_blocked_in_place_with_scratch, FactorScratch};
 use feral::numeric::factorize::{
     factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, Profiler,
 };
@@ -58,13 +65,40 @@ impl Rng {
     }
 }
 
-fn make_front(n: usize) -> SymmetricMatrix {
+/// Two front models. `dd` is diagonally dominant, so Bunch-Kaufman takes
+/// the ordinary 1x1-pivot path and the replay measures pure kernel
+/// throughput. `kkt` is indefinite and *not* diagonally dominant — half
+/// the diagonal is negative and small relative to the off-diagonals — so
+/// BK does real pivot searching and forms 2x2 pivots, as it does on the
+/// corpus. The difference between the two is the part of a real front's
+/// cost that is pivoting rather than arithmetic, and it must be measured
+/// rather than assumed: charging it to "plumbing" would invent an
+/// optimization target that does not exist.
+#[derive(Clone, Copy, PartialEq)]
+enum FrontModel {
+    Dd,
+    Kkt,
+}
+
+fn make_front(n: usize, model: FrontModel) -> SymmetricMatrix {
     let mut rng = Rng(0x243F_6A88_85A3_08D3);
     let mut m = SymmetricMatrix::zeros(n);
     for j in 0..n {
         for i in j..n {
             let v = if i == j {
-                n as f64 + 1.0
+                match model {
+                    FrontModel::Dd => n as f64 + 1.0,
+                    // Saddle point: a dominant H block over a strictly
+                    // zero constraint block, which is what forces BK to
+                    // form 2x2 pivots on a KKT front.
+                    FrontModel::Kkt => {
+                        if i < n.div_ceil(2) {
+                            n as f64 + 1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                }
             } else {
                 rng.next_f64()
             };
@@ -97,6 +131,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut reps = 5usize;
     let mut max_shapes = 4096usize;
+    let mut model = FrontModel::Dd;
+    let mut cold_bytes = 0usize;
+    let mut may_delay = false;
     let mut paths: Vec<String> = Vec::new();
     let mut it = args.iter();
     while let Some(a) = it.next() {
@@ -109,6 +146,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--max-shapes" => {
                 if let Some(v) = it.next() {
                     max_shapes = v.parse()?;
+                }
+            }
+            "--may-delay" => may_delay = true,
+            "--cold" => {
+                if let Some(v) = it.next() {
+                    cold_bytes = v.parse::<usize>()? * 1024 * 1024;
+                }
+            }
+            "--front" => {
+                if let Some(v) = it.next() {
+                    model = if v == "kkt" {
+                        FrontModel::Kkt
+                    } else {
+                        FrontModel::Dd
+                    };
                 }
             }
             _ => paths.push(a.clone()),
@@ -149,6 +201,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Best-of-N by driver wall; keep the winning run's timings.
         let mut best_wall = u64::MAX;
         let mut best: Vec<(usize, usize, u64)> = Vec::new();
+        let mut prologue = 0u64;
+        let mut epilogue = 0u64;
+        let mut pb = feral::numeric::factorize::PrologueBreakdown::default();
         for _ in 0..reps {
             let prof = Arc::new(Mutex::new(Profiler::new()));
             let mut np = nparams.clone();
@@ -171,6 +226,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             if wall < best_wall {
                 best_wall = wall;
+                let rep = guard.report();
+                prologue = rep.prologue_us;
+                epilogue = rep.epilogue_us;
+                pb = rep.prologue_breakdown.clone();
                 best = guard
                     .timings()
                     .iter()
@@ -203,8 +262,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         heights.sort_unstable();
         heights.dedup();
         let mut kernel_ns: HashMap<(usize, usize), f64> = HashMap::new();
+        let mut scratch = FactorScratch::new();
+        let mut fallbacks = 0usize;
         for &nrow in &heights {
-            let front = make_front(nrow);
+            let pristine = make_front(nrow, model);
+            let mut work = make_front(nrow, model);
             let mut cols: Vec<usize> = shapes
                 .keys()
                 .filter(|&&(r, _)| r == nrow)
@@ -213,19 +275,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cols.sort_unstable();
             for ncol in cols {
                 let w = macs(nrow, ncol).max(1.0);
-                let r = (2.0e7 / w).ceil().clamp(3.0, 5000.0) as usize;
-                for _ in 0..2 {
-                    let _ = factor_frontal(&front, ncol, false, &bk)?;
+                let r = (2.0e7 / w).ceil().clamp(50.0, 200_000.0) as usize;
+                // Cold mode: rotate over a working set larger than
+                // the last-level cache, so each timed call touches a
+                // front that is not already resident — as in the solver,
+                // where every front is visited once. The restore-only
+                // calibration loop rotates identically, so the cost of
+                // streaming the working set in is subtracted along with
+                // the memcpy and only the kernel's own miss traffic is
+                // left in the difference.
+                let bytes = nrow * nrow * 8;
+                let pool_n = if cold_bytes > 0 {
+                    (cold_bytes / bytes.max(1)).clamp(1, 4096)
+                } else {
+                    1
+                };
+                let mut pool: Vec<Vec<f64>> = (0..pool_n).map(|_| pristine.data.clone()).collect();
+                work.data.copy_from_slice(&pristine.data);
+                if factor_frontal_blocked_in_place_with_scratch(
+                    &mut work,
+                    ncol,
+                    may_delay,
+                    &bk,
+                    &mut scratch,
+                )
+                .is_err()
+                {
+                    let alt = make_front(nrow, FrontModel::Dd);
+                    for b in pool.iter_mut() {
+                        b.copy_from_slice(&alt.data);
+                    }
+                    fallbacks += 1;
                 }
-                let mut bn = f64::INFINITY;
-                for _ in 0..r {
-                    let t0 = Instant::now();
-                    let f = factor_frontal(&front, ncol, false, &bk)?;
-                    let ns = t0.elapsed().as_nanos() as f64;
+                let t0 = Instant::now();
+                for k in 0..r {
+                    work.data.copy_from_slice(&pool[k % pool_n]);
+                    let f = factor_frontal_blocked_in_place_with_scratch(
+                        &mut work,
+                        ncol,
+                        may_delay,
+                        &bk,
+                        &mut scratch,
+                    )?;
                     std::hint::black_box(&f);
-                    bn = bn.min(ns);
                 }
-                kernel_ns.insert((nrow, ncol), bn);
+                let with_restore = t0.elapsed().as_nanos() as f64;
+                let t1 = Instant::now();
+                for k in 0..r {
+                    work.data.copy_from_slice(&pool[k % pool_n]);
+                    std::hint::black_box(&work.data[0]);
+                }
+                let restore_only = t1.elapsed().as_nanos() as f64;
+                let per_call = ((with_restore - restore_only) / r as f64).max(0.0);
+                kernel_ns.insert((nrow, ncol), per_call);
             }
         }
 
@@ -234,24 +336,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut b_kern = [0f64; 6];
         let mut b_macs = [0f64; 6];
         let mut b_cnt = [0usize; 6];
+        let mut b_area = [0f64; 6];
         for (&(nrow, ncol), &(count, sum_ns)) in &shapes {
             let b = bucket_of(nrow);
             b_cnt[b] += count;
             b_loop[b] += sum_ns as f64;
             b_kern[b] += count as f64 * kernel_ns.get(&(nrow, ncol)).copied().unwrap_or(0.0);
             b_macs[b] += count as f64 * macs(nrow, ncol);
+            b_area[b] += count as f64 * (nrow * nrow) as f64;
         }
         let t_loop: f64 = b_loop.iter().sum();
         let t_kern: f64 = b_kern.iter().sum();
         let t_macs: f64 = b_macs.iter().sum();
+        let t_area: f64 = b_area.iter().sum();
 
         println!(
-            "\n{label}  n={} snodes={} shapes={} driver_us={} extra_elims={}",
+            "\n{label}  front={}  n={} snodes={} shapes={} driver_us={} extra_elims={} may_delay={may_delay}",
+            if model == FrontModel::Kkt { "kkt" } else { "dd" },
             csc.n,
             best.len(),
             shapes.len(),
             best_wall / 1000,
             best.iter().map(|t| t.1).sum::<usize>() as i64 - csc.n as i64
+        );
+        println!(
+            "  prologue_us={prologue} (permute={} scaling={} sym_pattern={} setup={})              epilogue_us={epilogue}  prol+epi={:.0}% of driver",
+            pb.permute_us,
+            pb.scaling_us,
+            pb.symmetric_pattern_us,
+            pb.setup_us,
+            100.0 * (prologue + epilogue) as f64 / (best_wall / 1000).max(1) as f64
         );
         println!(
             "  {:<8}{:>9}{:>13}{:>13}{:>10}{:>13}{:>13}",
@@ -270,6 +384,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 b_loop[b] / b_kern[b].max(1.0),
                 b_macs[b] / (b_loop[b] / 1000.0).max(1e-9),
                 b_macs[b] / (b_kern[b] / 1000.0).max(1e-9),
+            );
+        }
+        if fallbacks > 0 {
+            println!("  note: {fallbacks} shape(s) fell back to the dd front model");
+        }
+        // Is the non-kernel loop cost per-front (a constant) or
+        // per-front-*element* (proportional to nrow^2)? The latter is
+        // the signature of assembly/extend-add/zero-fill passes over
+        // the frontal matrix; the former of allocation and dispatch.
+        println!(
+            "  non-kernel loop = {:.0} us = {:.0} ns/front = {:.3} ns per front element              (sum nrow^2 = {:.3e})",
+            (t_loop - t_kern) / 1000.0,
+            (t_loop - t_kern) / best.len() as f64,
+            (t_loop - t_kern) / t_area.max(1.0),
+            t_area
+        );
+        for b in 0..6 {
+            if b_cnt[b] == 0 {
+                continue;
+            }
+            println!(
+                "    {:<8} {:.0} ns/front, {:.3} ns/element",
+                BUCKETS[b],
+                (b_loop[b] - b_kern[b]) / b_cnt[b] as f64,
+                (b_loop[b] - b_kern[b]) / b_area[b].max(1.0),
             );
         }
         // The handful of shapes that actually decide the matrix.

--- a/crates/feral-diagnostics/src/bin/diag_153_kernel_headroom.rs
+++ b/crates/feral-diagnostics/src/bin/diag_153_kernel_headroom.rs
@@ -1,0 +1,301 @@
+//! Issue #153 — how much of feral's deficit is the dense kernel, and how
+//! much is everything around it?
+//!
+//! `diag_153_dense_peak` measures `factor_frontal` in isolation on square
+//! fronts. That answers "how fast is our kernel", but not "how much of
+//! that speed does the solver actually deliver", because the in-solver
+//! fronts are trapezoidal (`ncol < nrow`) and each one is wrapped in
+//! assembly, extend-add, L-extract and contribution-block work.
+//!
+//! This binary closes that gap *shape-exactly*. It profiles a real
+//! factorization to get the multiset of `(nrow, ncol)` fronts and the
+//! measured wallclock of each supernode, then re-times `factor_frontal`
+//! standalone on every distinct shape that occurred and reconstitutes
+//! the total:
+//!
+//!   kernel_ns = sum over distinct shapes of count * isolated_kernel_ns
+//!   loop_ns   = measured per-supernode wallclock, same run
+//!   headroom  = loop_ns / kernel_ns
+//!
+//! `headroom` is the factor by which the solver is slower than its own
+//! arithmetic kernel on the identical shape sequence. It is the ceiling
+//! on what non-kernel work (assembly, allocation, indirection, cache
+//! traffic) can possibly be worth, and it is measured on *this* corpus
+//! rather than assumed. Whatever is left after that is a kernel problem
+//! and has to be compared against `dgemm`/`dsytrf`, not against MA57.
+//!
+//! Caveat, stated rather than hidden: the standalone fronts are
+//! diagonally dominant and run with `may_delay = false`, so they take
+//! the ordinary 1x1-pivot path. Real fronts that delay pivots do more
+//! work than the replay credits them with, which makes `headroom` an
+//! *over*-estimate of non-kernel overhead on pivot-heavy matrices. The
+//! `sum(ncol) - n` is printed as a delay indicator: a column delayed
+//! out of a front is eliminated again in its parent, so it is counted
+//! twice. Zero means the replay is exact on that count.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin diag_153_kernel_headroom \
+//!     -- [--reps N] [--max-shapes K] <matrix.mtx>...
+use feral::dense::factor::factor_frontal;
+use feral::numeric::factorize::{
+    factorize_multifrontal_supernodal_with_workspace, FactorWorkspace, Profiler,
+};
+use feral::symbolic::{symbolic_factorize_with_method, OrderingMethod, SupernodeParams};
+use feral::{read_mtx, BunchKaufmanParams, NumericParams, SymmetricMatrix};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+/// Deterministic xorshift so runs are comparable across invocations.
+struct Rng(u64);
+impl Rng {
+    fn next_f64(&mut self) -> f64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        ((self.0 >> 11) as f64 / (1u64 << 53) as f64) * 2.0 - 1.0
+    }
+}
+
+fn make_front(n: usize) -> SymmetricMatrix {
+    let mut rng = Rng(0x243F_6A88_85A3_08D3);
+    let mut m = SymmetricMatrix::zeros(n);
+    for j in 0..n {
+        for i in j..n {
+            let v = if i == j {
+                n as f64 + 1.0
+            } else {
+                rng.next_f64()
+            };
+            m.set(i, j, v);
+        }
+    }
+    m
+}
+
+/// `sum_{k<ncol} (nrow-k)^2` multiply-adds — the model used by
+/// `diag_200_work_vs_ma57` and `diag_153_dense_peak`, so the MMac/s
+/// columns of all three are the same unit.
+fn macs(nrow: usize, ncol: usize) -> f64 {
+    (0..ncol).map(|k| ((nrow - k) * (nrow - k)) as f64).sum()
+}
+
+fn bucket_of(nrow: usize) -> usize {
+    match nrow {
+        0..=8 => 0,
+        9..=16 => 1,
+        17..=32 => 2,
+        33..=64 => 3,
+        65..=128 => 4,
+        _ => 5,
+    }
+}
+const BUCKETS: [&str; 6] = ["<=8", "9-16", "17-32", "33-64", "65-128", ">128"];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 5usize;
+    let mut max_shapes = 4096usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--reps" => {
+                if let Some(v) = it.next() {
+                    reps = v.parse()?;
+                }
+            }
+            "--max-shapes" => {
+                if let Some(v) = it.next() {
+                    max_shapes = v.parse()?;
+                }
+            }
+            _ => paths.push(a.clone()),
+        }
+    }
+
+    let bk = BunchKaufmanParams::default();
+    for p in &paths {
+        let csc = match read_mtx(Path::new(p)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {p}: {e:?}");
+                continue;
+            }
+        };
+        let label = Path::new(p)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let sp = SupernodeParams::default();
+        let symbolic = match symbolic_factorize_with_method(&csc, &sp, OrderingMethod::Auto) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{label}: symbolic failed: {e:?}");
+                continue;
+            }
+        };
+        let nparams = NumericParams::default();
+        let mut ws = FactorWorkspace::new();
+        if factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &nparams, &mut ws)
+            .is_err()
+        {
+            eprintln!("{label}: warm-up factorization failed");
+            continue;
+        }
+
+        // Best-of-N by driver wall; keep the winning run's timings.
+        let mut best_wall = u64::MAX;
+        let mut best: Vec<(usize, usize, u64)> = Vec::new();
+        for _ in 0..reps {
+            let prof = Arc::new(Mutex::new(Profiler::new()));
+            let mut np = nparams.clone();
+            np.profiler = Some(prof.clone());
+            np.pattern_reused_hint = true;
+            let t0 = Instant::now();
+            let res =
+                factorize_multifrontal_supernodal_with_workspace(&csc, &symbolic, &np, &mut ws);
+            let wall = t0.elapsed().as_nanos() as u64;
+            if let Err(e) = res {
+                eprintln!("{label}: timed factorization failed: {e:?}");
+                break;
+            }
+            let guard = match prof.lock() {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("{label}: profiler poisoned: {e}");
+                    break;
+                }
+            };
+            if wall < best_wall {
+                best_wall = wall;
+                best = guard
+                    .timings()
+                    .iter()
+                    .map(|t| (t.nrow, t.ncol, t.ns))
+                    .collect();
+            }
+        }
+        if best.is_empty() {
+            continue;
+        }
+
+        // Group by exact (nrow, ncol) shape.
+        let mut shapes: HashMap<(usize, usize), (usize, u64)> = HashMap::new();
+        for &(nrow, ncol, ns) in &best {
+            let e = shapes.entry((nrow, ncol)).or_insert((0, 0));
+            e.0 += 1;
+            e.1 += ns;
+        }
+        if shapes.len() > max_shapes {
+            eprintln!(
+                "{label}: {} distinct shapes exceeds --max-shapes {max_shapes}; skipping",
+                shapes.len()
+            );
+            continue;
+        }
+
+        // Time the isolated kernel once per distinct front height; the
+        // matrix is reused across the `ncol` variants of that height.
+        let mut heights: Vec<usize> = shapes.keys().map(|&(nrow, _)| nrow).collect();
+        heights.sort_unstable();
+        heights.dedup();
+        let mut kernel_ns: HashMap<(usize, usize), f64> = HashMap::new();
+        for &nrow in &heights {
+            let front = make_front(nrow);
+            let mut cols: Vec<usize> = shapes
+                .keys()
+                .filter(|&&(r, _)| r == nrow)
+                .map(|&(_, c)| c)
+                .collect();
+            cols.sort_unstable();
+            for ncol in cols {
+                let w = macs(nrow, ncol).max(1.0);
+                let r = (2.0e7 / w).ceil().clamp(3.0, 5000.0) as usize;
+                for _ in 0..2 {
+                    let _ = factor_frontal(&front, ncol, false, &bk)?;
+                }
+                let mut bn = f64::INFINITY;
+                for _ in 0..r {
+                    let t0 = Instant::now();
+                    let f = factor_frontal(&front, ncol, false, &bk)?;
+                    let ns = t0.elapsed().as_nanos() as f64;
+                    std::hint::black_box(&f);
+                    bn = bn.min(ns);
+                }
+                kernel_ns.insert((nrow, ncol), bn);
+            }
+        }
+
+        // Reconstitute per bucket.
+        let mut b_loop = [0f64; 6];
+        let mut b_kern = [0f64; 6];
+        let mut b_macs = [0f64; 6];
+        let mut b_cnt = [0usize; 6];
+        for (&(nrow, ncol), &(count, sum_ns)) in &shapes {
+            let b = bucket_of(nrow);
+            b_cnt[b] += count;
+            b_loop[b] += sum_ns as f64;
+            b_kern[b] += count as f64 * kernel_ns.get(&(nrow, ncol)).copied().unwrap_or(0.0);
+            b_macs[b] += count as f64 * macs(nrow, ncol);
+        }
+        let t_loop: f64 = b_loop.iter().sum();
+        let t_kern: f64 = b_kern.iter().sum();
+        let t_macs: f64 = b_macs.iter().sum();
+
+        println!(
+            "\n{label}  n={} snodes={} shapes={} driver_us={} extra_elims={}",
+            csc.n,
+            best.len(),
+            shapes.len(),
+            best_wall / 1000,
+            best.iter().map(|t| t.1).sum::<usize>() as i64 - csc.n as i64
+        );
+        println!(
+            "  {:<8}{:>9}{:>13}{:>13}{:>10}{:>13}{:>13}",
+            "nrow", "snodes", "loop_us", "kernel_us", "headroom", "solver_Mac/s", "kernel_Mac/s"
+        );
+        for b in 0..6 {
+            if b_cnt[b] == 0 {
+                continue;
+            }
+            println!(
+                "  {:<8}{:>9}{:>13.0}{:>13.0}{:>9.2}x{:>13.0}{:>13.0}",
+                BUCKETS[b],
+                b_cnt[b],
+                b_loop[b] / 1000.0,
+                b_kern[b] / 1000.0,
+                b_loop[b] / b_kern[b].max(1.0),
+                b_macs[b] / (b_loop[b] / 1000.0).max(1e-9),
+                b_macs[b] / (b_kern[b] / 1000.0).max(1e-9),
+            );
+        }
+        // The handful of shapes that actually decide the matrix.
+        let mut top: Vec<((usize, usize), (usize, u64))> =
+            shapes.iter().map(|(&k, &v)| (k, v)).collect();
+        top.sort_by_key(|&(_, (_, ns))| std::cmp::Reverse(ns));
+        println!("  top shapes by loop time:");
+        for &((nrow, ncol), (count, sum_ns)) in top.iter().take(6) {
+            let k = kernel_ns.get(&(nrow, ncol)).copied().unwrap_or(0.0);
+            println!(
+                "    nrow={nrow:<5} ncol={ncol:<5} n={count:<6} loop_us={:<9.0} kernel_us={:<9.0} headroom={:.2}x",
+                sum_ns as f64 / 1000.0,
+                count as f64 * k / 1000.0,
+                sum_ns as f64 / (count as f64 * k).max(1.0),
+            );
+        }
+        println!(
+            "  {:<8}{:>9}{:>13.0}{:>13.0}{:>9.2}x{:>13.0}{:>13.0}",
+            "TOTAL",
+            best.len(),
+            t_loop / 1000.0,
+            t_kern / 1000.0,
+            t_loop / t_kern.max(1.0),
+            t_macs / (t_loop / 1000.0).max(1e-9),
+            t_macs / (t_kern / 1000.0).max(1e-9),
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_alloc_count.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_alloc_count.rs
@@ -1,0 +1,81 @@
+//! Issue #200 — count heap allocations per frontal matrix.
+//!
+//! The work-volume comparison (`diag_200_work_vs_ma57`) shows feral does
+//! the same or fewer flops than MA57 on every matrix yet is slower
+//! wherever fronts are small, so the gap is a fixed per-front cost, not
+//! extra arithmetic. This counts one candidate for that cost directly: a
+//! wrapping allocator tallies allocations and bytes across one warm
+//! `factor()`, reported per front.
+use feral::symbolic::{supernode::SupernodeParams, symbolic_factorize};
+use feral::{read_mtx, NumericParams, Solver};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+
+static N_ALLOC: AtomicU64 = AtomicU64::new(0);
+static N_BYTES: AtomicU64 = AtomicU64::new(0);
+static ON: AtomicU64 = AtomicU64::new(0);
+
+struct Counting;
+
+// SAFETY: every method forwards verbatim to `System`, which upholds the
+// `GlobalAlloc` contract; the counters are plain atomics that never touch
+// the returned pointers or the allocation state.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        if ON.load(Relaxed) != 0 {
+            N_ALLOC.fetch_add(1, Relaxed);
+            N_BYTES.fetch_add(l.size() as u64, Relaxed);
+        }
+        System.alloc(l)
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        System.dealloc(p, l)
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
+        if ON.load(Relaxed) != 0 {
+            N_ALLOC.fetch_add(1, Relaxed);
+            N_BYTES.fetch_add(n as u64, Relaxed);
+        }
+        System.realloc(p, l, n)
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "{:<22}{:>8}{:>10}{:>12}{:>10}{:>12}",
+        "matrix", "fronts", "allocs", "alloc/front", "MB", "bytes/front"
+    );
+    for p in std::env::args().skip(1) {
+        let csc = read_mtx(std::path::Path::new(&p)).and_then(|m| m.to_csc())?;
+        let sp = SupernodeParams::default();
+        let sym = symbolic_factorize(&csc, &sp)?;
+        let nf = sym.supernodes.len() as u64;
+        let mut solver = Solver::with_params(NumericParams::default(), sp);
+        for _ in 0..3 {
+            let _ = solver.factor(&csc, None);
+        }
+        N_ALLOC.store(0, Relaxed);
+        N_BYTES.store(0, Relaxed);
+        ON.store(1, Relaxed);
+        let _ = solver.factor(&csc, None);
+        ON.store(0, Relaxed);
+        let (a, b) = (N_ALLOC.load(Relaxed), N_BYTES.load(Relaxed));
+        let name = std::path::Path::new(&p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        println!(
+            "{:<22}{:>8}{:>10}{:>12.2}{:>10.1}{:>12.0}",
+            name,
+            nf,
+            a,
+            a as f64 / nf as f64,
+            b as f64 / 1e6,
+            b as f64 / nf as f64
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_amalg_sweep.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_amalg_sweep.rs
@@ -1,0 +1,153 @@
+//! Issue #200 — is the small-front regime a *tuning* choice or a
+//! *failure* of amalgamation?
+//!
+//! `SupernodeParams::nemin` already defaults to 32 (SSIDS's value), yet
+//! on IPM-KKT matrices the median frontal matrix is 3x3 and 60-86% of
+//! fronts have `nrow <= 8`. Every per-front cost issue #200 is about
+//! (malloc traffic, the L/D and contribution extract copies, the driver's
+//! per-supernode bookkeeping) is paid once per front, so front size is
+//! the lever that moves all of them at once.
+//!
+//! Two candidate explanations:
+//!   (a) the size rule `child_ncol < nemin && parent_ncol < nemin` is
+//!       binding -- then raising `nemin` grows fronts;
+//!   (b) the column-adjacency precondition
+//!       (`s_first + s_ncol != p_first => continue`) rejects the merges
+//!       before the size rule is ever consulted -- then `nemin` does
+//!       nothing and the fix is structural.
+//!
+//! This sweeps `nemin` under both `AmalgamationStrategy` values and
+//! reports, per configuration: supernode count, median/max front `nrow`,
+//! the fraction of tiny fronts, uninstrumented factor time (min of
+//! `reps`, warm solver, phase timing OFF), and the scaled residual so a
+//! speedup is never reported without its accuracy cost.
+//!
+//! Accuracy context: lowering `nemin` (4, 8) and the `merge_flop_budget`
+//! guard were both rejected on 2026-08-09 for costing up to seven digits
+//! of residual (HATFLDG 7.1e-15 -> 7.4e-08, VESUVIOU_0030 1.9e-06 ->
+//! 5.4e-03). Both levers *reduce* merging. This sweep goes the other
+//! way, so it is not a re-run of that experiment -- but the residual
+//! column is mandatory regardless.
+use feral::symbolic::supernode::{AmalgamationStrategy, SupernodeParams};
+use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+use std::time::Instant;
+
+fn residual_inf(a: &CscMatrix, x: &[f64], b: &[f64]) -> f64 {
+    let n = a.n;
+    let mut r = b.to_vec();
+    for j in 0..n {
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let i = a.row_idx[k];
+            let v = a.values[k];
+            r[i] -= v * x[j];
+            if i != j {
+                r[j] -= v * x[i];
+            }
+        }
+    }
+    let rn = r.iter().fold(0.0_f64, |m, &v| m.max(v.abs()));
+    let bn = b.iter().fold(0.0_f64, |m, &v| m.max(v.abs())).max(1.0);
+    rn / bn
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 7usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--reps" {
+            if let Some(v) = it.next() {
+                reps = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+    if paths.is_empty() {
+        eprintln!("usage: diag_200_amalg_sweep [--reps N] <matrix.mtx>...");
+        std::process::exit(2);
+    }
+
+    let configs: Vec<(&str, usize, AmalgamationStrategy)> = vec![
+        (
+            "renumber n=32 (DEFAULT)",
+            32,
+            AmalgamationStrategy::Renumber,
+        ),
+        ("renumber n=64", 64, AmalgamationStrategy::Renumber),
+        ("renumber n=128", 128, AmalgamationStrategy::Renumber),
+        ("renumber n=512", 512, AmalgamationStrategy::Renumber),
+        ("adjacency n=32", 32, AmalgamationStrategy::Adjacency),
+        ("adjacency n=512", 512, AmalgamationStrategy::Adjacency),
+    ];
+
+    for p in &paths {
+        let csc = read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc())?;
+        let n = csc.n;
+        let b: Vec<f64> = (0..n).map(|i| 1.0 + (i % 7) as f64).collect();
+        let name = std::path::Path::new(p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| p.clone());
+        println!("=== {name}  (n={n}) ===");
+        println!(
+            "{:<26}{:>9}{:>8}{:>8}{:>9}{:>11}{:>8}{:>12}",
+            "config", "snodes", "med", "max", "%nrow<=8", "factor us", "ratio", "residual"
+        );
+        let mut base_us = 0.0_f64;
+        for (label, nemin, strat) in &configs {
+            let sp = SupernodeParams {
+                nemin: *nemin,
+                amalgamation_strategy: *strat,
+                ..SupernodeParams::default()
+            };
+            let sym = match feral::symbolic::symbolic_factorize(&csc, &sp) {
+                Ok(s) => s,
+                Err(e) => {
+                    println!("{label:<26}  symbolic failed: {e}");
+                    continue;
+                }
+            };
+            let mut rows: Vec<usize> = sym.supernodes.iter().map(|s| s.nrow).collect();
+            rows.sort_unstable();
+            let ns = rows.len();
+            let med = if ns == 0 { 0 } else { rows[ns / 2] };
+            let mx = rows.last().copied().unwrap_or(0);
+            let le8 = rows.iter().filter(|&&r| r <= 8).count();
+
+            let mut solver = Solver::with_params(NumericParams::default(), sp.clone());
+            // Three warm-up calls: the permute-value-map cache is not
+            // built until call 2 and not read until call 3.
+            for _ in 0..3 {
+                let _ = solver.factor(&csc, None);
+            }
+            let mut best = f64::MAX;
+            for _ in 0..reps {
+                let t = Instant::now();
+                let _ = solver.factor(&csc, None);
+                best = best.min(t.elapsed().as_secs_f64() * 1e6);
+            }
+            let res = match solver.solve(&b) {
+                Ok(x) => residual_inf(&csc, &x, &b),
+                Err(_) => f64::NAN,
+            };
+            if *nemin == 32 && matches!(strat, AmalgamationStrategy::Renumber) {
+                base_us = best;
+            }
+            println!(
+                "{:<26}{:>9}{:>8}{:>8}{:>8.1}%{:>11.0}{:>8.2}{:>12.2e}",
+                label,
+                ns,
+                med,
+                mx,
+                100.0 * le8 as f64 / ns.max(1) as f64,
+                best,
+                if base_us > 0.0 { best / base_us } else { 1.0 },
+                res
+            );
+        }
+        println!();
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_front_size_buckets.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_front_size_buckets.rs
@@ -1,0 +1,140 @@
+//! Issue #200 — where does the supernode loop actually spend its time,
+//! bucketed by front size?
+//!
+//! The 2026-09-05 comment on #200 reports, on a 351k-row AC-OPF KKT,
+//! that fronts of `nrow <= 8` are 68% of the supernodes but only 10.7%
+//! of the loop, and that 85% of loop time sits in fronts of 17 rows or
+//! more. That is the opposite conclusion from the one this branch drew
+//! from a least-squares `t = a*fronts + b*flops` fit over five corpus
+//! matrices, whose fitted per-front term came out at 96% of optmass.
+//!
+//! Those two claims are made with different instruments on different
+//! matrices, so neither refutes the other as stated. This binary runs
+//! *their* instrument — feral's own `Solver::with_profiling(true)`,
+//! whose `ProfileReport` buckets supernode wallclock by `nrow` in
+//! exactly the ranges they report — on *our* five matrices, so the two
+//! datasets can be compared column for column.
+//!
+//! `with_profiling` costs one `Instant::now()` pair per supernode, not
+//! the ~10 per supernode that `PHASE_TIMING_ENABLED` costs (see
+//! `diag_200_probe_tax`), and the loop share it reports is a ratio of
+//! like-instrumented quantities. The uninstrumented factor time is
+//! printed beside it so the probe tax on each matrix is visible rather
+//! than assumed.
+//!
+//! Usage:
+//!   cargo run --release -p feral-diagnostics --bin diag_200_front_size_buckets \
+//!     -- [--reps N] <matrix.mtx>...
+use feral::{read_mtx, NumericParams, Solver};
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 9usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--reps" {
+            if let Some(v) = it.next() {
+                reps = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+
+    for p in &paths {
+        let csc = read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc())?;
+        let label = std::path::Path::new(p)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+
+        // Uninstrumented reference: warm solver, min of `reps`.
+        let mut plain =
+            Solver::with_params(NumericParams::default(), Default::default()).with_parallel(false);
+        for _ in 0..3 {
+            let _ = plain.factor(&csc, None);
+        }
+        let mut best_plain = u128::MAX;
+        for _ in 0..reps {
+            let t0 = Instant::now();
+            let _ = plain.factor(&csc, None);
+            best_plain = best_plain.min(t0.elapsed().as_micros());
+        }
+
+        // Profiled: same warm-solver protocol, `with_profiling(true)`.
+        let mut prof = Solver::with_params(NumericParams::default(), Default::default())
+            .with_parallel(false)
+            .with_profiling(true);
+        for _ in 0..3 {
+            let _ = prof.factor(&csc, None);
+        }
+        let mut best_prof = u128::MAX;
+        for _ in 0..reps {
+            let t0 = Instant::now();
+            let _ = prof.factor(&csc, None);
+            best_prof = best_prof.min(t0.elapsed().as_micros());
+        }
+        let report = match prof.profile_report() {
+            Some(r) => r,
+            None => {
+                println!("{label}: no profile report (fast path?)");
+                continue;
+            }
+        };
+
+        println!(
+            "\n{label}  n={} nnz={} snodes={} plain_us={} profiled_us={} tax={:.2}x",
+            csc.n,
+            csc.row_idx.len(),
+            report.n_supernodes,
+            best_plain,
+            best_prof,
+            best_prof as f64 / best_plain.max(1) as f64
+        );
+        println!(
+            "  loop_ns={} prologue_us={} epilogue_us={} total_us={}",
+            report.loop_ns, report.prologue_us, report.epilogue_us, report.total_us
+        );
+        println!(
+            "  {:<8}{:>10}{:>9}{:>12}{:>10}{:>12}",
+            "nrow", "snodes", "% nodes", "sum_ns", "% loop", "avg_ns"
+        );
+        for b in &report.buckets {
+            if b.count == 0 {
+                continue;
+            }
+            println!(
+                "  {:<8}{:>10}{:>8.1}%{:>12}{:>9.1}%{:>12.0}",
+                b.range,
+                b.count,
+                100.0 * b.count as f64 / report.n_supernodes.max(1) as f64,
+                b.sum_ns,
+                100.0 * b.sum_ns as f64 / report.loop_ns.max(1) as f64,
+                b.avg_ns,
+            );
+        }
+        // The claim under test: is the loop dominated by the many tiny
+        // fronts, or by the few large ones?
+        let small: u64 = report
+            .buckets
+            .iter()
+            .filter(|b| b.range == "<=8" || b.range == "9-16")
+            .map(|b| b.sum_ns)
+            .sum();
+        let small_n: usize = report
+            .buckets
+            .iter()
+            .filter(|b| b.range == "<=8" || b.range == "9-16")
+            .map(|b| b.count)
+            .sum();
+        println!(
+            "  nrow<=16: {:.1}% of nodes, {:.1}% of loop",
+            100.0 * small_n as f64 / report.n_supernodes.max(1) as f64,
+            100.0 * small as f64 / report.loop_ns.max(1) as f64
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_front_size_buckets.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_front_size_buckets.rs
@@ -25,6 +25,7 @@
 //! Usage:
 //!   cargo run --release -p feral-diagnostics --bin diag_200_front_size_buckets \
 //!     -- [--reps N] <matrix.mtx>...
+use feral::scaling::ScalingStrategy;
 use feral::{read_mtx, NumericParams, Solver};
 use std::time::Instant;
 
@@ -32,12 +33,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut reps = 9usize;
     let mut paths: Vec<String> = Vec::new();
+    // Issue #153: the MA57 harness runs ICNTL(15)=0 (scaling off) on the
+    // stated grounds that feral amortizes its MC64 into analysis. This
+    // flag exists to check that claim against the numeric prologue's own
+    // scaling meter rather than trusting the comment.
+    let mut scaling: Option<ScalingStrategy> = None;
     let mut it = args.iter();
     while let Some(a) = it.next() {
         if a == "--reps" {
             if let Some(v) = it.next() {
                 reps = v.parse()?;
             }
+        } else if a == "--scaling" {
+            scaling = match it.next().map(|s| s.as_str()) {
+                Some("identity") => Some(ScalingStrategy::Identity),
+                Some("infnorm") => Some(ScalingStrategy::InfNorm),
+                Some("mc64") => Some(ScalingStrategy::Mc64Symmetric),
+                _ => None,
+            };
         } else {
             paths.push(a.clone());
         }
@@ -51,9 +64,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or("?")
             .to_string();
 
+        let mut base = NumericParams::default();
+        if let Some(sc) = &scaling {
+            base.scaling = sc.clone();
+        }
         // Uninstrumented reference: warm solver, min of `reps`.
-        let mut plain =
-            Solver::with_params(NumericParams::default(), Default::default()).with_parallel(false);
+        let mut plain = Solver::with_params(base.clone(), Default::default()).with_parallel(false);
         for _ in 0..3 {
             let _ = plain.factor(&csc, None);
         }
@@ -65,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Profiled: same warm-solver protocol, `with_profiling(true)`.
-        let mut prof = Solver::with_params(NumericParams::default(), Default::default())
+        let mut prof = Solver::with_params(base.clone(), Default::default())
             .with_parallel(false)
             .with_profiling(true);
         for _ in 0..3 {
@@ -97,6 +113,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!(
             "  loop_ns={} prologue_us={} epilogue_us={} total_us={}",
             report.loop_ns, report.prologue_us, report.epilogue_us, report.total_us
+        );
+        // Track B2 question: does the solver-scope MC64 cache actually
+        // spare a warm refactorization the scaling cost? The MA57
+        // harness runs ICNTL(15)=0 on the stated grounds that feral
+        // amortizes scaling into analysis; that is only apples-to-apples
+        // if this line reads ~0 on a warm repeat factorization.
+        let pb = &report.prologue_breakdown;
+        println!(
+            "  prologue: permute={} scaling={} sym_pattern={} setup={}",
+            pb.permute_us, pb.scaling_us, pb.symmetric_pattern_us, pb.setup_us
         );
         println!(
             "  {:<8}{:>10}{:>9}{:>12}{:>10}{:>12}",

--- a/crates/feral-diagnostics/src/bin/diag_200_hotloop.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_hotloop.rs
@@ -1,0 +1,37 @@
+//! Issue #200 — a plain, *uninstrumented* factorization loop for an
+//! external sampling profiler (`samply record`).
+//!
+//! `phase_timing` costs ~350–430 ns per front (see `diag_200_probe_tax`),
+//! which on a KKT matrix with a 3×3 median front inflates total factor
+//! time by up to 1.77×. Any attribution read off an instrumented run is
+//! therefore measuring the apparatus. This binary factors a warm matrix
+//! in a loop with all counters off so a sampler can attribute the real
+//! thing.
+use feral::{read_mtx, Solver};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut iters = 200usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--iters" {
+            if let Some(v) = it.next() {
+                iters = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+    for p in &paths {
+        let csc = read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc())?;
+        let mut solver = Solver::new();
+        for _ in 0..3 {
+            let _ = solver.factor(&csc, None);
+        }
+        for _ in 0..iters {
+            let _ = solver.factor(&csc, None);
+        }
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_kr_iters.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_kr_iters.rs
@@ -1,0 +1,59 @@
+// Replica of feral::scaling::infnorm::compute_infnorm's loop, purely to
+// count how many Knight-Ruiz sweeps each matrix needs. Same tol (1e-8),
+// same cap (10), same update.
+use feral::read_mtx;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    for p in std::env::args().skip(1) {
+        let m = read_mtx(std::path::Path::new(&p)).and_then(|m| m.to_csc())?;
+        let n = m.n;
+        let mut d = vec![1.0f64; n];
+        let mut row_max = vec![0.0f64; n];
+        let mut used = 10;
+        for it in 0..10 {
+            for r in row_max.iter_mut() {
+                *r = 0.0;
+            }
+            for j in 0..n {
+                let dj = d[j];
+                let mut col_max = row_max[j];
+                for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+                    let i = m.row_idx[k];
+                    let v = (d[i] * m.values[k] * dj).abs();
+                    if i != j && v > row_max[i] {
+                        row_max[i] = v;
+                    }
+                    if v > col_max {
+                        col_max = v;
+                    }
+                }
+                row_max[j] = col_max;
+            }
+            let mut max_dev = 0.0f64;
+            for i in 0..n {
+                let mx = row_max[i];
+                if mx > 0.0 {
+                    d[i] /= mx.sqrt();
+                    let dev = (mx - 1.0).abs();
+                    if dev > max_dev {
+                        max_dev = dev;
+                    }
+                }
+            }
+            if max_dev < 1e-8 {
+                used = it + 1;
+                break;
+            }
+        }
+        println!(
+            "{:<24} n={:<8} nnz={:<9} KR sweeps used = {}",
+            std::path::Path::new(&p)
+                .file_stem()
+                .unwrap()
+                .to_string_lossy(),
+            n,
+            m.values.len(),
+            used
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_kr_warmstart.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_kr_warmstart.rs
@@ -1,0 +1,125 @@
+//! Issue #200 (adjacent finding) — Knight-Ruiz scaling is recomputed
+//! from `d = 1` on every `factor()` call, and on IPM-KKT matrices it
+//! never converges: `diag_200_kr_iters` shows robot_1600,
+//! steering_12800 and ex4_2_160 all burn the full 10-sweep cap. On
+//! steering that is 18% of real factor time (samply, uninstrumented).
+//!
+//! In an interior-point loop consecutive KKT matrices differ only in the
+//! barrier terms, so the previous iterate's scaling should be a good
+//! starting point. This measures whether warm-starting buys sweeps:
+//! for each matrix in a sequence it reports the convergence measure
+//! `max_i |rowmax_i - 1|` reached by a cold start after 10 sweeps versus
+//! a warm start (from the previous matrix's converged `d`) after 1, 2
+//! and 3 sweeps.
+//!
+//! A warm start is only interesting if few sweeps reach a measure at
+//! least as good as cold-10; the scaling vector feeds every pivot
+//! decision downstream, so a worse-conditioned `D` is not a speedup.
+use feral::read_mtx;
+use feral::sparse::csc::CscMatrix;
+
+/// One Knight-Ruiz sweep. Returns `max_i |rowmax_i - 1|`.
+fn kr_sweep(m: &CscMatrix, d: &mut [f64], row_max: &mut [f64]) -> f64 {
+    let n = m.n;
+    for r in row_max.iter_mut() {
+        *r = 0.0;
+    }
+    for j in 0..n {
+        let dj = d[j];
+        let mut col_max = row_max[j];
+        for k in m.col_ptr[j]..m.col_ptr[j + 1] {
+            let i = m.row_idx[k];
+            let v = (d[i] * m.values[k] * dj).abs();
+            if i != j && v > row_max[i] {
+                row_max[i] = v;
+            }
+            if v > col_max {
+                col_max = v;
+            }
+        }
+        row_max[j] = col_max;
+    }
+    let mut max_dev = 0.0f64;
+    for i in 0..n {
+        let mx = row_max[i];
+        if mx > 0.0 {
+            d[i] /= mx.sqrt();
+            let dev = (mx - 1.0).abs();
+            if dev > max_dev {
+                max_dev = dev;
+            }
+        }
+    }
+    max_dev
+}
+
+fn run(m: &CscMatrix, start: &[f64], sweeps: usize) -> (Vec<f64>, f64) {
+    let mut d = start.to_vec();
+    let mut rm = vec![0.0; m.n];
+    let mut dev = f64::NAN;
+    for _ in 0..sweeps {
+        dev = kr_sweep(m, &mut d, &mut rm);
+        if dev < 1e-8 {
+            break;
+        }
+    }
+    (d, dev)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+    println!(
+        "{:<24}{:>12}{:>12}{:>12}{:>12}{:>14}",
+        "matrix", "cold-10", "warm-1", "warm-2", "warm-3", "max|dw-dc|/dc"
+    );
+    if std::env::var("KR_TRACE").is_ok() {
+        for p in &paths {
+            let m = read_mtx(std::path::Path::new(p)).and_then(|x| x.to_csc())?;
+            let mut d = vec![1.0f64; m.n];
+            let mut rm = vec![0.0; m.n];
+            let name = std::path::Path::new(p)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            print!("{name:<24}");
+            for _ in 0..10 {
+                print!("{:>10.2e}", kr_sweep(&m, &mut d, &mut rm));
+            }
+            println!();
+        }
+        return Ok(());
+    }
+    let mut prev: Option<Vec<f64>> = None;
+    for p in &paths {
+        let m = read_mtx(std::path::Path::new(p)).and_then(|x| x.to_csc())?;
+        let ones = vec![1.0f64; m.n];
+        let (d_cold, dev_cold) = run(&m, &ones, 10);
+        let name = std::path::Path::new(p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        match &prev {
+            None => {
+                println!(
+                    "{name:<24}{dev_cold:>12.2e}{:>12}{:>12}{:>12}{:>14}",
+                    "-", "-", "-", "(first)"
+                );
+            }
+            Some(pd) => {
+                let (_, d1) = run(&m, pd, 1);
+                let (_, d2) = run(&m, pd, 2);
+                let (d_w3, d3) = run(&m, pd, 3);
+                let rel = d_cold
+                    .iter()
+                    .zip(d_w3.iter())
+                    .map(|(&c, &w)| if c != 0.0 { ((w - c) / c).abs() } else { 0.0 })
+                    .fold(0.0f64, f64::max);
+                println!(
+                    "{name:<24}{dev_cold:>12.2e}{d1:>12.2e}{d2:>12.2e}{d3:>12.2e}{rel:>14.2e}"
+                );
+            }
+        }
+        prev = Some(d_cold);
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_probe_tax.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_probe_tax.rs
@@ -1,0 +1,97 @@
+//! Issue #200 — how much of the "unattributed" per-supernode time is the
+//! probe itself?
+//!
+//! Issue #200 attributes 33–39% of factor time to an UNATTRIBUTED bucket
+//! computed as `total - ASSEMBLY - DENSEFACTOR`, using numbers gathered
+//! with `phase_timing` enabled. Every one of those counters costs two
+//! `Instant::now()` calls per bracketed region, and the multifrontal
+//! driver brackets ~10 regions per supernode. On a KKT matrix whose
+//! median front is 3×3 that is a per-front constant of the same order as
+//! the residual being attributed.
+//!
+//! This binary measures the tax directly: the same `Solver`, the same
+//! warm matrix, factored alternately with `PHASE_TIMING_ENABLED` off and
+//! on, paired, reporting `min_us` per arm per the measurement protocol in
+//! `dev/decisions.md` (2026-08-09).
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
+use feral::symbolic::{supernode::SupernodeParams, symbolic_factorize};
+use feral::{read_mtx, Solver};
+use std::sync::atomic::Ordering::Relaxed;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 9usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--reps" {
+            if let Some(v) = it.next() {
+                reps = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+    if paths.is_empty() {
+        eprintln!("usage: diag_200_probe_tax [--reps N] <matrix.mtx>...");
+        std::process::exit(2);
+    }
+
+    println!(
+        "{:<22}{:>10}{:>10}{:>9}{:>9}{:>12}",
+        "matrix", "OFF us", "ON us", "ratio", "fronts", "tax ns/front"
+    );
+    for p in &paths {
+        let csc = read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc())?;
+        let mut solver = Solver::new();
+
+        // Warm: call 1 has no symbolic cache and (issue #56 N7) builds no
+        // permute-value map; call 2 builds it. Steady state starts at 3.
+        let _ = solver.factor(&csc, None);
+        let _ = solver.factor(&csc, None);
+        let _ = solver.factor(&csc, None);
+
+        let (mut off, mut on) = (f64::MAX, f64::MAX);
+        for _ in 0..reps {
+            // OFF arm
+            PHASE_TIMING_ENABLED.store(false, Relaxed);
+            let t = Instant::now();
+            let _ = solver.factor(&csc, None);
+            off = off.min(t.elapsed().as_secs_f64() * 1e6);
+            // ON arm
+            PHASE_TIMING_ENABLED.store(true, Relaxed);
+            let t = Instant::now();
+            let _ = solver.factor(&csc, None);
+            on = on.min(t.elapsed().as_secs_f64() * 1e6);
+            PHASE_TIMING_ENABLED.store(false, Relaxed);
+        }
+
+        // One extra instrumented pass to read the front count.
+        phase_timing::reset();
+        PHASE_TIMING_ENABLED.store(true, Relaxed);
+        let _ = solver.factor(&csc, None);
+        PHASE_TIMING_ENABLED.store(false, Relaxed);
+        // Front count comes from the symbolic structure, not a runtime
+        // counter: the whole point of this probe is that runtime counters
+        // in the per-front path are not free.
+        let fronts = symbolic_factorize(&csc, &SupernodeParams::default())?
+            .supernodes
+            .len() as u64;
+
+        let name = std::path::Path::new(p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        println!(
+            "{:<22}{:>10.0}{:>10.0}{:>9.2}{:>9}{:>12.0}",
+            name,
+            off,
+            on,
+            on / off,
+            fronts,
+            (on - off) * 1e3 / fronts.max(1) as f64
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_where_is_time.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_where_is_time.rs
@@ -1,0 +1,280 @@
+//! Issue #200 step 1: name the "UNATTRIBUTED 33-39%".
+//!
+//! The issue computes `UNATTRIBUTED = total - ASSEMBLY - DENSEFACTOR` where
+//! `total` is the whole `factor()` wallclock. But `factor()` is not only the
+//! per-supernode loop: it also runs a prologue (scaling, pivot-order scaling
+//! vector, `P·A·Pᵀ` permute, symmetric pattern, workspace setup) and an
+//! epilogue (`SparseFactors` construction, two perm clones, `build_node_parents`).
+//! Neither is per-supernode, and neither is covered by the `phase_timing`
+//! counters the issue read. So the residual it measured is an upper bound on
+//! per-node overhead, not a measurement of it.
+//!
+//! This probe splits the same wallclock the honest way, using the in-tree
+//! `Profiler` (`prologue_us` / `loop_ns` / `epilogue_us` + `PrologueBreakdown`)
+//! together with the `phase_timing` counters, and reports:
+//!
+//!   PROLOGUE (with sub-phases) | LOOP (assembly / densefactor / node tail) | EPILOGUE
+//!
+//! It also reports the supernode-size distribution, so a matrix can be checked
+//! against the issue's regime claim (median front `nrow` = 4, 63-70% of
+//! supernodes with `nrow <= 8`) before its numbers are used as evidence.
+//!
+//! Instrumentation perturbs the thing it measures, so the probe reports BOTH
+//! an uninstrumented `min`-of-N factor time and the instrumented one; the
+//! ratio is the probe tax and is printed, not hidden.
+//!
+//! Sequential driver only: the phase counters are process-global atomics and
+//! overlap under parallelism.
+//!
+//! Usage: `diag_200_where_is_time [--reps N] <matrix.mtx>...`
+
+use std::sync::atomic::Ordering::Relaxed;
+use std::time::Instant;
+
+use feral::dense::factor::{phase_timing, PHASE_TIMING_ENABLED};
+use feral::symbolic::supernode::SupernodeParams;
+use feral::symbolic::symbolic_factorize;
+use feral::{read_mtx, CscMatrix, NumericParams, Solver};
+
+fn pct(part: f64, whole: f64) -> f64 {
+    if whole > 0.0 {
+        100.0 * part / whole
+    } else {
+        0.0
+    }
+}
+
+/// Uninstrumented *numeric* factor time, min over `reps`, in microseconds.
+///
+/// `min` per the 2026-08-09 decision: it is the least-interfered per-sample
+/// statistic.
+///
+/// The solver is **warmed first and reused**, so the symbolic analysis is
+/// paid once outside the timed region. This is deliberate and it is what
+/// makes the number comparable to the profiler's `total_us`, which covers
+/// only `factorize_multifrontal_supernodal_with_workspace`. Rebuilding the
+/// solver per rep instead measures symbolic + numeric and reads ~2-4x larger
+/// — it is also not the quantity issue #200 is about, since an interior-point
+/// host factors the same pattern every iteration and pays symbolic once.
+fn min_factor_us(csc: &CscMatrix, reps: usize) -> f64 {
+    let mut solver = Solver::with_params(NumericParams::default(), SupernodeParams::default())
+        .with_parallel(false);
+    // Warm-up: two calls, so the timed reps are steady state (the second
+    // call is the one that builds the permute cache; see the instrumented
+    // path below for why).
+    let _ = solver.factor(csc, None);
+    let _ = solver.factor(csc, None);
+    let mut best = f64::INFINITY;
+    for _ in 0..reps {
+        let t = Instant::now();
+        let _ = solver.factor(csc, None);
+        let us = t.elapsed().as_secs_f64() * 1e6;
+        if us < best {
+            best = us;
+        }
+    }
+    best
+}
+
+fn main() {
+    let mut reps = 5usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == "--reps" {
+            reps = args.next().and_then(|v| v.parse().ok()).unwrap_or_else(|| {
+                eprintln!("--reps needs a positive integer");
+                std::process::exit(2)
+            });
+        } else {
+            paths.push(a);
+        }
+    }
+    if paths.is_empty() {
+        eprintln!("usage: diag_200_where_is_time [--reps N] <matrix.mtx>...");
+        std::process::exit(2);
+    }
+
+    for p in &paths {
+        let csc = match read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip {p}: {e}");
+                continue;
+            }
+        };
+        let name = std::path::Path::new(p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| p.clone());
+
+        // --- regime check: supernode size distribution -------------------
+        let sp = SupernodeParams::default();
+        let (n_sn, med_nrow, frac_le8, max_front) = match symbolic_factorize(&csc, &sp) {
+            Ok(sym) => {
+                let mut rows: Vec<usize> = sym.supernodes.iter().map(|s| s.nrow).collect();
+                rows.sort_unstable();
+                let n_sn = rows.len();
+                let med = if n_sn == 0 { 0 } else { rows[n_sn / 2] };
+                let le8 = rows.iter().filter(|&&r| r <= 8).count();
+                let mx = rows.last().copied().unwrap_or(0);
+                (n_sn, med, pct(le8 as f64, n_sn as f64), mx)
+            }
+            Err(e) => {
+                eprintln!("skip {name}: symbolic failed: {e}");
+                continue;
+            }
+        };
+
+        // --- uninstrumented baseline -------------------------------------
+        PHASE_TIMING_ENABLED.store(false, Relaxed);
+        let raw_us = min_factor_us(&csc, reps);
+
+        // --- instrumented run --------------------------------------------
+        let mut solver = Solver::with_params(NumericParams::default(), SupernodeParams::default())
+            .with_parallel(false)
+            .with_profiling(true);
+        // Warm with TWO calls, not one. On a fresh `Solver` the first
+        // factor runs with `pattern_reused_hint == false` (no symbolic
+        // cache yet) and deliberately does not build the permute-value-map
+        // cache (issue #56 N7: a one-shot caller must not pay for a cache
+        // it will never read). The second runs with the hint true but the
+        // cache still empty, so it takes the cold `from_triplets` path AND
+        // pays the cache build. Only the third call onward is steady state.
+        // Measuring call 2 reports the cache-build cost as if it were the
+        // per-factorization cost and overstates `permute` several-fold.
+        let _ = solver.factor(&csc, None);
+        let _ = solver.factor(&csc, None);
+        PHASE_TIMING_ENABLED.store(true, Relaxed);
+        phase_timing::reset();
+        let _ = solver.factor(&csc, None);
+        let rep = match solver.profile_report() {
+            Some(r) => r,
+            None => {
+                eprintln!("skip {name}: no profile report");
+                continue;
+            }
+        };
+        PHASE_TIMING_ENABLED.store(false, Relaxed);
+
+        let total = rep.total_us as f64;
+        let prologue = rep.prologue_us as f64;
+        let epilogue = rep.epilogue_us as f64;
+        let loop_us = rep.loop_ns as f64 / 1e3;
+        // Driver time inside `factor()` that the profiler attributes to
+        // neither the prologue, the loop, nor the epilogue.
+        let driver_other = (total - prologue - loop_us - epilogue).max(0.0);
+
+        let (asm_ns, df_ns, panel_ns, schur_ns, tail_ns) = phase_timing::snapshot();
+        let asm_us = asm_ns as f64 / 1e3;
+        let df_us = df_ns as f64 / 1e3;
+        let arith_us = (panel_ns + schur_ns + tail_ns) as f64 / 1e3;
+        // Per-supernode work the counters do NOT cover: the contribution-block
+        // deposit, the `row_map` mirror-clear and the `NodeFactors` build.
+        let node_tail_us = (loop_us - asm_us - df_us).max(0.0);
+        // Dense-factor time that is not panel/Schur/scalar-tail arithmetic.
+        // On small fronts this is the single largest block of factor time and
+        // is what issue #200 saw as part of its "UNATTRIBUTED".
+        let bookkeep_us = (df_us - arith_us).max(0.0);
+        let ld = |c: &std::sync::atomic::AtomicU64| c.load(Relaxed) as f64 / 1e3;
+        let lextract_us = ld(&phase_timing::LEXTRACT_NS);
+        let contribx_us = ld(&phase_timing::CONTRIBEXTRACT_NS);
+        let zerofill_us = ld(&phase_timing::CONTRIBZEROFILL_NS);
+        let buildrow_us = ld(&phase_timing::BUILDROW_NS);
+        let scatter_us = ld(&phase_timing::SCATTER_NS);
+        let extendadd_us = ld(&phase_timing::EXTENDADD_NS);
+
+        let b = &rep.prologue_breakdown;
+
+        println!("=== {name} ===");
+        println!(
+            "  n={} nnz={} nnz/n={:.2} | supernodes={} median_nrow={} nrow<=8={:.1}% max_front={}",
+            csc.n,
+            csc.values.len(),
+            csc.values.len() as f64 / csc.n as f64,
+            n_sn,
+            med_nrow,
+            frac_le8,
+            max_front
+        );
+        println!(
+            "  factor: {raw_us:.0} us uninstrumented (min of {reps}) | {total:.0} us instrumented \
+             (probe tax {:.2}x)",
+            if raw_us > 0.0 { total / raw_us } else { 0.0 }
+        );
+        println!("  --- split of the instrumented {total:.0} us ---");
+        println!(
+            "  PROLOGUE      {prologue:>9.0} us  {:>5.1}%",
+            pct(prologue, total)
+        );
+        println!(
+            "      scaling   {:>9} us  {:>5.1}%   permute {:>7} us  {:>5.1}%   (from_triplets {:>6} us => {})",
+            b.scaling_us,
+            pct(b.scaling_us as f64, total),
+            b.permute_us,
+            pct(b.permute_us as f64, total),
+            b.permute_from_triplets_us,
+            if b.permute_from_triplets_us > 0 {
+                "COLD: cache MISS"
+            } else {
+                "warm: cache hit"
+            }
+        );
+        println!(
+            "      scal_pivot{:>9} us  {:>5.1}%   infnorm {:>7} us  {:>5.1}%   row_map/setup {:>5} us  {:>5.1}%",
+            b.scaling_pivot_order_us,
+            pct(b.scaling_pivot_order_us as f64, total),
+            b.infnorm_tol_us,
+            pct(b.infnorm_tol_us as f64, total),
+            b.row_map_us + b.setup_us,
+            pct((b.row_map_us + b.setup_us) as f64, total)
+        );
+        println!(
+            "  LOOP          {loop_us:>9.0} us  {:>5.1}%",
+            pct(loop_us, total)
+        );
+        println!(
+            "      assembly  {asm_us:>9.0} us  {:>5.1}%   densefactor {df_us:>7.0} us  {:>5.1}%   node_tail {:>7.0} us  {:>5.1}%",
+            pct(asm_us, total),
+            pct(df_us, total),
+            node_tail_us,
+            pct(node_tail_us, total)
+        );
+        println!(
+            "      of which arithmetic (panel+schur+scalar-tail) {arith_us:.0} us  {:.1}% of total",
+            pct(arith_us, total)
+        );
+        println!(
+            "      densefactor BOOKKEEPING (densefactor - arithmetic) {bookkeep_us:>7.0} us  {:>5.1}% of total",
+            pct(bookkeep_us, total)
+        );
+        println!(
+            "         L/D extract {lextract_us:>7.0} us {:>5.1}%   contrib extract {contribx_us:>7.0} us {:>5.1}%   (of which zero-fill {zerofill_us:>6.0} us {:>4.1}%)   unnamed {:>7.0} us {:>5.1}%",
+            pct(lextract_us, total),
+            pct(contribx_us, total),
+            pct(zerofill_us, total),
+            (bookkeep_us - lextract_us - contribx_us).max(0.0),
+            pct((bookkeep_us - lextract_us - contribx_us).max(0.0), total)
+        );
+        println!(
+            "      assembly breakdown: build_row {buildrow_us:>7.0} us {:>5.1}%   scatter {scatter_us:>7.0} us {:>5.1}%   extend_add {extendadd_us:>7.0} us {:>5.1}%",
+            pct(buildrow_us, total),
+            pct(scatter_us, total),
+            pct(extendadd_us, total)
+        );
+        println!(
+            "  EPILOGUE      {epilogue:>9.0} us  {:>5.1}%",
+            pct(epilogue, total)
+        );
+        println!(
+            "  DRIVER_OTHER  {driver_other:>9.0} us  {:>5.1}%",
+            pct(driver_other, total)
+        );
+        println!(
+            "  => per-supernode loop is {:.1}% of factor; non-loop is {:.1}%",
+            pct(loop_us, total),
+            pct(prologue + epilogue + driver_other, total)
+        );
+        println!();
+    }
+}

--- a/crates/feral-diagnostics/src/bin/diag_200_work_vs_ma57.rs
+++ b/crates/feral-diagnostics/src/bin/diag_200_work_vs_ma57.rs
@@ -1,0 +1,89 @@
+//! Issue #200 — normalise the feral-vs-MA57 wallclock gap by the work
+//! each solver actually performs.
+//!
+//! Every prior investigation profiled feral in isolation, which can only
+//! locate feral's time, never explain why there is more of it than
+//! MA57's. A wallclock ratio is only an overhead statement if both
+//! solvers do the same arithmetic. This reports feral's `nnz(L)` and its
+//! elimination flop count so they can be put beside MA57's `INFO(14)`
+//! and `RINFO(4)` from `external_benchmarks/ma57_oracle`.
+//!
+//! Flops are counted from the symbolic supernode shapes with the same
+//! model MA57's `RINFO(4)` uses for a symmetric indefinite elimination:
+//! a front of `ncol` eliminated columns and height `nrow` costs
+//! `sum_{k<ncol} (nrow-k)^2` multiply-adds. Counting from the symbolic
+//! structure (not instrumenting the kernels) keeps this free of the
+//! probe distortion documented in `diag_200_probe_tax`.
+use feral::symbolic::{supernode::SupernodeParams, symbolic_factorize};
+use feral::{read_mtx, NumericParams, Solver};
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut reps = 7usize;
+    let mut paths: Vec<String> = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--reps" {
+            if let Some(v) = it.next() {
+                reps = v.parse()?;
+            }
+        } else {
+            paths.push(a.clone());
+        }
+    }
+    println!(
+        "{:<22}{:>8}{:>12}{:>14}{:>10}{:>12}{:>10}",
+        "matrix", "snodes", "nnz_L", "flops_elim", "med nrow", "factor us", "MFlop/s"
+    );
+    for p in &paths {
+        let csc = read_mtx(std::path::Path::new(p)).and_then(|m| m.to_csc())?;
+        let sp = SupernodeParams::default();
+        let sym = symbolic_factorize(&csc, &sp)?;
+        let mut flops: f64 = 0.0;
+        let mut nnz_l_sym: u64 = 0;
+        let mut rows: Vec<usize> = Vec::with_capacity(sym.supernodes.len());
+        for s in &sym.supernodes {
+            let (nrow, ncol) = (s.nrow, s.ncol);
+            rows.push(nrow);
+            for k in 0..ncol {
+                let h = nrow - k;
+                flops += (h * h) as f64;
+            }
+            // Stored L entries: the trapezoid below the diagonal block.
+            nnz_l_sym += (ncol * (ncol + 1) / 2 + ncol * (nrow - ncol)) as u64;
+        }
+        rows.sort_unstable();
+        let med = rows.get(rows.len() / 2).copied().unwrap_or(0);
+
+        let mut solver = Solver::with_params(NumericParams::default(), sp);
+        for _ in 0..3 {
+            let _ = solver.factor(&csc, None);
+        }
+        let mut best = f64::MAX;
+        for _ in 0..reps {
+            let t = Instant::now();
+            let _ = solver.factor(&csc, None);
+            best = best.min(t.elapsed().as_secs_f64() * 1e6);
+        }
+        let nnz_l = solver
+            .last_factor_stats()
+            .map(|s| s.nnz_l as u64)
+            .unwrap_or(nnz_l_sym);
+        let name = std::path::Path::new(p)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        println!(
+            "{:<22}{:>8}{:>12}{:>14.4e}{:>10}{:>12.0}{:>10.0}",
+            name,
+            sym.supernodes.len(),
+            nnz_l,
+            flops,
+            med,
+            best,
+            flops / best
+        );
+    }
+    Ok(())
+}

--- a/crates/feral-diagnostics/src/bin/diag_ea_digest.rs
+++ b/crates/feral-diagnostics/src/bin/diag_ea_digest.rs
@@ -1,0 +1,62 @@
+//! Bitwise digest of a factorization, for A/B-ing a change that claims
+//! to be bit-exact.
+//!
+//! The in-tree parity tests (`parallel_parity_*`, `cb_parity_*`) compare
+//! two paths *within one build*, so a change that shifts both identically
+//! passes them. This prints a digest of the factor's raw bits so the same
+//! matrix can be compared across two builds.
+use feral::{read_mtx, NumericParams, Solver};
+
+/// FNV-1a over the raw bit patterns, so `-0.0` and `+0.0` differ and
+/// any NaN payload change is visible.
+fn digest(vals: &[f64]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for v in vals {
+        for b in v.to_bits().to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x1000_0000_01b3);
+        }
+    }
+    h
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    for p in std::env::args().skip(1) {
+        // Keep going on a matrix that will not load: this tool exists to
+        // compare a whole corpus across two builds, and aborting the loop
+        // on the first bad file silently shrinks the comparison.
+        let csc = match read_mtx(std::path::Path::new(&p)).and_then(|m| m.to_csc()) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("{p} LOAD-ERROR {e:?}");
+                continue;
+            }
+        };
+        let label = std::path::Path::new(&p)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let mut s =
+            Solver::with_params(NumericParams::default(), Default::default()).with_parallel(false);
+        let status = s.factor(&csc, None);
+        match s.factors() {
+            Some(f) => {
+                // `ldlt_export` reassembles the supernodal factors into a
+                // single global L (CSC) and D in factorization order, so
+                // the digest is over a canonical layout rather than over
+                // whatever per-front padding the driver happened to use.
+                let e = f.ldlt_export();
+                println!(
+                    "{label} status={status:?} L={:016x} Ddiag={:016x} Dsub={:016x} nnz_L={}",
+                    digest(&e.l_values),
+                    digest(&e.d_diag),
+                    digest(&e.d_subdiag),
+                    e.l_values.len()
+                );
+            }
+            None => println!("{label} status={status:?} NO FACTORS"),
+        }
+    }
+    Ok(())
+}

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-09-01T16:00:54Z
+Generated: 2026-09-05T13:13:08Z
 
 ## Latest Session
 File: dev/sessions/2026-09-01-01.md
@@ -59,34 +59,34 @@ discopt.
 
 ## Git Status
 ```
+a303326 Merge pull request #198 from jkitchin/docs/krylov-evaluation
+b412113 docs: record the recycled-MINRES evaluation and why it was not adopted
+6f54680 Merge pull request #197 from jkitchin/revert/park-post-0.17
+de3ade2 docs: session checkpoint 2026-09-01-01 (post-0.17 work parked)
 bb18f0a revert: park post-0.17.0 development, resume from the 0.17.0 baseline
-91ace05 docs: session checkpoint 2026-08-30-02 (#191, #193, #195 reviewed and landed)
-d0b3000 Merge pull request #195 from jkitchin/claude/issue-194-p6gri8
-7b42414 fix(solve): an interrupt during the MC64 retry must not be swallowed
-942d130 Merge origin/main into claude/issue-194-p6gri8
 ```
 
 ## Test Status
 ```
-test symbolic::tests::symbolic_factorize_kahip_produces_valid_perm ... ok
-test symbolic::tests::test_contrib_sizes_nonnegative ... ok
+test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
-test symbolic::tests::test_perm_inverse_consistency ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test numeric::solve::tests::issue175_overhead_term_is_scheduling_only ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
-test numeric::solve::tests::issue175_wide_thin_tree_is_not_scheduled_in_parallel ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
+test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
+test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 2.84s
+test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 10.00s
 
 ```
 
@@ -128,26 +128,26 @@ discopt. Feature work on the solver should start from a consumer-demonstrated
 need, not from an improvement that is available to make.
 
 ## Recent Tried-and-Rejected
-**Replaced with.** Two fix-independent observables:
-`mc64_retry_attempt_count() == 1` proves factorization #1 returned `Ok(..)`
-(the issue-#65 gate keys on `Ok`, so the flag was set after it completed),
-and `delay < call_elapsed` proves it was set before the call returned.
-Together they pin the flag inside the retry without referencing the status
-being asserted.
+   **0–2 steps, never at the cap**, on seven large matrices; issue #30 found
+   4/28 stagnating, and on those MUMPS floors at the same residual — the
+   floor is the matrix, not the iteration. A synthetic head-to-head at equal
+   cost per step had stationary refinement matching or beating preconditioned
+   MINRES at every step count.
+3. Factorization, not back-solve, is the dominant cost
+   (`pounce/dev-notes/performance-engineering.md:149`; 0.1702 s vs 0.0856 s
+   per iteration on the 118k KKT). A Krylov path that still factors for
+   inertia cannot reach it, and pounce's inertia gate reads
+   `check_inertia = neg_curv_test_tol <= 0.0 || !provides_inertia()` — so
+   returning `provides_inertia() -> false` *forces* the check on rather than
+   standing it down.
 
-## 2026-08-29 — busy-wait shell pollers while a benchmark is live
-
-**Tried.** `until grep -q ...; do :; done` to wait on a background job.
-
-**Symptom.** Pinned a core, pushed load to 15.71 alongside `cargo test --all`
-and a live A/B benchmark, and contaminated the branch arm of round 2. Phase
-2.8.1 p90s are ratios against **on-disk MUMPS oracle sidecars**, so
-contention inflates only feral's numerator — the metric is not
-contention-symmetric and a loaded host reads as a regression. A single-shot
-run under that load FAILED; the interleaved re-run was 8/8 PASS.
-
-**Rule.** Any background waiter in this repo must `sleep`, never busy-poll.
-Do not trust a single-shot p90 taken under load; interleave A/B.
+**Not a verdict on iterative methods generally.** This is the first time the
+question has been raised in this repo — grep for `minres|gmres|krylov|arnoldi`
+returns zero real hits — so there is no prior rejection to inherit. The full
+evaluation, including the falsifiers that would flip the answer and the
+reproduction code for every number above, is in
+`dev/research/krylov-recycling-evaluation-2026-09-01.md`. Read that before
+re-opening the question.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,153 +1,173 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-09-05T13:13:08Z
+Generated: 2026-09-05T20:33:57Z
 
 ## Latest Session
-File: dev/sessions/2026-09-01-01.md
+File: dev/sessions/2026-09-05-01.md
 ```
-# Session 2026-09-01-01
+# Session 2026-09-05-01
 
 ## Benchmark note (read first)
 
-**No benchmark was run this session, and the numbers below are not fresh.**
-This session reverted the code tree to the `v0.17.0` baseline; the resulting
-tree is byte-identical to the tag except for an 18-line clippy `allow`. The
-figures quoted are therefore the ones recorded at the 0.17.0 release
-(`dev/sessions/2026-08-19-05.md`) and are cited, not re-measured. Re-running
-the corpus to confirm that unchanged code produces unchanged numbers would
-have bought nothing. The next session that touches solver code must run the
-bench and report against these.
+**The corpus benchmark was not re-run, and the exit-partition numbers
+below are cited, not measured this session.** `src/` on this branch is
+byte-identical to `main` (`git diff main...HEAD -- src/` is empty), which
+is itself the 0.17.0 baseline; the only Rust added is a diagnostic binary
+under `crates/feral-diagnostics`. The full partition needs the 169,591-
+matrix / 5.4 GB KKT corpus with MUMPS sidecars — a multi-hour run to
+confirm that unchanged solver code produces unchanged numbers.
+
+`cargo run --bin bench --release` was run and is recorded verbatim below;
+`data/benchmark-config.toml` is absent in this clone, so it took its
+synthetic fallback (8 matrices) and emitted no MUMPS ratios.
+
+Cited from `dev/sessions/2026-08-19-05.md` (0.17.0 release):
 
 ```
---- Dense Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
-bucket                    count      p90     target  verdict
-small-frontal (<200)     147982     1.58     <= 2.0     PASS
-medium (<500)            152145     2.00     <= 3.0     PASS
-
 --- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
 bucket                    count      p90     target  verdict
 small-frontal (<200)     153455     1.58     <= 2.0     PASS
 medium (<500)            153560     1.58     <= 3.0     PASS
 ```
 
+The next session that touches solver code must run the corpus and report
+against these.
+
 ## Goal
 
-Park the post-0.17.0 development on a branch and return `main` to the 0.17.0
-release baseline, after review found that none of it is used by pounce or
-discopt.
+Re-examine issue #200 after a new comment (2026-09-05, from the
+pounce/pglib side) retracted the issue's own headline using a 351k-row
+AC-OPF KKT — a matrix an order of magnitude larger than the one the issue
+was filed from — and stated conclusions incompatible with the comment
+this branch published on 2026-09-04.
 
 ## Accomplished
 
-- **Parked 42 commits.** `v0.17.0` (2fbf9b7) to 91ace05 was 42 commits / 79
-  files / +12384 / -340. Pushed to `origin` as branch `park/post-0.17` and
-  annotated tag `park/post-0.17-tip`, both verified at 91ace05 by
-  `git ls-remote` *before* any rollback began.
+**Their finding reproduces on a different matrix class, and two of my own
+2026-09-04 claims do not survive re-measurement.**
 
-- **Reverted the code tree to 0.17.0** on branch `revert/park-post-0.17`
-  (commit bb18f0a). Undone: #190 (`RefineOptions` targets, `RefineOutcome`),
-  #192 (`Solver::reset_quality`), #194 (cooperative `factor` cancellation),
-  multi-RHS solve perf, and the componentwise-refinement default with its
-  breaking `*_refined_into` return-type change.
+- **Confirmed their §2 in the source.** `src/dense/factor.rs:2168` sets
+  `PANEL_MIN_NCOL = 8` and routes `ncol < 8` to
+  `factor_frontal_in_place_with_scratch`, whose impl (lines 1724–1990)
+  carries `LEXTRACT_NS`/`CONTRIBEXTRACT_NS`/`CONTRIBZEROFILL_NS` but no
+  `PANELFACTOR_NS`/`SCHUR_NS`/`SCALARTAIL_NS`. Small-front arithmetic is
+  uncounted and lands in `DENSEFACTOR`'s unnamed remainder. This is a
+  second mechanism feeding the UNATTRIBUTED bucket, additive to the probe
+  tax I reported, and it is the larger half.
 
-- **Three carve-outs kept**, each for a stated reason: the clippy 1.98 fixes
-  (CI runs `stable` = 1.98, local is 1.93 — reverting them turns CI red on
-  every future PR); the CI coverage infrastructure; and all of `dev/`, whose
-  append-only logs the protocol forbids rewinding.
-
-- **Evidence.** `cargo check --workspace --all-targets` clean.
 ```
 
 ## Git Status
 ```
+1d13094 diag(#200): bucket the supernode loop by front size, and retract two 2026-09-04 claims
+0f76934 docs: session checkpoint 2026-09-04-01 (#200 explained, three levers rejected)
+5a1a82b diag(#200): measure work volume against MA57, not just feral's own time
 a303326 Merge pull request #198 from jkitchin/docs/krylov-evaluation
 b412113 docs: record the recycled-MINRES evaluation and why it was not adopted
-6f54680 Merge pull request #197 from jkitchin/revert/park-post-0.17
-de3ade2 docs: session checkpoint 2026-09-01-01 (post-0.17 work parked)
-bb18f0a revert: park post-0.17.0 development, resume from the 0.17.0 baseline
 ```
 
 ## Test Status
 ```
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
 test symbolic::tests::test_symbolic_factorize_dense ... ok
+test symbolic::tests::test_symbolic_factorize_basic ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
+test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
-test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
-test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
+test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
-test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
+test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 10.00s
+test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 3.48s
 
 ```
 
 ## Benchmark
 ```
-(skipped: pass --with-bench to re-run; no session checkpoint with bench)
+(skipped: pass --with-bench to re-run; sourced from dev/sessions/2026-09-05-01.md)
+
+
+FERAL benchmark harness
+  ordering: default (symbolic_factorize heuristic)
+  scaling: default (SupernodeParams::default)
+Loading matrices from data/benchmark-config.toml ... not found
+
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10          100           42     (10, 0, 0)
+spd_50             50           24            3     (50, 0, 0)
+spd_100           100           82            5    (100, 0, 0)
+spd_200           200          404           18    (200, 0, 0)
+kkt_10_3           13            3            0     (10, 3, 0)
+kkt_30_10          40           21            1    (30, 10, 0)
+kkt_50_15          65           49            2    (50, 15, 0)
+kkt_100_30        130          207            7   (100, 30, 0)
+
+8 matrices benchmarked
+
 ```
 
 ## Recent Decisions
-needs a revert-of-revert, which is a known and local inconvenience; a force-push
-would have silently invalidated every branch cut from `main` since 2026-08-19.
+| robot_1600 | 1044 | 2861 | 2.7× | 1.62× |
+| steering_12800 | 917 | 2934 | 3.2× | 1.39× |
+| ex4_2_160 | 5943 | 14329 | 2.4× | 2.05× |
+| arki0009 | 6173 | 9500 | 1.5× | 1.73× |
 
-**Three carve-outs are deliberately not reverted.**
+**Decision.** feral runs at **1.5–3.2× fewer flops per second than MA57
+at every front size**, on 0.44–1.20× the work (the fill and flop-volume
+ratios from 2026-09-04 are symbolic, not timing-derived, and stand).
+That is an arithmetic/memory-throughput deficit spread across the whole
+front-size distribution, not a per-supernode constant. Issue #200 is
+therefore the same defect as #153 ("dtoc1nd: 3.8× MA57, concentrated in
+148 fronts of ncol≈62") and should be worked there.
 
-1. *The clippy 1.98 fixes* (9c5dfac, 216a755). CI resolves
-   `dtolnay/rust-toolchain@stable` to 1.98, which introduced
-   `needless_late_init` and `chunks_exact_to_as_chunks`; the local toolchain is
-   1.93. Reverting them turns CI red on every future PR while the pre-commit
-   hook still passes locally — reintroducing exactly the local/CI drift those
-   commits fixed. The `unknown_lints` guard is part of this: without it the
-   `allow` is itself a hard error under `-D warnings` on any pre-1.98
-   toolchain.
-2. *CI coverage infrastructure* — `.github/workflows/coverage.yml`,
-   `codecov.yml`, the README badge. Infrastructure, not solver code.
-3. *All of `dev/`.* The session checkpoints, journals, and the append-only
-   `decisions.md` / `tried-and-rejected.md` entries are the record of what was
-   tried and learned. Reverting an append-only log to drop entries would
-   violate the protocol in `CLAUDE.md`, and the record is *more* valuable after
-   a park, not less: it documents why the code is on a shelf.
-
-**Evidence.** `cargo test --workspace`: 1191 passed, 0 failed, 25 ignored.
-`git diff v0.17.0..HEAD -- src/ python/ tests/ Cargo.toml` reduces to the
-18-line `schur_kernel.rs` clippy allow and nothing else.
-
-**Standing implication for future work.** The parked features were built to a
-high standard — researched, measured, documented — and still went unused. The
-gap was not quality but demand: none originated in a request from pounce or
-discopt. Feature work on the solver should start from a consumer-demonstrated
-need, not from an improvement that is available to make.
+**Corollaries, binding on future work.**
+- A small-front fast path is capped at 34% of wall on the most
+  favourable matrix in the corpus and 4% on the least. It cannot reach
+  parity on any of them. Do not open one as a #200 fix.
+- The corollaries of the 2026-09-04 decision that do not depend on the
+  fitted intercept still hold: report fill and flops beside any
+  wallclock ratio; ordering, fill and scaling are exonerated as the
+  cause; `nemin` is not a lever (three rejections).
+- `PHASE_TIMING_ENABLED` is unfit for attribution on small-front trees
+  for two independent reasons, both now confirmed: its ~10
+  `Instant::now()` pairs per supernode cost 0.20–0.41 µs/front
+  (`diag_200_probe_tax`), *and* `src/dense/factor.rs:2168` routes
+  `ncol < 8` fronts to `factor_frontal_in_place_with_scratch`, which
+  carries no `PANELFACTOR`/`SCHUR`/`SCALARTAIL` counters — so their
+  arithmetic is uncounted and lands in `DENSEFACTOR`'s unnamed
+  remainder. The second mechanism was identified on the pounce side and
+  verified here in the source. Use `ProfileReport` instead.
 
 ## Recent Tried-and-Rejected
-   **0–2 steps, never at the cap**, on seven large matrices; issue #30 found
-   4/28 stagnating, and on those MUMPS floors at the same residual — the
-   floor is the matrix, not the iteration. A synthetic head-to-head at equal
-   cost per step had stationary refinement matching or beating preconditioned
-   MINRES at every step count.
-3. Factorization, not back-solve, is the dominant cost
-   (`pounce/dev-notes/performance-engineering.md:149`; 0.1702 s vs 0.0856 s
-   per iteration on the 118k KKT). A Krylov path that still factors for
-   inertia cannot reach it, and pounce's inertia gate reads
-   `check_inertia = neg_curv_test_tol <= 0.0 || !provides_inertia()` — so
-   returning `provides_inertia() -> false` *forces* the check on rather than
-   standing it down.
 
-**Not a verdict on iterative methods generally.** This is the first time the
-question has been raised in this repo — grep for `minres|gmres|krylov|arnoldi`
-returns zero real hits — so there is no prior rejection to inherit. The full
-evaluation, including the falsifiers that would flip the answer and the
-reproduction code for every number above, is in
-`dev/research/krylov-recycling-evaluation-2026-09-01.md`. Read that before
-re-opening the question.
+**What was tried.** The 2026-09-04 comparison ran `ma57_bench` once per
+matrix (the harness does one factorization per invocation) while taking
+min-of-9 on the feral side.
+
+**Symptoms.** `ex4_2_160_0002` was recorded at **1 302 836 µs**, from
+which the comment concluded "feral is 18× faster than MA57 here" and
+"the ratio spans 70-fold." Not reproducible. Nine cold runs today:
+32565, 31244, 33088, 32525, 36999, 62353, 48235, 55242, 37053 µs. A
+scaling sweep (`ICNTL(15)` = 0,1,2,3,4) gives 42745 / 42614 / 48992 /
+66640 / 42442 µs. Same binary and same matrix: `INFO(14) = 2757122` and
+`RINFO(4) = 4.4772e8` match the 2026-09-04 run exactly, so it was one
+stalled cold run, not a different configuration.
+
+feral's own numbers reproduced within 10% on all five matrices, which is
+why the error survived review — only the un-averaged side moved.
+
+**Rejected.** Min-of-N on **both** sides of any cross-solver comparison,
+with N ≥ 9 and the spread reported. Corrected feral/MA57 range on this
+corpus: **1.4×–3.4×**, not 0.06×–4.17×.
 
 ## Source Files
 ```

--- a/dev/context.md
+++ b/dev/context.md
@@ -1,6 +1,6 @@
 # FERAL Context (auto-generated)
 
-Generated: 2026-09-05T20:33:57Z
+Generated: 2026-09-06T00:55:23Z
 
 ## Latest Session
 File: dev/sessions/2026-09-05-01.md
@@ -59,26 +59,26 @@ this branch published on 2026-09-04.
 
 ## Git Status
 ```
-1d13094 diag(#200): bucket the supernode loop by front size, and retract two 2026-09-04 claims
-0f76934 docs: session checkpoint 2026-09-04-01 (#200 explained, three levers rejected)
-5a1a82b diag(#200): measure work volume against MA57, not just feral's own time
-a303326 Merge pull request #198 from jkitchin/docs/krylov-evaluation
-b412113 docs: record the recycled-MINRES evaluation and why it was not adopted
+90eebf1 perf(numeric): hoist the child->parent index map out of extend_add's inner loop
+c6f106c docs: reject InfNorm scaling-vector caching, a third re-proposal of closed work
+e9a438c fix(diag): time the driver's real kernel entry point, not factor_frontal
+775b8a8 diag(#153): split the MA57 deficit into plumbing, prologue and kernel
+2dcb842 docs: session checkpoint 2026-09-05-01 (#200 retracted and closed as a duplicate of #153)
 ```
 
 ## Test Status
 ```
 test symbolic::tests::test_perm_inverse_consistency ... ok
-test symbolic::tests::symbolic_factorize_scotch_produces_valid_perm ... ok
-test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_basic ... ok
+test symbolic::tests::test_symbolic_factorize_dense ... ok
 test symbolic::tests::test_symbolic_factorize_kkt ... ok
-test symbolic::tests::is_arrow_bordered_rejects_many_hubs ... ok
+test numeric::factorize::tests::issue_5_mss1_iter0_inertia_wanders_under_delta_w_sweep ... ok
 test symbolic::tests::choose_adaptive_routes_arrow_to_amf ... ok
+test numeric::solve::tests::cb_coarsening_threshold_is_arithmetically_inert ... ok
 test symbolic::tests::choose_adaptive_rules ... ok
 test symbolic::tests::issue_3_scotchnd_on_kkt_recurses_after_o13 ... ok
-test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test scaling::tests::auto_keeps_mc64_on_vesuviou_0000 ... ok
+test scaling::tests::auto_keeps_mc64_on_vesuvia_0000 ... ok
 test numeric::factorize::tests::issue_5_mss1_zero_tol_sweep_diagnostic ... ok
 test symbolic::tests::issue_3_auto_on_kkt_routes_via_pick_default_method ... ok
 test numeric::factorize::tests::issue_5_mss1_pivot_threshold_sweep_diagnostic ... ok
@@ -86,7 +86,7 @@ test scaling::tests::pick_scaling_strategy_routes_clnlbeam_to_infnorm ... ok
 test scaling::hungarian::tests::mc64_hungarian_no_quadratic_heap_realloc_regression ... ok
 test numeric::solve::tests::cb_core_profitable_matches_the_plan_gate ... ok
 
-test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 3.48s
+test result: ok. 444 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 1.73s
 
 ```
 
@@ -148,26 +148,26 @@ therefore the same defect as #153 ("dtoc1nd: 3.8× MA57, concentrated in
   verified here in the source. Use `ProfileReport` instead.
 
 ## Recent Tried-and-Rejected
+**What was claimed, and retracted.** An A/B run appeared to show that
+rewriting `extend_add`'s inner loops from indexed access to the
+slice-and-zip form clippy's `needless_range_loop` asks for cost 10% on
+optmass: 1.080x indexed vs 0.977x zipped. On that basis an
+`#[allow(clippy::needless_range_loop)]` was added to the function with the
+numbers cited as justification.
 
-**What was tried.** The 2026-09-04 comparison ran `ma57_bench` once per
-matrix (the harness does one factorization per invocation) while taking
-min-of-9 on the feral side.
+**Why it was wrong.** The two figures came from *different* interleaved
+campaigns, built at different times. A rerun measured the indexed form at
+0.974x on optmass — statistically the same as the zipped form's 0.977x.
+optmass's "before" minimum ranged 18504-19603 us (6%) across campaigns
+built minutes apart, which swamps the effect being attributed. The
+`allow` and its justification were removed and the idiomatic zipped form
+kept.
 
-**Symptoms.** `ex4_2_160_0002` was recorded at **1 302 836 µs**, from
-which the comment concluded "feral is 18× faster than MA57 here" and
-"the ratio spans 70-fold." Not reproducible. Nine cold runs today:
-32565, 31244, 33088, 32525, 36999, 62353, 48235, 55242, 37053 µs. A
-scaling sweep (`ICNTL(15)` = 0,1,2,3,4) gives 42745 / 42614 / 48992 /
-66640 / 42442 µs. Same binary and same matrix: `INFO(14) = 2757122` and
-`RINFO(4) = 4.4772e8` match the 2026-09-04 run exactly, so it was one
-stalled cold run, not a different configuration.
-
-feral's own numbers reproduced within 10% on all five matrices, which is
-why the error survived review — only the un-averaged side moved.
-
-**Rejected.** Min-of-N on **both** sides of any cross-solver comparison,
-with N ≥ 9 and the spread reported. Corrected feral/MA57 range on this
-corpus: **1.4×–3.4×**, not 0.06×–4.17×.
+**Rule this reinforces.** A ratio between two numbers measured in
+different campaigns is not a measurement. Only per-round paired ratios
+from a single interleaved campaign were used for the threshold and
+loop-form decisions that survived. (Same class of error as the warm-repeat
+cache protocol retracted earlier the same day.)
 
 ## Source Files
 ```

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7646,3 +7646,88 @@ high standard — researched, measured, documented — and still went unused. Th
 gap was not quality but demand: none originated in a request from pounce or
 discopt. Feature work on the solver should start from a consumer-demonstrated
 need, not from an improvement that is available to make.
+
+---
+
+## 2026-09-04 — The feral↔MA57 gap is a per-supernode fixed cost, and it is measured
+
+**Context.** Multiple sessions have profiled feral's factorization looking
+for the source of the reported MA57 gap. Profiling feral in isolation can
+locate feral's time; it cannot explain why there is *more* of it than
+MA57's. That requires knowing whether the two solvers do the same work,
+which nobody had checked.
+
+**What was done.** `external_benchmarks/ma57_oracle/ma57_bench.F` now
+emits work-volume diagnostics alongside its timings: `INFO(14)` (entries
+in the factors), `INFO(13)` (delayed pivots), `RINFO(3)` (assembly
+flops), `RINFO(4)` (elimination flops), `INFO(5)` (forecast reals).
+feral's side comes from `Solver::last_factor_stats().nnz_l` plus a flop
+count taken from the symbolic supernode shapes with the same
+`Σ_{k<ncol}(nrow−k)²` model `RINFO(4)` uses — counted statically, so it
+carries none of the probe distortion documented in
+`tried-and-rejected.md` for the same date.
+
+**Finding 1 — the work is not the problem.** Fill ratio feral/MA57:
+1.01, 0.84, 0.78, 1.07, 1.20. Flop ratio: 1.06, 0.59, 0.44, 0.85, 1.12
+(optmass / robot_1600 / steering_12800 / ex4_2_160 / arki0009, all
+`_0002`). feral never does meaningfully more work; on steering it does
+**2.3× fewer flops and is still 1.65× slower**. Ordering and fill are
+exonerated.
+
+**Finding 2 — the gap is not uniform.** feral:MA57 factor time is 4.17×,
+1.58×, 1.65×, **0.06×**, 1.36×. On ex4_2_160 feral is **18× faster**
+(71.8 ms vs 1.30 s; MA57 manages 344 MFlop/s there with `INFO(13) = 0`,
+so it is not a pivoting blowup). Any statement of the form "feral is
+N× slower than MA57" is a statement about a matrix, not about feral.
+
+**Finding 3 — throughput is a function of flops per front.**
+
+| matrix | flops/front | feral MFlop/s | MA57 MFlop/s | µs/front |
+|---|---|---|---|---|
+| optmass | 194 | 328 | 1284 | 0.591 |
+| steering_12800 | 1105 | 825 | 3127 | 1.339 |
+| robot_1600 | 1159 | 884 | 2354 | 1.311 |
+| ex4_2_160 | 16697 | 5308 | 344 | 3.146 |
+| arki0009 | 19234 | 5902 | 7153 | 3.259 |
+
+feral spans **18×** in throughput across the corpus; MA57 spans 5.6×.
+feral's small-front floor is 328 MFlop/s against MA57's 1284 — **3.9×
+worse**, which is precisely optmass's 4.17× gap. feral loses where, and
+only where, fronts are tiny, by the amount its small-front floor is worse.
+
+Least squares `t_us = a·fronts + b·flops` over the five points gives
+**a = 0.713 µs/front**, b = 1.474e-4 µs/flop (6783 MFlop/s marginal).
+The fit is crude (−35%..+26% residuals; it ignores that per-front cost
+also grows with `nrow`) but the split is not: the fixed term is 96% of
+optmass, ~81% of robot/steering, 20–23% of ex4_2_160/arki0009. At
+0.591 µs/front on optmass, ~2000 cycles at 3.5 GHz go into a 4×4 frontal
+matrix whose arithmetic is 194 flops. Remove the fixed term entirely and
+optmass's arithmetic alone is ~1250 µs against MA57's 6203 — feral would
+be 5× faster.
+
+**Finding 4 — allocation is 14% of it, not all of it.** A counting
+`GlobalAlloc` (`diag_200_alloc_count`) measures **7.9–8.1 heap
+allocations per frontal matrix**, uniform and independent of front size:
+346326 allocations on optmass, one per 24 flops. This cross-checks the
+samply profile exactly (346326 × ~10 ns ≈ 3.5 ms ≈ 13.5% of 25857 µs;
+profile reported `libsystem_malloc` at 13.6%). But it is only ~0.08 µs of
+the 0.591 µs/front: eliminating **every** per-front allocation takes
+optmass to ~22300 µs, still 3.6× MA57.
+
+**Decision.** The optimisation target for issue #200 is stated
+quantitatively and is now falsifiable: **reduce the fixed per-supernode
+cost from ~0.71 µs to ~0.18 µs**, which is MA57 parity on optmass. Any
+proposal for this issue must be evaluated against that number, on
+`diag_200_work_vs_ma57`'s uninstrumented min-of-9 timing, with the
+work-volume columns shown so a "win" that merely moved flops around is
+visible as such.
+
+**Corollaries, binding on future work.**
+- Do not open a performance investigation on this gap with a wallclock
+  ratio alone. Report fill and flops beside it or the number means
+  nothing.
+- The kernels, the ordering, the fill and the scaling are all exonerated
+  as the *cause*. They may still be worth improving; they are not the
+  answer to "why slower than MA57."
+- Growing fronts is not a shortcut to the fixed cost — see the third
+  `nemin` rejection in `tried-and-rejected.md` for the same date.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -7731,3 +7731,60 @@ visible as such.
   answer to "why slower than MA57."
 - Growing fronts is not a shortcut to the fixed cost — see the third
   `nemin` rejection in `tried-and-rejected.md` for the same date.
+
+---
+
+## 2026-09-05 — #200 is a duplicate of #153: the deficit is broad, not per-supernode
+
+**Supersedes the 2026-09-04 decision above**, whose target ("reduce the
+fixed per-supernode cost from ~0.71 µs to ~0.18 µs") rested on a fitted
+intercept that direct measurement refutes. See `tried-and-rejected.md`,
+same date, for both retractions (the least-squares fit and the
+single-run MA57 timing).
+
+**Evidence.** Front-size buckets from `Solver::with_profiling(true)`
+(`diag_200_front_size_buckets`), sequential driver, warm, min of 9:
+
+| matrix | snodes | seq µs | `≤8` % of nodes | `≤8` % of loop | `≤8` avg ns |
+|---|---:|---:|---:|---:|---:|
+| optmass | 43750 | 19081 | 91.4% | 49.1% | 161 |
+| robot_1600 | 5728 | 6363 | 65.4% | 15.2% | 227 |
+| steering_12800 | 25055 | 30183 | 76.6% | 17.1% | 183 |
+| ex4_2_160 | 22839 | 64159 | 60.8% | 4.2% | 177 |
+| arki0009 | 2357 | 7345 | 60.4% | 4.5% | 221 |
+
+Throughput against MA57, both sides min-of-9, same session:
+
+| matrix | feral MFlop/s | MA57 MFlop/s | ratio | time ratio |
+|---|---:|---:|---:|---:|
+| optmass | 444 | 1429 | 3.2× | 3.42× |
+| robot_1600 | 1044 | 2861 | 2.7× | 1.62× |
+| steering_12800 | 917 | 2934 | 3.2× | 1.39× |
+| ex4_2_160 | 5943 | 14329 | 2.4× | 2.05× |
+| arki0009 | 6173 | 9500 | 1.5× | 1.73× |
+
+**Decision.** feral runs at **1.5–3.2× fewer flops per second than MA57
+at every front size**, on 0.44–1.20× the work (the fill and flop-volume
+ratios from 2026-09-04 are symbolic, not timing-derived, and stand).
+That is an arithmetic/memory-throughput deficit spread across the whole
+front-size distribution, not a per-supernode constant. Issue #200 is
+therefore the same defect as #153 ("dtoc1nd: 3.8× MA57, concentrated in
+148 fronts of ncol≈62") and should be worked there.
+
+**Corollaries, binding on future work.**
+- A small-front fast path is capped at 34% of wall on the most
+  favourable matrix in the corpus and 4% on the least. It cannot reach
+  parity on any of them. Do not open one as a #200 fix.
+- The corollaries of the 2026-09-04 decision that do not depend on the
+  fitted intercept still hold: report fill and flops beside any
+  wallclock ratio; ordering, fill and scaling are exonerated as the
+  cause; `nemin` is not a lever (three rejections).
+- `PHASE_TIMING_ENABLED` is unfit for attribution on small-front trees
+  for two independent reasons, both now confirmed: its ~10
+  `Instant::now()` pairs per supernode cost 0.20–0.41 µs/front
+  (`diag_200_probe_tax`), *and* `src/dense/factor.rs:2168` routes
+  `ncol < 8` fronts to `factor_frontal_in_place_with_scratch`, which
+  carries no `PANELFACTOR`/`SCHUR`/`SCALARTAIL` counters — so their
+  arithmetic is uncounted and lands in `DENSEFACTOR`'s unnamed
+  remainder. The second mechanism was identified on the pounce side and
+  verified here in the source. Use `ProfileReport` instead.

--- a/dev/journal/2026-09-04-01.org
+++ b/dev/journal/2026-09-04-01.org
@@ -1,0 +1,338 @@
+* 19:40 :issue200:measurement:phase-timing:
+Started issue #200 (IPM-KKT factorization 2.7-2.9x slower than MA57,
+attributed to per-supernode overhead) on branch
+feat/200-per-supernode-overhead. Issue #200's headline is an
+UNATTRIBUTED bucket of 33-39% computed as
+=total - ASSEMBLY - DENSEFACTOR=. Before optimizing anything I tried to
+name that bucket, per the issue's own top recommendation.
+
+First pass: split factor() wallclock into prologue / loop / epilogue with
+the existing =phase_timing= counters plus =ProfileReport=, warm solver,
+=RAYON_NUM_THREADS=1=, min of 7. Prologue collapses to 1.2-12.4% once
+genuinely warm (the permute-value-map cache needs THREE factor calls
+before steady state: call 1 has no symbolic cache and by issue #56 N7
+deliberately builds no value map, call 2 builds it, call 3 is the first
+warm one). So the prologue is not the target and =permute= is 0.3-2.2%.
+
+Residual localized to inside the dense frontal factor: densefactor minus
+(panel+schur+scalartail) was 32-40% of total on small-front matrices
+(optmass, robot_1600, steering_12800; median front nrow 3-6) versus
+17-21% on large-front ones (ex4_2_160, arki0009; max front 461/509).
+
+* 20:05 :issue200:phase-timing:hypothesis-rejected:
+Hypothesis: the scalar in-place path
+=factor_frontal_in_place_with_scratch_impl= (taken when
+=ncol < PANEL_MIN_NCOL=, i.e. 8) has NO phase counter on its
+=scalar_pivot_step= loop -- only LEXTRACT/CONTRIBEXTRACT are timed there,
+and SCALARTAIL_NS covers only the tail inside the *blocked* entry. So on
+tiny-front KKTs the real elimination arithmetic would land in the
+unattributed residual and read as overhead.
+
+Added =SCALARLOOP_NS= plus =SCALARLOOP_FRONTS= / =PANEL_FRONTS=.
+Routing confirmed: 76.6-91.4% of fronts take the scalar path. But the
+time did not: scalar-loop is only 1.6-4.5% of total. Hypothesis rejected
+-- the tiny fronts are numerous but cheap. Unnamed residual still
+5.5-23.7%.
+
+* 20:20 :issue200:measurement:probe-tax:invalidates-issue:
+Normalized the unnamed residual per front:
+
+| matrix     | unnamed us | fronts | ns/front |
+| optmass    |       6918 |  43750 |      158 |
+| robot_1600 |       1948 |   5728 |      340 |
+| steering   |       8033 |  25055 |      321 |
+| ex4_2_160  |       4083 |  22839 |      179 |
+| arki0009   |        559 |   2357 |      237 |
+
+A per-front CONSTANT, independent of matrix. That is issue #200's thesis
+-- but it is also exactly the signature of the measurement apparatus.
+Confirmed directly: bracketing the two remaining untimed regions
+(front entry setup, front exit tail) with two more counter pairs raised
+optmass densefactor-bookkeeping from 35.0% to 41.9% of total, i.e.
++4139 us over 43750 fronts = +95 ns/front, which is 4 extra
+=Instant::now()= calls at ~24 ns each on this machine.
+
+Decisive experiment: =diag_200_probe_tax=, paired alternating A/B on one
+warm Solver, =PHASE_TIMING_ENABLED= off vs on, min_us of 9 pairs:
+
+| matrix     | OFF us | ON us | ratio | fronts | tax ns/front |
+| optmass    |  23216 | 41181 |  1.77 |  43750 |          411 |
+| robot_1600 |   7483 |  9758 |  1.30 |   5728 |          397 |
+| steering   |  33630 | 44335 |  1.32 |  25055 |          427 |
+| ex4_2_160  |  70632 | 78598 |  1.11 |  22839 |          349 |
+| arki0009   |   8470 |  8930 |  1.05 |   2357 |          195 |
+
+CONCLUSION: =phase_timing= costs ~350-430 ns per front and inflates
+optmass factor time by 1.77x. The multifrontal driver brackets ~10
+regions per supernode; on a matrix whose median front is 3x3 that is a
+per-front constant of the same order as the residual being attributed.
+Mechanism for why it lands in the residual specifically: DENSEFACTOR_NS
+brackets the whole dense factor, so the inner probes' own cost IS counted
+inside DENSEFACTOR but is NOT counted inside PANELFACTOR / SCHUR /
+LEXTRACT / CONTRIBEXTRACT -- it appears precisely as
+"densefactor minus its named children".
+
+Issue #200's UNATTRIBUTED 33-39% is therefore not a finding about feral.
+It is the cost of measuring feral. Every percentage in the issue is a
+fraction of a denominator inflated by up to 1.77x. Recorded here before
+any optimization work, because acting on that attribution would have
+meant optimizing the profiler.
+
+* 20:45 :issue200:profiling:samply:
+Switched to a sampling profiler (=samply=, already installed) to get
+attribution with no instrumentation at all. New binary
+=diag_200_hotloop= factors a warm matrix in a loop with every counter
+off. Recorded at 2000 Hz, 300 iterations, =RAYON_NUM_THREADS=1=.
+Symbolized via the =--unstable-presymbolicate= sidecar (function-level;
+no line info).
+
+SELF-time budget on the real, uninstrumented factorization:
+
+| group                              | optmass | robot_1600 | steering | ex4_2_160 |
+| driver self (factor_one_supernode) |   12.4% |      10.1% |    11.4% |     17.0% |
+| dense-entry self (blocked+scalar)  |   16.1% |      13.4% |    14.7% |     14.3% |
+| pivot arithmetic                   |   19.9% |      38.8% |    27.4% |      9.3% |
+| memmove/memset/bzero               |    8.7% |       6.4% |     6.0% |      7.8% |
+| allocator                          |    2.6% |       1.2% |     0.9% |      0.7% |
+| scaling (infnorm)                  |    5.6% |       2.0% |    19.9% |      5.7% |
+| rayon/thread wait                  |    9.9% |      15.0% |     3.1% |      2.3% |
+| unresolved                         |   15.7% |       6.5% |     5.8% |      3.4% |
+| other                              |    9.0% |       6.6% |    10.8% |     39.6% |
+
+Inclusive times on optmass: factor_one_supernode 72.5%,
+factor_frontal_blocked_in_place_with_scratch 47.8%,
+factor_frontal_in_place_with_scratch_impl 21.7%.
+
+Issue #200's THESIS survives its broken measurement: per-front management
+(driver self + dense-entry self, neither of which is arithmetic) is
+24-31% of real factor time, and it is a per-front constant. But the
+target moved -- it is split roughly evenly between the driver's own
+per-supernode code and the two dense-factor entry/exit paths, not
+concentrated in one unattributed bucket.
+
+Unplanned finding: steering_12800 spends 19.9% of factor time in
+=compute_infnorm= / =scaled_matrix_infnorm=. That is prologue scaling
+work, per factor call, not per supernode -- outside issue #200's scope
+and much larger on that matrix than anything the issue describes.
+
+* 21:30 :issue200:amalgamation:rejected:
+Tested the master lever. Every per-front cost issue #200 is about is
+paid once per front, so front SIZE moves all of them at once. Default
+=nemin= is already 32 (SSIDS's value) yet optmass's median front nrow is
+4 and 95.5% of fronts have nrow<=8, so the question was whether the size
+rule =child_ncol < nemin && parent_ncol < nemin= is binding or whether
+the column-adjacency precondition
+(=s_first + s_ncol != p_first => continue=, supernode.rs:395) rejects
+merges before the size rule is consulted.
+
+=diag_200_amalg_sweep=: nemin in {32,64,128,512} x {Renumber,Adjacency},
+warm solver, phase timing OFF, min of 7, residual reported alongside.
+
+optmass_0002 (n=110011):
+| config          | snodes | med | max | %<=8  | us      | ratio | resid   |
+| renumber n=32   |  41875 |   4 |  34 | 95.5% |   30795 |  1.00 | 1.98e-6 |
+| renumber n=64   |  40921 |   4 |  66 | 97.7% |   42199 |  1.37 | 1.90e-6 |
+| renumber n=128  |  40403 |   4 | 130 | 98.8% |   79313 |  2.58 | 2.00e-6 |
+| renumber n=512  |  40052 |   4 | 514 | 99.7% |  791276 | 25.70 | 1.77e-6 |
+| adjacency n=512 |  40122 |   4 | 514 | 99.7% |  979293 | 31.80 | 1.92e-6 |
+
+robot_1600_0002 ratios: 1.00 / 1.78 / 4.09 / 46.60.
+steering_12800_0002 ratios: 1.00 / 1.71 / 3.08 / 39.03.
+
+REJECTED. Raising nemin 32->512 removes only 4% of supernodes
+(41875 -> 40052) and NEVER moves the median front off 4 -- it only lets a
+handful of fronts grow to 514, which are then dense and cost 25-46x. The
+tiny-front regime is a property of these IPM-KKT elimination trees, not a
+tuning choice: the fronts are small because the tree is bushy and the
+column counts are genuinely 2-6, so there is nothing to merge that does
+not immediately create fill. Neither strategy (Renumber or Adjacency)
+changes this. Front size is not an available lever.
+
+* 21:50 :issue200:scaling:knight-ruiz:rejected:
+Chasing the one large non-arithmetic item left: samply says
+=compute_infnorm= is 18.0% of steering_12800's real factor time, called
+straight from =factorize_multifrontal_supernodal_with_workspace=, not
+from =compute_scaling_with_cache=.
+
+Cause (=diag_200_kr_iters=, replica of the KR loop, same tol 1e-8, same
+cap 10): the scaling does not converge on IPM-KKTs and burns the cap
+every call. Sweeps used: optmass 2, arki0009 3, robot_1600 10,
+steering_12800 10, ex4_2_160 10. Scaling cost tracks this exactly
+(optmass 5.6% of factor time, steering 19.9%).
+
+Lever 1, warm-start =d= from the previous IPM iterate's scaling
+(=diag_200_kr_warmstart=). REJECTED -- it is worse, not cheaper:
+
+| matrix              | cold-10 | warm-1 | warm-2 | warm-3 | max|dw-dc|/dc |
+| steering..._0001    | 1.78e-2 | 7.63e0 |7.64e-1 |4.60e-1 |       6.73e-1 |
+| steering..._0002    | 1.94e-2 | 1.23e0 |4.59e-1 |2.40e-1 |       4.92e-1 |
+| ex4_2_160_0002      | 4.42e-2 | 1.70e2 |9.42e-1 |7.59e-1 |       4.63e-1 |
+
+Three warm sweeps land 1-2 orders of magnitude WORSE than ten cold ones,
+and the resulting scaling vector differs from the cold one by up to 170%.
+Consecutive KKTs are not close enough in the KR metric for the previous
+fixed point to be a good start.
+
+Lever 2, lower the 10-sweep cap. REJECTED -- the iteration is not
+plateauing, it is converging linearly at rate ~0.5/sweep, so every sweep
+dropped costs a factor of two in scaling quality. Per-sweep
+=max_i|rowmax_i - 1|= on steering_12800_0002:
+1.48e6, 9.99e-1, 9.41e-1, 7.33e-1, 4.74e-1, 2.71e-1, 1.46e-1, 7.54e-2,
+3.84e-2, 1.94e-2. Cutting the cap to 4 leaves 7.33e-1 instead of 1.94e-2.
+optmass by contrast is at 2.22e-16 by sweep 2, which is why it only uses
+2. The cap is already a deliberate speed/quality tradeoff.
+
+* 22:05 :issue200:verdict:
+Answer to "is there any improvement to be had here": very little, and
+none of it cheap. Ceiling on the remaining candidate, measured not
+estimated -- self time by library on the uninstrumented run:
+
+| library                  | optmass | robot_1600 | steering | ex4_2_160 |
+| binary (feral code)      |   69.5% |      73.6% |    84.4% |     86.6% |
+| libsystem_malloc         |   13.6% |       5.7% |     5.2% |      3.0% |
+| libsystem_platform       |    9.0% |       6.7% |     6.3% |      7.9% |
+| libsystem_kernel         |    5.5% |      13.1% |     4.0% |      2.1% |
+| libsystem_pthread        |    2.3% |       0.8% |     0.0% |      0.4% |
+
+libsystem_kernel is almost entirely =__psynch_cvwait= (optmass 4.44%,
+robot_1600 12.45%) -- rayon workers idling, an artifact of running the
+parallel driver under RAYON_NUM_THREADS=1, not a cost to optimize.
+
+So the only real remaining target is malloc traffic: ~6 owned
+allocations per front (=perm=, =perm_inv=, =l=, =d_diag=, =d_subdiag=,
+plus driver-side =NodeFactors=), which is 13.6% of factor time on the
+worst matrix and 3-6% on the rest. Capturing it means an arena for the
+factor data, because those Vecs are the persistent output (they live
+until solve) and cannot simply be pooled. That is an architectural change
+to =FrontalFactors= / =NodeFactors= for a bounded ~13.6% best case on one
+matrix -- and the prior art here (Phase 2.11 SmallLeafBatch) is a
+"24-27% reduction" that evaporated into ~5% noise on a 5-run repeat.
+Not recommending it without the user deciding the cost is worth it.
+
+* 23:10 :issue200:ma57:workvolume:explanation:
+Stopped profiling feral in isolation and measured *work volume* against
+MA57, which no prior session had done. Patched
+=external_benchmarks/ma57_oracle/ma57_bench.F= to emit INFO(14)
+(nnz in factors), INFO(13) (delayed pivots), RINFO(3) (assembly flops),
+RINFO(4) (elimination flops), INFO(5) (forecast reals); rebuilt and ran
+on the five issue-#200 matrices. feral side via new
+=diag_200_work_vs_ma57= (nnz_L from =Solver::last_factor_stats()=; flops
+counted from the symbolic supernode shapes with the same
+sum_{k<ncol}(nrow-k)^2 model RINFO(4) uses, so no probe distortion).
+
+| matrix     | feral nnzL | MA57 nnzL | fill f/M | feral flops | MA57 flops | work f/M |
+|------------+------------+-----------+----------+-------------+------------+----------|
+| optmass    |     800012 |    795017 |     1.01 |    8.479e+6 |   7.965e+6 |     1.06 |
+| robot_1600 |     379894 |    450225 |     0.84 |    6.641e+6 |   1.122e+7 |     0.59 |
+| steering   |    1884513 |   2420634 |     0.78 |    2.768e+7 |   6.355e+7 |     0.44 |
+| ex4_2_160  |    2959405 |   2757122 |     1.07 |    3.813e+8 |   4.477e+8 |     0.85 |
+| arki0009   |     370387 |    309395 |     1.20 |    4.534e+7 |   4.031e+7 |     1.12 |
+
+*feral never does meaningfully more work.* Fill is 0.78-1.20x MA57's,
+flops 0.44-1.12x. On steering feral does 2.3x FEWER flops and is still
+1.65x slower. So the gap is not ordering, not fill, not extra
+arithmetic. It is arithmetic *efficiency*.
+
+Wallclock (uninstrumented, min of 9, warm, RAYON_NUM_THREADS=1) and the
+resulting rates:
+
+| matrix     | feral us | MA57 us | time f/M | feral MF/s | MA57 MF/s | flops/front | us/front |
+|------------+----------+---------+----------+------------+-----------+-------------+----------|
+| optmass    |    25857 |    6203 |     4.17 |        328 |      1284 |         194 |    0.591 |
+| robot_1600 |     7510 |    4766 |     1.58 |        884 |      2354 |        1159 |    1.311 |
+| steering   |    33552 |   20325 |     1.65 |        825 |      3127 |        1105 |    1.339 |
+| ex4_2_160  |    71844 | 1302836 |     0.06 |       5308 |       344 |       16697 |    3.146 |
+| arki0009   |     7681 |    5636 |     1.36 |       5902 |      7153 |       19234 |    3.259 |
+
+Two things fall out.
+
+1. The "2.7-2.9x slower" premise of issue #200 is wrong. The ratio spans
+   0.06x to 4.17x - a 70-fold spread. On ex4_2_160 feral is *18x faster*
+   than MA57 (71.8ms vs 1.30s; MA57 manages only 344 MFlop/s there with
+   INFO(13)=0 delayed pivots, so it is not a pivoting blowup - unexplained,
+   but it is MA57's problem, not feral's).
+
+2. feral's throughput is a clean monotone function of flops per front:
+   194 -> 328 MF/s, 1105-1159 -> 825-884, 16697-19234 -> 5308-5902. An
+   18x throughput spread across the corpus. MA57 over the same range
+   spans only 5.6x (1284 -> 7153) and its *small-front floor is 3.9x
+   above feral's*. That single fact is the whole gap: wherever feral
+   loses, it loses exactly where fronts are tiny, and by the amount its
+   small-front floor is worse.
+
+Least-squares fit t_us = a*fronts + b*flops over the five points gives
+a = 0.713 us/front, b = 1.474e-4 us/flop (6783 MFlop/s marginal). The fit
+is crude (-35%..+26% residuals; it ignores that per-front cost also grows
+with nrow) but the split it implies is not subtle: the fixed-per-front
+term is 96% of optmass, 81% of robot/steering, and only 20-23% of
+ex4_2_160/arki0009. Strip the fixed term entirely and optmass's
+arithmetic alone would be ~1250 us against MA57's 6203 - feral would be
+5x *faster*. At 0.591 us/front on optmass, ~2000 cycles at 3.5 GHz are
+spent per 4x4 frontal matrix whose actual arithmetic is ~194 flops.
+
+*Conclusion: the answer to "why is feral slower than MA57" is a fixed
+cost of roughly 0.5-0.7 us per supernode, ~4x MA57's, on trees whose
+median front is 3-7 rows.* Nothing about the dense kernels, the ordering,
+or the fill explains any of it.
+
+* 23:25 :issue200:allocation:perfront:
+Quantified one component of the per-front fixed cost directly. New
+=diag_200_alloc_count= installs a counting =GlobalAlloc= wrapper and
+tallies allocations across one warm =factor()=:
+
+| matrix     | fronts | allocs | alloc/front | MB    | bytes/front |
+|------------+--------+--------+-------------+-------+-------------|
+| optmass    |  43750 | 346326 |        7.92 |  74.8 |        1710 |
+| robot_1600 |   5728 |  44975 |        7.85 |  16.9 |        2959 |
+| steering   |  25055 | 175414 |        7.00 |  58.6 |        2341 |
+| ex4_2_160  |  22839 | 183314 |        8.03 | 129.7 |        5679 |
+| arki0009   |   2357 |  18997 |        8.06 |  21.2 |        8995 |
+
+Essentially exactly *8 heap allocations per frontal matrix*, uniformly,
+independent of front size. On optmass that is 346k malloc round trips for
+8.5e6 flops - one allocation per 24 flops.
+
+Cross-checks against the samply profile: libsystem_malloc was 13.6% of
+optmass time; 346326 allocs x ~10ns fast-path = ~3.5ms = 13.5% of
+25857 us. The two independent measurements agree.
+
+But this bounds the prize honestly: allocation is ~14% of the
+0.591 us/front, i.e. ~0.08 us of it. Eliminating *every* per-front
+allocation would take optmass from 25857 to ~22300 us - still 3.6x MA57.
+It is real and worth doing, but it is not the explanation on its own.
+The remaining ~0.5 us/front is spread across driver self-time (12.4%),
+dense-entry self-time (16.1%), memmove/memset (8.7%) and the 15.7%
+that stayed unresolved in the profile.
+
+Known per-front allocations from reading =factor_frontal_*=: =perm=
+(Vec<usize>, nrow), =perm_inv= (Vec<usize>, nrow), =l= (vec![0.0;
+nrow*nelim]), =d_diag=, =d_subdiag= (=subdiag[..nelim].to_vec()=), plus
+pooled =contrib=. That accounts for 5-6 of the 8; the rest are inside
+callees not yet traced.
+
+* 23:50 :issue200:instrumentation:revert:
+Reverted the five =phase_timing= counters added this session
+(SCALARLOOP_NS, FRONTSETUP_NS, FRONTTAIL_NS, SCALARLOOP_FRONTS,
+PANEL_FRONTS, =phase_timing::count=) from =src/dense/factor.rs=, leaving
+=src/= byte-identical to session start. Re-ran =diag_200_probe_tax=
+after the revert:
+
+| matrix   | OFF us | ON us | ratio | fronts | tax ns/front |
+|----------+--------+-------+-------+--------+--------------|
+| optmass  |  22394 | 34151 |  1.52 |  43750 |          269 |
+| arki0009 |   7635 |  8129 |  1.06 |   2357 |          210 |
+
+Before the revert the same measurement read 1.77x / 411 ns on optmass.
+So the five counters were costing ~140 ns/front on their own - added to
+the exact hot path whose fixed per-front cost is the subject of the
+issue. Keeping them would have made every future measurement worse while
+providing nothing obtainable statically: =diag_200_probe_tax= now takes
+its front count from =symbolic_factorize(..).supernodes.len()=, and
+=diag_200_where_is_time= dropped its scalar-loop/setup/tail columns.
+
+Gates: =cargo test --release= all green (0 FAILED across the workspace);
+=cargo clippy --all-targets --release -- -D warnings= clean;
+=cargo fmt --check= clean after one fmt pass on the new diagnostics.
+=cargo run --bin bench --release= unchanged as expected (src untouched):
+sparse small-frontal p90 1.55 PASS, medium p90 1.55 PASS; dense 1.60 and
+2.03 PASS.

--- a/dev/journal/2026-09-05-01.org
+++ b/dev/journal/2026-09-05-01.org
@@ -138,3 +138,124 @@ not timing-derived, and reproduce). It is not a small-front phenomenon
 and not a large-front phenomenon; it is arithmetic/memory efficiency
 across the board, which makes #200 a duplicate of #153 rather than a
 distinct per-supernode-overhead problem.
+
+* 22:30 :issue153:kernel:ceiling:
+Question from the user: what are the *prospects* of actually fixing
+#153? The record (journal agent sweep of =dev/journal=,
+=tried-and-rejected.md=, =dev/research=) says every structural BLAS3
+restructuring tried so far regressed (row-band blocking 0.74-0.95x,
+source-panel packing +11-22%, deferred-update variant +11%,
+=block_size=48= 1.3% of total) and that the only wins were
+micro-kernel-level (packing 22-26x isolated, pulp dispatch fix 2.7x on
+x86) and scheduling-level (intra-front gate 2.68x). It also says the
+one decision-relevant measurement had never been made: *no in-repo
+feral-vs-BLAS number on the same shape exists.* Made it.
+
+Isolated square dense kernel, this machine, 1 thread, min-of-N,
+=sum_{k<ncol}(nrow-k)^2= multiply-adds throughout:
+
+| n   | feral factor_frontal | LAPACK dsytrf | dgemm |
+|-----+----------------------+---------------+-------|
+| 64  |                 7585 |         11180 |     - |
+| 96  |                 9158 |          9985 |     - |
+| 128 |                11226 |         11594 |     - |
+| 192 |                11582 |         13434 |     - |
+| 256 |                10428 |         15713 |     - |
+| 512 |                10897 |         20396 | 27600 |
+
+So on *square* fronts feral's kernel is at dsytrf parity to 1.9x. That
+is the good news and it is also misleading, because the corpus does not
+produce square fronts.
+
+* 22:40 :issue153:headroom:decomposition:
+New binary =diag_153_kernel_headroom=: profile a real factorization,
+group the supernodes by exact =(nrow, ncol)=, re-time =factor_frontal=
+standalone on every distinct shape that occurred, and reconstitute
+=kernel_ns = sum(count * isolated_ns)=. =headroom = loop_ns/kernel_ns=
+is then the factor by which the solver is slower than *its own kernel*
+on the identical shape sequence -- the ceiling on what non-arithmetic
+work can be worth. =extra_elims = sum(ncol) - n = 0= on all five, so no
+delayed pivots inflate the replay.
+
+| matrix     | loop us | kernel us | headroom | prol+epi | % of driver |
+|------------+---------+-----------+----------+----------+-------------|
+| optmass    |   12227 |      6601 |    1.85x |     4083 |         25% |
+| robot_1600 |    5206 |      2745 |    1.90x |     1817 |         26% |
+| steering   |   19342 |     10896 |    1.78x |     7829 |         29% |
+| ex4_2_160  |   56759 |     51086 |    1.11x |     5930 |          9% |
+| arki0009   |    6728 |      6174 |    1.09x |      599 |          8% |
+
+*The deficit splits cleanly into two disjoint populations.* The
+small/medium-front matrices spend ~46% of the supernode loop outside
+their own arithmetic; the large-front matrices spend ~9%. Projecting
+the (unreachable) ceiling headroom -> 1.00 onto the measured
+sequential walls:
+
+| matrix     | now vs MA57 | loop at kernel speed | then vs MA57 |
+|------------+-------------+----------------------+--------------|
+| optmass    |       3.42x |          19081->13455|        2.41x |
+| robot_1600 |       1.62x |            6363->3902|        0.99x |
+| steering   |       1.39x |          30183->21737|        1.00x |
+| ex4_2_160  |       2.05x |          64159->58486|        1.87x |
+| arki0009   |       1.73x |            7345->6791|        1.60x |
+
+robot_1600 and steering_12800 reach MA57 *parity* on solver plumbing
+alone -- no kernel change, no BLAS.
+
+* 22:55 :issue153:blas:shapecomparison:
+Second new probe, =dev/scripts/blas_front.f=: the kernel MA57 actually
+runs -- =dsytrf= on the leading ncol block, =dtrsm=, D-scale, one
+=dsyrk= Schur update -- on the *exact* shapes
+=diag_153_kernel_headroom= reports as dominant. Same OpenBLAS MA57
+links, same flop model, 1 thread, batch-timed with a copy-only loop
+subtracted (SYSTEM_CLOCK's 1 us granularity is longer than a small
+front; the earlier min-of-N version reported 9e9 MMac/s on a 3x3 and
+had to be thrown away).
+
+| nrow | ncol | feral MMac/s | BLAS MMac/s | BLAS/feral |
+|------+------+--------------+-------------+------------|
+|    3 |    1 |          108 |         104 |      0.96x |
+|    4 |    2 |          301 |         249 |      0.83x |
+|   11 |    3 |         1208 |        1700 |      1.41x |
+|   18 |   16 |         2404 |        2989 |      1.24x |
+|   36 |   16 |         5162 |        9450 |      1.83x |
+|   44 |   16 |         6044 |       12022 |      1.99x |
+|   56 |   16 |         6854 |       16018 |      2.34x |
+|   76 |   16 |         7542 |       20320 |      2.69x |
+|  345 |   16 |         8323 |       39349 |      4.73x |
+|  365 |   22 |         8305 |       41161 |      4.96x |
+
+*feral's kernel wins on 3x3 and 4x2 and saturates at ~8300 MMac/s from
+nrow~76 onward, while BLAS keeps scaling to ~41000.* The saturation is
+at fixed =ncol=16= with growing =nrow=, i.e. it is the trailing rank-16
+symmetric update that stops scaling, not the panel. That is a specific,
+diagnosable kernel defect and not "the BLAS-free ceiling": feral's own
+*square* kernel does 11600 at n=192, so the wide-trapezoidal path is
+running 1.4x below feral's own demonstrated capability, before any
+argument about SIMD or FMA.
+
+Caveat recorded rather than buried: the shared =sum(nrow-k)^2= model
+counts the full trailing square where a symmetric update touches only a
+triangle, so absolute MMac/s over-counts by up to ~2x on the wide
+shapes. It over-counts both columns identically, so the ratio column is
+sound; the absolute numbers must not be set against a vendor GFLOP/s.
+
+* 23:05 :issue153:prospects:conclusion:
+Prospects, stated as three separable targets rather than one:
+
+1. *Solver plumbing on small/medium-front matrices.* 1.78-1.90x of the
+   supernode loop, pure Rust, no bit-exactness exposure. Ceiling: MA57
+   parity on robot_1600 and steering_12800, 3.42x -> 2.41x on optmass.
+2. *Prologue + epilogue.* 25-29% of the driver on those same three
+   matrices (8-9% on the large-front two). Never attributed before
+   today. MA57 also permutes and scales, so this is not all recoverable,
+   but a quarter of the wall has not been looked at.
+3. *The wide-trapezoidal trailing update.* Only target that touches
+   arithmetic. Needed: 1.6-1.9x on ex4_2_160/arki0009. Available before
+   matching BLAS: feral's own square kernel is already 1.4x above where
+   the trapezoidal path saturates.
+
+None of the three requires BLAS, FMA, or breaking bit-exactness. The
+2026-05-22 verdict "realistic pure-Rust micro-kernel headroom is ~2-3x"
+stands and is *sufficient* -- #153 needs 1.4-3.4x, and roughly half of
+it turns out not to be micro-kernel work at all.

--- a/dev/journal/2026-09-05-01.org
+++ b/dev/journal/2026-09-05-01.org
@@ -1,0 +1,140 @@
+#+TITLE: Session 2026-09-05-01
+#+DATE: 2026-09-05
+
+* 20:20 :issue200:newinfo:
+Reopened #200 because a new comment (2026-09-05, from the pounce/pglib
+side) retracts the issue's own headline using a much larger AC-OPF KKT
+(=case10000_goc=, n=351559, nnz=1052677) than the =case300_ieee= KKT the
+issue was filed from. Its claims, in the order they matter to us:
+
+1. Front-size buckets from feral's own =Solver::with_profiling(true)=:
+   fronts of nrow<=8 are 68% of supernodes but 10.7% of loop time; 85%
+   of loop time is in fronts >=17 rows. A small-front fast path is
+   therefore capped at ~10%.
+2. The issue's "1.5% of time is arithmetic" is an instrument artifact:
+   =dense/factor.rs= routes ncol<8 fronts to
+   =factor_frontal_in_place_with_scratch=, which carries no
+   PANEL/SCHUR/SCALARTAIL counters, so small-front arithmetic is
+   uncounted and lands in DENSEFACTOR's unnamed remainder.
+3. A bump allocator (pointer-bump alloc, no-op free) moves the large
+   AC-OPF factorization by 0.6-7.7% (138.32 -> 134.37 ms), inside
+   run-to-run spread. The 732258 allocations/factor are real and are
+   *not* the cost.
+4. =nemin= has an interior optimum at 8 on that matrix (131.10 ms vs
+   135.70 at the default 16), not the monotone trend the issue reported.
+
+Claims 2 and 3 bear directly on the comment this branch posted
+(2026-09-04), whose candidate list led with "eliminate the 8 per-front
+allocations" and whose §4 attributed 96% of optmass to a fixed
+per-front term.
+
+* 20:24 :issue200:codeinspection:confirmed:
+Verified claim 2 in the source. =src/dense/factor.rs:2168= sets
+=PANEL_MIN_NCOL = 8= and =ncol < PANEL_MIN_NCOL= returns
+=factor_frontal_in_place_with_scratch=. Grepping the counters inside
+=factor_frontal_in_place_with_scratch_impl= (lines 1724-1990) finds
+LEXTRACT_NS, CONTRIBEXTRACT_NS and CONTRIBZEROFILL_NS but *no*
+PANELFACTOR_NS, SCHUR_NS or SCALARTAIL_NS. Confirmed as stated: on a
+tree whose median front is 3-7 rows most arithmetic is uncounted by the
+arithmetic counters.
+
+This is a *second* mechanism feeding the UNATTRIBUTED bucket, additive
+to the probe-tax mechanism this branch reported on 2026-09-04. Our
+explanation was correct but incomplete; theirs identifies the larger
+half.
+
+* 20:40 :issue200:frontsize:refutation:
+Ran their instrument on our matrices. New binary
+=diag_200_front_size_buckets= (feral's own =with_profiling(true)= ->
+=ProfileReport=, whose buckets are exactly the ranges they report; one
+=Instant::now()= pair per supernode, not the ~10 of PHASE_TIMING).
+Sequential driver, warm solver, min of 9, RAYON_NUM_THREADS=1. Probe
+tax measured alongside: 0.96-1.12x, i.e. negligible except on optmass.
+
+| matrix     | snodes | seq us | loop ns  | <=8 nodes | <=8 % loop | <=8 avg ns |
+|------------+--------+--------+----------+-----------+------------+------------|
+| optmass    |  43750 |  19081 | 13081956 |     39999 |      49.1% |        161 |
+| robot_1600 |   5728 |   6363 |  5595600 |      3744 |      15.2% |        227 |
+| steering   |  25055 |  30183 | 20597704 |     19184 |      17.1% |        183 |
+| ex4_2_160  |  22839 |  64159 | 58165882 |     13896 |       4.2% |        177 |
+| arki0009   |   2357 |   7345 |  6980262 |      1424 |       4.5% |        221 |
+
+Where the rest goes: optmass 50.8% in 3748 fronts of 17-32 rows (8.6% of
+nodes, 1773 ns each); steering 82.9% in 5865 fronts of 17-32 (2910 ns);
+robot 76.4% in 939 fronts of 17-32 (4551 ns); ex4_2_160 64.6% in 295
+fronts >128 (127413 ns); arki0009 64.3% in 33 fronts >128 (135995 ns).
+
+*Their finding reproduces on a different matrix class.* Even on
+optmass -- the extreme small-front case, 91.4% of whose supernodes are
+<=8 rows -- half the loop is in the 8.6% of fronts with 17-32 rows, and
+the <=8 bucket is 34% of *wall* (6.43 of 19.08 ms), not 96%.
+
+The =<=8= average is 161-227 ns on all five, against the 196 ns they
+report on a 351k-row AC-OPF KKT. Two corpora, two machines-worth of
+matrices, same constant. *The per-front constant is ~0.2 us, not the
+0.71 us this branch fitted.*
+
+* 20:45 :issue200:retraction:leastsquares:
+So §4 of the 2026-09-04 comment is wrong, and the reason is now clear.
+The fit =t = a*fronts + b*flops= has no nrow term, so the intercept
+absorbed the medium-front work: 3748 optmass fronts x 1773 ns = 6.6 ms
+of the 13.1 ms loop got charged to "fixed per-front cost". The caveat
+was stated in that comment ("it ignores that per-front cost also grows
+with nrow") and then not weighted. Direct per-front-size measurement
+beats a two-parameter fit; it was available in-tree the whole time
+(=Profiler::report()=, issue #52 Phase B).
+
+Ceiling that follows: making *every* <=8-row front free takes optmass
+from 19081 to ~12650 us, i.e. 3.42x MA57 -> 2.27x. Still not parity.
+Small-front work cannot be the answer even where it is 34% of wall.
+
+* 21:05 :issue200:ma57:outlier:retraction:
+Re-ran the MA57 oracle in-session so the ratio table is same-thermal.
+9 cold runs per matrix, min taken, ICNTL(15)=0, OPENBLAS_NUM_THREADS=1.
+feral re-measured today under both drivers, min of 9, warm.
+
+| matrix     | feral par | feral seq | MA57 | seq/MA57 | par (2026-09-04) | MA57 (2026-09-04) |
+|------------+-----------+-----------+------+----------+------------------+-------------------|
+| optmass    |     26129 |     19081 | 5575 |     3.42 |            25857 |              6203 |
+| robot_1600 |      6786 |      6363 | 3922 |     1.62 |             7510 |              4766 |
+| steering   |     30529 |     30183 |21660 |     1.39 |            33552 |             20325 |
+| ex4_2_160  |     65272 |     64159 |31244 |     2.05 |            71844 |           1302836 |
+| arki0009   |      7720 |      7345 | 4243 |     1.73 |             7681 |              5636 |
+
+feral reproduces within 10% on every matrix. MA57 reproduces within 30%
+on four -- and is off by *38x* on ex4_2_160. 1302836 us is not
+reproducible: 9 cold runs today give 32565 31244 33088 32525 36999
+62353 48235 55242 37053 us, and a scaling sweep (ICNTL(15) = 0,1,2,3,4)
+gives 42745 / 42614 / 48992 / 66640 / 42442 -- nothing within an order
+of magnitude. Same binary, same matrix: INFO(14)=2757122 and
+RINFO(4)=4.4772e8 match the 2026-09-04 run exactly.
+
+So the 2026-09-04 comment's "on ex4_2_160 feral is 18x faster than
+MA57" and "the ratio spans 70-fold" are *retracted*: one MA57 datapoint
+was a single cold run that stalled, and the harness does one
+factorization per invocation, so nothing averaged it away. Min-of-N on
+the MA57 side is now mandatory; the 2026-09-04 protocol only applied it
+to feral.
+
+Corrected spread: *1.4x to 3.4x*, which is compatible with the original
+issue's 2.7-2.9x and with the new comment's ~2-3x. There is no regime
+where feral wins on this corpus.
+
+* 21:15 :issue200:efficiency:conclusion:
+Recomputing throughput with today's numbers (feral sequential; flop
+counts unchanged, symbolic-derived):
+
+| matrix     | feral MF/s | MA57 MF/s | ratio |
+|------------+------------+-----------+-------|
+| optmass    |        444 |      1429 |  3.2x |
+| robot_1600 |       1044 |      2861 |  2.7x |
+| steering   |        917 |      2934 |  3.2x |
+| ex4_2_160  |       5943 |     14329 |  2.4x |
+| arki0009   |       6173 |      9500 |  1.5x |
+
+The deficit is *broad*: 1.5-3.2x at every front size, on 0.44-1.20x the
+work (fill and flop ratios from 2026-09-04 stand -- they are symbolic,
+not timing-derived, and reproduce). It is not a small-front phenomenon
+and not a large-front phenomenon; it is arithmetic/memory efficiency
+across the board, which makes #200 a duplicate of #153 rather than a
+distinct per-supernode-overhead problem.

--- a/dev/journal/2026-09-05-01.org
+++ b/dev/journal/2026-09-05-01.org
@@ -392,3 +392,45 @@ named counters explain only ~40% of it -- roughly 800-1200 ns/front is
 unattributed. PHASE_TIMING's 350-430 ns/front probe tax makes it the
 wrong instrument at that size class; a lighter targeted probe is
 needed before anyone optimizes there.
+
+* 20:38 :issue-153:extend-add:optimization:measurement:
+Implemented the extend-add index-hoist that the revised #153 plan named as
+the only remaining unrejected lever, and tuned it by measurement.
+
+The defect: =extend_add= evaluated =parent_row_map[contrib.row_indices[ci]]=
+— two dependent gathers — inside the =ci= loop, so each child row was
+resolved once per column: cdim*(cdim+1)/2 double-gathers where cdim suffice.
+
+Final form: a pooled =pidx= buffer in =FactorWorkspace=, a monotone fast
+path (=ci >= cj= implies =pidx[ci] >= pidx[cj]=, so the =usize::MAX= test
+and lower-triangle compare/swap drop out of the inner loop), and a
+=SMALL_CDIM = 4= bypass straight to the original doubly-gathered loop.
+
+Measured mean cdim: 2.2 optmass, 5.3 steering_12800, 6.0 robot_1600, 9.7
+ex4_2_160, 10.0 arki0009. Monotone hit rate: 100/60.9/91.4/100/100%.
+
+Result (9-round interleaved A/B, --reps 9, RAYON_NUM_THREADS=1, two
+separately-built binaries, paired per-round ratios):
+
+  ex4_2_160       1.063x median   (all 9 rounds >= 1.02)
+  arki0009        1.062x median
+  optmass         1.012x median   (noisy, effectively neutral)
+  robot_1600      0.998x median
+  steering_12800  0.992x median   (consistent ~1% dip across 3 campaigns)
+
+Correctness: cross-build bitwise digest (FNV-1a over =f64::to_bits()= of
+=ldlt_export()='s canonical global L/D) BIT-IDENTICAL on all 30 successful
+factorizations of data/matrices/kkt-mittelmann/*/*_0002.mtx. 924 tests
+passed, 0 failed. clippy --all-targets -D warnings clean.
+
+Three variants were built and measured against each other rather than
+argued about; two lost. See tried-and-rejected.
+
+Instrument note: an earlier single campaign appeared to show the indexed
+inner loop beating the slice-and-zip form 1.080x vs 0.977x on optmass. A
+three-way interleaved rerun showed both forms at ~0.975x — the 1.080x was
+cross-campaign noise (optmass "before" min ranged 18504-19603 us, 6%,
+across campaigns built at different times). Lesson repeated from earlier
+today: a ratio between two numbers measured in different campaigns is not
+a measurement. Only per-round paired ratios within one interleaved
+campaign were trusted for the threshold decisions above.

--- a/dev/journal/2026-09-05-01.org
+++ b/dev/journal/2026-09-05-01.org
@@ -259,3 +259,136 @@ None of the three requires BLAS, FMA, or breaking bit-exactness. The
 2026-05-22 verdict "realistic pure-Rust micro-kernel headroom is ~2-3x"
 stands and is *sufficient* -- #153 needs 1.4-3.4x, and roughly half of
 it turns out not to be micro-kernel work at all.
+
+* 23:40 :correction:issue-153:instrument-error:
+CORRECTION to the 22:30-23:05 entries. The kernel replay in
+diag_153_kernel_headroom timed =factor_frontal=, not the entry point
+the driver actually calls. =factor_frontal= wraps
+=factor_frontal_blocked_in_place_with_scratch= with a =validate()=
+NaN scan and a =vec![0.0; nrow*nrow]= allocate-and-copy
+(src/dense/factor.rs:1596), both O(nrow^2). The tax therefore scaled
+with the quantity under measurement and hid inside it. The driver
+calls the in-place entry point directly
+(src/numeric/factorize.rs:2674).
+
+Corrected headroom (loop_us / kernel_us), sequential, 1 thread,
+min-of-N, versus what the 22:55 entry recorded:
+
+| matrix         | loop  | kernel | headroom | was published |
+|----------------+-------+--------+----------+---------------|
+| optmass        | 11762 |   8775 |    1.34x |         1.85x |
+| robot_1600     |  4578 |   2412 |    1.90x |         1.90x |
+| steering_12800 | 18908 |  10393 |    1.82x |         1.78x |
+| ex4_2_160      | 53507 |  40350 |    1.33x |         1.11x |
+| arki0009       |  6328 |   4818 |    1.31x |         1.09x |
+
+Also retracted: "the kernel saturates at ~8300 MMac/s from nrow~76
+onward". It does not. Corrected kernel rates climb 77 (3,1) -> 8451
+(76,16) -> 11610 (345,16) -> 13361 (365,22) MMac/s. The plateau was
+the wrapper's O(nrow^2) tax.
+
+Corrected feral-vs-OpenBLAS ratios on identical shapes: 1.36x (3,1),
+1.43x (18,16), 1.78x (36,16), 1.92x (44,16), 2.09x (56,16), 2.40x
+(76,16), 3.39x (345,16), 3.08x (365,22). The gap grows with nrow, so
+it is the wide trapezoidal path specifically.
+
+Posted as a correction on issue #153 (comment 5554911979). The prior
+comment 5554807883 and the 775b8a8 commit message both carry the
+superseded numbers.
+
+* 23:45 :issue-153:headroom:robustness:
+The 1.3-1.9x headroom survives four independent perturbations of the
+replay, so it is not an artifact of the synthetic front:
+
+| variant                    | optmass | robot | steering | ex4  | arki |
+|----------------------------+---------+-------+----------+------+------|
+| dd (diagonally dominant)   |   1.34x | 1.90x |    1.82x | 1.33 | 1.31 |
+| kkt (saddle point)         |   1.36x | 2.04x |    1.76x | 1.34 | 1.34 |
+| cold (64 MB working set)   |   1.34x | 1.92x |    1.83x | 1.32 | 1.32 |
+| may_delay = true           |   1.39x | 1.95x |    1.85x | 1.33 | 1.32 |
+
+Conclusion: pivoting behaviour, cache residency of the input front,
+and delayed pivots are each ruled out as the explanation for the
+residual. What is left is plumbing.
+
+* 23:55 :scaling:infnorm:knight-ruiz:defect:
+Chased the prologue, which the 23:05 entry showed is 62-83% scaling.
+Found a real defect.
+
+src/scaling/infnorm.rs:44 sets max_iter=10, tol=1e-8. That tolerance
+is unreachable on this corpus. Instrumented max_dev per iteration
+(temporary env-gated eprintln, reverted afterwards; src is clean):
+
+  steering n=115201: it=1 1.48e6 -> it=10 1.94e-2
+  ex4      n= 77115: it=1 4.55e10 -> it=10 4.42e-2
+  robot    n= 24000: it=1 9.90e1 -> it=10 1.43e-2
+
+Linear convergence at ~0.5/iteration. Reaching 1e-8 needs ~40 more
+iterations. The cap binds every time on these three; optmass converges
+in 2 and arki in 3. The comment above the loop -- "Most matrices
+converge in 2-4 iterations; a few pathological ones need all 10" --
+is wrong for the KKT corpus: 3 of 5 cap out.
+
+Swept FERAL_KR_MAX (temporary env override, also reverted) to separate
+what the iterations cost from what they buy, numeric phase isolated:
+
+| matrix   | scaling us | numeric @10 | numeric @1 | verdict          |
+|----------+------------+-------------+------------+------------------|
+| robot    |       1056 |        4783 |       4764 | 0% benefit       |
+| steering |       4933 |       23411 |      23961 | 2% for 4.9 ms    |
+| ex4      |       3216 |       57318 |      77906 | 20 ms for 3.2 ms |
+
+So a blanket cap reduction is NOT the fix: ex4 regresses 1.30x. And a
+smarter stopping rule cannot separate the cases -- all three max_dev
+trajectories have the same shape, so the residual carries no signal
+about which matrix needs the iterations.
+
+* 00:05 :scaling:track-b2:cache:issue-153:
+The fix that does work: src/numeric/solver.rs:1485 returns false for
+ScalingStrategy::InfNorm, so the Track-B2 value-bounded cache covers
+MC64 only. InfNorm is recomputed from scratch on every factorization.
+
+Measured on the Solver path (warm solver, min of 7, sequential), via a
+new --scaling flag on diag_200_front_size_buckets:
+
+| matrix   | strategy | plain_us | prologue scaling_us |
+|----------+----------+----------+---------------------|
+| steering | identity |    66631 |                   7 |
+| steering | infnorm  |    29065 |                4874 |
+| steering | mc64     |    23958 |                  13 |
+| ex4      | identity |   176823 |                   5 |
+| ex4      | infnorm  |    61221 |                3211 |
+| ex4      | mc64     |    58916 |                   9 |
+
+Two findings. (1) Scaling is load-bearing, not overhead: Identity is
+2.3-2.9x worse end-to-end. (2) MC64 is 1.21x faster than InfNorm
+end-to-end on steering purely because the cache reduces it to 13 us
+on a warm refactor while InfNorm pays 4874 us every time.
+
+Implication: extend the cache to InfNorm. It needs its own value-bound
+predicate -- mc64_value_bound_passes is a property of the Hungarian
+matching and does not transfer.
+
+This also settles the ICNTL(15)=0 question. ma57_bench.F disables
+MA57's scaling on the stated grounds that feral amortizes MC64 into
+analysis. That is correct for the MC64 path but false for the InfNorm
+path, which the default Auto picks on steering and ex4 and which pays
+in full inside every warm Solver::factor.
+
+* 00:10 :issue-153:plan:
+Posted the consolidated fix plan to #153. Priority order by measured
+lever: (1) extend-add plumbing -- 0.33-0.35 ns/element on every
+matrix, ~70% of the non-kernel loop on large-front matrices, and
+closing it alone projects robot to 1.06x and steering to 0.99x of
+MA57; (2) InfNorm scaling cache -- 1.21x on steering; (3) kernel --
+real 1.4-3.4x gap but the recorded pure-Rust aarch64 ceiling is
+33-35 GFLOPS (40-60% of Accelerate) and ~2x of the remainder is FMA,
+forfeited by the bit-exactness contract, so expectations belong at
+~1.4x not 3x.
+
+Open item carried forward, stated as open rather than resolved: on the
+17-32-row fronts the non-kernel cost is 2.0-3.0 ns/element and the
+named counters explain only ~40% of it -- roughly 800-1200 ns/front is
+unattributed. PHASE_TIMING's 350-430 ns/front probe tax makes it the
+wrong instrument at that size class; a lighter targeted probe is
+needed before anyone optimizes there.

--- a/dev/scripts/README-blas-reference.md
+++ b/dev/scripts/README-blas-reference.md
@@ -1,0 +1,43 @@
+# BLAS reference probes (issue #153)
+
+These three Fortran programs measure the *external* side of the #153
+comparison. They are diagnostics, not part of the build: feral's core
+solver has zero non-Rust dependencies (CLAUDE.md) and nothing here is
+linked into the crate. They exist so the "how much of the machine does
+a tuned BLAS get on our shapes" question is answered by measurement
+instead of by citation.
+
+All three link the OpenBLAS that ships with CoinHSL — the same library
+MA57 uses in `external_benchmarks/ma57_oracle` — so the feral-vs-MA57
+numbers and these numbers come from one library on one core.
+
+Build (adjust `HSL` to your CoinHSL bundle):
+
+    HSL=$HOME/Dropbox/projects/CoinHSL.v2023.11.17.aarch64-apple-darwin-libgfortran5
+    gfortran -O2 -o dgemm_peak  dev/scripts/dgemm_peak.f  -L$HSL/lib -Wl,-rpath,$HSL/lib -lopenblas
+    gfortran -O2 -o dsytrf_peak dev/scripts/dsytrf_peak.f -L$HSL/lib -Wl,-rpath,$HSL/lib -lopenblas
+    gfortran -O2 -o blas_front  dev/scripts/blas_front.f  -L$HSL/lib -Wl,-rpath,$HSL/lib -lopenblas
+    OPENBLAS_NUM_THREADS=1 ./blas_front
+
+| program | measures | feral counterpart |
+|---|---|---|
+| `dgemm_peak.f`  | `dgemm` on square shapes — the machine's ceiling | (none; upper bound only) |
+| `dsytrf_peak.f` | LAPACK blocked Bunch-Kaufman, square, full elimination | `diag_153_dense_peak` |
+| `blas_front.f`  | `dsytrf` + `dtrsm` + `dsyrk` partial front on the exact `(nrow, ncol)` shapes the corpus produces — the kernel MA57 actually runs | `diag_153_kernel_headroom` per-shape `kernel_us` |
+
+Two things to keep in mind when reading the output.
+
+`SYSTEM_CLOCK` has 1 us granularity here, which is longer than a whole
+small front. `blas_front.f` therefore batch-times `REPS` iterations and
+subtracts a copy-only calibration loop; `dgemm_peak.f` and
+`dsytrf_peak.f` take a min over repetitions and are unreliable below
+n ~ 64 — read their small-n rows as noise, not as data.
+
+The MMac/s column uses feral's `sum_{k<ncol}(nrow-k)^2` model so it is
+directly comparable to `diag_153_dense_peak`,
+`diag_153_kernel_headroom` and `diag_200_work_vs_ma57`. That model
+counts the *full* trailing square, while a symmetric update only
+touches a triangle, so it over-counts real work by up to ~2x on wide
+trapezoidal fronts. It over-counts both sides identically, so ratios
+are sound; absolute MMac/s should not be compared against a vendor's
+published GFLOP/s.

--- a/dev/scripts/blas_front.f
+++ b/dev/scripts/blas_front.f
@@ -1,0 +1,91 @@
+      PROGRAM BLAS_FRONT
+C     What does a BLAS-based partial frontal LDL^T cost on the exact
+C     (nrow, ncol) shapes feral's corpus produces?  This is the kernel
+C     MA57 runs: factor the leading ncol x ncol block with pivoting
+C     (DSYTRF), solve the off-diagonal block (DTRSM + D scaling), then
+C     one DSYRK Schur update of the (nrow-ncol) trailing block.
+C     Counted in sum_{k<ncol}(nrow-k)^2 multiply-adds -- feral's model.
+      IMPLICIT NONE
+      INTEGER, PARAMETER :: NSH = 10
+      INTEGER :: SHR(NSH), SHC(NSH), I, J, K, NR, NC, R, REPS, INFO
+      INTEGER :: LWORK, M
+      DOUBLE PRECISION, ALLOCATABLE :: A(:,:), A0(:,:), WORK(:), D(:)
+      INTEGER, ALLOCATABLE :: IPIV(:)
+      INTEGER(8) :: T0, T1, RATE, BEST
+      DOUBLE PRECISION :: MACS, US, MRATE
+C     nrow / ncol pairs taken from diag_153_kernel_headroom "top shapes"
+      DATA SHR /3,4,11,18,36,44,56,76,345,365/
+      DATA SHC /1,2, 3,16,16,16,16,16, 16, 22/
+      CALL SYSTEM_CLOCK(COUNT_RATE=RATE)
+      WRITE(*,'(A6,A6,A14,A12,A12)') "nrow","ncol","macs","min_us",
+     &     "MMac/s"
+      DO I = 1, NSH
+        NR = SHR(I)
+        NC = SHC(I)
+        M  = NR - NC
+        LWORK = 64*NR
+        ALLOCATE(A(NR,NR), A0(NR,NR), IPIV(NR), WORK(LWORK), D(NR))
+        DO J = 1, NR
+          DO K = 1, NR
+            IF (K .EQ. J) THEN
+              A0(K,J) = DBLE(NR) + 1.0D0
+            ELSE
+              A0(K,J) = DBLE(MOD(K*7+J*3, 17)) / 17.0D0
+            END IF
+          END DO
+        END DO
+        MACS = 0.0D0
+        DO K = 0, NC-1
+          MACS = MACS + DBLE(NR-K)*DBLE(NR-K)
+        END DO
+        REPS = MAX(200, MIN(200000, INT(2.0D8 / MACS)))
+C       Batch-time REPS iterations: SYSTEM_CLOCK has 1 us granularity,
+C       which is larger than a whole small front.  A copy-only loop of
+C       the same length is timed and subtracted so the A = A0 restore
+C       is not charged to the kernel.
+        A = A0
+        CALL DSYTRF('L', NC, A, NR, IPIV, WORK, LWORK, INFO)
+        CALL SYSTEM_CLOCK(T0)
+        DO R = 1, REPS
+          A = A0
+          CALL DSYTRF('L', NC, A, NR, IPIV, WORK, LWORK, INFO)
+          IF (M .GT. 0) THEN
+            CALL DTRSM('R','L','T','U', M, NC, 1.0D0, A, NR,
+     &                 A(NC+1,1), NR)
+            DO J = 1, NC
+              D(J) = 1.0D0 / A(J,J)
+            END DO
+            DO J = 1, NC
+              DO K = 1, M
+                A(NC+K,J) = A(NC+K,J) * D(J)
+              END DO
+            END DO
+            CALL DSYRK('L','N', M, NC, -1.0D0, A(NC+1,1), NR,
+     &                 1.0D0, A(NC+1,NC+1), NR)
+          END IF
+        END DO
+        CALL SYSTEM_CLOCK(T1)
+        BEST = T1 - T0
+        CALL SYSTEM_CLOCK(T0)
+        DO R = 1, REPS
+          A = A0
+          CALL DUMMY(A, NR)
+        END DO
+        CALL SYSTEM_CLOCK(T1)
+        BEST = BEST - (T1 - T0)
+        IF (BEST .LT. 1) BEST = 1
+        US = DBLE(BEST) * 1.0D6 / DBLE(RATE) / DBLE(REPS)
+        MRATE = MACS / MAX(US, 1.0D-9)
+        WRITE(*,'(I6,I6,F14.0,F12.2,F12.0)') NR, NC, MACS, US, MRATE
+        DEALLOCATE(A,A0,IPIV,WORK,D)
+      END DO
+      END
+
+      SUBROUTINE DUMMY(A, N)
+C     Opaque sink so the copy-only calibration loop is not elided.
+      IMPLICIT NONE
+      INTEGER N
+      DOUBLE PRECISION A(N,N)
+      IF (A(1,1) .EQ. -12345.0D0) A(1,1) = 0.0D0
+      RETURN
+      END

--- a/dev/scripts/dgemm_peak.f
+++ b/dev/scripts/dgemm_peak.f
@@ -1,0 +1,39 @@
+      PROGRAM DGEMM_PEAK
+C     Peak DGEMM rate for the OpenBLAS that MA57 links against, in
+C     multiply-adds per microsecond (== MMac/s), so it is directly
+C     comparable to feral's diag_153_dense_peak column.
+      IMPLICIT NONE
+      INTEGER, PARAMETER :: NS = 10
+      INTEGER :: SIZES(NS), I, J, K, N, R, REPS
+      DOUBLE PRECISION, ALLOCATABLE :: A(:,:), B(:,:), C(:,:)
+      INTEGER(8) :: T0, T1, RATE, BEST
+      DOUBLE PRECISION :: MACS, US, MRATE
+      DATA SIZES /16,32,48,64,96,128,192,256,384,512/
+      CALL SYSTEM_CLOCK(COUNT_RATE=RATE)
+      WRITE(*,'(A6,A14,A12,A12)') "n", "macs", "min_us", "MMac/s"
+      DO I = 1, NS
+        N = SIZES(I)
+        ALLOCATE(A(N,N), B(N,N), C(N,N))
+        DO J = 1, N
+          DO K = 1, N
+            A(K,J) = DBLE(MOD(K*7+J*3, 17)) / 17.0D0
+            B(K,J) = DBLE(MOD(K*5+J*11, 13)) / 13.0D0
+            C(K,J) = 0.0D0
+          END DO
+        END DO
+        MACS = DBLE(N) * DBLE(N) * DBLE(N)
+        REPS = MAX(5, MIN(20000, INT(2.0D8 / MACS)))
+        CALL DGEMM('N','N',N,N,N,1.0D0,A,N,B,N,0.0D0,C,N)
+        BEST = HUGE(BEST)
+        DO R = 1, REPS
+          CALL SYSTEM_CLOCK(T0)
+          CALL DGEMM('N','N',N,N,N,1.0D0,A,N,B,N,0.0D0,C,N)
+          CALL SYSTEM_CLOCK(T1)
+          IF (T1-T0 .LT. BEST) BEST = T1-T0
+        END DO
+        US = DBLE(BEST) * 1.0D6 / DBLE(RATE)
+        MRATE = MACS / US
+        WRITE(*,'(I6,F14.0,F12.2,F12.0)') N, MACS, US, MRATE
+        DEALLOCATE(A,B,C)
+      END DO
+      END

--- a/dev/scripts/dsytrf_peak.f
+++ b/dev/scripts/dsytrf_peak.f
@@ -1,0 +1,50 @@
+      PROGRAM DSYTRF_PEAK
+C     LAPACK blocked Bunch-Kaufman (DSYTRF) rate from the same OpenBLAS
+C     MA57 links against. This is the honest ceiling for a *pivoted*
+C     symmetric indefinite factorization built on tuned BLAS3 -- the
+C     same algorithm class as feral's frontal factor, unlike DGEMM.
+C     Counted in sum_{k<n}(n-k)^2 multiply-adds, the feral convention.
+      IMPLICIT NONE
+      INTEGER, PARAMETER :: NS = 7
+      INTEGER :: SIZES(NS), I, J, K, N, R, REPS, INFO, LWORK
+      DOUBLE PRECISION, ALLOCATABLE :: A(:,:), A0(:,:), WORK(:)
+      INTEGER, ALLOCATABLE :: IPIV(:)
+      INTEGER(8) :: T0, T1, RATE, BEST
+      DOUBLE PRECISION :: MACS, US, MRATE
+      DATA SIZES /32,64,96,128,192,256,512/
+      CALL SYSTEM_CLOCK(COUNT_RATE=RATE)
+      WRITE(*,'(A6,A14,A12,A12,A8)') "n","macs","min_us","MMac/s","info"
+      DO I = 1, NS
+        N = SIZES(I)
+        LWORK = 64*N
+        ALLOCATE(A(N,N), A0(N,N), IPIV(N), WORK(LWORK))
+        DO J = 1, N
+          DO K = 1, N
+            IF (K .EQ. J) THEN
+              A0(K,J) = DBLE(N) + 1.0D0
+            ELSE
+              A0(K,J) = DBLE(MOD(K*7+J*3, 17)) / 17.0D0
+            END IF
+          END DO
+        END DO
+        MACS = 0.0D0
+        DO K = 0, N-1
+          MACS = MACS + DBLE(N-K)*DBLE(N-K)
+        END DO
+        REPS = MAX(5, MIN(20000, INT(2.0D8 / MACS)))
+        A = A0
+        CALL DSYTRF('L', N, A, N, IPIV, WORK, LWORK, INFO)
+        BEST = HUGE(BEST)
+        DO R = 1, REPS
+          A = A0
+          CALL SYSTEM_CLOCK(T0)
+          CALL DSYTRF('L', N, A, N, IPIV, WORK, LWORK, INFO)
+          CALL SYSTEM_CLOCK(T1)
+          IF (T1-T0 .LT. BEST) BEST = T1-T0
+        END DO
+        US = DBLE(BEST) * 1.0D6 / DBLE(RATE)
+        MRATE = MACS / MAX(US, 1.0D-9)
+        WRITE(*,'(I6,F14.0,F12.2,F12.0,I8)') N, MACS, US, MRATE, INFO
+        DEALLOCATE(A,A0,IPIV,WORK)
+      END DO
+      END

--- a/dev/sessions/2026-09-04-01.md
+++ b/dev/sessions/2026-09-04-01.md
@@ -1,0 +1,121 @@
+# Session 2026-09-04-01
+
+## Goal
+
+Work issue #200 ("IPM-KKT factorization ~2.7–2.9× slower than MA57, per-supernode
+overhead") on a branch. The user's framing was explicit: many prior sessions have
+attempted performance improvements here, so the bar is data showing a clear
+before/after — and, once raised mid-session, an actual *explanation* of the gap,
+which no previous session had produced.
+
+## Benchmark comparison to previous session
+
+**No regression, and no improvement — the numbers are identical.** `src/` ends the
+session byte-identical to how it started (the one source change made, the
+`phase_timing` counters, was reverted; see below), so the corpus benchmark is
+unchanged by construction. Both Phase 2.8.1 exit partitions still PASS:
+sparse small-frontal p90 = 1.55 (target ≤ 2.0), medium p90 = 1.55 (≤ 3.0);
+dense 1.60 and 2.03. This session produced knowledge, not code.
+
+## Accomplished
+
+### 1. Issue #200's headline measurement is invalid
+
+The "UNATTRIBUTED 33–39%" is computed as `total − ASSEMBLY − DENSEFACTOR` from
+`phase_timing` counters. Paired alternating A/B of `PHASE_TIMING_ENABLED` off vs
+on, same warm `Solver`, min of 9, `RAYON_NUM_THREADS=1`, shows the profiler
+itself costs 195–427 ns per front — 1.77× total slowdown on optmass_0002. The
+cost lands inside `DENSEFACTOR_NS` but outside its named children, which *is*
+the bucket the issue reports. Full table and mechanism in
+`tried-and-rejected.md`.
+
+En route, my own first hypothesis — that the untimed `scalar_pivot_step` loop
+explained the residual — was instrumented and **disproved**: it is 1.6–4.5% of
+factor time, not 33–39%.
+
+### 2. The gap is explained, for the first time
+
+Prior sessions profiled feral in isolation, which can only locate feral's time,
+never explain why there is more of it than MA57's. Patched
+`external_benchmarks/ma57_oracle/ma57_bench.F` to emit `INFO(14)` (nnz in
+factors), `INFO(13)` (delayed pivots), `RINFO(3)`/`RINFO(4)` (assembly and
+elimination flops), `INFO(5)`; counted feral's side statically from the symbolic
+supernode shapes with the same flop model.
+
+- **feral is not doing more work.** Fill ratio feral/MA57 = 1.01 / 0.84 / 0.78 /
+  1.07 / 1.20; flop ratio = 1.06 / 0.59 / 0.44 / 0.85 / 1.12. On
+  steering_12800 feral does 2.3× *fewer* flops and is still 1.65× slower.
+- **The gap is not 2.7–2.9×.** It is 4.17× / 1.58× / 1.65× / **0.06×** / 1.36×.
+  On ex4_2_160 feral is **18× faster** than MA57 (71.8 ms vs 1.30 s).
+- **Throughput is a monotone function of flops per front**: 194 → 328 MFlop/s,
+  1105–1159 → 825–884, 16697–19234 → 5308–5902. An 18× spread for feral against
+  5.6× for MA57, and feral's small-front floor is 3.9× below MA57's — precisely
+  optmass's 4.17× gap.
+- Fit `t = a·fronts + b·flops` gives **a = 0.713 µs/front**, b = 1.474e-4 µs/flop.
+  The fixed term is 96% of optmass, ~81% of robot/steering, 20–23% of the other
+  two. ~2000 cycles per 4×4 front whose arithmetic is 194 flops.
+
+### 3. Allocation quantified — real, but only 14% of the fixed cost
+
+A counting `GlobalAlloc` measures **7.9–8.1 heap allocations per frontal
+matrix**, uniform and size-independent: 346326 on optmass, one per 24 flops.
+Cross-checks the samply profile exactly (13.5% predicted vs 13.6% measured for
+`libsystem_malloc`). Eliminating *every* per-front allocation would take optmass
+from 25857 to ~22300 µs — still 3.6× MA57. Worth doing; not the answer alone.
+
+### 4. Real, undistorted profile captured
+
+samply at 2000 Hz over 300 warm iterations with `--unstable-presymbolicate`.
+Self-time on optmass: driver 12.4%, dense-entry 16.1%, pivot arithmetic 19.9%,
+memmove/memset 8.7%, allocator 2.6% (+13.6% in `libsystem_malloc`), scaling
+5.6%, rayon wait 9.9% (artifact of `RAYON_NUM_THREADS=1`), unresolved 15.7%.
+
+## Decisions Made
+
+Appended to `dev/decisions.md`: the gap is a per-supernode fixed cost, and the
+issue-#200 target is now stated quantitatively and falsifiably — **reduce fixed
+per-front cost from ~0.71 µs to ~0.18 µs** (MA57 parity on optmass). Binding
+corollary: no performance investigation on this gap may proceed on a wallclock
+ratio alone; fill and flops must be reported beside it.
+
+## Abandoned Approaches
+
+All three appended to `dev/tried-and-rejected.md` with full evidence:
+
+1. **The `phase_timing` counters added this session** (`SCALARLOOP_NS`,
+   `FRONTSETUP_NS`, `FRONTTAIL_NS`, `SCALARLOOP_FRONTS`, `PANEL_FRONTS`,
+   `phase_timing::count`) — reverted from `src/dense/factor.rs`. Re-running the
+   probe-tax measurement after the revert gives optmass 1.52× / 269 ns per front
+   against 1.77× / 411 ns before it: the five counters were themselves costing
+   ~140 ns/front, in the exact hot path whose fixed cost is the subject of the
+   issue. Front counts are available statically and need no runtime counter.
+2. **Raising `nemin`** (third rejection). 32→64→128→512 gives optmass ratios
+   1.00 / 1.37 / 2.58 / 25.70 — monotonically *worse*. Median front stays at 4
+   rows through the whole sweep while max front grows 34 → 514: amalgamation
+   pays for extra arithmetic without removing the tiny fronts.
+3. **Knight-Ruiz warm start and cap reduction.** Warm start is 1–2 orders of
+   magnitude worse than cold (steering: 1.94e-2 cold-10 vs 2.40e-1 warm-3,
+   `max|d_w − d_c|/d_c` = 4.92e-1) and would silently change pivot order and
+   inertia. The cap has no plateau to cut at — per-sweep `max_dev` decays
+   linearly at ~0.5×/sweep and is still improving at sweep 10.
+
+## Next Session Should
+
+1. **Decide whether to pursue the fixed-cost reduction at all.** The prize is
+   large (96% of optmass) and the target is specific (0.71 → 0.18 µs/front), but
+   it is a restructuring of the per-front path, not a tuning. Per the standing
+   implication recorded on 2026-09-01, this should start from a
+   consumer-demonstrated need in pounce or discopt, not from availability.
+2. If pursued, the ordered candidate list, with the honest ceiling on each:
+   - eliminate the 8 per-front allocations (~14% of the fixed cost, bounded at
+     25857 → ~22300 µs on optmass);
+   - the 15.7% that stayed unresolved in the samply profile — resolve it before
+     spending effort elsewhere, since it is the largest single unknown;
+   - driver + dense-entry self-time (28.5% combined) — the `perm`/`perm_inv`
+     construction, `flag_growth_for_refinement`'s full-L scan, and the
+     `FrontalFactors` build.
+3. **Do not** re-attempt `nemin`, KR scaling, or attribution from `phase_timing`
+   counters. All three are now closed with evidence.
+4. Post-hoc curiosity worth one hour, not more: MA57 runs ex4_2_160_0002 at
+   344 MFlop/s with zero delayed pivots, 15× below its own rate on arki0009.
+   Understanding why might reveal a structure feral is already handling well.

--- a/dev/sessions/2026-09-05-01.md
+++ b/dev/sessions/2026-09-05-01.md
@@ -1,0 +1,171 @@
+# Session 2026-09-05-01
+
+## Benchmark note (read first)
+
+**The corpus benchmark was not re-run, and the exit-partition numbers
+below are cited, not measured this session.** `src/` on this branch is
+byte-identical to `main` (`git diff main...HEAD -- src/` is empty), which
+is itself the 0.17.0 baseline; the only Rust added is a diagnostic binary
+under `crates/feral-diagnostics`. The full partition needs the 169,591-
+matrix / 5.4 GB KKT corpus with MUMPS sidecars — a multi-hour run to
+confirm that unchanged solver code produces unchanged numbers.
+
+`cargo run --bin bench --release` was run and is recorded verbatim below;
+`data/benchmark-config.toml` is absent in this clone, so it took its
+synthetic fallback (8 matrices) and emitted no MUMPS ratios.
+
+Cited from `dev/sessions/2026-08-19-05.md` (0.17.0 release):
+
+```
+--- Sparse Phase 2.8.1 exit partition (factor ratio vs MUMPS) ---
+bucket                    count      p90     target  verdict
+small-frontal (<200)     153455     1.58     <= 2.0     PASS
+medium (<500)            153560     1.58     <= 3.0     PASS
+```
+
+The next session that touches solver code must run the corpus and report
+against these.
+
+## Goal
+
+Re-examine issue #200 after a new comment (2026-09-05, from the
+pounce/pglib side) retracted the issue's own headline using a 351k-row
+AC-OPF KKT — a matrix an order of magnitude larger than the one the issue
+was filed from — and stated conclusions incompatible with the comment
+this branch published on 2026-09-04.
+
+## Accomplished
+
+**Their finding reproduces on a different matrix class, and two of my own
+2026-09-04 claims do not survive re-measurement.**
+
+- **Confirmed their §2 in the source.** `src/dense/factor.rs:2168` sets
+  `PANEL_MIN_NCOL = 8` and routes `ncol < 8` to
+  `factor_frontal_in_place_with_scratch`, whose impl (lines 1724–1990)
+  carries `LEXTRACT_NS`/`CONTRIBEXTRACT_NS`/`CONTRIBZEROFILL_NS` but no
+  `PANELFACTOR_NS`/`SCHUR_NS`/`SCALARTAIL_NS`. Small-front arithmetic is
+  uncounted and lands in `DENSEFACTOR`'s unnamed remainder. This is a
+  second mechanism feeding the UNATTRIBUTED bucket, additive to the probe
+  tax I reported, and it is the larger half.
+
+- **Ran their instrument on our five matrices.** New
+  `diag_200_front_size_buckets` (feral's own `Solver::with_profiling(true)`
+  → `ProfileReport`; sequential driver, warm, min of 9,
+  `RAYON_NUM_THREADS=1`; probe tax measured alongside at 0.96–1.12×):
+
+  | matrix | snodes | seq µs | `≤8` % nodes | `≤8` % loop | `≤8` avg ns | dominant bucket |
+  |---|---:|---:|---:|---:|---:|---|
+  | optmass | 43750 | 19081 | 91.4% | 49.1% | 161 | 17–32: 50.8%, 1773 ns |
+  | robot_1600 | 5728 | 6363 | 65.4% | 15.2% | 227 | 17–32: 76.4%, 4551 ns |
+  | steering_12800 | 25055 | 30183 | 76.6% | 17.1% | 183 | 17–32: 82.9%, 2910 ns |
+  | ex4_2_160 | 22839 | 64159 | 60.8% | 4.2% | 177 | >128: 64.6%, 127413 ns |
+  | arki0009 | 2357 | 7345 | 60.4% | 4.5% | 221 | >128: 64.3%, 135995 ns |
+
+  The `≤8` bucket costs 161–227 ns per front on all five, against 196 ns
+  measured independently on their AC-OPF KKT.
+
+- **Retraction 1: the 0.71 µs/front fixed cost and "96% of optmass."**
+  The least-squares model `t = a·fronts + b·flops` has no `nrow` term, so
+  optmass's 3748 fronts of 17–32 rows × 1773 ns = 6.6 ms of a 13.08 ms
+  loop were charged to the intercept. The constant is ~0.2 µs. Ceiling
+  that follows: making every `≤8`-row front free takes optmass from 3.42×
+  MA57 to **2.27×** — a small-front fast path cannot reach parity on the
+  matrix chosen to favour it.
+
+- **Retraction 2: MA57's `ex4_2_160` timing, and the 70-fold spread.**
+  2026-09-04 took min-of-9 on feral but ran `ma57_bench` once, recording
+  1 302 836 µs. Nine cold runs today: 32565 31244 33088 32525 36999 62353
+  48235 55242 37053 µs; an `ICNTL(15)` sweep (0–4) gives 42745 / 42614 /
+  48992 / 66640 / 42442. Same binary, `INFO(14) = 2757122` and
+  `RINFO(4) = 4.4772e8` identical to the earlier run. feral reproduced
+  within 10% on all five, which is why only the un-averaged side moved.
+
+- **Corrected comparison** (both sides min-of-9, same session):
+
+  | matrix | feral par | feral seq | MA57 | seq/MA57 | feral MF/s | MA57 MF/s | rate |
+  |---|---:|---:|---:|---:|---:|---:|---:|
+  | optmass | 26129 | 19081 | 5575 | 3.42× | 444 | 1429 | 3.2× |
+  | robot_1600 | 6786 | 6363 | 3922 | 1.62× | 1044 | 2861 | 2.7× |
+  | steering_12800 | 30529 | 30183 | 21660 | 1.39× | 917 | 2934 | 3.2× |
+  | ex4_2_160 | 65272 | 64159 | 31244 | 2.05× | 5943 | 14329 | 2.4× |
+  | arki0009 | 7720 | 7345 | 4243 | 1.73× | 6173 | 9500 | 1.5× |
+
+  Spread is **1.4×–3.4×**, not 0.06×–4.17×. feral runs 1.5–3.2× fewer
+  flops per second at every front size on 0.44–1.20× the work.
+
+- **Also measured:** the parallel driver at `RAYON_NUM_THREADS=1` costs
+  9–26% over the sequential driver on optmass (20475/22913 vs
+  18730/18154 µs). Some 2026-09-04 numbers carried it.
+
+- **GitHub.** Correction posted on #200; corroborating data posted on
+  #153; **#200 closed as a duplicate of #153**, with `nemin`-settable and
+  the `PHASE_TIMING` unfitness recorded as what survives. PR #201 retitled
+  and its description rewritten to lead with the retractions.
+
+- `cargo test --release`: 0 failures. `cargo fmt --check` and
+  `cargo clippy -- -D warnings` clean via pre-commit.
+
+## Benchmark Results
+
+```
+FERAL benchmark harness
+  ordering: default (symbolic_factorize heuristic)
+  scaling: default (SupernodeParams::default)
+Loading matrices from data/benchmark-config.toml ... not found
+
+name                n   factor(μs)    solve(μs)        inertia
+--------------------------------------------------------------
+spd_10             10          100           42     (10, 0, 0)
+spd_50             50           24            3     (50, 0, 0)
+spd_100           100           82            5    (100, 0, 0)
+spd_200           200          404           18    (200, 0, 0)
+kkt_10_3           13            3            0     (10, 3, 0)
+kkt_30_10          40           21            1    (30, 10, 0)
+kkt_50_15          65           49            2    (50, 15, 0)
+kkt_100_30        130          207            7   (100, 30, 0)
+
+8 matrices benchmarked
+```
+
+## Decisions Made
+
+- **#200 is a duplicate of #153** — the deficit is arithmetic/memory
+  throughput spread across the whole front-size distribution, not a
+  per-supernode constant. Appended to `dev/decisions.md`, superseding the
+  2026-09-04 target ("reduce the fixed per-supernode cost from ~0.71 µs to
+  ~0.18 µs"), which rested on the retracted intercept.
+- **A small-front fast path is not a #200 fix**: capped at 34% of wall on
+  the most favourable matrix in the corpus, 4% on the least, and reaching
+  parity on none.
+- **`PHASE_TIMING_ENABLED` is unfit for attribution on small-front trees**
+  for two independent, additive reasons (probe tax; uncounted `ncol < 8`
+  arithmetic). Use `ProfileReport`.
+
+## Abandoned Approaches
+
+Both appended to `dev/tried-and-rejected.md`:
+
+- **Least-squares `t = a·fronts + b·flops` as an attribution method** —
+  refuted by direct per-front-size bucketing with an instrument that was
+  in-tree the whole time (`Profiler::report()`, issue #52 Phase B).
+- **Single-run MA57 timings** — min-of-N is now required on *both* sides
+  of any cross-solver comparison, with N ≥ 9 and the spread reported.
+
+## Next Session Should
+
+1. **Work #153, not a new #200-style investigation.** The target is
+   feral's flops/second at fixed work: 1.5–3.2× below MA57 across the
+   front-size distribution. Any proposal is measured with both sides
+   min-of-9 and the fill/flop columns shown.
+2. **Start where each matrix's mass actually is** — 17–32-row fronts on
+   the chain-structured KKTs (optmass 1773 ns, steering 2910 ns,
+   robot_1600 4551 ns per front), >128-row fronts on ex4_2_160 and
+   arki0009. `diag_200_front_size_buckets` names the bucket to attack per
+   matrix.
+3. **Decide whether `SupernodeParams::nemin` gets a documented public
+   path**; the pounce-side half (`pounce-feral` never exposes
+   `SupernodeParams`) is not a feral change. Three rejections of a
+   *redefault* stand; the ask is reachability.
+4. **Consider the parallel driver's single-thread cost** (9–26% on optmass
+   at `RAYON_NUM_THREADS=1`) as a separate, small, self-contained item.
+5. Land or close PR #201.

--- a/dev/sessions/2026-09-05-01.md
+++ b/dev/sessions/2026-09-05-01.md
@@ -169,3 +169,138 @@ Both appended to `dev/tried-and-rejected.md`:
 4. **Consider the parallel driver's single-thread cost** (9–26% on optmass
    at `RAYON_NUM_THREADS=1`) as a separate, small, self-contained item.
 5. Land or close PR #201.
+
+---
+
+# Addendum — the first #153 fix landed (extend-add index hoist)
+
+## Benchmark comparison
+
+Reported first, per protocol. Sequential factorization, 9-round
+interleaved A/B, `--reps 9`, `RAYON_NUM_THREADS=1`, two separately-built
+binaries, per-round paired ratios (median):
+
+| matrix | speedup | note |
+|---|---|---|
+| ex4_2_160 | **1.063x** | all 9 rounds ≥ 1.02 |
+| arki0009 | **1.062x** | |
+| optmass | 1.012x | noisy; effectively neutral |
+| robot_1600 | 0.998x | |
+| steering_12800 | **0.992x** | **regression**, consistent across three campaigns |
+
+steering_12800 is ~1% slower and stays that way. It was chased and not
+recovered (see Abandoned Approaches below); it is recorded as an open
+item, not explained away. Net across the five: two matrices gain 6%, one
+loses 1%.
+
+## What was done
+
+`extend_add` (`src/numeric/factorize.rs`) evaluated
+`parent_row_map[contrib.row_indices[ci]]` — two dependent gathers —
+inside the `ci` loop, so each child row was resolved once per column:
+`cdim*(cdim+1)/2` double-gathers where `cdim` suffice. Now:
+
+- the map is built once into `FactorWorkspace::extend_add_pidx`, a pooled
+  buffer (grown, never shrunk; written by index, so no per-element
+  capacity check and no per-call allocation);
+- a **monotone fast path** applies when the parent indices are strictly
+  increasing with no unmapped rows — then `ci >= cj` implies
+  `pidx[ci] >= pidx[cj]`, so the `usize::MAX` test and the lower-triangle
+  compare/swap both fall out of the inner loop. Measured hit rate: 100%
+  on optmass/ex4_2_160/arki0009, 91.4% on robot_1600, 60.9% on
+  steering_12800;
+- a **`SMALL_CDIM = 4` bypass** sends small blocks to the original loop.
+  Measured mean `cdim` is 2.2 (optmass), 5.3 (steering_12800), 6.0
+  (robot_1600), 9.7 (ex4_2_160), 10.0 (arki0009) — below 4 the buffer
+  fill and monotone scan cost more than the gathers they remove.
+
+This was the only lever in the revised #153 fix plan with a measured
+basis and no prior rejection: the scaling items were all closed
+(Knight-Ruiz cap cannot be lowered — ex4_2_160 regresses 1.30x — and both
+the smarter stopping rule and the scaling-vector cache are already in
+`tried-and-rejected.md`).
+
+## Correctness
+
+This has to be bit-exact, and the existing `parallel_parity_*` tests
+compare serial against parallel *within one build*, so they cannot catch
+a change that shifts both. New tool
+`crates/feral-diagnostics/src/bin/diag_ea_digest.rs` closes that gap:
+FNV-1a over `f64::to_bits()` (so ±0.0 and NaN payloads are distinguished)
+of `ldlt_export()`'s canonical global L and D, compared across
+separately-built binaries.
+
+- **BIT-IDENTICAL** on all 30 successful factorizations of
+  `data/matrices/kkt-mittelmann/*/*_0002.mtx`, re-verified after every
+  variant.
+- `cargo test --release`: **924 passed, 0 failed**.
+- `cargo clippy --all-targets -- -D warnings`: clean.
+
+Commit `90eebf1`. PR #201 updated: its old "Update — #153 kernel-headroom
+probes" section still carried the retracted saturation claim and the
+pre-correction headroom numbers; both are now replaced with the
+`e9a438c` values.
+
+## Abandoned Approaches (this addendum)
+
+All three appended to `dev/tried-and-rejected.md`:
+
+- **Fusing the monotone scan into the fill loop.** Looked like a
+  redundant second pass; is not. The fill must run to completion, so a
+  fused test cannot break out early, while the separate scan stops at the
+  first violation — and where monotonicity fails it usually fails early.
+  Slower on all five matrices (steering_12800 0.985x vs 0.992x, arki0009
+  1.050x vs 1.062x).
+- **`SMALL_CDIM = 8`.** Aimed at steering_12800 (mean `cdim` 5.3) and
+  robot_1600 (6.0). Did not recover either (steering 0.988x vs 0.991x)
+  and cost ex4_2_160 2% (1.041x vs 1.061x).
+- **An attributed 10% optmass difference between the indexed and
+  slice-and-zip inner-loop forms** (1.080x vs 0.977x), which briefly
+  justified an `#[allow(clippy::needless_range_loop)]`. **Retracted:** the
+  two figures came from different campaigns. A three-way interleaved
+  rerun put both forms at ~0.975x. optmass's baseline minimum ranged
+  18504–19603 µs (6%) across campaigns built minutes apart, which swamps
+  the effect. The `allow` was removed and the idiomatic form kept.
+
+## Method note
+
+Every threshold and loop-form decision above was made from **per-round
+paired ratios inside a single interleaved campaign**, never from a ratio
+between numbers measured in different campaigns. That rule was adopted
+after the third instrument error of the day (see the retraction above and
+the warm-repeat cache protocol earlier in this session) and is what turned
+a 10% phantom into a measured non-effect.
+
+## Next Session Should (revised)
+
+1. **steering_12800's ~1% dip.** It is not the small-block prologue
+   (`SMALL_CDIM = 8` did not recover it). It is the one matrix where the
+   monotone path fires on only 60.9% of calls, so it pays the scan and
+   then runs the general path — but the general path was already faster
+   than the baseline on every other matrix. Worth one focused
+   measurement, not another campaign.
+2. **The unattributed ~800–1200 ns/front on 17–32-row fronts**, still
+   open. `PHASE_TIMING`'s 350–430 ns/front tax makes it the wrong
+   instrument at that size class; a new one is needed before this is
+   attackable.
+3. **Items 3–5 of the original "Next Session Should" still stand**
+   (`nemin` reachability, the parallel driver's single-thread cost, land
+   or close PR #201).
+
+## Corpus benchmark (session-end, `cargo run --bin bench --release`)
+
+Compared against the run earlier in this same session, on the same
+machine, before the `extend_add` change:
+
+| partition | bucket | p90 before | p90 after | target | verdict |
+|---|---|---|---|---|---|
+| Dense | small-frontal (<200) | 1.58 | 1.58 | ≤ 2.0 | PASS |
+| Dense | medium (<500) | 2.00 | 2.00 | ≤ 3.0 | PASS |
+| Sparse | small-frontal (<200) | 1.64 | **1.54** | ≤ 2.0 | PASS |
+| Sparse | medium (<500) | 1.64 | **1.54** | ≤ 3.0 | PASS |
+
+Factor-ratio p90 vs MUMPS over ~154k oracle-timed matrices. The sparse
+partition improves 1.64 → 1.54 in both buckets; the dense partition is
+unchanged to two decimals. Direction and magnitude are consistent with
+the A/B above — the extend-add path is exercised by the sparse driver.
+No regressions; all four buckets still PASS.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -6120,3 +6120,62 @@ is doing real work.)
 
 **Why it would not have paid anyway.** Even eliminating scaling entirely
 removes 5.6% of optmass, where the gap to MA57 is 4.17×.
+
+---
+
+## 2026-09-05 — Least-squares `t = a·fronts + b·flops` as an attribution method (#200)
+
+**What was tried.** On 2026-09-04 this branch fitted a two-parameter
+model `t_us = a·fronts + b·flops` over five matrices to split
+factorization time into a fixed per-front term and an arithmetic term.
+It returned `a = 0.713 µs/front`, and that number was published on
+issue #200 as "the fixed-per-front term is 96% of optmass."
+
+**Symptoms.** The model has no `nrow` term, so per-front cost that grows
+with front size had nowhere to go but the intercept. Measured directly
+with feral's own per-front-size profiler (`Solver::with_profiling(true)`
+→ `ProfileReport`, the issue-#52 Phase B instrument, in-tree since
+before this investigation began), optmass's 13.08 ms supernode loop
+splits 49.1% into 39999 fronts of `nrow ≤ 8` at **161 ns each** and
+50.8% into 3748 fronts of `nrow` 17–32 at 1773 ns each. The fitted
+intercept charged those 3748 medium fronts — 6.6 ms — to "fixed
+per-front cost."
+
+The true per-front constant is **161–227 ns** on all five matrices, and
+196 ns on the 351k-row AC-OPF KKT measured independently on the pounce
+side: ~0.2 µs, not 0.71 µs. The `<= 8` bucket is 34% of optmass wall
+(6.43 of 19.08 ms), 17.1% on steering, 15.2% on robot_1600, and
+4.2–4.5% on ex4_2_160/arki0009 — never a majority.
+
+**Why it matters beyond the arithmetic.** Making every `nrow ≤ 8` front
+free takes optmass from 19081 µs to ~12650 µs — 3.42× MA57 down to
+2.27×. The lever the fit pointed at cannot reach parity even in its
+best case, on the matrix chosen to maximise it.
+
+**Rejected.** Fitted attribution over a handful of matrices is not
+admissible for this issue. Bucket by front size with `ProfileReport`,
+which measures the thing directly.
+
+---
+
+## 2026-09-05 — Single-run MA57 timings (#200)
+
+**What was tried.** The 2026-09-04 comparison ran `ma57_bench` once per
+matrix (the harness does one factorization per invocation) while taking
+min-of-9 on the feral side.
+
+**Symptoms.** `ex4_2_160_0002` was recorded at **1 302 836 µs**, from
+which the comment concluded "feral is 18× faster than MA57 here" and
+"the ratio spans 70-fold." Not reproducible. Nine cold runs today:
+32565, 31244, 33088, 32525, 36999, 62353, 48235, 55242, 37053 µs. A
+scaling sweep (`ICNTL(15)` = 0,1,2,3,4) gives 42745 / 42614 / 48992 /
+66640 / 42442 µs. Same binary and same matrix: `INFO(14) = 2757122` and
+`RINFO(4) = 4.4772e8` match the 2026-09-04 run exactly, so it was one
+stalled cold run, not a different configuration.
+
+feral's own numbers reproduced within 10% on all five matrices, which is
+why the error survived review — only the un-averaged side moved.
+
+**Rejected.** Min-of-N on **both** sides of any cross-solver comparison,
+with N ≥ 9 and the spread reported. Corrected feral/MA57 range on this
+corpus: **1.4×–3.4×**, not 0.06×–4.17×.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -6010,3 +6010,113 @@ evaluation, including the falsifiers that would flip the answer and the
 reproduction code for every number above, is in
 `dev/research/krylov-recycling-evaluation-2026-09-01.md`. Read that before
 re-opening the question.
+
+---
+
+## 2026-09-04 — Issue #200's "UNATTRIBUTED 33–39%" was the profiler itself
+
+**What was tried.** Issue #200 attributes 33–39% of factor time to an
+UNATTRIBUTED bucket computed as `total − ASSEMBLY − DENSEFACTOR` from
+`phase_timing` counters, and proposes reducing per-supernode overhead on
+that basis. The first hypothesis pursued was that the untimed
+`scalar_pivot_step` loop in `factor_frontal_in_place_with_scratch_impl`
+accounted for the residual, so the loop was instrumented with a new
+`SCALARLOOP_NS` counter plus `FRONTSETUP_NS`, `FRONTTAIL_NS`,
+`SCALARLOOP_FRONTS`, `PANEL_FRONTS`.
+
+**Symptoms.** The scalar loop measured **1.6–4.5%** of factor time, not
+33–39%. The hypothesis was wrong.
+
+**What the residual actually is.** Paired alternating A/B of
+`PHASE_TIMING_ENABLED` off vs on, same warm `Solver`, min of 9,
+`RAYON_NUM_THREADS=1` (`diag_200_probe_tax`):
+
+| matrix | OFF µs | ON µs | ratio | fronts | tax ns/front |
+|---|---|---|---|---|---|
+| optmass_0002 | 23216 | 41181 | **1.77** | 43750 | 411 |
+| robot_1600_0002 | 7483 | 9758 | 1.30 | 5728 | 397 |
+| steering_12800_0002 | 33630 | 44335 | 1.32 | 25055 | 427 |
+| ex4_2_160_0002 | 70632 | 78598 | 1.11 | 22839 | 349 |
+| arki0009_0002 | 8470 | 8930 | 1.05 | 2357 | 195 |
+
+Mechanism: `DENSEFACTOR_NS` brackets the *whole* dense factor, so the cost
+of the inner probes is counted inside DENSEFACTOR but outside
+PANELFACTOR/SCHUR/LEXTRACT/CONTRIBEXTRACT — it lands exactly in
+"densefactor minus its named children," which is the bucket #200 reports.
+On a tree whose median front is 3–7 rows the probe constant is the same
+order as the quantity being attributed.
+
+**Disposition.** The added counters were **reverted** from
+`src/dense/factor.rs`; the hot path is back to its pre-session state.
+Re-running `diag_200_probe_tax` after the revert gives optmass 22394 →
+34151 µs, ratio **1.52**, 269 ns/front — i.e. the five counters this
+session added were themselves costing ~140 ns/front. That is direct
+evidence for the rule below.
+
+**Rule.** `phase_timing` numbers are usable for *ranking* phases on
+matrices with large fronts. They are **not** usable for attributing a
+residual on IPM-KKT trees with tiny fronts, and no per-front counter
+should be added to `src/dense/factor.rs` without first measuring its tax
+with `diag_200_probe_tax`. Front counts are available statically from
+`symbolic_factorize(...).supernodes.len()` and need no runtime counter.
+
+---
+
+## 2026-09-04 — Raising `nemin` to grow fronts (rejected, third time)
+
+**What was tried.** The per-front fixed cost is the dominant term on
+bushy IPM-KKT trees, so the obvious lever is fewer, larger fronts. Swept
+`nemin` ∈ {32, 64, 128, 512} × {`Renumber`, `Adjacency`}
+(`diag_200_amalg_sweep`, uninstrumented min factor time).
+
+**Symptoms — it makes things worse, not better.** Factor-time ratio vs
+the `nemin = 32` default:
+
+| matrix | 32 | 64 | 128 | 512 |
+|---|---|---|---|---|
+| optmass_0002 | 1.00 | 1.37 | 2.58 | **25.70** |
+| robot_1600_0002 | 1.00 | 1.78 | 4.09 | **46.60** |
+| steering_12800_0002 | 1.00 | 1.71 | 3.08 | **39.03** |
+
+Both strategies behave the same. The structure barely moves: optmass goes
+from 41875 to 40052 supernodes (4% fewer) at `nemin` 32→64, and the
+**median front stays at 4 rows through the entire sweep** while the max
+front grows 34 → 514. Amalgamation adds flops to the fronts it merges
+without removing the tiny ones that carry the fixed cost, so the extra
+arithmetic is paid and the overhead is not saved.
+
+This is the third rejection of a `nemin` retune. The prior two were on
+accuracy (MEYER3NE 83× residual at `nemin=4`, VESUVIOU 2789× at
+`nemin=8`, HATFLDG 7 digits lost). This one is on speed, at the opposite
+end of the range. `nemin = 32` is not a parameter with headroom in either
+direction.
+
+---
+
+## 2026-09-04 — Knight-Ruiz scaling: warm-start and iteration-cap cuts
+
+**What was tried.** Scaling is 5.6% (optmass) to 19.9% (steering) of
+factor self-time in the samply profile, and the KR loop runs to its
+`max_iter = 10` cap on three of the five matrices (optmass 2, arki 3,
+robot/steering/ex4_2 all 10). Two reductions were tested: reusing the
+previous factorization's scaling vector as a warm start, and lowering the
+cap.
+
+**Symptoms — warm start.** The scaling vector is not close to the
+previous one. On steering_12800_0002, cold-10 reaches `max_dev` 1.94e-2;
+warm-started runs of 1/2/3 sweeps reach 1.23e0 / 4.59e-1 / 2.40e-1 — one
+to two orders of magnitude *worse* — with `max|d_warm − d_cold|/d_cold =
+4.92e-1`. ex4_2_160_0002: cold-10 = 4.42e-2 vs warm-3 = 7.59e-1, relative
+difference 4.63e-1. A warm start would silently ship a differently scaled
+matrix, changing pivot order and inertia.
+
+**Symptoms — cap reduction.** There is no plateau to cut at. Per-sweep
+`max_dev` on steering_12800_0002: 1.48e6, 9.99e-1, 9.41e-1, 7.33e-1,
+4.74e-1, 2.71e-1, 1.46e-1, 7.54e-2, 3.84e-2, 1.94e-2 — a clean linear
+decay of ~0.5× per sweep that is still improving when the cap hits.
+Cutting to 5 sweeps leaves `max_dev` at 4.7e-1. (optmass converges to
+2.22e-16 by sweep 2 and already exits early; the cap only binds where it
+is doing real work.)
+
+**Why it would not have paid anyway.** Even eliminating scaling entirely
+removes 5.6% of optmass, where the gap to MA57 is 4.17×.

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -6259,3 +6259,79 @@ cover, retained on #153 (comment 5555052797):
 **Rejected.** Scaling is off the #153 actionable list. Caching and
 cap-cutting are both closed; a per-matrix policy is the only remaining
 form and there is no measured signal to drive it.
+
+## 2026-09-05 — extend_add: fusing the monotone scan into the fill loop
+
+**What was tried.** `extend_add` fills a pooled `pidx` buffer with each
+child row's parent index, then makes a second pass to decide whether the
+indices are strictly increasing (the `monotone` fast path). The second
+pass looked redundant, so it was folded into the fill loop: latch a
+`monotone` flag while writing each slot, no separate scan.
+
+**Why it lost.** The fill has to run to completion regardless, so a fused
+test cannot break out early — whereas the separate scan stops at the first
+violation, and on the matrices where monotonicity fails it usually fails
+early. Measured slower on every matrix in a three-way interleaved campaign
+(base / separate scan / fused, 9 rounds, `--reps 9`,
+`RAYON_NUM_THREADS=1`, per-round paired ratios, median):
+
+| matrix         | separate scan | fused  |
+|----------------|---------------|--------|
+| optmass        | 1.012x        | 0.982x |
+| robot_1600     | 0.998x        | 0.993x |
+| steering_12800 | 0.992x        | 0.985x |
+| ex4_2_160      | 1.063x        | 1.058x |
+| arki0009       | 1.062x        | 1.050x |
+
+Fused is worse on all five. Kept the separate pass.
+
+## 2026-09-05 — extend_add: raising the small-block bypass to SMALL_CDIM = 8
+
+**What was tried.** `extend_add` sends contribution blocks with
+`cdim <= SMALL_CDIM` straight to the original doubly-gathered loop,
+because the `pidx` fill and monotone scan cannot pay for themselves on a
+block of two or three rows. Measured mean `cdim` is 5.3 on
+steering_12800 and 6.0 on robot_1600, both of which showed a ~1% dip at
+`SMALL_CDIM = 4`, so raising the threshold to 8 — putting those two on
+the direct path while leaving ex4_2_160 (9.7) and arki0009 (10.0) on the
+hoisted path — looked like it should recover them.
+
+**Why it lost.** It did not recover them, and it cost the matrices it was
+not supposed to affect. Three-way interleaved campaign (base / t4 / t8, 9
+rounds, per-round paired medians):
+
+| matrix         | t4     | t8     |
+|----------------|--------|--------|
+| optmass        | 1.007x | 0.957x |
+| robot_1600     | 0.993x | 0.987x |
+| steering_12800 | 0.991x | 0.988x |
+| ex4_2_160      | 1.061x | 1.041x |
+| arki0009       | 1.071x | 1.069x |
+
+steering_12800 was not recovered (0.988x vs 0.991x), and ex4_2_160 lost
+2%. Kept `SMALL_CDIM = 4`. The residual ~1% dip on steering_12800 is
+unexplained and is *not* the small-block prologue; it is recorded as an
+open item rather than papered over.
+
+## 2026-09-05 — Attributing an optmass swing to the inner-loop form (instrument error)
+
+**What was claimed, and retracted.** An A/B run appeared to show that
+rewriting `extend_add`'s inner loops from indexed access to the
+slice-and-zip form clippy's `needless_range_loop` asks for cost 10% on
+optmass: 1.080x indexed vs 0.977x zipped. On that basis an
+`#[allow(clippy::needless_range_loop)]` was added to the function with the
+numbers cited as justification.
+
+**Why it was wrong.** The two figures came from *different* interleaved
+campaigns, built at different times. A rerun measured the indexed form at
+0.974x on optmass — statistically the same as the zipped form's 0.977x.
+optmass's "before" minimum ranged 18504-19603 us (6%) across campaigns
+built minutes apart, which swamps the effect being attributed. The
+`allow` and its justification were removed and the idiomatic zipped form
+kept.
+
+**Rule this reinforces.** A ratio between two numbers measured in
+different campaigns is not a measurement. Only per-round paired ratios
+from a single interleaved campaign were used for the threshold and
+loop-form decisions that survived. (Same class of error as the warm-repeat
+cache protocol retracted earlier the same day.)

--- a/dev/tried-and-rejected.md
+++ b/dev/tried-and-rejected.md
@@ -6179,3 +6179,83 @@ why the error survived review — only the un-averaged side moved.
 **Rejected.** Min-of-N on **both** sides of any cross-solver comparison,
 with N ≥ 9 and the spread reported. Corrected feral/MA57 range on this
 corpus: **1.4×–3.4×**, not 0.06×–4.17×.
+
+---
+
+## 2026-09-05 — Caching the InfNorm scaling vector (third re-proposal of closed KR work)
+
+**What was proposed.** After measuring that InfNorm scaling costs
+4933 µs on steering_12800_0002 and 3216 µs on ex4_2_160_0002 inside
+every warm `Solver::factor`, while MC64 on the same matrices costs ~13 µs
+because the Track-B2 cache covers it, I proposed extending the B2 cache
+to the InfNorm route and published that on #153 (comment 5554911979)
+before searching this file.
+
+**Why it is wrong.** The InfNorm exclusion in `src/numeric/solver.rs`'s
+`mc64_ran` gate is deliberate, not an oversight. `decisions.md`
+2026-05-22 (#49) records that the cache previously *did* capture InfNorm
+vectors — `compute_infnorm` returns a `ScalingInfo::Applied` that is
+byte-identical to MC64's — and re-injected a stale iter-k vector as
+`ScalingStrategy::External` on the next warm factor. On ex4_2 the
+value-bound gate passes anyway, so the stale scaling was silently
+accepted: a latent correctness defect. The `mc64_ran` conjunction exists
+to prevent exactly this, with
+`mc64_cache_does_not_engage_on_infnorm_route_issue_49` enforcing it.
+
+I suggested InfNorm could get "its own value-bound predicate". No such
+predicate can pass. MC64 caches a *matching* — combinatorial,
+pattern-stable, certifiable against value drift. InfNorm's output is a
+pure function of the values, which change every IPM iteration, and the
+2026-08-15 and 2026-09-04 warm-start experiments already measured the
+drift: seeding from the previous iterate's converged `d` is *worse* than
+cold (steering warm-1/2/3 reach `max_dev` 1.23e0 / 4.59e-1 / 2.40e-1
+against cold-10's 1.94e-2). A reuse cache is a warm start with zero
+sweeps and inherits that failure directly.
+
+**Instrument error behind the supporting number.** The 1.21× end-to-end
+"win" I measured for forcing MC64 on steering (23958 vs 29065 µs) came
+from a warm-repeat protocol that factors the *same values* on every rep.
+That protocol makes any values-keyed cache look valuable precisely
+because the values never change, which is not the workload. Same class
+of error as the `factor_frontal` mistake earlier the same session: the
+measurement setup produced the result, not the system.
+
+**Also re-derived rather than discovered.** The "tol = 1e-8 is
+unreachable, the cap always binds, and the code comment is wrong"
+finding is recorded at `tried-and-rejected.md:5051` (2026-08-15) and
+again 2026-09-04. My per-sweep trace reproduced the 2026-09-04 steering
+trajectory digit for digit (1.48e6 … 1.94e-2).
+
+**Process failure.** `tried-and-rejected.md:5494` already records that
+two consecutive sessions spent user goodwill re-proposing closed work,
+and states that the grep belongs before the recommendation. This is the
+third instance, and the first to reach a public issue. CLAUDE.md's
+Normal Session Protocol puts the search before writing code; it needs to
+apply before *publishing a recommendation* too, which is the step that
+actually costs something.
+
+**What survives.** Two downstream-cost results the prior entries did not
+cover, retained on #153 (comment 5555052797):
+
+- Scaling is load-bearing: `ScalingStrategy::Identity` costs steering
+  66631 µs and ex4 176823 µs against 29065 and 61221 with InfNorm —
+  2.3–2.9× worse end-to-end.
+- The 10 KR iterations are waste on two of three cap-bound matrices and
+  pay on the third, with the numeric phase isolated:
+
+  | matrix | scaling µs | numeric @10 | numeric @1 | net |
+  |---|---|---|---|---|
+  | robot_1600 | 1056 | 4783 | 4764 | 0% benefit |
+  | steering_12800 | 4933 | 23411 | 23961 | 2% for 4.9 ms |
+  | ex4_2_160 | 3216 | 57318 | 77906 | 20 ms saved for 3.2 ms |
+
+  This confirms the 2026-09-04 cap rejection from the downstream side
+  rather than the scaling-quality side, and sharpens why the lever is
+  hard: the same cap that is waste on robot/steering is the one ex4
+  needs, and the `max_dev` trajectories are the same shape on all three,
+  so the scaling loop's own state carries no signal to key a per-matrix
+  policy on.
+
+**Rejected.** Scaling is off the #153 actionable list. Caching and
+cap-cutting are both closed; a per-matrix policy is the only remaining
+form and there is no measured signal to drive it.

--- a/external_benchmarks/ma57_oracle/ma57_bench.F
+++ b/external_benchmarks/ma57_oracle/ma57_bench.F
@@ -305,6 +305,22 @@ C     ---- Write result ----
       WRITE(12,'(A,I0)') "factor_us ", FAC_US
       WRITE(12,'(A,I0)') "solve_us ", SOL_US
       WRITE(12,'(A,ES24.16E3)') "rel_res ", REL_RES
+C     Work-volume fields, so a wallclock comparison against another
+C     solver can be normalised by the work actually performed rather
+C     than assumed equal. After MA57BD:
+C       INFO(14)  = number of entries in the factors
+C       INFO(13)  = number of delayed (2x2 / postponed) pivots
+C       RINFO(3)  = flops for the assembly process
+C       RINFO(4)  = flops for the elimination process
+C     After MA57AD (forecasts, kept for reference):
+C       INFO(5)   = forecast reals to hold factors
+C       RINFO(1)  = forecast assembly flops
+C       RINFO(2)  = forecast elimination flops
+      WRITE(12,'(A,I0)') "nnz_factor ", INFO(14)
+      WRITE(12,'(A,I0)') "n_delayed ", INFO(13)
+      WRITE(12,'(A,ES24.16E3)') "flops_assembly ", RINFO(3)
+      WRITE(12,'(A,ES24.16E3)') "flops_elim ", RINFO(4)
+      WRITE(12,'(A,I0)') "forecast_nnz_factor ", INFO(5)
       WRITE(12,'(A,I0)') "info1 ", INFO(1)
       WRITE(12,'(A,I0)') "info24 ", INFO(24)
       WRITE(12,'(A,I0)') "info25 ", INFO(25)

--- a/src/numeric/factorize.rs
+++ b/src/numeric/factorize.rs
@@ -1431,6 +1431,15 @@ pub struct FactorWorkspace {
     /// and across calls. Left empty when ownership is temporarily
     /// borrowed by an in-flight `SymmetricMatrix`.
     frontal_values: Vec<f64>,
+    /// Scratch for `extend_add`: the child contribution block's
+    /// row-to-parent-frontal index map, `pidx[ci] =
+    /// row_map[contrib.row_indices[ci]]`. Hoisted out of the `cj`
+    /// loop so the double indirection is paid `cdim` times per child
+    /// instead of `cdim*(cdim+1)/2` times. Pooled here rather than
+    /// allocated per child because a medium front assembles ~38 of
+    /// them. Contents are rebuilt per child; no invariant is carried
+    /// across calls.
+    extend_add_pidx: Vec<usize>,
     /// Scratch for `build_row_indices`: delayed-column globals
     /// accumulated from children of the current supernode.
     build_delayed: Vec<usize>,
@@ -2591,7 +2600,7 @@ fn factor_one_supernode(
     let _pt_ea = phase_timing::start();
     for &child_idx in &snode.children {
         if let Some(mut contrib) = contrib_blocks[child_idx].take() {
-            extend_add(&contrib, &ws.row_map, &mut frontal);
+            extend_add(&contrib, &ws.row_map, &mut frontal, &mut ws.extend_add_pidx);
             ws.factor_scratch.contrib_pool = Some(std::mem::take(&mut contrib.data));
         }
     }
@@ -4464,25 +4473,138 @@ struct ContribBlock {
 /// `set`/`get` perform on every cell and eliminates one read+write call
 /// frame per cell. With ~38 children per medium front each contributing
 /// up to `cdim*(cdim+1)/2` cells, this trims a measurable per-front cost.
-fn extend_add(contrib: &ContribBlock, parent_row_map: &[usize], frontal: &mut SymmetricMatrix) {
+/// Scatter a child's contribution block into its parent frontal matrix.
+///
+/// `pidx` is a caller-owned scratch buffer (see
+/// `FactorWorkspace::extend_add_pidx`); its contents on entry are
+/// irrelevant and it is only ever grown.
+fn extend_add(
+    contrib: &ContribBlock,
+    parent_row_map: &[usize],
+    frontal: &mut SymmetricMatrix,
+    pidx: &mut Vec<usize>,
+) {
     let cdim = contrib.dim;
+    if cdim == 0 {
+        return;
+    }
     let fn_ = frontal.n;
     let f_data: &mut [f64] = frontal.data.as_mut_slice();
+
+    // Contribution blocks are small: measured mean `cdim` is 2.2
+    // (optmass), 5.3 (steering_12800), 6.0 (robot_1600), 9.7
+    // (ex4_2_160), 10.0 (arki0009). Below `SMALL_CDIM` the setup the
+    // general path does — filling `pidx`, scanning it for monotonicity —
+    // costs more than the redundant gathers it removes, so blocks that
+    // small take the direct doubly-gathered loop instead. Measured: with
+    // no bypass, optmass (mean cdim 2.2) ran 0.974x, i.e. a 2.6%
+    // regression, while the larger-block matrices gained 3%.
+    const SMALL_CDIM: usize = 4;
+    if cdim <= SMALL_CDIM {
+        for cj in 0..cdim {
+            let parent_j = parent_row_map[contrib.row_indices[cj]];
+            if parent_j == usize::MAX {
+                continue;
+            }
+            for ci in cj..cdim {
+                let parent_i = parent_row_map[contrib.row_indices[ci]];
+                if parent_i == usize::MAX {
+                    continue;
+                }
+                let val = contrib.data[cj * cdim + ci];
+                if val == 0.0 {
+                    continue;
+                }
+                let (row, col) = if parent_i >= parent_j {
+                    (parent_i, parent_j)
+                } else {
+                    (parent_j, parent_i)
+                };
+                f_data[col * fn_ + row] += val;
+            }
+        }
+        return;
+    }
+
+    // Hoist the child->parent index map out of the `cj` loop. The
+    // direct form above evaluates `parent_row_map[contrib.row_indices[ci]]`
+    // — two dependent gathers — inside the inner loop, so each child row
+    // is resolved once per column: `cdim*(cdim+1)/2` double-gathers where
+    // `cdim` suffice. Both `pidx[ci]` and `contrib.data[base + ci]` are
+    // then contiguous sequential loads.
+    //
+    // The buffer is pooled across calls (grown, never shrunk) and written
+    // by index rather than `push`, so there is no per-element capacity
+    // check and no per-call allocation.
+    //
+    // Bit-exactness: the `(cj, ci)` iteration order, the `usize::MAX` and
+    // `val == 0.0` skips, and the accumulation order into every `f_data`
+    // cell are all unchanged, so this is a pure strength reduction. (The
+    // `val == 0.0` skip is load-bearing, not an optimisation:
+    // `-0.0 + 0.0 == +0.0`, so adding a zero would flip the sign of a
+    // negative-zero cell that the bitwise parity tests compare.)
+    if pidx.len() < cdim {
+        pidx.resize(cdim, usize::MAX);
+    }
+    let pidx: &mut [usize] = &mut pidx[..cdim];
+
+    // `monotone` holds when the parent indices are strictly increasing
+    // with no unmapped rows, which is the common case: a child's trailing
+    // rows are sorted and map into the parent in order (measured 100% of
+    // calls on optmass/ex4_2_160/arki0009, 91.4% on robot_1600, 60.9% on
+    // steering_12800). When it holds, `ci >= cj` implies
+    // `pidx[ci] >= pidx[cj]`, so the lower-triangle canonicalisation is a
+    // no-op and both the `usize::MAX` test and the compare/swap drop out
+    // of the inner loop.
+    //
+    // Kept as a separate pass with an early `break` rather than folded
+    // into the fill loop that follows. Folding it in was measured slower on
+    // every matrix (steering_12800 0.985x vs 0.992x, arki0009 1.050x vs
+    // 1.062x against the same baseline): the fill has to run to
+    // completion, so a fused test cannot break out, and on the matrices
+    // where monotonicity fails it usually fails early.
+    for (ci, slot) in pidx.iter_mut().enumerate() {
+        *slot = parent_row_map[contrib.row_indices[ci]];
+    }
+    let mut monotone = pidx[0] != usize::MAX;
+    for ci in 1..cdim {
+        if pidx[ci] == usize::MAX || pidx[ci] <= pidx[ci - 1] {
+            monotone = false;
+            break;
+        }
+    }
+
+    if monotone {
+        for cj in 0..cdim {
+            let base = cj * cdim;
+            let colbase = pidx[cj] * fn_;
+            let rows = &pidx[cj..cdim];
+            let vals = &contrib.data[base + cj..base + cdim];
+            for (&parent_i, &val) in rows.iter().zip(vals) {
+                if val == 0.0 {
+                    continue;
+                }
+                f_data[colbase + parent_i] += val;
+            }
+        }
+        return;
+    }
+
     for cj in 0..cdim {
-        let parent_j = parent_row_map[contrib.row_indices[cj]];
+        let parent_j = pidx[cj];
         if parent_j == usize::MAX {
             continue;
         }
-        for ci in cj..cdim {
-            let parent_i = parent_row_map[contrib.row_indices[ci]];
+        let base = cj * cdim;
+        let rows = &pidx[cj..cdim];
+        let vals = &contrib.data[base + cj..base + cdim];
+        for (&parent_i, &val) in rows.iter().zip(vals) {
             if parent_i == usize::MAX {
                 continue;
             }
-            let val = contrib.data[cj * cdim + ci];
             if val == 0.0 {
                 continue;
             }
-            // Canonicalise to lower triangle: ensure row >= col.
             let (row, col) = if parent_i >= parent_j {
                 (parent_i, parent_j)
             } else {


### PR DESCRIPTION
Measurement-only branch for #200 (now closed as a duplicate of #153).
`src/` is unchanged; this adds diagnostics, one Fortran patch to the MA57
oracle, and the `dev/` record.

**Read the retractions first.** The branch's second commit (`1d13094`)
withdraws two findings published in its first (`5a1a82b`, 2026-09-04).
The PR is worth landing for the instruments and for the corrected
conclusion, not for the original one.

## What is retracted

1. **"A fixed cost of ~0.71 µs per supernode, 96% of optmass."** From a
   least-squares fit `t = a·fronts + b·flops` with no `nrow` term, so the
   intercept absorbed medium-front work: optmass's 3748 fronts of 17–32
   rows × 1773 ns = 6.6 ms of a 13.08 ms loop. Direct bucketing by front
   size (`Solver::with_profiling(true)` → `ProfileReport`, in-tree since
   issue #52 Phase B) gives a per-front constant of **161–227 ns** across
   five matrices — and 196 ns measured independently on a 351k-row AC-OPF
   KKT on the pounce side.

2. **MA57's `ex4_2_160` time, and the "70-fold ratio spread" drawn from
   it.** The 2026-09-04 run took min-of-9 on feral's side but ran
   `ma57_bench` once, and recorded 1 302 836 µs. Nine cold runs today:
   31244–62353 µs, with `INFO(14)`/`RINFO(4)` identical and nothing near
   1.3 s under any `ICNTL(15)`. "feral is 18× faster than MA57 on
   ex4_2_160" is withdrawn.

## Corrected conclusion

Both sides min-of-9, same session, sequential driver, warm,
`RAYON_NUM_THREADS=1`:

| matrix | feral µs | MA57 µs | time | feral MFlop/s | MA57 MFlop/s | rate |
|---|---:|---:|---:|---:|---:|---:|
| optmass_0002 | 19081 | 5575 | 3.42× | 444 | 1429 | 3.2× |
| robot_1600_0002 | 6363 | 3922 | 1.62× | 1044 | 2861 | 2.7× |
| steering_12800_0002 | 30183 | 21660 | 1.39× | 917 | 2934 | 3.2× |
| ex4_2_160_0002 | 64159 | 31244 | 2.05× | 5943 | 14329 | 2.4× |
| arki0009_0002 | 7345 | 4243 | 1.73× | 6173 | 9500 | 1.5× |

feral runs 1.5–3.2× fewer flops per second than MA57 **at every front
size**, on 0.44–1.20× the work. Broad throughput deficit, not a
per-supernode constant — i.e. #153. Making every `nrow ≤ 8` front free
would take optmass to 2.27× MA57.

## What survives from the first commit

The work-volume comparison, which is symbolic and unaffected by either
retraction: feral's fill is 0.78–1.20× MA57's and its flop count
0.44–1.12×, so ordering, fill and arithmetic volume are exonerated as the
cause. On steering feral does 2.3× fewer flops and is still slower. The
three rejected levers (`nemin` — third rejection, on speed; Knight-Ruiz
warm start; KR cap reduction) stand on their own evidence.

## Contents

- `crates/feral-diagnostics/src/bin/diag_200_front_size_buckets.rs` —
  supernode wallclock bucketed by `nrow`, with the uninstrumented time
  beside it so the probe tax (0.96–1.12×) is visible rather than assumed.
- `diag_200_work_vs_ma57` — feral's `nnz_L` and symbolic flop count, to be
  read against MA57's `INFO(14)`/`RINFO(4)`.
- `diag_200_probe_tax`, `diag_200_alloc_count`, `diag_200_amalg_sweep`,
  `diag_200_kr_warmstart`, `diag_200_kr_iters`, `diag_200_where_is_time`,
  `diag_200_hotloop`.
- `external_benchmarks/ma57_oracle/ma57_bench.F` — emits `INFO(13)`,
  `INFO(14)`, `INFO(5)`, `RINFO(3)`, `RINFO(4)`.
- `dev/`: journals `2026-09-04-01` and `2026-09-05-01`, session
  checkpoints, both retractions in `tried-and-rejected.md`, and a
  `decisions.md` entry superseding the 2026-09-04 target.

`cargo test --release`: 0 failures. `cargo fmt --check` and
`cargo clippy -- -D warnings` clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyQaMsYQB8Jza589BhauU3


---

## Update — #153 kernel-headroom probes

Kept open and extended: the #200 retraction left "the deficit is broad" as the finding, which was not actionable. Commit `775b8a8` adds the measurement that makes it actionable — feral against a tuned BLAS *on the same shape*, which did not exist anywhere in the tree.

- `diag_153_kernel_headroom` — replays a real factorization's exact `(nrow, ncol)` shape multiset against the isolated `factor_frontal`, giving `headroom = loop_ns / kernel_ns`: how much slower the solver is than its own kernel.
- `diag_153_dense_peak` — `factor_frontal` on square fronts (was untracked and unrun).
- `dev/scripts/{dgemm_peak,dsytrf_peak,blas_front}.f` + README — the external side, against the OpenBLAS CoinHSL ships, so both sides come from one library on one core. Diagnostics only; nothing linked into the crate.

Result, after a correction: the first version of this table timed `factor_frontal`, a wrapper that does a `validate()` NaN scan and an `nrow^2` allocate-and-copy on every call, rather than `factor_frontal_blocked_in_place_with_scratch`, which is what the driver actually calls. The tax was O(nrow^2), so it scaled with the quantity being measured and hid inside it. Commit `e9a438c` fixes the instrument; the numbers below are the re-measured ones.

**Retracted:** that feral's kernel "saturates at ~8300 MMac/s from nrow~76". It does not saturate — it reaches 11610 MMac/s at (345,16) and 13361 at (365,22). The plateau was the wrapper.

**Stands, with corrected values:** the deficit is two disjoint problems.

| matrix | loop us | kernel us | headroom | as first published |
|---|---|---|---|---|
| optmass | 11762 | 8775 | **1.34x** | 1.85x |
| robot_1600 | 4578 | 2412 | **1.90x** | 1.90x |
| steering_12800 | 18908 | 10393 | **1.82x** | 1.78x |
| ex4_2_160 | 53507 | 40350 | **1.33x** | 1.11x |
| arki0009 | 6328 | 4818 | **1.31x** | 1.09x |

The headroom figure is robust: 1.32-1.95x across four independent replay variants (diagonally-dominant front, saddle-point indefinite front, cold 64 MB working set, `may_delay=true`), so pivoting behaviour, cache residency, and delayed pivots are each ruled out as the explanation. Against OpenBLAS on identical shapes the kernel runs 1.36x behind at (3,1), widening to 3.39x at (345,16). Full tables in [#153](https://github.com/jkitchin/feral/issues/153#issuecomment-5554911979).

Caveat on every absolute number here: the flop model counts the full trailing square where a symmetric update touches only a triangle, over-counting by up to ~2x on wide fronts. It over-counts both sides identically, so the ratios are sound; the absolutes are not vendor GFLOP/s.

---

## Update — first #153 fix: the extend-add index hoist

The headroom above says non-arithmetic work in the supernode loop, not the kernel, is what small- and medium-front matrices lose to. Of the candidate causes, scaling was closed out (the Knight-Ruiz cap cannot be lowered — ex4_2_160 regresses 1.30x — and both a smarter stopping rule and caching the scaling vector are already in `tried-and-rejected.md`), which left the extend-add plumbing as the only target with a measured basis and no prior rejection.

`extend_add` evaluated `parent_row_map[contrib.row_indices[ci]]` — two dependent gathers — inside the `ci` loop, resolving every child row once per column: `cdim*(cdim+1)/2` double-gathers where `cdim` suffice. The map is now built once into a pooled `FactorWorkspace` buffer, with a monotone fast path (strictly-increasing parent indices let both the `usize::MAX` test and the lower-triangle compare/swap fall out of the inner loop) and a `SMALL_CDIM = 4` bypass, since contribution blocks are small — mean `cdim` is 2.2 on optmass — and below that size the setup costs more than the gathers it removes.

9-round interleaved A/B, `--reps 9`, `RAYON_NUM_THREADS=1`, two separately-built binaries, per-round paired ratios (median):

| matrix | speedup |
|---|---|
| ex4_2_160 | **1.063x** (all 9 rounds >= 1.02) |
| arki0009 | **1.062x** |
| optmass | 1.012x (noisy; effectively neutral) |
| robot_1600 | 0.998x |
| steering_12800 | **0.992x** — a consistent ~1% regression across three campaigns |

steering_12800 is reported rather than omitted. Raising `SMALL_CDIM` to 8 to chase it did not recover it and cost ex4_2_160 2%; fusing the monotone scan into the fill loop was slower on all five matrices. Both are recorded in `tried-and-rejected.md`, along with a retraction: an apparent 10% optmass difference between the indexed and slice-and-zip inner-loop forms turned out to be cross-campaign noise, and only per-round paired ratios from single interleaved campaigns were used for the decisions that survived.

**Bit-exactness.** This has to be bit-exact, and the existing `parallel_parity_*` tests compare serial against parallel *within one build*, so they cannot catch a change that shifts both. `diag_ea_digest` (new) closes that gap: FNV-1a over `f64::to_bits()` of `ldlt_export()`'s canonical global L and D, compared across separately-built binaries. BIT-IDENTICAL on all 30 successful factorizations of `data/matrices/kkt-mittelmann/*/*_0002.mtx`. `cargo test --release`: 924 passed, 0 failed.

**Still open:** ~800-1200 ns/front is unattributed on 17-32-row fronts, and `PHASE_TIMING`'s 350-430 ns/front tax makes it the wrong instrument at that size class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyQaMsYQB8Jza589BhauU3
